### PR TITLE
Add Rails type definitions

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,9 @@
 [submodule "gems/rainbow/3.0/_src"]
 	path = gems/rainbow/3.0/_src
 	url = https://github.com/sickill/rainbow.git
+[submodule "gems/railties/6.0.3.2/_src"]
+	path = gems/railties/6.0.3.2/_src
+	url = https://github.com/rails/rails.git
+[submodule "gems/railties/6.0.3.2/_rbs_rails"]
+	path = gems/railties/6.0.3.2/_rbs_rails
+	url = https://github.com/pocke/rbs_rails.git

--- a/gems/actionpack/6.0.3.2/actioncontroller.rbs
+++ b/gems/actionpack/6.0.3.2/actioncontroller.rbs
@@ -1,30 +1,3 @@
-interface _ActionController_API_and_Base
-  def request: () -> untyped
-  def params: () -> untyped
-  def session: () -> untyped
-  def cookies: () -> untyped
-  def flash: () -> untyped
-  def render: (*untyped) -> void
-  def redirect_to: (*untyped) -> void
-end
-
-interface _ActionController_API_and_Base_singletion
-  # hooks
-  def before_action: (*untyped) -> void
-  def around_action: (*untyped) -> void
-  def after_action: (*untyped) -> void
-  def skip_before_action: (*untyped) -> void
-  def skip_around_action: (*untyped) -> void
-  def skip_after_action: (*untyped) -> void
-  def prepend_before_action: (*untyped) -> void
-  def prepend_around_action: (*untyped) -> void
-  def prepend_after_action: (*untyped) -> void
-  def append_before_action: (*untyped) -> void
-  def append_around_action: (*untyped) -> void
-  def append_after_action: (*untyped) -> void
-
-  def rescue_from: (*Class, ?with: Symbol | Proc) { (Exception) -> void } -> void
-end
 
 module AbstractController
   class Base
@@ -32,18 +5,45 @@ module AbstractController
 end
 
 module ActionController
+  interface _API_and_Base
+    def request: () -> untyped
+    def session: () -> untyped
+    def cookies: () -> untyped
+    def flash: () -> untyped
+    def render: (*untyped) -> void
+    def redirect_to: (*untyped) -> void
+  end
+
+  interface _API_and_Base_singletion
+    # hooks
+    def before_action: (*untyped) -> void
+    def around_action: (*untyped) -> void
+    def after_action: (*untyped) -> void
+    def skip_before_action: (*untyped) -> void
+    def skip_around_action: (*untyped) -> void
+    def skip_after_action: (*untyped) -> void
+    def prepend_before_action: (*untyped) -> void
+    def prepend_around_action: (*untyped) -> void
+    def prepend_after_action: (*untyped) -> void
+    def append_before_action: (*untyped) -> void
+    def append_around_action: (*untyped) -> void
+    def append_after_action: (*untyped) -> void
+
+    def rescue_from: (*Class, ?with: Symbol | Proc) { (Exception) -> void } -> void
+  end
+
   class Metal < ::AbstractController::Base
   end
 
   class Base < Metal
-    include _ActionController_API_and_Base
-    extend _ActionController_API_and_Base_singletion
+    include _API_and_Base
+    extend _API_and_Base_singletion
     extend ::ActionView::Layouts::ClassMethods
   end
 
   class API < Metal
-    include _ActionController_API_and_Base
-    extend _ActionController_API_and_Base_singletion
+    include _API_and_Base
+    extend _API_and_Base_singletion
   end
 end
 

--- a/gems/actionpack/6.0.3.2/actioncontroller.rbs
+++ b/gems/actionpack/6.0.3.2/actioncontroller.rbs
@@ -6,7 +6,6 @@ end
 
 module ActionController
   interface _API_and_Base
-    def request: () -> untyped
     def session: () -> untyped
     def cookies: () -> untyped
     def flash: () -> untyped

--- a/gems/actionpack/6.0.3.2/actioncontroller.rbs
+++ b/gems/actionpack/6.0.3.2/actioncontroller.rbs
@@ -1,0 +1,49 @@
+interface _ActionController_API_and_Base
+  def request: () -> untyped
+  def params: () -> untyped
+  def session: () -> untyped
+  def cookies: () -> untyped
+  def flash: () -> untyped
+  def render: (*untyped) -> void
+  def redirect_to: (*untyped) -> void
+end
+
+interface _ActionController_API_and_Base_singletion
+  # hooks
+  def before_action: (*untyped) -> void
+  def around_action: (*untyped) -> void
+  def after_action: (*untyped) -> void
+  def skip_before_action: (*untyped) -> void
+  def skip_around_action: (*untyped) -> void
+  def skip_after_action: (*untyped) -> void
+  def prepend_before_action: (*untyped) -> void
+  def prepend_around_action: (*untyped) -> void
+  def prepend_after_action: (*untyped) -> void
+  def append_before_action: (*untyped) -> void
+  def append_around_action: (*untyped) -> void
+  def append_after_action: (*untyped) -> void
+
+  def rescue_from: (*Class, ?with: Symbol | Proc) { (Exception) -> void } -> void
+end
+
+module AbstractController
+  class Base
+  end
+end
+
+module ActionController
+  class Metal < ::AbstractController::Base
+  end
+
+  class Base < Metal
+    include _ActionController_API_and_Base
+    extend _ActionController_API_and_Base_singletion
+    extend ::ActionView::Layouts::ClassMethods
+  end
+
+  class API < Metal
+    include _ActionController_API_and_Base
+    extend _ActionController_API_and_Base_singletion
+  end
+end
+

--- a/gems/actionpack/6.0.3.2/actioncontroller.rbs
+++ b/gems/actionpack/6.0.3.2/actioncontroller.rbs
@@ -1,48 +1,109 @@
-
-module AbstractController
-  class Base
-  end
-end
-
 module ActionController
   interface _API_and_Base
     def session: () -> untyped
-    def cookies: () -> untyped
     def flash: () -> untyped
-    def render: (*untyped) -> void
-    def redirect_to: (*untyped) -> void
   end
 
   interface _API_and_Base_singletion
-    # hooks
-    def before_action: (*untyped) -> void
-    def around_action: (*untyped) -> void
-    def after_action: (*untyped) -> void
-    def skip_before_action: (*untyped) -> void
-    def skip_around_action: (*untyped) -> void
-    def skip_after_action: (*untyped) -> void
-    def prepend_before_action: (*untyped) -> void
-    def prepend_around_action: (*untyped) -> void
-    def prepend_after_action: (*untyped) -> void
-    def append_before_action: (*untyped) -> void
-    def append_around_action: (*untyped) -> void
-    def append_after_action: (*untyped) -> void
-
     def rescue_from: (*Class, ?with: Symbol | Proc) { (Exception) -> void } -> void
-  end
-
-  class Metal < ::AbstractController::Base
   end
 
   class Base < Metal
     include _API_and_Base
     extend _API_and_Base_singletion
+
+    # https://github.com/rails/rails/blob/v6.0.3.2/actionpack/lib/action_controller/base.rb#L205-L255
+    include AbstractController::Rendering
+    include AbstractController::Translation
+    include AbstractController::AssetPaths
+    include Helpers
+    extend Helpers::ClassMethods
+    include UrlFor
+    include Redirecting
+    include ActionView::Layouts
     extend ::ActionView::Layouts::ClassMethods
+    include Rendering
+    extend Rendering::ClassMethods
+    include Renderers::All
+    include ConditionalGet
+    extend ConditionalGet::ClassMethods
+    include EtagWithTemplateDigest
+    include EtagWithFlash
+    include Caching
+    include MimeResponds
+    include ImplicitRender
+    include StrongParameters
+    include ParameterEncoding
+    extend ParameterEncoding::ClassMethods
+    include Cookies
+    include Flash
+    extend Flash::ClassMethods
+    include FormBuilder
+    extend FormBuilder::ClassMethods
+    include RequestForgeryProtection
+    extend RequestForgeryProtection::ClassMethods
+    include ContentSecurityPolicy
+    extend ContentSecurityPolicy::ClassMethods
+    include ForceSSL
+    extend ForceSSL::ClassMethods
+    include Streaming
+    include DataStreaming
+    include HttpAuthentication::Basic::ControllerMethods
+    extend HttpAuthentication::Basic::ControllerMethods::ClassMethods
+    include HttpAuthentication::Digest::ControllerMethods
+    include HttpAuthentication::Token::ControllerMethods
+    include DefaultHeaders
+    extend DefaultHeaders::ClassMethods
+    include AbstractController::Callbacks
+    extend AbstractController::Callbacks::ClassMethods
+    include Rescue
+    include Instrumentation
+    extend Instrumentation::ClassMethods
+    include ParamsWrapper
+    extend ParamsWrapper::ClassMethods
   end
 
   class API < Metal
     include _API_and_Base
     extend _API_and_Base_singletion
+
+    # https://github.com/rails/rails/blob/v6.0.3.2/actionpack/lib/action_controller/api.rb#L112-L145
+    include AbstractController::Rendering
+    include UrlFor
+    include Redirecting
+    include ApiRendering
+    include Renderers::All
+    include ConditionalGet
+    extend ConditionalGet::ClassMethods
+    include BasicImplicitRender
+    include StrongParameters
+    include ForceSSL
+    extend ForceSSL::ClassMethods
+    include DataStreaming
+    include DefaultHeaders
+    extend DefaultHeaders::ClassMethods
+    include AbstractController::Callbacks
+    extend AbstractController::Callbacks::ClassMethods
+    include Rescue
+    include Instrumentation
+    extend Instrumentation::ClassMethods
+    include ParamsWrapper
+    extend ParamsWrapper::ClassMethods
   end
+end
+
+module AbstractController::Callbacks::ClassMethods
+  def before_action: (*untyped) -> void
+  def around_action: (*untyped) -> void
+  def after_action: (*untyped) -> void
+  def skip_before_action: (*untyped) -> void
+  def skip_around_action: (*untyped) -> void
+  def skip_after_action: (*untyped) -> void
+  def prepend_before_action: (*untyped) -> void
+  def prepend_around_action: (*untyped) -> void
+  def prepend_after_action: (*untyped) -> void
+  def append_before_action: (*untyped) -> void
+  def append_around_action: (*untyped) -> void
+  def append_after_action: (*untyped) -> void
 end
 

--- a/gems/actionpack/6.0.3.2/actionpack-generated.rbs
+++ b/gems/actionpack/6.0.3.2/actionpack-generated.rbs
@@ -1,3 +1,27 @@
+# The generated code is based on Ruby on Rails source code
+# You can find the license of Ruby on Rails from following.
+
+#Copyright (c) 2005-2019 David Heinemeier Hansson
+#
+#Permission is hereby granted, free of charge, to any person obtaining
+#a copy of this software and associated documentation files (the
+#"Software"), to deal in the Software without restriction, including
+#without limitation the rights to use, copy, modify, merge, publish,
+#distribute, sublicense, and/or sell copies of the Software, and to
+#permit persons to whom the Software is furnished to do so, subject to
+#the following conditions:
+#
+#The above copyright notice and this permission notice shall be
+#included in all copies or substantial portions of the Software.
+#
+#THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+#EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+#MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+#LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+#OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+#WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 module AbstractController
   module AssetPaths
     # nodoc:

--- a/gems/actionpack/6.0.3.2/actionpack-generated.rbs
+++ b/gems/actionpack/6.0.3.2/actionpack-generated.rbs
@@ -1,0 +1,11786 @@
+module AbstractController
+  module AssetPaths
+    # nodoc:
+    extend ActiveSupport::Concern
+  end
+end
+
+module AbstractController
+  # Raised when a non-existing controller action is triggered.
+  class ActionNotFound < StandardError
+  end
+
+  # AbstractController::Base is a low-level API. Nobody should be
+  # using it directly, and subclasses (like ActionController::Base) are
+  # expected to provide their own +render+ method, since rendering means
+  # different things depending on the context.
+  class Base
+    include ActiveSupport::Configurable
+
+    extend ActiveSupport::DescendantsTracker
+
+    attr_reader abstract: untyped
+
+    alias self.abstract? self.abstract
+
+    # Define a controller as abstract. See internal_methods for more
+    # details.
+    def self.abstract!: () -> untyped
+
+    def self.inherited: (untyped klass) -> untyped
+
+    # A list of all internal methods for a controller. This finds the first
+    # abstract superclass of a controller, and gets a list of all public
+    # instance methods on that abstract class. Public instance methods of
+    # a controller would normally be considered action methods, so methods
+    # declared on abstract classes are being removed.
+    # (<tt>ActionController::Metal</tt> and ActionController::Base are defined as abstract)
+    def self.internal_methods: () -> untyped
+
+    # A list of method names that should be considered actions. This
+    # includes all public instance methods on a controller, less
+    # any internal methods (see internal_methods), adding back in
+    # any methods that are internal, but still exist on the class
+    # itself.
+    #
+    # ==== Returns
+    # * <tt>Set</tt> - A set of all methods that should be considered actions.
+    def self.action_methods: () -> untyped
+
+    # action_methods are cached and there is sometimes a need to refresh
+    # them. ::clear_action_methods! allows you to do that, so next time
+    # you run action_methods, they will be recalculated.
+    def self.clear_action_methods!: () -> untyped
+
+    # Returns the full controller name, underscored, without the ending Controller.
+    #
+    #   class MyApp::MyPostsController < AbstractController::Base
+    #
+    #   end
+    #
+    #   MyApp::MyPostsController.controller_path # => "my_app/my_posts"
+    #
+    # ==== Returns
+    # * <tt>String</tt>
+    def self.controller_path: () -> untyped
+
+    # Refresh the cached action_methods when a new action_method is added.
+    def self.method_added: (untyped name) -> untyped
+
+    # Calls the action going through the entire action dispatch stack.
+    #
+    # The actual method that is called is determined by calling
+    # #method_for_action. If no method can handle the action, then an
+    # AbstractController::ActionNotFound error is raised.
+    #
+    # ==== Returns
+    # * <tt>self</tt>
+    def process: (untyped action, *untyped args) -> untyped
+
+    # Delegates to the class' ::controller_path
+    def controller_path: () -> untyped
+
+    # Delegates to the class' ::action_methods
+    def action_methods: () -> untyped
+
+    # Returns true if a method for the action is available and
+    # can be dispatched, false otherwise.
+    #
+    # Notice that <tt>action_methods.include?("foo")</tt> may return
+    # false and <tt>available_action?("foo")</tt> returns true because
+    # this method considers actions that are also available
+    # through other means, for example, implicit render ones.
+    #
+    # ==== Parameters
+    # * <tt>action_name</tt> - The name of an action to be tested
+    def available_action?: (untyped action_name) -> untyped
+
+    # Tests if a response body is set. Used to determine if the
+    # +process_action+ callback needs to be terminated in
+    # +AbstractController::Callbacks+.
+    def performed?: () -> untyped
+
+    # Returns true if the given controller is capable of rendering
+    # a path. A subclass of +AbstractController::Base+
+    # may return false. An Email controller for example does not
+    # support paths, only full URLs.
+    def self.supports_path?: () -> ::TrueClass
+
+    # Returns true if the name can be considered an action because
+    # it has a method defined in the controller.
+    #
+    # ==== Parameters
+    # * <tt>name</tt> - The name of an action to be tested
+    def action_method?: (untyped name) -> untyped
+
+    # Call the action. Override this in a subclass to modify the
+    # behavior around processing an action. This, and not #process,
+    # is the intended way to override action dispatching.
+    #
+    # Notice that the first argument is the method to be dispatched
+    # which is *not* necessarily the same as the action name.
+    def process_action: (untyped method_name, *untyped args) -> untyped
+
+    # Actually call the method associated with the action. Override
+    # this method if you wish to change how action methods are called,
+    # not to add additional behavior around it. For example, you would
+    # override #send_action if you want to inject arguments into the
+    # method.
+    alias send_action send
+
+    # If the action name was not found, but a method called "action_missing"
+    # was found, #method_for_action will return "_handle_action_missing".
+    # This method calls #action_missing with the current action name.
+    def _handle_action_missing: (*untyped args) -> untyped
+
+    # Takes an action name and returns the name of the method that will
+    # handle the action.
+    #
+    # It checks if the action name is valid and returns false otherwise.
+    #
+    # See method_for_action for more information.
+    #
+    # ==== Parameters
+    # * <tt>action_name</tt> - An action name to find a method name for
+    #
+    # ==== Returns
+    # * <tt>string</tt> - The name of the method that handles the action
+    # * false           - No valid method name could be found.
+    # Raise +AbstractController::ActionNotFound+.
+    def _find_action_name: (untyped action_name) -> untyped
+
+    # Takes an action name and returns the name of the method that will
+    # handle the action. In normal cases, this method returns the same
+    # name as it receives. By default, if #method_for_action receives
+    # a name that is not an action, it will look for an #action_missing
+    # method and return "_handle_action_missing" if one is found.
+    #
+    # Subclasses may override this method to add additional conditions
+    # that should be considered an action. For instance, an HTTP controller
+    # with a template matching the action name is considered to exist.
+    #
+    # If you override this method to handle additional cases, you may
+    # also provide a method (like +_handle_method_missing+) to handle
+    # the case.
+    #
+    # If none of these conditions are true, and +method_for_action+
+    # returns +nil+, an +AbstractController::ActionNotFound+ exception will be raised.
+    #
+    # ==== Parameters
+    # * <tt>action_name</tt> - An action name to find a method name for
+    #
+    # ==== Returns
+    # * <tt>string</tt> - The name of the method that handles the action
+    # * <tt>nil</tt>    - No method name could be found.
+    def method_for_action: (untyped action_name) -> untyped
+
+    # Checks if the action name is valid and returns false otherwise.
+    def _valid_action_name?: (untyped action_name) -> untyped
+  end
+end
+
+module AbstractController
+  module Caching
+    # Fragment caching is used for caching various blocks within
+    # views without caching the entire action as a whole. This is
+    # useful when certain elements of an action change frequently or
+    # depend on complicated state while other parts rarely change or
+    # can be shared amongst multiple parties. The caching is done using
+    # the +cache+ helper available in the Action View. See
+    # ActionView::Helpers::CacheHelper for more information.
+    #
+    # While it's strongly recommended that you use key-based cache
+    # expiration (see links in CacheHelper for more information),
+    # it is also possible to manually expire caches. For example:
+    #
+    #   expire_fragment('name_of_cache')
+    module Fragments
+      extend ActiveSupport::Concern
+
+      module ClassMethods
+        # Allows you to specify controller-wide key prefixes for
+        # cache fragments. Pass either a constant +value+, or a block
+        # which computes a value each time a cache key is generated.
+        #
+        # For example, you may want to prefix all fragment cache keys
+        # with a global version identifier, so you can easily
+        # invalidate all caches.
+        #
+        #   class ApplicationController
+        #     fragment_cache_key "v1"
+        #   end
+        #
+        # When it's time to invalidate all fragments, simply change
+        # the string constant. Or, progressively roll out the cache
+        # invalidation using a computed value:
+        #
+        #   class ApplicationController
+        #     fragment_cache_key do
+        #       @account.id.odd? ? "v1" : "v2"
+        #     end
+        #   end
+        def fragment_cache_key: (?untyped? value) { () -> untyped } -> untyped
+      end
+
+      # Given a key (as described in +expire_fragment+), returns
+      # a key array suitable for use in reading, writing, or expiring a
+      # cached fragment. All keys begin with <tt>:views</tt>,
+      # followed by <tt>ENV["RAILS_CACHE_ID"]</tt> or <tt>ENV["RAILS_APP_VERSION"]</tt> if set,
+      # followed by any controller-wide key prefix values, ending
+      # with the specified +key+ value.
+      def combined_fragment_cache_key: (untyped key) -> untyped
+
+      # Writes +content+ to the location signified by
+      # +key+ (see +expire_fragment+ for acceptable formats).
+      def write_fragment: (untyped key, untyped content, ?untyped? options) -> untyped
+
+      # Reads a cached fragment from the location signified by +key+
+      # (see +expire_fragment+ for acceptable formats).
+      def read_fragment: (untyped key, ?untyped? options) -> (nil | untyped)
+
+      # Check if a cached fragment from the location signified by
+      # +key+ exists (see +expire_fragment+ for acceptable formats).
+      def fragment_exist?: (untyped key, ?untyped? options) -> (nil | untyped)
+
+      # Removes fragments from the cache.
+      #
+      # +key+ can take one of three forms:
+      #
+      # * String - This would normally take the form of a path, like
+      #   <tt>pages/45/notes</tt>.
+      # * Hash - Treated as an implicit call to +url_for+, like
+      #   <tt>{ controller: 'pages', action: 'notes', id: 45}</tt>
+      # * Regexp - Will remove any fragment that matches, so
+      #   <tt>%r{pages/\d*/notes}</tt> might remove all notes. Make sure you
+      #   don't use anchors in the regex (<tt>^</tt> or <tt>$</tt>) because
+      #   the actual filename matched looks like
+      #   <tt>./cache/filename/path.cache</tt>. Note: Regexp expiration is
+      #   only supported on caches that can iterate over all keys (unlike
+      #   memcached).
+      #
+      # +options+ is passed through to the cache store's +delete+
+      # method (or <tt>delete_matched</tt>, for Regexp keys).
+      def expire_fragment: (untyped key, ?untyped? options) -> (nil | untyped)
+
+      def instrument_fragment_cache: (untyped name, untyped key) { () -> untyped } -> untyped
+    end
+  end
+end
+
+module AbstractController
+  module Caching
+    extend ActiveSupport::Concern
+
+    extend ActiveSupport::Autoload
+
+    module ConfigMethods
+      def cache_store: () -> untyped
+
+      def cache_store=: (untyped store) -> untyped
+
+      def cache_configured?: () -> untyped
+    end
+
+    include ConfigMethods
+
+    include AbstractController::Caching::Fragments
+
+    extend ConfigMethods
+
+    module ClassMethods
+      def view_cache_dependency: () { () -> untyped } -> untyped
+    end
+
+    def view_cache_dependencies: () -> untyped
+
+    def cache: (untyped key, ?::Hash[untyped, untyped] options) { () -> untyped } -> untyped
+  end
+end
+
+module AbstractController
+  # = Abstract Controller Callbacks
+  #
+  # Abstract Controller provides hooks during the life cycle of a controller action.
+  # Callbacks allow you to trigger logic during this cycle. Available callbacks are:
+  #
+  # * <tt>after_action</tt>
+  # * <tt>append_after_action</tt>
+  # * <tt>append_around_action</tt>
+  # * <tt>append_before_action</tt>
+  # * <tt>around_action</tt>
+  # * <tt>before_action</tt>
+  # * <tt>prepend_after_action</tt>
+  # * <tt>prepend_around_action</tt>
+  # * <tt>prepend_before_action</tt>
+  # * <tt>skip_after_action</tt>
+  # * <tt>skip_around_action</tt>
+  # * <tt>skip_before_action</tt>
+  #
+  # NOTE: Calling the same callback multiple times will overwrite previous callback definitions.
+  #
+  module Callbacks
+    extend ActiveSupport::Concern
+
+    # Uses ActiveSupport::Callbacks as the base functionality. For
+    # more details on the whole callback system, read the documentation
+    # for ActiveSupport::Callbacks.
+    include ActiveSupport::Callbacks
+
+    # Override <tt>AbstractController::Base#process_action</tt> to run the
+    # <tt>process_action</tt> callbacks around the normal behavior.
+    def process_action: (*untyped args) -> untyped
+
+    module ClassMethods
+      # If +:only+ or +:except+ are used, convert the options into the
+      # +:if+ and +:unless+ options of ActiveSupport::Callbacks.
+      #
+      # The basic idea is that <tt>:only => :index</tt> gets converted to
+      # <tt>:if => proc {|c| c.action_name == "index" }</tt>.
+      #
+      # Note that <tt>:only</tt> has priority over <tt>:if</tt> in case they
+      # are used together.
+      #
+      #   only: :index, if: -> { true } # the :if option will be ignored.
+      #
+      # Note that <tt>:if</tt> has priority over <tt>:except</tt> in case they
+      # are used together.
+      #
+      #   except: :index, if: -> { true } # the :except option will be ignored.
+      #
+      # ==== Options
+      # * <tt>only</tt>   - The callback should be run only for this action.
+      # * <tt>except</tt>  - The callback should be run for all actions except this action.
+      def _normalize_callback_options: (untyped options) -> untyped
+
+      def _normalize_callback_option: (untyped options, untyped from, untyped to) -> untyped
+
+      # Take callback names and an optional callback proc, normalize them,
+      # then call the block with each callback. This allows us to abstract
+      # the normalization across several methods that use it.
+      #
+      # ==== Parameters
+      # * <tt>callbacks</tt> - An array of callbacks, with an optional
+      #   options hash as the last parameter.
+      # * <tt>block</tt>    - A proc that should be added to the callbacks.
+      #
+      # ==== Block Parameters
+      # * <tt>name</tt>     - The callback to be added.
+      # * <tt>options</tt>  - A hash of options to be used when adding the callback.
+      def _insert_callbacks: (untyped callbacks, ?untyped? block) { (untyped, untyped) -> untyped } -> untyped
+    end
+  end
+end
+
+module AbstractController
+  module Collector
+    def self.generate_method_for_mime: (untyped mime) -> untyped
+
+    def method_missing: (untyped symbol) { () -> untyped } -> untyped
+  end
+end
+
+module AbstractController
+  class Error < StandardError
+  end
+end
+
+module AbstractController
+  module Helpers
+    extend ActiveSupport::Concern
+
+    class MissingHelperError < LoadError
+      def initialize: (untyped error, untyped path) -> untyped
+    end
+
+    module ClassMethods
+      # When a class is inherited, wrap its helper module in a new module.
+      # This ensures that the parent class's module can be changed
+      # independently of the child class's.
+      def inherited: (untyped klass) -> untyped
+
+      # Declare a controller method as a helper. For example, the following
+      # makes the +current_user+ and +logged_in?+ controller methods available
+      # to the view:
+      #   class ApplicationController < ActionController::Base
+      #     helper_method :current_user, :logged_in?
+      #
+      #     def current_user
+      #       @current_user ||= User.find_by(id: session[:user])
+      #     end
+      #
+      #     def logged_in?
+      #       current_user != nil
+      #     end
+      #   end
+      #
+      # In a view:
+      #  <% if logged_in? -%>Welcome, <%= current_user.name %><% end -%>
+      #
+      # ==== Parameters
+      # * <tt>method[, method]</tt> - A name or names of a method on the controller
+      #   to be made available on the view.
+      def helper_method: (*untyped meths) -> untyped
+
+      # The +helper+ class method can take a series of helper module names, a block, or both.
+      #
+      # ==== Options
+      # * <tt>*args</tt> - Module, Symbol, String
+      # * <tt>block</tt> - A block defining helper methods
+      #
+      # When the argument is a module it will be included directly in the template class.
+      #   helper FooHelper # => includes FooHelper
+      #
+      # When the argument is a string or symbol, the method will provide the "_helper" suffix, require the file
+      # and include the module in the template class. The second form illustrates how to include custom helpers
+      # when working with namespaced controllers, or other cases where the file containing the helper definition is not
+      # in one of Rails' standard load paths:
+      #   helper :foo             # => requires 'foo_helper' and includes FooHelper
+      #   helper 'resources/foo'  # => requires 'resources/foo_helper' and includes Resources::FooHelper
+      #
+      # Additionally, the +helper+ class method can receive and evaluate a block, making the methods defined available
+      # to the template.
+      #
+      #   # One line
+      #   helper { def hello() "Hello, world!" end }
+      #
+      #   # Multi-line
+      #   helper do
+      #     def foo(bar)
+      #       "#{bar} is the very best"
+      #     end
+      #   end
+      #
+      # Finally, all the above styles can be mixed together, and the +helper+ method can be invoked with a mix of
+      # +symbols+, +strings+, +modules+ and blocks.
+      #
+      #   helper(:three, BlindHelper) { def mice() 'mice' end }
+      #
+      def helper: (*untyped args) { () -> untyped } -> untyped
+
+      # Clears up all existing helpers in this class, only keeping the helper
+      # with the same name as this class.
+      def clear_helpers: () -> untyped
+
+      # Returns a list of modules, normalized from the acceptable kinds of
+      # helpers with the following behavior:
+      #
+      # String or Symbol:: :FooBar or "FooBar" becomes "foo_bar_helper",
+      # and "foo_bar_helper.rb" is loaded using require_dependency.
+      #
+      # Module:: No further processing
+      #
+      # After loading the appropriate files, the corresponding modules
+      # are returned.
+      #
+      # ==== Parameters
+      # * <tt>args</tt> - An array of helpers
+      #
+      # ==== Returns
+      # * <tt>Array</tt> - A normalized list of modules for the list of
+      #   helpers provided.
+      def modules_for_helpers: (untyped args) -> untyped
+
+      # Makes all the (instance) methods in the helper module available to templates
+      # rendered through this controller.
+      #
+      # ==== Parameters
+      # * <tt>module</tt> - The module to include into the current helper module
+      #   for the class
+      def add_template_helper: (untyped mod) -> untyped
+
+      def default_helper_module!: () -> untyped
+    end
+  end
+end
+
+module AbstractController
+  module Logger
+    # nodoc:
+    extend ActiveSupport::Concern
+
+    include ActiveSupport::Benchmarkable
+  end
+end
+
+module AbstractController
+  module Railties
+    module RoutesHelpers
+      def self.with: (untyped routes, ?bool include_path_helpers) -> untyped
+    end
+  end
+end
+
+module AbstractController
+  class DoubleRenderError < Error
+    DEFAULT_MESSAGE: ::String
+
+    def initialize: (?untyped? message) -> untyped
+  end
+
+  module Rendering
+    extend ActiveSupport::Concern
+
+    include ActionView::ViewPaths
+
+    # Normalizes arguments, options and then delegates render_to_body and
+    # sticks the result in <tt>self.response_body</tt>.
+    def render: (*untyped args) { () -> untyped } -> untyped
+
+    # Raw rendering of a template to a string.
+    #
+    # It is similar to render, except that it does not
+    # set the +response_body+ and it should be guaranteed
+    # to always return a string.
+    #
+    # If a component extends the semantics of +response_body+
+    # (as ActionController extends it to be anything that
+    # responds to the method each), this method needs to be
+    # overridden in order to still return a string.
+    def render_to_string: (*untyped args) { () -> untyped } -> untyped
+
+    # Performs the actual template rendering.
+    def render_to_body: (?::Hash[untyped, untyped] options) -> nil
+
+    # Returns Content-Type of rendered content.
+    def rendered_format: () -> untyped
+
+    DEFAULT_PROTECTED_INSTANCE_VARIABLES: untyped
+
+    # This method should return a hash with assigns.
+    # You can overwrite this configuration per controller.
+    def view_assigns: () -> untyped
+
+    def _normalize_args: (?untyped? action, ?::Hash[untyped, untyped] options) -> untyped
+
+    def _normalize_options: (untyped options) -> untyped
+
+    def _process_options: (untyped options) -> untyped
+
+    def _process_format: (untyped format) -> nil
+
+    def _process_variant: (untyped options) -> nil
+
+    def _set_html_content_type: () -> nil
+
+    def _set_rendered_content_type: (untyped format) -> nil
+
+    def _normalize_render: (*untyped args) { () -> untyped } -> untyped
+
+    def _protected_ivars: () -> untyped
+  end
+end
+
+module AbstractController
+  module Translation
+    # Delegates to <tt>I18n.translate</tt>. Also aliased as <tt>t</tt>.
+    #
+    # When the given key starts with a period, it will be scoped by the current
+    # controller and action. So if you call <tt>translate(".foo")</tt> from
+    # <tt>PeopleController#index</tt>, it will convert the call to
+    # <tt>I18n.translate("people.index.foo")</tt>. This makes it less repetitive
+    # to translate many keys within the same controller / action and gives you a
+    # simple framework for scoping them consistently.
+    def translate: (untyped key, **untyped options) -> untyped
+
+    alias t translate
+
+    # Delegates to <tt>I18n.localize</tt>. Also aliased as <tt>l</tt>.
+    def localize: (untyped object, **untyped options) -> untyped
+
+    alias l localize
+  end
+end
+
+module AbstractController
+  # Includes +url_for+ into the host class (e.g. an abstract controller or mailer). The class
+  # has to provide a +RouteSet+ by implementing the <tt>_routes</tt> methods. Otherwise, an
+  # exception will be raised.
+  #
+  # Note that this module is completely decoupled from HTTP - the only requirement is a valid
+  # <tt>_routes</tt> implementation.
+  module UrlFor
+    extend ActiveSupport::Concern
+
+    include ActionDispatch::Routing::UrlFor
+
+    def _routes: () -> untyped
+
+    module ClassMethods
+      def _routes: () -> nil
+
+      def action_methods: () -> untyped
+    end
+  end
+end
+
+module AbstractController
+  extend ActiveSupport::Autoload
+
+  def self.eager_load!: () -> untyped
+end
+
+module ActionController
+  module ApiRendering
+    extend ActiveSupport::Concern
+
+    include Rendering
+
+    def render_to_body: (?::Hash[untyped, untyped] options) -> untyped
+  end
+end
+
+module ActionController
+  # API Controller is a lightweight version of <tt>ActionController::Base</tt>,
+  # created for applications that don't require all functionalities that a complete
+  # \Rails controller provides, allowing you to create controllers with just the
+  # features that you need for API only applications.
+  #
+  # An API Controller is different from a normal controller in the sense that
+  # by default it doesn't include a number of features that are usually required
+  # by browser access only: layouts and templates rendering,
+  # flash, assets, and so on. This makes the entire controller stack thinner,
+  # suitable for API applications. It doesn't mean you won't have such
+  # features if you need them: they're all available for you to include in
+  # your application, they're just not part of the default API controller stack.
+  #
+  # Normally, +ApplicationController+ is the only controller that inherits from
+  # <tt>ActionController::API</tt>. All other controllers in turn inherit from
+  # +ApplicationController+.
+  #
+  # A sample controller could look like this:
+  #
+  #   class PostsController < ApplicationController
+  #     def index
+  #       posts = Post.all
+  #       render json: posts
+  #     end
+  #   end
+  #
+  # Request, response, and parameters objects all work the exact same way as
+  # <tt>ActionController::Base</tt>.
+  #
+  # == Renders
+  #
+  # The default API Controller stack includes all renderers, which means you
+  # can use <tt>render :json</tt> and brothers freely in your controllers. Keep
+  # in mind that templates are not going to be rendered, so you need to ensure
+  # your controller is calling either <tt>render</tt> or <tt>redirect_to</tt> in
+  # all actions, otherwise it will return 204 No Content.
+  #
+  #   def show
+  #     post = Post.find(params[:id])
+  #     render json: post
+  #   end
+  #
+  # == Redirects
+  #
+  # Redirects are used to move from one action to another. You can use the
+  # <tt>redirect_to</tt> method in your controllers in the same way as in
+  # <tt>ActionController::Base</tt>. For example:
+  #
+  #   def create
+  #     redirect_to root_url and return if not_authorized?
+  #     # do stuff here
+  #   end
+  #
+  # == Adding New Behavior
+  #
+  # In some scenarios you may want to add back some functionality provided by
+  # <tt>ActionController::Base</tt> that is not present by default in
+  # <tt>ActionController::API</tt>, for instance <tt>MimeResponds</tt>. This
+  # module gives you the <tt>respond_to</tt> method. Adding it is quite simple,
+  # you just need to include the module in a specific controller or in
+  # +ApplicationController+ in case you want it available in your entire
+  # application:
+  #
+  #   class ApplicationController < ActionController::API
+  #     include ActionController::MimeResponds
+  #   end
+  #
+  #   class PostsController < ApplicationController
+  #     def index
+  #       posts = Post.all
+  #
+  #       respond_to do |format|
+  #         format.json { render json: posts }
+  #         format.xml  { render xml: posts }
+  #       end
+  #     end
+  #   end
+  #
+  # Make sure to check the modules included in <tt>ActionController::Base</tt>
+  # if you want to use any other functionality that is not provided
+  # by <tt>ActionController::API</tt> out of the box.
+  class API < Metal
+    # Shortcut helper that returns all the ActionController::API modules except
+    # the ones passed as arguments:
+    #
+    #   class MyAPIBaseController < ActionController::Metal
+    #     ActionController::API.without_modules(:ForceSSL, :UrlFor).each do |left|
+    #       include left
+    #     end
+    #   end
+    #
+    # This gives better control over what you want to exclude and makes it easier
+    # to create an API controller class, instead of listing the modules required
+    # manually.
+    def self.without_modules: (*untyped modules) -> untyped
+
+    MODULES: ::Array[untyped]
+  end
+end
+
+module ActionController
+  # Action Controllers are the core of a web request in \Rails. They are made up of one or more actions that are executed
+  # on request and then either it renders a template or redirects to another action. An action is defined as a public method
+  # on the controller, which will automatically be made accessible to the web-server through \Rails Routes.
+  #
+  # By default, only the ApplicationController in a \Rails application inherits from <tt>ActionController::Base</tt>. All other
+  # controllers inherit from ApplicationController. This gives you one class to configure things such as
+  # request forgery protection and filtering of sensitive request parameters.
+  #
+  # A sample controller could look like this:
+  #
+  #   class PostsController < ApplicationController
+  #     def index
+  #       @posts = Post.all
+  #     end
+  #
+  #     def create
+  #       @post = Post.create params[:post]
+  #       redirect_to posts_path
+  #     end
+  #   end
+  #
+  # Actions, by default, render a template in the <tt>app/views</tt> directory corresponding to the name of the controller and action
+  # after executing code in the action. For example, the +index+ action of the PostsController would render the
+  # template <tt>app/views/posts/index.html.erb</tt> by default after populating the <tt>@posts</tt> instance variable.
+  #
+  # Unlike index, the create action will not render a template. After performing its main purpose (creating a
+  # new post), it initiates a redirect instead. This redirect works by returning an external
+  # <tt>302 Moved</tt> HTTP response that takes the user to the index action.
+  #
+  # These two methods represent the two basic action archetypes used in Action Controllers: Get-and-show and do-and-redirect.
+  # Most actions are variations on these themes.
+  #
+  # == Requests
+  #
+  # For every request, the router determines the value of the +controller+ and +action+ keys. These determine which controller
+  # and action are called. The remaining request parameters, the session (if one is available), and the full request with
+  # all the HTTP headers are made available to the action through accessor methods. Then the action is performed.
+  #
+  # The full request object is available via the request accessor and is primarily used to query for HTTP headers:
+  #
+  #   def server_ip
+  #     location = request.env["REMOTE_ADDR"]
+  #     render plain: "This server hosted at #{location}"
+  #   end
+  #
+  # == Parameters
+  #
+  # All request parameters, whether they come from a query string in the URL or form data submitted through a POST request are
+  # available through the <tt>params</tt> method which returns a hash. For example, an action that was performed through
+  # <tt>/posts?category=All&limit=5</tt> will include <tt>{ "category" => "All", "limit" => "5" }</tt> in <tt>params</tt>.
+  #
+  # It's also possible to construct multi-dimensional parameter hashes by specifying keys using brackets, such as:
+  #
+  #   <input type="text" name="post[name]" value="david">
+  #   <input type="text" name="post[address]" value="hyacintvej">
+  #
+  # A request coming from a form holding these inputs will include <tt>{ "post" => { "name" => "david", "address" => "hyacintvej" } }</tt>.
+  # If the address input had been named <tt>post[address][street]</tt>, the <tt>params</tt> would have included
+  # <tt>{ "post" => { "address" => { "street" => "hyacintvej" } } }</tt>. There's no limit to the depth of the nesting.
+  #
+  # == Sessions
+  #
+  # Sessions allow you to store objects in between requests. This is useful for objects that are not yet ready to be persisted,
+  # such as a Signup object constructed in a multi-paged process, or objects that don't change much and are needed all the time, such
+  # as a User object for a system that requires login. The session should not be used, however, as a cache for objects where it's likely
+  # they could be changed unknowingly. It's usually too much work to keep it all synchronized -- something databases already excel at.
+  #
+  # You can place objects in the session by using the <tt>session</tt> method, which accesses a hash:
+  #
+  #   session[:person] = Person.authenticate(user_name, password)
+  #
+  # You can retrieve it again through the same hash:
+  #
+  #   "Hello #{session[:person]}"
+  #
+  # For removing objects from the session, you can either assign a single key to +nil+:
+  #
+  #   # removes :person from session
+  #   session[:person] = nil
+  #
+  # or you can remove the entire session with +reset_session+.
+  #
+  # Sessions are stored by default in a browser cookie that's cryptographically signed, but unencrypted.
+  # This prevents the user from tampering with the session but also allows them to see its contents.
+  #
+  # Do not put secret information in cookie-based sessions!
+  #
+  # == Responses
+  #
+  # Each action results in a response, which holds the headers and document to be sent to the user's browser. The actual response
+  # object is generated automatically through the use of renders and redirects and requires no user intervention.
+  #
+  # == Renders
+  #
+  # Action Controller sends content to the user by using one of five rendering methods. The most versatile and common is the rendering
+  # of a template. Included in the Action Pack is the Action View, which enables rendering of ERB templates. It's automatically configured.
+  # The controller passes objects to the view by assigning instance variables:
+  #
+  #   def show
+  #     @post = Post.find(params[:id])
+  #   end
+  #
+  # Which are then automatically available to the view:
+  #
+  #   Title: <%= @post.title %>
+  #
+  # You don't have to rely on the automated rendering. For example, actions that could result in the rendering of different templates
+  # will use the manual rendering methods:
+  #
+  #   def search
+  #     @results = Search.find(params[:query])
+  #     case @results.count
+  #       when 0 then render action: "no_results"
+  #       when 1 then render action: "show"
+  #       when 2..10 then render action: "show_many"
+  #     end
+  #   end
+  #
+  # Read more about writing ERB and Builder templates in ActionView::Base.
+  #
+  # == Redirects
+  #
+  # Redirects are used to move from one action to another. For example, after a <tt>create</tt> action, which stores a blog entry to the
+  # database, we might like to show the user the new entry. Because we're following good DRY principles (Don't Repeat Yourself), we're
+  # going to reuse (and redirect to) a <tt>show</tt> action that we'll assume has already been created. The code might look like this:
+  #
+  #   def create
+  #     @entry = Entry.new(params[:entry])
+  #     if @entry.save
+  #       # The entry was saved correctly, redirect to show
+  #       redirect_to action: 'show', id: @entry.id
+  #     else
+  #       # things didn't go so well, do something else
+  #     end
+  #   end
+  #
+  # In this case, after saving our new entry to the database, the user is redirected to the <tt>show</tt> method, which is then executed.
+  # Note that this is an external HTTP-level redirection which will cause the browser to make a second request (a GET to the show action),
+  # and not some internal re-routing which calls both "create" and then "show" within one request.
+  #
+  # Learn more about <tt>redirect_to</tt> and what options you have in ActionController::Redirecting.
+  #
+  # == Calling multiple redirects or renders
+  #
+  # An action may contain only a single render or a single redirect. Attempting to try to do either again will result in a DoubleRenderError:
+  #
+  #   def do_something
+  #     redirect_to action: "elsewhere"
+  #     render action: "overthere" # raises DoubleRenderError
+  #   end
+  #
+  # If you need to redirect on the condition of something, then be sure to add "and return" to halt execution.
+  #
+  #   def do_something
+  #     redirect_to(action: "elsewhere") and return if monkeys.nil?
+  #     render action: "overthere" # won't be called if monkeys is nil
+  #   end
+  #
+  class Base < Metal
+    # Shortcut helper that returns all the modules included in
+    # ActionController::Base except the ones passed as arguments:
+    #
+    #   class MyBaseController < ActionController::Metal
+    #     ActionController::Base.without_modules(:ParamsWrapper, :Streaming).each do |left|
+    #       include left
+    #     end
+    #   end
+    #
+    # This gives better control over what you want to exclude and makes it
+    # easier to create a bare controller class, instead of listing the modules
+    # required manually.
+    def self.without_modules: (*untyped modules) -> untyped
+
+    MODULES: ::Array[untyped]
+
+    # Define some internal variables that should not be propagated to the view.
+    PROTECTED_IVARS: untyped
+
+    def _protected_ivars: () -> untyped
+  end
+end
+
+module ActionController
+  # \Caching is a cheap way of speeding up slow applications by keeping the result of
+  # calculations, renderings, and database calls around for subsequent requests.
+  #
+  # You can read more about each approach by clicking the modules below.
+  #
+  # Note: To turn off all caching provided by Action Controller, set
+  #   config.action_controller.perform_caching = false
+  #
+  # == \Caching stores
+  #
+  # All the caching stores from ActiveSupport::Cache are available to be used as backends
+  # for Action Controller caching.
+  #
+  # Configuration examples (FileStore is the default):
+  #
+  #   config.action_controller.cache_store = :memory_store
+  #   config.action_controller.cache_store = :file_store, '/path/to/cache/directory'
+  #   config.action_controller.cache_store = :mem_cache_store, 'localhost'
+  #   config.action_controller.cache_store = :mem_cache_store, Memcached::Rails.new('localhost:11211')
+  #   config.action_controller.cache_store = MyOwnStore.new('parameter')
+  module Caching
+    extend ActiveSupport::Autoload
+
+    extend ActiveSupport::Concern
+
+    include AbstractController::Caching
+
+    def instrument_payload: (untyped key) -> { controller: untyped, action: untyped, key: untyped }
+
+    def instrument_name: () -> "action_controller"
+  end
+end
+
+module ActionController
+  # Override the default form builder for all views rendered by this
+  # controller and any of its descendants. Accepts a subclass of
+  # +ActionView::Helpers::FormBuilder+.
+  #
+  # For example, given a form builder:
+  #
+  #   class AdminFormBuilder < ActionView::Helpers::FormBuilder
+  #     def special_field(name)
+  #     end
+  #   end
+  #
+  # The controller specifies a form builder as its default:
+  #
+  #   class AdminAreaController < ApplicationController
+  #     default_form_builder AdminFormBuilder
+  #   end
+  #
+  # Then in the view any form using +form_for+ will be an instance of the
+  # specified form builder:
+  #
+  #   <%= form_for(@instance) do |builder| %>
+  #     <%= builder.special_field(:name) %>
+  #   <% end %>
+  module FormBuilder
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      # Set the form builder to be used as the default for all forms
+      # in the views rendered by this controller and its subclasses.
+      #
+      # ==== Parameters
+      # * <tt>builder</tt> - Default form builder, an instance of +ActionView::Helpers::FormBuilder+
+      def default_form_builder: (untyped builder) -> untyped
+    end
+
+    # Default form builder for the controller
+    def default_form_builder: () -> untyped
+  end
+end
+
+module ActionController
+  class LogSubscriber < ActiveSupport::LogSubscriber
+    INTERNAL_PARAMS: ::Array[untyped]
+
+    def start_processing: (untyped event) -> (nil | untyped)
+
+    def process_action: (untyped event) -> untyped
+
+    def halted_callback: (untyped event) -> untyped
+
+    def send_file: (untyped event) -> untyped
+
+    def redirect_to: (untyped event) -> untyped
+
+    def send_data: (untyped event) -> untyped
+
+    def unpermitted_parameters: (untyped event) -> untyped
+
+    def logger: () -> untyped
+  end
+end
+
+module ActionController
+  module BasicImplicitRender
+    # :nodoc:
+    def send_action: (untyped method, *untyped args) -> untyped
+
+    def default_render: () -> untyped
+  end
+end
+
+module ActionController
+  module ConditionalGet
+    extend ActiveSupport::Concern
+
+    include Head
+
+    module ClassMethods
+      # Allows you to consider additional controller-wide information when generating an ETag.
+      # For example, if you serve pages tailored depending on who's logged in at the moment, you
+      # may want to add the current user id to be part of the ETag to prevent unauthorized displaying
+      # of cached pages.
+      #
+      #   class InvoicesController < ApplicationController
+      #     etag { current_user.try :id }
+      #
+      #     def show
+      #       # Etag will differ even for the same invoice when it's viewed by a different current_user
+      #       @invoice = Invoice.find(params[:id])
+      #       fresh_when(@invoice)
+      #     end
+      #   end
+      def etag: () { () -> untyped } -> untyped
+    end
+
+    # Sets the +etag+, +last_modified+, or both on the response and renders a
+    # <tt>304 Not Modified</tt> response if the request is already fresh.
+    #
+    # === Parameters:
+    #
+    # * <tt>:etag</tt> Sets a "weak" ETag validator on the response. See the
+    #   +:weak_etag+ option.
+    # * <tt>:weak_etag</tt> Sets a "weak" ETag validator on the response.
+    #   Requests that set If-None-Match header may return a 304 Not Modified
+    #   response if it matches the ETag exactly. A weak ETag indicates semantic
+    #   equivalence, not byte-for-byte equality, so they're good for caching
+    #   HTML pages in browser caches. They can't be used for responses that
+    #   must be byte-identical, like serving Range requests within a PDF file.
+    # * <tt>:strong_etag</tt> Sets a "strong" ETag validator on the response.
+    #   Requests that set If-None-Match header may return a 304 Not Modified
+    #   response if it matches the ETag exactly. A strong ETag implies exact
+    #   equality: the response must match byte for byte. This is necessary for
+    #   doing Range requests within a large video or PDF file, for example, or
+    #   for compatibility with some CDNs that don't support weak ETags.
+    # * <tt>:last_modified</tt> Sets a "weak" last-update validator on the
+    #   response. Subsequent requests that set If-Modified-Since may return a
+    #   304 Not Modified response if last_modified <= If-Modified-Since.
+    # * <tt>:public</tt> By default the Cache-Control header is private, set this to
+    #   +true+ if you want your application to be cacheable by other devices (proxy caches).
+    # * <tt>:template</tt> By default, the template digest for the current
+    #   controller/action is included in ETags. If the action renders a
+    #   different template, you can include its digest instead. If the action
+    #   doesn't render a template at all, you can pass <tt>template: false</tt>
+    #   to skip any attempt to check for a template digest.
+    #
+    # === Example:
+    #
+    #   def show
+    #     @article = Article.find(params[:id])
+    #     fresh_when(etag: @article, last_modified: @article.updated_at, public: true)
+    #   end
+    #
+    # This will render the show template if the request isn't sending a matching ETag or
+    # If-Modified-Since header and just a <tt>304 Not Modified</tt> response if there's a match.
+    #
+    # You can also just pass a record. In this case +last_modified+ will be set
+    # by calling +updated_at+ and +etag+ by passing the object itself.
+    #
+    #   def show
+    #     @article = Article.find(params[:id])
+    #     fresh_when(@article)
+    #   end
+    #
+    # You can also pass an object that responds to +maximum+, such as a
+    # collection of active records. In this case +last_modified+ will be set by
+    # calling <tt>maximum(:updated_at)</tt> on the collection (the timestamp of the
+    # most recently updated record) and the +etag+ by passing the object itself.
+    #
+    #   def index
+    #     @articles = Article.all
+    #     fresh_when(@articles)
+    #   end
+    #
+    # When passing a record or a collection, you can still set the public header:
+    #
+    #   def show
+    #     @article = Article.find(params[:id])
+    #     fresh_when(@article, public: true)
+    #   end
+    #
+    # When rendering a different template than the default controller/action
+    # style, you can indicate which digest to include in the ETag:
+    #
+    #   before_action { fresh_when @article, template: 'widgets/show' }
+    #
+    def fresh_when: (?untyped? object, ?template: untyped? template, ?public: bool `public`, ?last_modified: untyped? last_modified, ?strong_etag: untyped? strong_etag, ?weak_etag: untyped? weak_etag, ?etag: untyped? etag) -> untyped
+
+    # Sets the +etag+ and/or +last_modified+ on the response and checks it against
+    # the client request. If the request doesn't match the options provided, the
+    # request is considered stale and should be generated from scratch. Otherwise,
+    # it's fresh and we don't need to generate anything and a reply of <tt>304 Not Modified</tt> is sent.
+    #
+    # === Parameters:
+    #
+    # * <tt>:etag</tt> Sets a "weak" ETag validator on the response. See the
+    #   +:weak_etag+ option.
+    # * <tt>:weak_etag</tt> Sets a "weak" ETag validator on the response.
+    #   Requests that set If-None-Match header may return a 304 Not Modified
+    #   response if it matches the ETag exactly. A weak ETag indicates semantic
+    #   equivalence, not byte-for-byte equality, so they're good for caching
+    #   HTML pages in browser caches. They can't be used for responses that
+    #   must be byte-identical, like serving Range requests within a PDF file.
+    # * <tt>:strong_etag</tt> Sets a "strong" ETag validator on the response.
+    #   Requests that set If-None-Match header may return a 304 Not Modified
+    #   response if it matches the ETag exactly. A strong ETag implies exact
+    #   equality: the response must match byte for byte. This is necessary for
+    #   doing Range requests within a large video or PDF file, for example, or
+    #   for compatibility with some CDNs that don't support weak ETags.
+    # * <tt>:last_modified</tt> Sets a "weak" last-update validator on the
+    #   response. Subsequent requests that set If-Modified-Since may return a
+    #   304 Not Modified response if last_modified <= If-Modified-Since.
+    # * <tt>:public</tt> By default the Cache-Control header is private, set this to
+    #   +true+ if you want your application to be cacheable by other devices (proxy caches).
+    # * <tt>:template</tt> By default, the template digest for the current
+    #   controller/action is included in ETags. If the action renders a
+    #   different template, you can include its digest instead. If the action
+    #   doesn't render a template at all, you can pass <tt>template: false</tt>
+    #   to skip any attempt to check for a template digest.
+    #
+    # === Example:
+    #
+    #   def show
+    #     @article = Article.find(params[:id])
+    #
+    #     if stale?(etag: @article, last_modified: @article.updated_at)
+    #       @statistics = @article.really_expensive_call
+    #       respond_to do |format|
+    #         # all the supported formats
+    #       end
+    #     end
+    #   end
+    #
+    # You can also just pass a record. In this case +last_modified+ will be set
+    # by calling +updated_at+ and +etag+ by passing the object itself.
+    #
+    #   def show
+    #     @article = Article.find(params[:id])
+    #
+    #     if stale?(@article)
+    #       @statistics = @article.really_expensive_call
+    #       respond_to do |format|
+    #         # all the supported formats
+    #       end
+    #     end
+    #   end
+    #
+    # You can also pass an object that responds to +maximum+, such as a
+    # collection of active records. In this case +last_modified+ will be set by
+    # calling +maximum(:updated_at)+ on the collection (the timestamp of the
+    # most recently updated record) and the +etag+ by passing the object itself.
+    #
+    #   def index
+    #     @articles = Article.all
+    #
+    #     if stale?(@articles)
+    #       @statistics = @articles.really_expensive_call
+    #       respond_to do |format|
+    #         # all the supported formats
+    #       end
+    #     end
+    #   end
+    #
+    # When passing a record or a collection, you can still set the public header:
+    #
+    #   def show
+    #     @article = Article.find(params[:id])
+    #
+    #     if stale?(@article, public: true)
+    #       @statistics = @article.really_expensive_call
+    #       respond_to do |format|
+    #         # all the supported formats
+    #       end
+    #     end
+    #   end
+    #
+    # When rendering a different template than the default controller/action
+    # style, you can indicate which digest to include in the ETag:
+    #
+    #   def show
+    #     super if stale? @article, template: 'widgets/show'
+    #   end
+    #
+    def stale?: (?untyped? object, **untyped freshness_kwargs) -> untyped
+
+    # Sets an HTTP 1.1 Cache-Control header. Defaults to issuing a +private+
+    # instruction, so that intermediate caches must not cache the response.
+    #
+    #   expires_in 20.minutes
+    #   expires_in 3.hours, public: true
+    #   expires_in 3.hours, public: true, must_revalidate: true
+    #
+    # This method will overwrite an existing Cache-Control header.
+    # See https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html for more possibilities.
+    #
+    # HTTP Cache-Control Extensions for Stale Content. See https://tools.ietf.org/html/rfc5861
+    # It helps to cache an asset and serve it while is being revalidated and/or returning with an error.
+    #
+    #   expires_in 3.hours, public: true, stale_while_revalidate: 60.seconds
+    #   expires_in 3.hours, public: true, stale_while_revalidate: 60.seconds, stale_if_error: 5.minutes
+    #
+    # The method will also ensure an HTTP Date header for client compatibility.
+    def expires_in: (untyped seconds, ?::Hash[untyped, untyped] options) -> untyped
+
+    # Sets an HTTP 1.1 Cache-Control header of <tt>no-cache</tt>. This means the
+    # resource will be marked as stale, so clients must always revalidate.
+    # Intermediate/browser caches may still store the asset.
+    def expires_now: () -> untyped
+
+    # Cache or yield the block. The cache is supposed to never expire.
+    #
+    # You can use this method when you have an HTTP response that never changes,
+    # and the browser and proxies should cache it indefinitely.
+    #
+    # * +public+: By default, HTTP responses are private, cached only on the
+    #   user's web browser. To allow proxies to cache the response, set +true+ to
+    #   indicate that they can serve the cached response to all users.
+    def http_cache_forever: (?public: bool `public`) { () -> untyped } -> untyped
+
+    def combine_etags: (untyped validator, untyped options) -> untyped
+  end
+end
+
+module ActionController
+  # nodoc:
+  module ContentSecurityPolicy
+    # TODO: Documentation
+    extend ActiveSupport::Concern
+
+    include AbstractController::Helpers
+
+    include AbstractController::Callbacks
+
+    module ClassMethods
+      def content_security_policy: (?bool enabled, **untyped options) { (untyped) -> untyped } -> untyped
+
+      def content_security_policy_report_only: (?bool report_only, **untyped options) -> untyped
+    end
+
+    def content_security_policy?: () -> untyped
+
+    def content_security_policy_nonce: () -> untyped
+
+    def current_content_security_policy: () -> untyped
+  end
+end
+
+module ActionController
+  # nodoc:
+  module Cookies
+    extend ActiveSupport::Concern
+
+    def cookies: () -> untyped
+  end
+end
+
+module ActionController
+  # nodoc:
+  # Methods for sending arbitrary data and for streaming files to the browser,
+  # instead of rendering.
+  module DataStreaming
+    extend ActiveSupport::Concern
+
+    include ActionController::Rendering
+
+    DEFAULT_SEND_FILE_TYPE: ::String
+
+    DEFAULT_SEND_FILE_DISPOSITION: ::String
+
+    def send_file: (untyped path, ?::Hash[untyped, untyped] options) -> untyped
+
+    def send_data: (untyped data, ?::Hash[untyped, untyped] options) -> untyped
+
+    def send_file_headers!: (untyped options) -> untyped
+  end
+end
+
+module ActionController
+  # Allows configuring default headers that will be automatically merged into
+  # each response.
+  module DefaultHeaders
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      def make_response!: (untyped request) -> untyped
+    end
+  end
+end
+
+module ActionController
+  # When you're using the flash, it's generally used as a conditional on the view.
+  # This means the content of the view depends on the flash. Which in turn means
+  # that the ETag for a response should be computed with the content of the flash
+  # in mind. This does that by including the content of the flash as a component
+  # in the ETag that's generated for a response.
+  module EtagWithFlash
+    extend ActiveSupport::Concern
+
+    include ActionController::ConditionalGet
+  end
+end
+
+module ActionController
+  # When our views change, they should bubble up into HTTP cache freshness
+  # and bust browser caches. So the template digest for the current action
+  # is automatically included in the ETag.
+  #
+  # Enabled by default for apps that use Action View. Disable by setting
+  #
+  #   config.action_controller.etag_with_template_digest = false
+  #
+  # Override the template to digest by passing +:template+ to +fresh_when+
+  # and +stale?+ calls. For example:
+  #
+  #   # We're going to render widgets/show, not posts/show
+  #   fresh_when @post, template: 'widgets/show'
+  #
+  #   # We're not going to render a template, so omit it from the ETag.
+  #   fresh_when @post, template: false
+  #
+  module EtagWithTemplateDigest
+    extend ActiveSupport::Concern
+
+    include ActionController::ConditionalGet
+
+    def determine_template_etag: (untyped options) -> untyped
+
+    # Pick the template digest to include in the ETag. If the +:template+ option
+    # is present, use the named template. If +:template+ is +nil+ or absent, use
+    # the default controller/action template. If +:template+ is false, omit the
+    # template digest from the ETag.
+    def pick_template_for_etag: (untyped options) -> untyped
+
+    def lookup_and_digest_template: (untyped template) -> untyped
+  end
+end
+
+module ActionController
+  class ActionControllerError < StandardError
+  end
+
+  class BadRequest < ActionControllerError
+    # nodoc:
+    def initialize: (?untyped? msg) -> untyped
+  end
+
+  class RenderError < ActionControllerError
+  end
+
+  class RoutingError < ActionControllerError
+    # nodoc:
+    attr_reader failures: untyped
+
+    def initialize: (untyped message, ?untyped failures) -> untyped
+  end
+
+  class UrlGenerationError < ActionControllerError
+  end
+
+  class MethodNotAllowed < ActionControllerError
+    # nodoc:
+    def initialize: (*untyped allowed_methods) -> untyped
+  end
+
+  class NotImplemented < MethodNotAllowed
+  end
+
+  class MissingFile < ActionControllerError
+  end
+
+  class SessionOverflowError < ActionControllerError
+    # nodoc:
+    DEFAULT_MESSAGE: ::String
+
+    def initialize: (?untyped? message) -> untyped
+  end
+
+  class UnknownHttpMethod < ActionControllerError
+  end
+
+  class UnknownFormat < ActionControllerError
+  end
+
+  # Raised when a nested respond_to is triggered and the content types of each
+  # are incompatible. For example:
+  #
+  #  respond_to do |outer_type|
+  #    outer_type.js do
+  #      respond_to do |inner_type|
+  #        inner_type.html { render body: "HTML" }
+  #      end
+  #    end
+  #  end
+  class RespondToMismatchError < ActionControllerError
+    DEFAULT_MESSAGE: ::String
+
+    def initialize: (?untyped? message) -> untyped
+  end
+
+  class MissingExactTemplate < UnknownFormat
+  end
+end
+
+module ActionController
+  # nodoc:
+  module Flash
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      # Creates new flash types. You can pass as many types as you want to create
+      # flash types other than the default <tt>alert</tt> and <tt>notice</tt> in
+      # your controllers and views. For instance:
+      #
+      #   # in application_controller.rb
+      #   class ApplicationController < ActionController::Base
+      #     add_flash_types :warning
+      #   end
+      #
+      #   # in your controller
+      #   redirect_to user_path(@user), warning: "Incomplete profile"
+      #
+      #   # in your view
+      #   <%= warning %>
+      #
+      # This method will automatically define a new method for each of the given
+      # names, and it will be available in your views.
+      def add_flash_types: (*untyped types) -> untyped
+    end
+
+    def redirect_to: (?::Hash[untyped, untyped] options, ?::Hash[untyped, untyped] response_options_and_flash) -> untyped
+  end
+end
+
+module ActionController
+  module ForceSSL
+    # This module is deprecated in favor of +config.force_ssl+ in your environment
+    # config file. This will ensure all endpoints not explicitly marked otherwise
+    # will have all communication served over HTTPS.
+    # :nodoc:
+    extend ActiveSupport::Concern
+
+    include AbstractController::Callbacks
+
+    ACTION_OPTIONS: ::Array[untyped]
+
+    URL_OPTIONS: ::Array[untyped]
+
+    REDIRECT_OPTIONS: ::Array[untyped]
+
+    module ClassMethods
+      # :nodoc:
+      def force_ssl: (?::Hash[untyped, untyped] options) -> untyped
+    end
+
+    def force_ssl_redirect: (?untyped? host_or_options) -> untyped
+  end
+end
+
+module ActionController
+  module Head
+    # Returns a response that has no content (merely headers). The options
+    # argument is interpreted to be a hash of header names and values.
+    # This allows you to easily return a response that consists only of
+    # significant headers:
+    #
+    #   head :created, location: person_path(@person)
+    #
+    #   head :created, location: @person
+    #
+    # It can also be used to return exceptional conditions:
+    #
+    #   return head(:method_not_allowed) unless request.post?
+    #   return head(:bad_request) unless valid_request?
+    #   render
+    #
+    # See Rack::Utils::SYMBOL_TO_STATUS_CODE for a full list of valid +status+ symbols.
+    def head: (untyped status, ?::Hash[untyped, untyped] options) -> ::TrueClass
+
+    def include_content?: (untyped status) -> untyped
+  end
+end
+
+module ActionController
+  # The \Rails framework provides a large number of helpers for working with assets, dates, forms,
+  # numbers and model objects, to name a few. These helpers are available to all templates
+  # by default.
+  #
+  # In addition to using the standard template helpers provided, creating custom helpers to
+  # extract complicated logic or reusable functionality is strongly encouraged. By default, each controller
+  # will include all helpers. These helpers are only accessible on the controller through <tt>#helpers</tt>
+  #
+  # In previous versions of \Rails the controller will include a helper which
+  # matches the name of the controller, e.g., <tt>MyController</tt> will automatically
+  # include <tt>MyHelper</tt>. To return old behavior set +config.action_controller.include_all_helpers+ to +false+.
+  #
+  # Additional helpers can be specified using the +helper+ class method in ActionController::Base or any
+  # controller which inherits from it.
+  #
+  # The +to_s+ method from the \Time class can be wrapped in a helper method to display a custom message if
+  # a \Time object is blank:
+  #
+  #   module FormattedTimeHelper
+  #     def format_time(time, format=:long, blank_message="&nbsp;")
+  #       time.blank? ? blank_message : time.to_s(format)
+  #     end
+  #   end
+  #
+  # FormattedTimeHelper can now be included in a controller, using the +helper+ class method:
+  #
+  #   class EventsController < ActionController::Base
+  #     helper FormattedTimeHelper
+  #     def index
+  #       @events = Event.all
+  #     end
+  #   end
+  #
+  # Then, in any view rendered by <tt>EventsController</tt>, the <tt>format_time</tt> method can be called:
+  #
+  #   <% @events.each do |event| -%>
+  #     <p>
+  #       <%= format_time(event.time, :short, "N/A") %> | <%= event.name %>
+  #     </p>
+  #   <% end -%>
+  #
+  # Finally, assuming we have two event instances, one which has a time and one which does not,
+  # the output might look like this:
+  #
+  #   23 Aug 11:30 | Carolina Railhawks Soccer Match
+  #   N/A | Carolina Railhawks Training Workshop
+  #
+  module Helpers
+    extend ActiveSupport::Concern
+
+    attr_accessor helpers_path: untyped
+
+    include AbstractController::Helpers
+
+    module ClassMethods
+      # Declares helper accessors for controller attributes. For example, the
+      # following adds new +name+ and <tt>name=</tt> instance methods to a
+      # controller and makes them available to the view:
+      #   attr_accessor :name
+      #   helper_attr :name
+      #
+      # ==== Parameters
+      # * <tt>attrs</tt> - Names of attributes to be converted into helpers.
+      def helper_attr: (*untyped attrs) -> untyped
+
+      # Provides a proxy to access helper methods from outside the view.
+      def helpers: () -> untyped
+
+      # Overwrite modules_for_helpers to accept :all as argument, which loads
+      # all helpers in helpers_path.
+      #
+      # ==== Parameters
+      # * <tt>args</tt> - A list of helpers
+      #
+      # ==== Returns
+      # * <tt>array</tt> - A normalized list of modules for the list of helpers provided.
+      def modules_for_helpers: (untyped args) -> untyped
+
+      # Returns a list of helper names in a given path.
+      #
+      #   ActionController::Base.all_helpers_from_path 'app/helpers'
+      #   # => ["application", "chart", "rubygems"]
+      def all_helpers_from_path: (untyped path) -> untyped
+
+      # Extract helper names from files in <tt>app/helpers/**/*_helper.rb</tt>
+      def all_application_helpers: () -> untyped
+    end
+
+    # Provides a proxy to access helper methods from outside the view.
+    def helpers: () -> untyped
+  end
+end
+
+module ActionController
+  # Makes it dead easy to do HTTP Basic, Digest and Token authentication.
+  module HttpAuthentication
+    # Makes it dead easy to do HTTP \Basic authentication.
+    #
+    # === Simple \Basic example
+    #
+    #   class PostsController < ApplicationController
+    #     http_basic_authenticate_with name: "dhh", password: "secret", except: :index
+    #
+    #     def index
+    #       render plain: "Everyone can see me!"
+    #     end
+    #
+    #     def edit
+    #       render plain: "I'm only accessible if you know the password"
+    #     end
+    #  end
+    #
+    # === Advanced \Basic example
+    #
+    # Here is a more advanced \Basic example where only Atom feeds and the XML API is protected by HTTP authentication,
+    # the regular HTML interface is protected by a session approach:
+    #
+    #   class ApplicationController < ActionController::Base
+    #     before_action :set_account, :authenticate
+    #
+    #     private
+    #       def set_account
+    #         @account = Account.find_by(url_name: request.subdomains.first)
+    #       end
+    #
+    #       def authenticate
+    #         case request.format
+    #         when Mime[:xml], Mime[:atom]
+    #           if user = authenticate_with_http_basic { |u, p| @account.users.authenticate(u, p) }
+    #             @current_user = user
+    #           else
+    #             request_http_basic_authentication
+    #           end
+    #         else
+    #           if session_authenticated?
+    #             @current_user = @account.users.find(session[:authenticated][:user_id])
+    #           else
+    #             redirect_to(login_url) and return false
+    #           end
+    #         end
+    #       end
+    #   end
+    #
+    # In your integration tests, you can do something like this:
+    #
+    #   def test_access_granted_from_xml
+    #     authorization = ActionController::HttpAuthentication::Basic.encode_credentials(users(:dhh).name, users(:dhh).password)
+    #
+    #     get "/notes/1.xml", headers: { 'HTTP_AUTHORIZATION' => authorization }
+    #
+    #     assert_equal 200, status
+    #   end
+    module Basic
+      module ControllerMethods
+        extend ActiveSupport::Concern
+
+        module ClassMethods
+          def http_basic_authenticate_with: (password: untyped password, name: untyped name, ?realm: untyped? realm, **untyped options) -> untyped
+        end
+
+        def http_basic_authenticate_or_request_with: (password: untyped password, name: untyped name, ?message: untyped? message, ?realm: untyped? realm) -> untyped
+
+        def authenticate_or_request_with_http_basic: (?untyped? realm, ?untyped? message) { () -> untyped } -> untyped
+
+        def authenticate_with_http_basic: () { () -> untyped } -> untyped
+
+        def request_http_basic_authentication: (?::String realm, ?untyped? message) -> untyped
+      end
+
+      def authenticate: (untyped request) { () -> untyped } -> untyped
+
+      def has_basic_credentials?: (untyped request) -> untyped
+
+      def user_name_and_password: (untyped request) -> untyped
+
+      def decode_credentials: (untyped request) -> untyped
+
+      def auth_scheme: (untyped request) -> untyped
+
+      def auth_param: (untyped request) -> untyped
+
+      def encode_credentials: (untyped user_name, untyped password) -> ::String
+
+      def authentication_request: (untyped controller, untyped realm, untyped message) -> untyped
+    end
+
+    # Makes it dead easy to do HTTP \Digest authentication.
+    #
+    # === Simple \Digest example
+    #
+    #   require 'digest/md5'
+    #   class PostsController < ApplicationController
+    #     REALM = "SuperSecret"
+    #     USERS = {"dhh" => "secret", #plain text password
+    #              "dap" => Digest::MD5.hexdigest(["dap",REALM,"secret"].join(":"))}  #ha1 digest password
+    #
+    #     before_action :authenticate, except: [:index]
+    #
+    #     def index
+    #       render plain: "Everyone can see me!"
+    #     end
+    #
+    #     def edit
+    #       render plain: "I'm only accessible if you know the password"
+    #     end
+    #
+    #     private
+    #       def authenticate
+    #         authenticate_or_request_with_http_digest(REALM) do |username|
+    #           USERS[username]
+    #         end
+    #       end
+    #   end
+    #
+    # === Notes
+    #
+    # The +authenticate_or_request_with_http_digest+ block must return the user's password
+    # or the ha1 digest hash so the framework can appropriately hash to check the user's
+    # credentials. Returning +nil+ will cause authentication to fail.
+    #
+    # Storing the ha1 hash: MD5(username:realm:password), is better than storing a plain password. If
+    # the password file or database is compromised, the attacker would be able to use the ha1 hash to
+    # authenticate as the user at this +realm+, but would not have the user's password to try using at
+    # other sites.
+    #
+    # In rare instances, web servers or front proxies strip authorization headers before
+    # they reach your application. You can debug this situation by logging all environment
+    # variables, and check for HTTP_AUTHORIZATION, amongst others.
+    module Digest
+      module ControllerMethods
+        def authenticate_or_request_with_http_digest: (?::String realm, ?untyped? message) { () -> untyped } -> untyped
+
+        # Authenticate with HTTP Digest, returns true or false
+        def authenticate_with_http_digest: (?::String realm) { () -> untyped } -> untyped
+
+        # Render output including the HTTP Digest authentication header
+        def request_http_digest_authentication: (?::String realm, ?untyped? message) -> untyped
+      end
+
+      # Returns false on a valid response, true otherwise
+      def authenticate: (untyped request, untyped realm) { () -> untyped } -> untyped
+
+      # Returns false unless the request credentials response value matches the expected value.
+      # First try the password as a ha1 digest password. If this fails, then try it as a plain
+      # text password.
+      def validate_digest_response: (untyped request, untyped realm) { () -> untyped } -> (::FalseClass | untyped)
+
+      # Returns the expected response for a request of +http_method+ to +uri+ with the decoded +credentials+ and the expected +password+
+      # Optional parameter +password_is_ha1+ is set to +true+ by default, since best practice is to store ha1 digest instead
+      # of a plain-text password.
+      def expected_response: (untyped http_method, untyped uri, untyped credentials, untyped password, ?bool password_is_ha1) -> untyped
+
+      def ha1: (untyped credentials, untyped password) -> untyped
+
+      def encode_credentials: (untyped http_method, untyped credentials, untyped password, untyped password_is_ha1) -> untyped
+
+      def decode_credentials_header: (untyped request) -> untyped
+
+      def decode_credentials: (untyped header) -> untyped
+
+      def authentication_header: (untyped controller, untyped realm) -> untyped
+
+      def authentication_request: (untyped controller, untyped realm, ?untyped? message) -> untyped
+
+      def secret_token: (untyped request) -> untyped
+
+      # Uses an MD5 digest based on time to generate a value to be used only once.
+      #
+      # A server-specified data string which should be uniquely generated each time a 401 response is made.
+      # It is recommended that this string be base64 or hexadecimal data.
+      # Specifically, since the string is passed in the header lines as a quoted string, the double-quote character is not allowed.
+      #
+      # The contents of the nonce are implementation dependent.
+      # The quality of the implementation depends on a good choice.
+      # A nonce might, for example, be constructed as the base 64 encoding of
+      #
+      #   time-stamp H(time-stamp ":" ETag ":" private-key)
+      #
+      # where time-stamp is a server-generated time or other non-repeating value,
+      # ETag is the value of the HTTP ETag header associated with the requested entity,
+      # and private-key is data known only to the server.
+      # With a nonce of this form a server would recalculate the hash portion after receiving the client authentication header and
+      # reject the request if it did not match the nonce from that header or
+      # if the time-stamp value is not recent enough. In this way the server can limit the time of the nonce's validity.
+      # The inclusion of the ETag prevents a replay request for an updated version of the resource.
+      # (Note: including the IP address of the client in the nonce would appear to offer the server the ability
+      # to limit the reuse of the nonce to the same client that originally got it.
+      # However, that would break proxy farms, where requests from a single user often go through different proxies in the farm.
+      # Also, IP address spoofing is not that hard.)
+      #
+      # An implementation might choose not to accept a previously used nonce or a previously used digest, in order to
+      # protect against a replay attack. Or, an implementation might choose to use one-time nonces or digests for
+      # POST, PUT, or PATCH requests and a time-stamp for GET requests. For more details on the issues involved see Section 4
+      # of this document.
+      #
+      # The nonce is opaque to the client. Composed of Time, and hash of Time with secret
+      # key from the Rails session secret generated upon creation of project. Ensures
+      # the time cannot be modified by client.
+      def nonce: (untyped secret_key, ?untyped time) -> untyped
+
+      # Might want a shorter timeout depending on whether the request
+      # is a PATCH, PUT, or POST, and if the client is a browser or web service.
+      # Can be much shorter if the Stale directive is implemented. This would
+      # allow a user to use new nonce without prompting the user again for their
+      # username and password.
+      def validate_nonce: (untyped secret_key, untyped request, untyped value, ?untyped seconds_to_timeout) -> (::FalseClass | untyped)
+
+      # Opaque based on digest of secret key
+      def opaque: (untyped secret_key) -> untyped
+    end
+
+    # Makes it dead easy to do HTTP Token authentication.
+    #
+    # Simple Token example:
+    #
+    #   class PostsController < ApplicationController
+    #     TOKEN = "secret"
+    #
+    #     before_action :authenticate, except: [ :index ]
+    #
+    #     def index
+    #       render plain: "Everyone can see me!"
+    #     end
+    #
+    #     def edit
+    #       render plain: "I'm only accessible if you know the password"
+    #     end
+    #
+    #     private
+    #       def authenticate
+    #         authenticate_or_request_with_http_token do |token, options|
+    #           # Compare the tokens in a time-constant manner, to mitigate
+    #           # timing attacks.
+    #           ActiveSupport::SecurityUtils.secure_compare(token, TOKEN)
+    #         end
+    #       end
+    #   end
+    #
+    #
+    # Here is a more advanced Token example where only Atom feeds and the XML API is protected by HTTP token authentication,
+    # the regular HTML interface is protected by a session approach:
+    #
+    #   class ApplicationController < ActionController::Base
+    #     before_action :set_account, :authenticate
+    #
+    #     private
+    #       def set_account
+    #         @account = Account.find_by(url_name: request.subdomains.first)
+    #       end
+    #
+    #       def authenticate
+    #         case request.format
+    #         when Mime[:xml], Mime[:atom]
+    #           if user = authenticate_with_http_token { |t, o| @account.users.authenticate(t, o) }
+    #             @current_user = user
+    #           else
+    #             request_http_token_authentication
+    #           end
+    #         else
+    #           if session_authenticated?
+    #             @current_user = @account.users.find(session[:authenticated][:user_id])
+    #           else
+    #             redirect_to(login_url) and return false
+    #           end
+    #         end
+    #       end
+    #   end
+    #
+    #
+    # In your integration tests, you can do something like this:
+    #
+    #   def test_access_granted_from_xml
+    #     authorization = ActionController::HttpAuthentication::Token.encode_credentials(users(:dhh).token)
+    #
+    #     get "/notes/1.xml", headers: { 'HTTP_AUTHORIZATION' => authorization }
+    #
+    #     assert_equal 200, status
+    #   end
+    #
+    #
+    # On shared hosts, Apache sometimes doesn't pass authentication headers to
+    # FCGI instances. If your environment matches this description and you cannot
+    # authenticate, try this rule in your Apache setup:
+    #
+    #   RewriteRule ^(.*)$ dispatch.fcgi [E=X-HTTP_AUTHORIZATION:%{HTTP:Authorization},QSA,L]
+    module Token
+      TOKEN_KEY: ::String
+
+      TOKEN_REGEX: untyped
+
+      AUTHN_PAIR_DELIMITERS: untyped
+
+      module ControllerMethods
+        def authenticate_or_request_with_http_token: (?::String realm, ?untyped? message) { () -> untyped } -> untyped
+
+        def authenticate_with_http_token: () { () -> untyped } -> untyped
+
+        def request_http_token_authentication: (?::String realm, ?untyped? message) -> untyped
+      end
+
+      def authenticate: (untyped controller) { () -> untyped } -> untyped
+
+      # Parses the token and options out of the token Authorization header.
+      # The value for the Authorization header is expected to have the prefix
+      # <tt>"Token"</tt> or <tt>"Bearer"</tt>. If the header looks like this:
+      #   Authorization: Token token="abc", nonce="def"
+      # Then the returned token is <tt>"abc"</tt>, and the options are
+      # <tt>{nonce: "def"}</tt>
+      #
+      # request - ActionDispatch::Request instance with the current headers.
+      #
+      # Returns an +Array+ of <tt>[String, Hash]</tt> if a token is present.
+      # Returns +nil+ if no token is found.
+      def token_and_options: (untyped request) -> untyped
+
+      def token_params_from: (untyped auth) -> untyped
+
+      # Takes raw_params and turns it into an array of parameters
+      def params_array_from: (untyped raw_params) -> untyped
+
+      # This removes the <tt>"</tt> characters wrapping the value.
+      def rewrite_param_values: (untyped array_params) -> untyped
+
+      # This method takes an authorization body and splits up the key-value
+      # pairs by the standardized <tt>:</tt>, <tt>;</tt>, or <tt>\t</tt>
+      # delimiters defined in +AUTHN_PAIR_DELIMITERS+.
+      def raw_params: (untyped auth) -> untyped
+
+      # Encodes the given token and options into an Authorization header value.
+      #
+      # token   - String token.
+      # options - optional Hash of the options.
+      #
+      # Returns String.
+      def encode_credentials: (untyped token, ?::Hash[untyped, untyped] options) -> ::String
+
+      # Sets a WWW-Authenticate header to let the client know a token is desired.
+      #
+      # controller - ActionController::Base instance for the outgoing response.
+      # realm      - String realm to use in the header.
+      #
+      # Returns nothing.
+      def authentication_request: (untyped controller, untyped realm, ?untyped? message) -> untyped
+    end
+  end
+end
+
+module ActionController
+  # Handles implicit rendering for a controller action that does not
+  # explicitly respond with +render+, +respond_to+, +redirect+, or +head+.
+  #
+  # For API controllers, the implicit response is always <tt>204 No Content</tt>.
+  #
+  # For all other controllers, we use these heuristics to decide whether to
+  # render a template, raise an error for a missing template, or respond with
+  # <tt>204 No Content</tt>:
+  #
+  # First, if we DO find a template, it's rendered. Template lookup accounts
+  # for the action name, locales, format, variant, template handlers, and more
+  # (see +render+ for details).
+  #
+  # Second, if we DON'T find a template but the controller action does have
+  # templates for other formats, variants, etc., then we trust that you meant
+  # to provide a template for this response, too, and we raise
+  # <tt>ActionController::UnknownFormat</tt> with an explanation.
+  #
+  # Third, if we DON'T find a template AND the request is a page load in a web
+  # browser (technically, a non-XHR GET request for an HTML response) where
+  # you reasonably expect to have rendered a template, then we raise
+  # <tt>ActionView::UnknownFormat</tt> with an explanation.
+  #
+  # Finally, if we DON'T find a template AND the request isn't a browser page
+  # load, then we implicitly respond with <tt>204 No Content</tt>.
+  module ImplicitRender
+    # :stopdoc:
+    include BasicImplicitRender
+
+    def default_render: () -> untyped
+
+    def method_for_action: (untyped action_name) -> untyped
+
+    def interactive_browser_request?: () -> untyped
+  end
+end
+
+module ActionController
+  # Adds instrumentation to several ends in ActionController::Base. It also provides
+  # some hooks related with process_action. This allows an ORM like Active Record
+  # and/or DataMapper to plug in ActionController and show related information.
+  #
+  # Check ActiveRecord::Railties::ControllerRuntime for an example.
+  module Instrumentation
+    extend ActiveSupport::Concern
+
+    include AbstractController::Logger
+
+    def process_action: (*untyped args) -> untyped
+
+    def render: (*untyped args) -> untyped
+
+    def send_file: (untyped path, ?::Hash[untyped, untyped] options) -> untyped
+
+    def send_data: (untyped data, ?::Hash[untyped, untyped] options) -> untyped
+
+    def redirect_to: (*untyped args) -> untyped
+
+    # A hook invoked every time a before callback is halted.
+    def halted_callback_hook: (untyped filter) -> untyped
+
+    def cleanup_view_runtime: () { () -> untyped } -> untyped
+
+    def append_info_to_payload: (untyped payload) -> untyped
+
+    module ClassMethods
+      def log_process_action: (untyped payload) -> untyped
+    end
+  end
+end
+
+module ActionController
+  # Mix this module into your controller, and all actions in that controller
+  # will be able to stream data to the client as it's written.
+  #
+  #   class MyController < ActionController::Base
+  #     include ActionController::Live
+  #
+  #     def stream
+  #       response.headers['Content-Type'] = 'text/event-stream'
+  #       100.times {
+  #         response.stream.write "hello world\n"
+  #         sleep 1
+  #       }
+  #     ensure
+  #       response.stream.close
+  #     end
+  #   end
+  #
+  # There are a few caveats with this module. You *cannot* write headers after the
+  # response has been committed (Response#committed? will return truthy).
+  # Calling +write+ or +close+ on the response stream will cause the response
+  # object to be committed. Make sure all headers are set before calling write
+  # or close on your stream.
+  #
+  # You *must* call close on your stream when you're finished, otherwise the
+  # socket may be left open forever.
+  #
+  # The final caveat is that your actions are executed in a separate thread than
+  # the main thread. Make sure your actions are thread safe, and this shouldn't
+  # be a problem (don't share state across threads, etc).
+  module Live
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      def make_response!: (untyped request) -> untyped
+    end
+
+    # This class provides the ability to write an SSE (Server Sent Event)
+    # to an IO stream. The class is initialized with a stream and can be used
+    # to either write a JSON string or an object which can be converted to JSON.
+    #
+    # Writing an object will convert it into standard SSE format with whatever
+    # options you have configured. You may choose to set the following options:
+    #
+    #   1) Event. If specified, an event with this name will be dispatched on
+    #   the browser.
+    #   2) Retry. The reconnection time in milliseconds used when attempting
+    #   to send the event.
+    #   3) Id. If the connection dies while sending an SSE to the browser, then
+    #   the server will receive a +Last-Event-ID+ header with value equal to +id+.
+    #
+    # After setting an option in the constructor of the SSE object, all future
+    # SSEs sent across the stream will use those options unless overridden.
+    #
+    # Example Usage:
+    #
+    #   class MyController < ActionController::Base
+    #     include ActionController::Live
+    #
+    #     def index
+    #       response.headers['Content-Type'] = 'text/event-stream'
+    #       sse = SSE.new(response.stream, retry: 300, event: "event-name")
+    #       sse.write({ name: 'John'})
+    #       sse.write({ name: 'John'}, id: 10)
+    #       sse.write({ name: 'John'}, id: 10, event: "other-event")
+    #       sse.write({ name: 'John'}, id: 10, event: "other-event", retry: 500)
+    #     ensure
+    #       sse.close
+    #     end
+    #   end
+    #
+    # Note: SSEs are not currently supported by IE. However, they are supported
+    # by Chrome, Firefox, Opera, and Safari.
+    class SSE
+      PERMITTED_OPTIONS: ::Array[untyped]
+
+      def initialize: (untyped stream, ?::Hash[untyped, untyped] options) -> untyped
+
+      def close: () -> untyped
+
+      def write: (untyped object, ?::Hash[untyped, untyped] options) -> untyped
+
+      def perform_write: (untyped json, untyped options) -> untyped
+    end
+
+    class ClientDisconnected < RuntimeError
+    end
+
+    class Buffer < ActionDispatch::Response::Buffer
+      # nodoc:
+      include MonitorMixin
+
+      # Ignore that the client has disconnected.
+      #
+      # If this value is `true`, calling `write` after the client
+      # disconnects will result in the written content being silently
+      # discarded. If this value is `false` (the default), a
+      # ClientDisconnected exception will be raised.
+      attr_accessor ignore_disconnect: untyped
+
+      def initialize: (untyped response) -> untyped
+
+      def write: (untyped string) -> untyped
+
+      # Write a 'close' event to the buffer; the producer/writing thread
+      # uses this to notify us that it's finished supplying content.
+      #
+      # See also #abort.
+      def close: () -> untyped
+
+      # Inform the producer/writing thread that the client has
+      # disconnected; the reading thread is no longer interested in
+      # anything that's being written.
+      #
+      # See also #close.
+      def abort: () -> untyped
+
+      # Is the client still connected and waiting for content?
+      #
+      # The result of calling `write` when this is `false` is determined
+      # by `ignore_disconnect`.
+      def connected?: () -> untyped
+
+      def on_error: () { () -> untyped } -> untyped
+
+      def call_on_error: () -> untyped
+
+      def each_chunk: () { (untyped) -> untyped } -> untyped
+    end
+
+    class Response < ActionDispatch::Response
+      def before_committed: () -> untyped
+
+      def build_buffer: (untyped response, untyped body) -> untyped
+    end
+
+    def process: (untyped name) -> untyped
+
+    def response_body=: (untyped body) -> untyped
+
+    def new_controller_thread: () { () -> untyped } -> untyped
+
+    def log_error: (untyped exception) -> (nil | untyped)
+  end
+end
+
+module ActionController
+  # nodoc:
+  module MimeResponds
+    # Without web-service support, an action which collects the data for displaying a list of people
+    # might look something like this:
+    #
+    #   def index
+    #     @people = Person.all
+    #   end
+    #
+    # That action implicitly responds to all formats, but formats can also be explicitly enumerated:
+    #
+    #   def index
+    #     @people = Person.all
+    #     respond_to :html, :js
+    #   end
+    #
+    # Here's the same action, with web-service support baked in:
+    #
+    #   def index
+    #     @people = Person.all
+    #
+    #     respond_to do |format|
+    #       format.html
+    #       format.js
+    #       format.xml { render xml: @people }
+    #     end
+    #   end
+    #
+    # What that says is, "if the client wants HTML or JS in response to this action, just respond as we
+    # would have before, but if the client wants XML, return them the list of people in XML format."
+    # (Rails determines the desired response format from the HTTP Accept header submitted by the client.)
+    #
+    # Supposing you have an action that adds a new person, optionally creating their company
+    # (by name) if it does not already exist, without web-services, it might look like this:
+    #
+    #   def create
+    #     @company = Company.find_or_create_by(name: params[:company][:name])
+    #     @person  = @company.people.create(params[:person])
+    #
+    #     redirect_to(person_list_url)
+    #   end
+    #
+    # Here's the same action, with web-service support baked in:
+    #
+    #   def create
+    #     company  = params[:person].delete(:company)
+    #     @company = Company.find_or_create_by(name: company[:name])
+    #     @person  = @company.people.create(params[:person])
+    #
+    #     respond_to do |format|
+    #       format.html { redirect_to(person_list_url) }
+    #       format.js
+    #       format.xml  { render xml: @person.to_xml(include: @company) }
+    #     end
+    #   end
+    #
+    # If the client wants HTML, we just redirect them back to the person list. If they want JavaScript,
+    # then it is an Ajax request and we render the JavaScript template associated with this action.
+    # Lastly, if the client wants XML, we render the created person as XML, but with a twist: we also
+    # include the person's company in the rendered XML, so you get something like this:
+    #
+    #   <person>
+    #     <id>...</id>
+    #     ...
+    #     <company>
+    #       <id>...</id>
+    #       <name>...</name>
+    #       ...
+    #     </company>
+    #   </person>
+    #
+    # Note, however, the extra bit at the top of that action:
+    #
+    #   company  = params[:person].delete(:company)
+    #   @company = Company.find_or_create_by(name: company[:name])
+    #
+    # This is because the incoming XML document (if a web-service request is in process) can only contain a
+    # single root-node. So, we have to rearrange things so that the request looks like this (url-encoded):
+    #
+    #   person[name]=...&person[company][name]=...&...
+    #
+    # And, like this (xml-encoded):
+    #
+    #   <person>
+    #     <name>...</name>
+    #     <company>
+    #       <name>...</name>
+    #     </company>
+    #   </person>
+    #
+    # In other words, we make the request so that it operates on a single entity's person. Then, in the action,
+    # we extract the company data from the request, find or create the company, and then create the new person
+    # with the remaining data.
+    #
+    # Note that you can define your own XML parameter parser which would allow you to describe multiple entities
+    # in a single request (i.e., by wrapping them all in a single root node), but if you just go with the flow
+    # and accept Rails' defaults, life will be much easier.
+    #
+    # If you need to use a MIME type which isn't supported by default, you can register your own handlers in
+    # +config/initializers/mime_types.rb+ as follows.
+    #
+    #   Mime::Type.register "image/jpg", :jpg
+    #
+    # +respond_to+ also allows you to specify a common block for different formats by using +any+:
+    #
+    #   def index
+    #     @people = Person.all
+    #
+    #     respond_to do |format|
+    #       format.html
+    #       format.any(:xml, :json) { render request.format.to_sym => @people }
+    #     end
+    #   end
+    #
+    # In the example above, if the format is xml, it will render:
+    #
+    #   render xml: @people
+    #
+    # Or if the format is json:
+    #
+    #   render json: @people
+    #
+    # +any+ can also be used with no arguments, in which case it will be used for any format requested by
+    # the user:
+    #
+    #   respond_to do |format|
+    #     format.html
+    #     format.any { redirect_to support_path }
+    #   end
+    #
+    # Formats can have different variants.
+    #
+    # The request variant is a specialization of the request format, like <tt>:tablet</tt>,
+    # <tt>:phone</tt>, or <tt>:desktop</tt>.
+    #
+    # We often want to render different html/json/xml templates for phones,
+    # tablets, and desktop browsers. Variants make it easy.
+    #
+    # You can set the variant in a +before_action+:
+    #
+    #   request.variant = :tablet if request.user_agent =~ /iPad/
+    #
+    # Respond to variants in the action just like you respond to formats:
+    #
+    #   respond_to do |format|
+    #     format.html do |variant|
+    #       variant.tablet # renders app/views/projects/show.html+tablet.erb
+    #       variant.phone { extra_setup; render ... }
+    #       variant.none  { special_setup } # executed only if there is no variant set
+    #     end
+    #   end
+    #
+    # Provide separate templates for each format and variant:
+    #
+    #   app/views/projects/show.html.erb
+    #   app/views/projects/show.html+tablet.erb
+    #   app/views/projects/show.html+phone.erb
+    #
+    # When you're not sharing any code within the format, you can simplify defining variants
+    # using the inline syntax:
+    #
+    #   respond_to do |format|
+    #     format.js         { render "trash" }
+    #     format.html.phone { redirect_to progress_path }
+    #     format.html.none  { render "trash" }
+    #   end
+    #
+    # Variants also support common +any+/+all+ block that formats have.
+    #
+    # It works for both inline:
+    #
+    #   respond_to do |format|
+    #     format.html.any   { render html: "any"   }
+    #     format.html.phone { render html: "phone" }
+    #   end
+    #
+    # and block syntax:
+    #
+    #   respond_to do |format|
+    #     format.html do |variant|
+    #       variant.any(:tablet, :phablet){ render html: "any" }
+    #       variant.phone { render html: "phone" }
+    #     end
+    #   end
+    #
+    # You can also set an array of variants:
+    #
+    #   request.variant = [:tablet, :phone]
+    #
+    # This will work similarly to formats and MIME types negotiation. If there
+    # is no +:tablet+ variant declared, the +:phone+ variant will be used:
+    #
+    #   respond_to do |format|
+    #     format.html.none
+    #     format.html.phone # this gets rendered
+    #   end
+    def respond_to: (*untyped mimes) { (untyped) -> untyped } -> untyped
+
+    # A container for responses available from the current controller for
+    # requests for different mime-types sent to a particular action.
+    #
+    # The public controller methods +respond_to+ may be called with a block
+    # that is used to define responses to different mime-types, e.g.
+    # for +respond_to+ :
+    #
+    #   respond_to do |format|
+    #     format.html
+    #     format.xml { render xml: @people }
+    #   end
+    #
+    # In this usage, the argument passed to the block (+format+ above) is an
+    # instance of the ActionController::MimeResponds::Collector class. This
+    # object serves as a container in which available responses can be stored by
+    # calling any of the dynamically generated, mime-type-specific methods such
+    # as +html+, +xml+ etc on the Collector. Each response is represented by a
+    # corresponding block if present.
+    #
+    # A subsequent call to #negotiate_format(request) will enable the Collector
+    # to determine which specific mime-type it should respond with for the current
+    # request, with this response then being accessible by calling #response.
+    class Collector
+      include AbstractController::Collector
+
+      attr_accessor format: untyped
+
+      def initialize: (untyped mimes, ?untyped? variant) -> untyped
+
+      def `any`: (*untyped args) { () -> untyped } -> untyped
+
+      alias all any
+
+      def custom: (untyped mime_type) { () -> untyped } -> untyped
+
+      def response: () -> untyped
+
+      def negotiate_format: (untyped request) -> untyped
+
+      class VariantCollector
+        # nodoc:
+        def initialize: (?untyped? variant) -> untyped
+
+        def `any`: (*untyped args) { () -> untyped } -> untyped
+
+        alias all any
+
+        def method_missing: (untyped name, *untyped args) { () -> untyped } -> untyped
+
+        def variant: () -> untyped
+
+        def variant_key: () -> untyped
+      end
+    end
+  end
+end
+
+module ActionController
+  # Specify binary encoding for parameters for a given action.
+  module ParameterEncoding
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      def inherited: (untyped klass) -> untyped
+
+      def setup_param_encode: () -> untyped
+
+      def binary_params_for?: (untyped action) -> untyped
+
+      # Specify that a given action's parameters should all be encoded as
+      # ASCII-8BIT (it "skips" the encoding default of UTF-8).
+      #
+      # For example, a controller would use it like this:
+      #
+      #   class RepositoryController < ActionController::Base
+      #     skip_parameter_encoding :show
+      #
+      #     def show
+      #       @repo = Repository.find_by_filesystem_path params[:file_path]
+      #
+      #       # `repo_name` is guaranteed to be UTF-8, but was ASCII-8BIT, so
+      #       # tag it as such
+      #       @repo_name = params[:repo_name].force_encoding 'UTF-8'
+      #     end
+      #
+      #     def index
+      #       @repositories = Repository.all
+      #     end
+      #   end
+      #
+      # The show action in the above controller would have all parameter values
+      # encoded as ASCII-8BIT. This is useful in the case where an application
+      # must handle data but encoding of the data is unknown, like file system data.
+      def skip_parameter_encoding: (untyped action) -> untyped
+    end
+  end
+end
+
+module ActionController
+  # Wraps the parameters hash into a nested hash. This will allow clients to
+  # submit requests without having to specify any root elements.
+  #
+  # This functionality is enabled in +config/initializers/wrap_parameters.rb+
+  # and can be customized.
+  #
+  # You could also turn it on per controller by setting the format array to
+  # a non-empty array:
+  #
+  #     class UsersController < ApplicationController
+  #       wrap_parameters format: [:json, :xml, :url_encoded_form, :multipart_form]
+  #     end
+  #
+  # If you enable +ParamsWrapper+ for +:json+ format, instead of having to
+  # send JSON parameters like this:
+  #
+  #     {"user": {"name": "Konata"}}
+  #
+  # You can send parameters like this:
+  #
+  #     {"name": "Konata"}
+  #
+  # And it will be wrapped into a nested hash with the key name matching the
+  # controller's name. For example, if you're posting to +UsersController+,
+  # your new +params+ hash will look like this:
+  #
+  #     {"name" => "Konata", "user" => {"name" => "Konata"}}
+  #
+  # You can also specify the key in which the parameters should be wrapped to,
+  # and also the list of attributes it should wrap by using either +:include+ or
+  # +:exclude+ options like this:
+  #
+  #     class UsersController < ApplicationController
+  #       wrap_parameters :person, include: [:username, :password]
+  #     end
+  #
+  # On Active Record models with no +:include+ or +:exclude+ option set,
+  # it will only wrap the parameters returned by the class method
+  # <tt>attribute_names</tt>.
+  #
+  # If you're going to pass the parameters to an +ActiveModel+ object (such as
+  # <tt>User.new(params[:user])</tt>), you might consider passing the model class to
+  # the method instead. The +ParamsWrapper+ will actually try to determine the
+  # list of attribute names from the model and only wrap those attributes:
+  #
+  #     class UsersController < ApplicationController
+  #       wrap_parameters Person
+  #     end
+  #
+  # You still could pass +:include+ and +:exclude+ to set the list of attributes
+  # you want to wrap.
+  #
+  # By default, if you don't specify the key in which the parameters would be
+  # wrapped to, +ParamsWrapper+ will actually try to determine if there's
+  # a model related to it or not. This controller, for example:
+  #
+  #     class Admin::UsersController < ApplicationController
+  #     end
+  #
+  # will try to check if <tt>Admin::User</tt> or +User+ model exists, and use it to
+  # determine the wrapper key respectively. If both models don't exist,
+  # it will then fallback to use +user+ as the key.
+  module ParamsWrapper
+    extend ActiveSupport::Concern
+
+    EXCLUDE_PARAMETERS: ::Array[untyped]
+
+    class Options
+      # :nodoc:
+      include Mutex_m
+
+      def self.from_hash: (untyped hash) -> untyped
+
+      def initialize: (untyped name, untyped format, untyped `include`, untyped exclude, untyped klass, untyped model) -> untyped
+
+      def model: () -> untyped
+
+      def `include`: () -> untyped
+
+      def name: () -> untyped
+
+      # Determine the wrapper model from the controller's name. By convention,
+      # this could be done by trying to find the defined model that has the
+      # same singular name as the controller. For example, +UsersController+
+      # will try to find if the +User+ model exists.
+      #
+      # This method also does namespace lookup. Foo::Bar::UsersController will
+      # try to find Foo::Bar::User, Foo::User and finally User.
+      def _default_wrap_model: () -> (nil | untyped)
+    end
+
+    module ClassMethods
+      def _set_wrapper_options: (untyped options) -> untyped
+
+      # Sets the name of the wrapper key, or the model which +ParamsWrapper+
+      # would use to determine the attribute names from.
+      #
+      # ==== Examples
+      #   wrap_parameters format: :xml
+      #     # enables the parameter wrapper for XML format
+      #
+      #   wrap_parameters :person
+      #     # wraps parameters into +params[:person]+ hash
+      #
+      #   wrap_parameters Person
+      #     # wraps parameters by determining the wrapper key from Person class
+      #     (+person+, in this case) and the list of attribute names
+      #
+      #   wrap_parameters include: [:username, :title]
+      #     # wraps only +:username+ and +:title+ attributes from parameters.
+      #
+      #   wrap_parameters false
+      #     # disables parameters wrapping for this controller altogether.
+      #
+      # ==== Options
+      # * <tt>:format</tt> - The list of formats in which the parameters wrapper
+      #   will be enabled.
+      # * <tt>:include</tt> - The list of attribute names which parameters wrapper
+      #   will wrap into a nested hash.
+      # * <tt>:exclude</tt> - The list of attribute names which parameters wrapper
+      #   will exclude from a nested hash.
+      def wrap_parameters: (untyped name_or_model_or_options, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Sets the default wrapper key or model which will be used to determine
+      # wrapper key and attribute names. Called automatically when the
+      # module is inherited.
+      def inherited: (untyped klass) -> untyped
+    end
+
+    # Performs parameters wrapping upon the request. Called automatically
+    # by the metal call stack.
+    def process_action: (*untyped args) -> untyped
+
+    # Returns the wrapper key which will be used to store wrapped parameters.
+    def _wrapper_key: () -> untyped
+
+    # Returns the list of enabled formats.
+    def _wrapper_formats: () -> untyped
+
+    # Returns the list of parameters which will be selected for wrapped.
+    def _wrap_parameters: (untyped parameters) -> ::Hash[untyped, untyped]
+
+    def _extract_parameters: (untyped parameters) -> untyped
+
+    # Checks if we should perform parameters wrapping.
+    def _wrapper_enabled?: () -> (::FalseClass | untyped)
+
+    def _perform_parameter_wrapping: () -> untyped
+  end
+end
+
+module ActionController
+  module Redirecting
+    extend ActiveSupport::Concern
+
+    include AbstractController::Logger
+
+    include ActionController::UrlFor
+
+    # Redirects the browser to the target specified in +options+. This parameter can be any one of:
+    #
+    # * <tt>Hash</tt> - The URL will be generated by calling url_for with the +options+.
+    # * <tt>Record</tt> - The URL will be generated by calling url_for with the +options+, which will reference a named URL for that record.
+    # * <tt>String</tt> starting with <tt>protocol://</tt> (like <tt>http://</tt>) or a protocol relative reference (like <tt>//</tt>) - Is passed straight through as the target for redirection.
+    # * <tt>String</tt> not containing a protocol - The current protocol and host is prepended to the string.
+    # * <tt>Proc</tt> - A block that will be executed in the controller's context. Should return any option accepted by +redirect_to+.
+    #
+    # === Examples:
+    #
+    #   redirect_to action: "show", id: 5
+    #   redirect_to @post
+    #   redirect_to "http://www.rubyonrails.org"
+    #   redirect_to "/images/screenshot.jpg"
+    #   redirect_to posts_url
+    #   redirect_to proc { edit_post_url(@post) }
+    #
+    # The redirection happens as a <tt>302 Found</tt> header unless otherwise specified using the <tt>:status</tt> option:
+    #
+    #   redirect_to post_url(@post), status: :found
+    #   redirect_to action: 'atom', status: :moved_permanently
+    #   redirect_to post_url(@post), status: 301
+    #   redirect_to action: 'atom', status: 302
+    #
+    # The status code can either be a standard {HTTP Status code}[https://www.iana.org/assignments/http-status-codes] as an
+    # integer, or a symbol representing the downcased, underscored and symbolized description.
+    # Note that the status code must be a 3xx HTTP code, or redirection will not occur.
+    #
+    # If you are using XHR requests other than GET or POST and redirecting after the
+    # request then some browsers will follow the redirect using the original request
+    # method. This may lead to undesirable behavior such as a double DELETE. To work
+    # around this you can return a <tt>303 See Other</tt> status code which will be
+    # followed using a GET request.
+    #
+    #   redirect_to posts_url, status: :see_other
+    #   redirect_to action: 'index', status: 303
+    #
+    # It is also possible to assign a flash message as part of the redirection. There are two special accessors for the commonly used flash names
+    # +alert+ and +notice+ as well as a general purpose +flash+ bucket.
+    #
+    #   redirect_to post_url(@post), alert: "Watch it, mister!"
+    #   redirect_to post_url(@post), status: :found, notice: "Pay attention to the road"
+    #   redirect_to post_url(@post), status: 301, flash: { updated_post_id: @post.id }
+    #   redirect_to({ action: 'atom' }, alert: "Something serious happened")
+    #
+    # Statements after +redirect_to+ in our controller get executed, so +redirect_to+ doesn't stop the execution of the function.
+    # To terminate the execution of the function immediately after the +redirect_to+, use return.
+    #   redirect_to post_url(@post) and return
+    def redirect_to: (?::Hash[untyped, untyped] options, ?::Hash[untyped, untyped] response_options) -> untyped
+
+    # Redirects the browser to the page that issued the request (the referrer)
+    # if possible, otherwise redirects to the provided default fallback
+    # location.
+    #
+    # The referrer information is pulled from the HTTP +Referer+ (sic) header on
+    # the request. This is an optional header and its presence on the request is
+    # subject to browser security settings and user preferences. If the request
+    # is missing this header, the <tt>fallback_location</tt> will be used.
+    #
+    #   redirect_back fallback_location: { action: "show", id: 5 }
+    #   redirect_back fallback_location: @post
+    #   redirect_back fallback_location: "http://www.rubyonrails.org"
+    #   redirect_back fallback_location: "/images/screenshot.jpg"
+    #   redirect_back fallback_location: posts_url
+    #   redirect_back fallback_location: proc { edit_post_url(@post) }
+    #   redirect_back fallback_location: '/', allow_other_host: false
+    #
+    # ==== Options
+    # * <tt>:fallback_location</tt> - The default fallback location that will be used on missing +Referer+ header.
+    # * <tt>:allow_other_host</tt> - Allow or disallow redirection to the host that is different to the current host, defaults to true.
+    #
+    # All other options that can be passed to <tt>redirect_to</tt> are accepted as
+    # options and the behavior is identical.
+    def redirect_back: (fallback_location: untyped fallback_location, ?allow_other_host: bool allow_other_host, **untyped args) -> untyped
+
+    def _compute_redirect_to_location: (untyped request, untyped options) -> untyped
+
+    def _extract_redirect_to_status: (untyped options, untyped response_options) -> untyped
+
+    def _url_host_allowed?: (untyped url) -> untyped
+  end
+end
+
+module ActionController
+  # See <tt>Renderers.add</tt>
+  def self.add_renderer: (untyped key) { () -> untyped } -> untyped
+
+  # See <tt>Renderers.remove</tt>
+  def self.remove_renderer: (untyped key) -> untyped
+
+  # See <tt>Responder#api_behavior</tt>
+  class MissingRenderer < LoadError
+    def initialize: (untyped format) -> untyped
+  end
+
+  module Renderers
+    extend ActiveSupport::Concern
+
+    # A Set containing renderer names that correspond to available renderer procs.
+    # Default values are <tt>:json</tt>, <tt>:js</tt>, <tt>:xml</tt>.
+    RENDERERS: untyped
+
+    # Used in <tt>ActionController::Base</tt>
+    # and <tt>ActionController::API</tt> to include all
+    # renderers by default.
+    module All
+      extend ActiveSupport::Concern
+
+      include Renderers
+    end
+
+    # Adds a new renderer to call within controller actions.
+    # A renderer is invoked by passing its name as an option to
+    # <tt>AbstractController::Rendering#render</tt>. To create a renderer
+    # pass it a name and a block. The block takes two arguments, the first
+    # is the value paired with its key and the second is the remaining
+    # hash of options passed to +render+.
+    #
+    # Create a csv renderer:
+    #
+    #   ActionController::Renderers.add :csv do |obj, options|
+    #     filename = options[:filename] || 'data'
+    #     str = obj.respond_to?(:to_csv) ? obj.to_csv : obj.to_s
+    #     send_data str, type: Mime[:csv],
+    #       disposition: "attachment; filename=#{filename}.csv"
+    #   end
+    #
+    # Note that we used Mime[:csv] for the csv mime type as it comes with Rails.
+    # For a custom renderer, you'll need to register a mime type with
+    # <tt>Mime::Type.register</tt>.
+    #
+    # To use the csv renderer in a controller action:
+    #
+    #   def show
+    #     @csvable = Csvable.find(params[:id])
+    #     respond_to do |format|
+    #       format.html
+    #       format.csv { render csv: @csvable, filename: @csvable.name }
+    #     end
+    #   end
+    def self.add: (untyped key) { () -> untyped } -> untyped
+
+    # This method is the opposite of add method.
+    #
+    # To remove a csv renderer:
+    #
+    #   ActionController::Renderers.remove(:csv)
+    def self.remove: (untyped key) -> untyped
+
+    def self._render_with_renderer_method_name: (untyped key) -> ::String
+
+    module ClassMethods
+      # Adds, by name, a renderer or renderers to the +_renderers+ available
+      # to call within controller actions.
+      #
+      # It is useful when rendering from an <tt>ActionController::Metal</tt> controller or
+      # otherwise to add an available renderer proc to a specific controller.
+      #
+      # Both <tt>ActionController::Base</tt> and <tt>ActionController::API</tt>
+      # include <tt>ActionController::Renderers::All</tt>, making all renderers
+      # available in the controller. See <tt>Renderers::RENDERERS</tt> and <tt>Renderers.add</tt>.
+      #
+      # Since <tt>ActionController::Metal</tt> controllers cannot render, the controller
+      # must include <tt>AbstractController::Rendering</tt>, <tt>ActionController::Rendering</tt>,
+      # and <tt>ActionController::Renderers</tt>, and have at least one renderer.
+      #
+      # Rather than including <tt>ActionController::Renderers::All</tt> and including all renderers,
+      # you may specify which renderers to include by passing the renderer name or names to
+      # +use_renderers+. For example, a controller that includes only the <tt>:json</tt> renderer
+      # (+_render_with_renderer_json+) might look like:
+      #
+      #   class MetalRenderingController < ActionController::Metal
+      #     include AbstractController::Rendering
+      #     include ActionController::Rendering
+      #     include ActionController::Renderers
+      #
+      #     use_renderers :json
+      #
+      #     def show
+      #       render json: record
+      #     end
+      #   end
+      #
+      # You must specify a +use_renderer+, else the +controller.renderer+ and
+      # +controller._renderers+ will be <tt>nil</tt>, and the action will fail.
+      def use_renderers: (*untyped args) -> untyped
+
+      alias use_renderer use_renderers
+    end
+
+    # Called by +render+ in <tt>AbstractController::Rendering</tt>
+    # which sets the return value as the +response_body+.
+    #
+    # If no renderer is found, +super+ returns control to
+    # <tt>ActionView::Rendering.render_to_body</tt>, if present.
+    def render_to_body: (untyped options) -> untyped
+
+    def _render_to_body_with_renderer: (untyped options) -> (untyped | nil)
+  end
+end
+
+module ActionController
+  module Rendering
+    extend ActiveSupport::Concern
+
+    RENDER_FORMATS_IN_PRIORITY: ::Array[untyped]
+
+    module ClassMethods
+      # Returns a renderer instance (inherited from ActionController::Renderer)
+      # for the controller.
+      attr_reader renderer: untyped
+
+      def setup_renderer!: () -> untyped
+
+      def inherited: (untyped klass) -> untyped
+    end
+
+    def process_action: () -> untyped
+
+    def render: (*untyped args) -> untyped
+
+    # Overwrite render_to_string because body can now be set to a Rack body.
+    def render_to_string: () -> untyped
+
+    def render_to_body: (?::Hash[untyped, untyped] options) -> untyped
+
+    def _process_variant: (untyped options) -> untyped
+
+    def _render_in_priorities: (untyped options) -> (untyped | nil)
+
+    def _set_html_content_type: () -> untyped
+
+    def _set_rendered_content_type: (untyped format) -> untyped
+
+    # Normalize arguments by catching blocks and setting them on :update.
+    def _normalize_args: (?untyped? action, ?::Hash[untyped, untyped] options) { () -> untyped } -> untyped
+
+    # Normalize both text and status options.
+    def _normalize_options: (untyped options) -> untyped
+
+    def _normalize_text: (untyped options) -> untyped
+
+    # Process controller specific options, as status, content-type and location.
+    def _process_options: (untyped options) -> untyped
+  end
+end
+
+module ActionController
+  class InvalidAuthenticityToken < ActionControllerError
+  end
+
+  class InvalidCrossOriginRequest < ActionControllerError
+  end
+
+  # Controller actions are protected from Cross-Site Request Forgery (CSRF) attacks
+  # by including a token in the rendered HTML for your application. This token is
+  # stored as a random string in the session, to which an attacker does not have
+  # access. When a request reaches your application, \Rails verifies the received
+  # token with the token in the session. All requests are checked except GET requests
+  # as these should be idempotent. Keep in mind that all session-oriented requests
+  # are CSRF protected by default, including JavaScript and HTML requests.
+  #
+  # Since HTML and JavaScript requests are typically made from the browser, we
+  # need to ensure to verify request authenticity for the web browser. We can
+  # use session-oriented authentication for these types of requests, by using
+  # the <tt>protect_from_forgery</tt> method in our controllers.
+  #
+  # GET requests are not protected since they don't have side effects like writing
+  # to the database and don't leak sensitive information. JavaScript requests are
+  # an exception: a third-party site can use a <script> tag to reference a JavaScript
+  # URL on your site. When your JavaScript response loads on their site, it executes.
+  # With carefully crafted JavaScript on their end, sensitive data in your JavaScript
+  # response may be extracted. To prevent this, only XmlHttpRequest (known as XHR or
+  # Ajax) requests are allowed to make requests for JavaScript responses.
+  #
+  # It's important to remember that XML or JSON requests are also checked by default. If
+  # you're building an API or an SPA you could change forgery protection method in
+  # <tt>ApplicationController</tt> (by default: <tt>:exception</tt>):
+  #
+  #   class ApplicationController < ActionController::Base
+  #     protect_from_forgery unless: -> { request.format.json? }
+  #   end
+  #
+  # It is generally safe to exclude XHR requests from CSRF protection
+  # (like the code snippet above does), because XHR requests can only be made from
+  # the same origin. Note however that any cross-origin third party domain
+  # allowed via {CORS}[https://en.wikipedia.org/wiki/Cross-origin_resource_sharing]
+  # will also be able to create XHR requests. Be sure to check your
+  # CORS configuration before disabling forgery protection for XHR.
+  #
+  # CSRF protection is turned on with the <tt>protect_from_forgery</tt> method.
+  # By default <tt>protect_from_forgery</tt> protects your session with
+  # <tt>:null_session</tt> method, which provides an empty session
+  # during request.
+  #
+  # We may want to disable CSRF protection for APIs since they are typically
+  # designed to be state-less. That is, the request API client will handle
+  # the session for you instead of Rails.
+  #
+  # The token parameter is named <tt>authenticity_token</tt> by default. The name and
+  # value of this token must be added to every layout that renders forms by including
+  # <tt>csrf_meta_tags</tt> in the HTML +head+.
+  #
+  # Learn more about CSRF attacks and securing your application in the
+  # {Ruby on Rails Security Guide}[https://guides.rubyonrails.org/security.html].
+  module RequestForgeryProtection
+    extend ActiveSupport::Concern
+
+    include AbstractController::Helpers
+
+    include AbstractController::Callbacks
+
+    module ClassMethods
+      # Turn on request forgery protection. Bear in mind that GET and HEAD requests are not checked.
+      #
+      #   class ApplicationController < ActionController::Base
+      #     protect_from_forgery
+      #   end
+      #
+      #   class FooController < ApplicationController
+      #     protect_from_forgery except: :index
+      #   end
+      #
+      # You can disable forgery protection on controller by skipping the verification before_action:
+      #
+      #   skip_before_action :verify_authenticity_token
+      #
+      # Valid Options:
+      #
+      # * <tt>:only/:except</tt> - Only apply forgery protection to a subset of actions. For example <tt>only: [ :create, :create_all ]</tt>.
+      # * <tt>:if/:unless</tt> - Turn off the forgery protection entirely depending on the passed Proc or method reference.
+      # * <tt>:prepend</tt> - By default, the verification of the authentication token will be added at the position of the
+      #   protect_from_forgery call in your application. This means any callbacks added before are run first. This is useful
+      #   when you want your forgery protection to depend on other callbacks, like authentication methods (Oauth vs Cookie auth).
+      #
+      #   If you need to add verification to the beginning of the callback chain, use <tt>prepend: true</tt>.
+      # * <tt>:with</tt> - Set the method to handle unverified request.
+      #
+      # Valid unverified request handling methods are:
+      # * <tt>:exception</tt> - Raises ActionController::InvalidAuthenticityToken exception.
+      # * <tt>:reset_session</tt> - Resets the session.
+      # * <tt>:null_session</tt> - Provides an empty session during request but doesn't reset it completely. Used as default if <tt>:with</tt> option is not specified.
+      def protect_from_forgery: (?::Hash[untyped, untyped] options) -> untyped
+
+      # Turn off request forgery protection. This is a wrapper for:
+      #
+      #   skip_before_action :verify_authenticity_token
+      #
+      # See +skip_before_action+ for allowed options.
+      def skip_forgery_protection: (?::Hash[untyped, untyped] options) -> untyped
+
+      def protection_method_class: (untyped name) -> untyped
+    end
+
+    module ProtectionMethods
+      class NullSession
+        def initialize: (untyped controller) -> untyped
+
+        # This is the method that defines the application behavior when a request is found to be unverified.
+        def handle_unverified_request: () -> untyped
+
+        class NullSessionHash < Rack::Session::Abstract::SessionHash
+          # nodoc:
+          def initialize: (untyped req) -> untyped
+
+          # no-op
+          def destroy: () -> nil
+
+          def exists?: () -> ::TrueClass
+        end
+
+        class NullCookieJar < ActionDispatch::Cookies::CookieJar
+          # nodoc:
+          def write: () -> nil
+        end
+      end
+
+      class ResetSession
+        def initialize: (untyped controller) -> untyped
+
+        def handle_unverified_request: () -> untyped
+      end
+
+      class Exception
+        def initialize: (untyped controller) -> untyped
+
+        def handle_unverified_request: () -> untyped
+      end
+    end
+
+    def verify_authenticity_token: () -> untyped
+
+    def handle_unverified_request: () -> untyped
+
+    # nodoc:
+    CROSS_ORIGIN_JAVASCRIPT_WARNING: ::String
+
+    def verify_same_origin_request: () -> untyped
+
+    def mark_for_same_origin_verification!: () -> untyped
+
+    def marked_for_same_origin_verification?: () -> untyped
+
+    def non_xhr_javascript_response?: () -> untyped
+
+    AUTHENTICITY_TOKEN_LENGTH: ::Integer
+
+    def verified_request?: () -> untyped
+
+    def any_authenticity_token_valid?: () -> untyped
+
+    def request_authenticity_tokens: () -> ::Array[untyped]
+
+    # Sets the token value for the current session.
+    def form_authenticity_token: (?form_options: ::Hash[untyped, untyped] form_options) -> untyped
+
+    def masked_authenticity_token: (untyped session, ?form_options: ::Hash[untyped, untyped] form_options) -> untyped
+
+    def valid_authenticity_token?: (untyped session, untyped encoded_masked_token) -> (::FalseClass | untyped)
+
+    def unmask_token: (untyped masked_token) -> untyped
+
+    def mask_token: (untyped raw_token) -> untyped
+
+    def compare_with_real_token: (untyped token, untyped session) -> untyped
+
+    def compare_with_global_token: (untyped token, untyped session) -> untyped
+
+    def valid_per_form_csrf_token?: (untyped token, untyped session) -> untyped
+
+    def real_csrf_token: (untyped session) -> untyped
+
+    def per_form_csrf_token: (untyped session, untyped action_path, untyped method) -> untyped
+
+    GLOBAL_CSRF_TOKEN_IDENTIFIER: ::String
+
+    def global_csrf_token: (untyped session) -> untyped
+
+    def csrf_token_hmac: (untyped session, untyped identifier) -> untyped
+
+    def xor_byte_strings: (untyped s1, untyped s2) -> untyped
+
+    def form_authenticity_param: () -> untyped
+
+    def protect_against_forgery?: () -> untyped
+
+    NULL_ORIGIN_MESSAGE: ::String
+
+    def valid_request_origin?: () -> untyped
+
+    def normalize_action_path: (untyped action_path) -> untyped
+  end
+end
+
+module ActionController
+  # nodoc:
+  # This module is responsible for providing +rescue_from+ helpers
+  # to controllers and configuring when detailed exceptions must be
+  # shown.
+  module Rescue
+    extend ActiveSupport::Concern
+
+    include ActiveSupport::Rescuable
+
+    # Override this method if you want to customize when detailed
+    # exceptions must be shown. This method is only called when
+    # +consider_all_requests_local+ is +false+. By default, it returns
+    # +false+, but someone may set it to <tt>request.local?</tt> so local
+    # requests in production still show the detailed exception pages.
+    def show_detailed_exceptions?: () -> ::FalseClass
+
+    def process_action: (*untyped args) -> untyped
+  end
+end
+
+module ActionController
+  # nodoc:
+  # Allows views to be streamed back to the client as they are rendered.
+  #
+  # By default, Rails renders views by first rendering the template
+  # and then the layout. The response is sent to the client after the whole
+  # template is rendered, all queries are made, and the layout is processed.
+  #
+  # Streaming inverts the rendering flow by rendering the layout first and
+  # streaming each part of the layout as they are processed. This allows the
+  # header of the HTML (which is usually in the layout) to be streamed back
+  # to client very quickly, allowing JavaScripts and stylesheets to be loaded
+  # earlier than usual.
+  #
+  # This approach was introduced in Rails 3.1 and is still improving. Several
+  # Rack middlewares may not work and you need to be careful when streaming.
+  # Those points are going to be addressed soon.
+  #
+  # In order to use streaming, you will need to use a Ruby version that
+  # supports fibers (fibers are supported since version 1.9.2 of the main
+  # Ruby implementation).
+  #
+  # Streaming can be added to a given template easily, all you need to do is
+  # to pass the :stream option.
+  #
+  #   class PostsController
+  #     def index
+  #       @posts = Post.all
+  #       render stream: true
+  #     end
+  #   end
+  #
+  # == When to use streaming
+  #
+  # Streaming may be considered to be overkill for lightweight actions like
+  # +new+ or +edit+. The real benefit of streaming is on expensive actions
+  # that, for example, do a lot of queries on the database.
+  #
+  # In such actions, you want to delay queries execution as much as you can.
+  # For example, imagine the following +dashboard+ action:
+  #
+  #   def dashboard
+  #     @posts = Post.all
+  #     @pages = Page.all
+  #     @articles = Article.all
+  #   end
+  #
+  # Most of the queries here are happening in the controller. In order to benefit
+  # from streaming you would want to rewrite it as:
+  #
+  #   def dashboard
+  #     # Allow lazy execution of the queries
+  #     @posts = Post.all
+  #     @pages = Page.all
+  #     @articles = Article.all
+  #     render stream: true
+  #   end
+  #
+  # Notice that :stream only works with templates. Rendering :json
+  # or :xml with :stream won't work.
+  #
+  # == Communication between layout and template
+  #
+  # When streaming, rendering happens top-down instead of inside-out.
+  # Rails starts with the layout, and the template is rendered later,
+  # when its +yield+ is reached.
+  #
+  # This means that, if your application currently relies on instance
+  # variables set in the template to be used in the layout, they won't
+  # work once you move to streaming. The proper way to communicate
+  # between layout and template, regardless of whether you use streaming
+  # or not, is by using +content_for+, +provide+ and +yield+.
+  #
+  # Take a simple example where the layout expects the template to tell
+  # which title to use:
+  #
+  #   <html>
+  #     <head><title><%= yield :title %></title></head>
+  #     <body><%= yield %></body>
+  #   </html>
+  #
+  # You would use +content_for+ in your template to specify the title:
+  #
+  #   <%= content_for :title, "Main" %>
+  #   Hello
+  #
+  # And the final result would be:
+  #
+  #   <html>
+  #     <head><title>Main</title></head>
+  #     <body>Hello</body>
+  #   </html>
+  #
+  # However, if +content_for+ is called several times, the final result
+  # would have all calls concatenated. For instance, if we have the following
+  # template:
+  #
+  #   <%= content_for :title, "Main" %>
+  #   Hello
+  #   <%= content_for :title, " page" %>
+  #
+  # The final result would be:
+  #
+  #   <html>
+  #     <head><title>Main page</title></head>
+  #     <body>Hello</body>
+  #   </html>
+  #
+  # This means that, if you have <code>yield :title</code> in your layout
+  # and you want to use streaming, you would have to render the whole template
+  # (and eventually trigger all queries) before streaming the title and all
+  # assets, which kills the purpose of streaming. For this purpose, you can use
+  # a helper called +provide+ that does the same as +content_for+ but tells the
+  # layout to stop searching for other entries and continue rendering.
+  #
+  # For instance, the template above using +provide+ would be:
+  #
+  #   <%= provide :title, "Main" %>
+  #   Hello
+  #   <%= content_for :title, " page" %>
+  #
+  # Giving:
+  #
+  #   <html>
+  #     <head><title>Main</title></head>
+  #     <body>Hello</body>
+  #   </html>
+  #
+  # That said, when streaming, you need to properly check your templates
+  # and choose when to use +provide+ and +content_for+.
+  #
+  # == Headers, cookies, session and flash
+  #
+  # When streaming, the HTTP headers are sent to the client right before
+  # it renders the first line. This means that, modifying headers, cookies,
+  # session or flash after the template starts rendering will not propagate
+  # to the client.
+  #
+  # == Middlewares
+  #
+  # Middlewares that need to manipulate the body won't work with streaming.
+  # You should disable those middlewares whenever streaming in development
+  # or production. For instance, <tt>Rack::Bug</tt> won't work when streaming as it
+  # needs to inject contents in the HTML body.
+  #
+  # Also <tt>Rack::Cache</tt> won't work with streaming as it does not support
+  # streaming bodies yet. Whenever streaming Cache-Control is automatically
+  # set to "no-cache".
+  #
+  # == Errors
+  #
+  # When it comes to streaming, exceptions get a bit more complicated. This
+  # happens because part of the template was already rendered and streamed to
+  # the client, making it impossible to render a whole exception page.
+  #
+  # Currently, when an exception happens in development or production, Rails
+  # will automatically stream to the client:
+  #
+  #   "><script>window.location = "/500.html"</script></html>
+  #
+  # The first two characters (">) are required in case the exception happens
+  # while rendering attributes for a given tag. You can check the real cause
+  # for the exception in your logger.
+  #
+  # == Web server support
+  #
+  # Not all web servers support streaming out-of-the-box. You need to check
+  # the instructions for each of them.
+  #
+  # ==== Unicorn
+  #
+  # Unicorn supports streaming but it needs to be configured. For this, you
+  # need to create a config file as follow:
+  #
+  #   # unicorn.config.rb
+  #   listen 3000, tcp_nopush: false
+  #
+  # And use it on initialization:
+  #
+  #   unicorn_rails --config-file unicorn.config.rb
+  #
+  # You may also want to configure other parameters like <tt>:tcp_nodelay</tt>.
+  # Please check its documentation for more information: https://bogomips.org/unicorn/Unicorn/Configurator.html#method-i-listen
+  #
+  # If you are using Unicorn with NGINX, you may need to tweak NGINX.
+  # Streaming should work out of the box on Rainbows.
+  #
+  # ==== Passenger
+  #
+  # To be described.
+  #
+  module Streaming
+    extend ActiveSupport::Concern
+
+    # Set proper cache control and transfer encoding when streaming
+    def _process_options: (untyped options) -> untyped
+
+    # Call render_body if we are streaming instead of usual +render+.
+    def _render_template: (untyped options) -> untyped
+  end
+end
+
+module ActionController
+  # Raised when a required parameter is missing.
+  #
+  #   params = ActionController::Parameters.new(a: {})
+  #   params.fetch(:b)
+  #   # => ActionController::ParameterMissing: param is missing or the value is empty: b
+  #   params.require(:a)
+  #   # => ActionController::ParameterMissing: param is missing or the value is empty: a
+  class ParameterMissing[T, U] < KeyError[T, U]
+    attr_reader param: untyped
+
+    def initialize: (untyped param) -> untyped
+  end
+
+  # Raised when a supplied parameter is not expected and
+  # ActionController::Parameters.action_on_unpermitted_parameters
+  # is set to <tt>:raise</tt>.
+  #
+  #   params = ActionController::Parameters.new(a: "123", b: "456")
+  #   params.permit(:c)
+  #   # => ActionController::UnpermittedParameters: found unpermitted parameters: :a, :b
+  class UnpermittedParameters < IndexError
+    attr_reader params: untyped
+
+    def initialize: (untyped params) -> untyped
+  end
+
+  # Raised when a Parameters instance is not marked as permitted and
+  # an operation to transform it to hash is called.
+  #
+  #   params = ActionController::Parameters.new(a: "123", b: "456")
+  #   params.to_h
+  #   # => ActionController::UnfilteredParameters: unable to convert unpermitted parameters to hash
+  class UnfilteredParameters < ArgumentError
+    def initialize: () -> untyped
+  end
+
+  # == Action Controller \Parameters
+  #
+  # Allows you to choose which attributes should be permitted for mass updating
+  # and thus prevent accidentally exposing that which shouldn't be exposed.
+  # Provides two methods for this purpose: #require and #permit. The former is
+  # used to mark parameters as required. The latter is used to set the parameter
+  # as permitted and limit which attributes should be allowed for mass updating.
+  #
+  #   params = ActionController::Parameters.new({
+  #     person: {
+  #       name: "Francesco",
+  #       age:  22,
+  #       role: "admin"
+  #     }
+  #   })
+  #
+  #   permitted = params.require(:person).permit(:name, :age)
+  #   permitted            # => <ActionController::Parameters {"name"=>"Francesco", "age"=>22} permitted: true>
+  #   permitted.permitted? # => true
+  #
+  #   Person.first.update!(permitted)
+  #   # => #<Person id: 1, name: "Francesco", age: 22, role: "user">
+  #
+  # It provides two options that controls the top-level behavior of new instances:
+  #
+  # * +permit_all_parameters+ - If it's +true+, all the parameters will be
+  #   permitted by default. The default is +false+.
+  # * +action_on_unpermitted_parameters+ - Allow to control the behavior when parameters
+  #   that are not explicitly permitted are found. The values can be +false+ to just filter them
+  #   out, <tt>:log</tt> to additionally write a message on the logger, or <tt>:raise</tt> to raise
+  #   ActionController::UnpermittedParameters exception. The default value is <tt>:log</tt>
+  #   in test and development environments, +false+ otherwise.
+  #
+  # Examples:
+  #
+  #   params = ActionController::Parameters.new
+  #   params.permitted? # => false
+  #
+  #   ActionController::Parameters.permit_all_parameters = true
+  #
+  #   params = ActionController::Parameters.new
+  #   params.permitted? # => true
+  #
+  #   params = ActionController::Parameters.new(a: "123", b: "456")
+  #   params.permit(:c)
+  #   # => <ActionController::Parameters {} permitted: true>
+  #
+  #   ActionController::Parameters.action_on_unpermitted_parameters = :raise
+  #
+  #   params = ActionController::Parameters.new(a: "123", b: "456")
+  #   params.permit(:c)
+  #   # => ActionController::UnpermittedParameters: found unpermitted keys: a, b
+  #
+  # Please note that these options *are not thread-safe*. In a multi-threaded
+  # environment they should only be set once at boot-time and never mutated at
+  # runtime.
+  #
+  # You can fetch values of <tt>ActionController::Parameters</tt> using either
+  # <tt>:key</tt> or <tt>"key"</tt>.
+  #
+  #   params = ActionController::Parameters.new(key: "value")
+  #   params[:key]  # => "value"
+  #   params["key"] # => "value"
+  class Parameters
+    # Returns a new instance of <tt>ActionController::Parameters</tt>.
+    # Also, sets the +permitted+ attribute to the default value of
+    # <tt>ActionController::Parameters.permit_all_parameters</tt>.
+    #
+    #   class Person < ActiveRecord::Base
+    #   end
+    #
+    #   params = ActionController::Parameters.new(name: "Francesco")
+    #   params.permitted?  # => false
+    #   Person.new(params) # => ActiveModel::ForbiddenAttributesError
+    #
+    #   ActionController::Parameters.permit_all_parameters = true
+    #
+    #   params = ActionController::Parameters.new(name: "Francesco")
+    #   params.permitted?  # => true
+    #   Person.new(params) # => #<Person id: nil, name: "Francesco">
+    def initialize: (?::Hash[untyped, untyped] parameters) -> untyped
+
+    # Returns true if another +Parameters+ object contains the same content and
+    # permitted flag.
+    def ==: (untyped other) -> untyped
+
+    # Returns a safe <tt>ActiveSupport::HashWithIndifferentAccess</tt>
+    # representation of the parameters with all unpermitted keys removed.
+    #
+    #   params = ActionController::Parameters.new({
+    #     name: "Senjougahara Hitagi",
+    #     oddity: "Heavy stone crab"
+    #   })
+    #   params.to_h
+    #   # => ActionController::UnfilteredParameters: unable to convert unpermitted parameters to hash
+    #
+    #   safe_params = params.permit(:name)
+    #   safe_params.to_h # => {"name"=>"Senjougahara Hitagi"}
+    def to_h: () -> untyped
+
+    # Returns a safe <tt>Hash</tt> representation of the parameters
+    # with all unpermitted keys removed.
+    #
+    #   params = ActionController::Parameters.new({
+    #     name: "Senjougahara Hitagi",
+    #     oddity: "Heavy stone crab"
+    #   })
+    #   params.to_hash
+    #   # => ActionController::UnfilteredParameters: unable to convert unpermitted parameters to hash
+    #
+    #   safe_params = params.permit(:name)
+    #   safe_params.to_hash # => {"name"=>"Senjougahara Hitagi"}
+    def to_hash: () -> untyped
+
+    # Returns a string representation of the receiver suitable for use as a URL
+    # query string:
+    #
+    #   params = ActionController::Parameters.new({
+    #     name: "David",
+    #     nationality: "Danish"
+    #   })
+    #   params.to_query
+    #   # => ActionController::UnfilteredParameters: unable to convert unpermitted parameters to hash
+    #
+    #   safe_params = params.permit(:name, :nationality)
+    #   safe_params.to_query
+    #   # => "name=David&nationality=Danish"
+    #
+    # An optional namespace can be passed to enclose key names:
+    #
+    #   params = ActionController::Parameters.new({
+    #     name: "David",
+    #     nationality: "Danish"
+    #   })
+    #   safe_params = params.permit(:name, :nationality)
+    #   safe_params.to_query("user")
+    #   # => "user%5Bname%5D=David&user%5Bnationality%5D=Danish"
+    #
+    # The string pairs "key=value" that conform the query string
+    # are sorted lexicographically in ascending order.
+    #
+    # This method is also aliased as +to_param+.
+    def to_query: (*untyped args) -> untyped
+
+    alias to_param to_query
+
+    # Returns an unsafe, unfiltered
+    # <tt>ActiveSupport::HashWithIndifferentAccess</tt> representation of the
+    # parameters.
+    #
+    #   params = ActionController::Parameters.new({
+    #     name: "Senjougahara Hitagi",
+    #     oddity: "Heavy stone crab"
+    #   })
+    #   params.to_unsafe_h
+    #   # => {"name"=>"Senjougahara Hitagi", "oddity" => "Heavy stone crab"}
+    def to_unsafe_h: () -> untyped
+
+    alias to_unsafe_hash to_unsafe_h
+
+    # Convert all hashes in values into parameters, then yield each pair in
+    # the same way as <tt>Hash#each_pair</tt>.
+    def each_pair: () { (untyped) -> untyped } -> untyped
+
+    alias each each_pair
+
+    # Convert all hashes in values into parameters, then yield each value in
+    # the same way as <tt>Hash#each_value</tt>.
+    def each_value: () { (untyped) -> untyped } -> untyped
+
+    # Attribute that keeps track of converted arrays, if any, to avoid double
+    # looping in the common use case permit + mass-assignment. Defined in a
+    # method to instantiate it only if needed.
+    #
+    # Testing membership still loops, but it's going to be faster than our own
+    # loop that converts values. Also, we are not going to build a new array
+    # object per fetch.
+    def converted_arrays: () -> untyped
+
+    # Returns +true+ if the parameter is permitted, +false+ otherwise.
+    #
+    #   params = ActionController::Parameters.new
+    #   params.permitted? # => false
+    #   params.permit!
+    #   params.permitted? # => true
+    def permitted?: () -> untyped
+
+    # Sets the +permitted+ attribute to +true+. This can be used to pass
+    # mass assignment. Returns +self+.
+    #
+    #   class Person < ActiveRecord::Base
+    #   end
+    #
+    #   params = ActionController::Parameters.new(name: "Francesco")
+    #   params.permitted?  # => false
+    #   Person.new(params) # => ActiveModel::ForbiddenAttributesError
+    #   params.permit!
+    #   params.permitted?  # => true
+    #   Person.new(params) # => #<Person id: nil, name: "Francesco">
+    def permit!: () -> untyped
+
+    # This method accepts both a single key and an array of keys.
+    #
+    # When passed a single key, if it exists and its associated value is
+    # either present or the singleton +false+, returns said value:
+    #
+    #   ActionController::Parameters.new(person: { name: "Francesco" }).require(:person)
+    #   # => <ActionController::Parameters {"name"=>"Francesco"} permitted: false>
+    #
+    # Otherwise raises <tt>ActionController::ParameterMissing</tt>:
+    #
+    #   ActionController::Parameters.new.require(:person)
+    #   # ActionController::ParameterMissing: param is missing or the value is empty: person
+    #
+    #   ActionController::Parameters.new(person: nil).require(:person)
+    #   # ActionController::ParameterMissing: param is missing or the value is empty: person
+    #
+    #   ActionController::Parameters.new(person: "\t").require(:person)
+    #   # ActionController::ParameterMissing: param is missing or the value is empty: person
+    #
+    #   ActionController::Parameters.new(person: {}).require(:person)
+    #   # ActionController::ParameterMissing: param is missing or the value is empty: person
+    #
+    # When given an array of keys, the method tries to require each one of them
+    # in order. If it succeeds, an array with the respective return values is
+    # returned:
+    #
+    #   params = ActionController::Parameters.new(user: { ... }, profile: { ... })
+    #   user_params, profile_params = params.require([:user, :profile])
+    #
+    # Otherwise, the method re-raises the first exception found:
+    #
+    #   params = ActionController::Parameters.new(user: {}, profile: {})
+    #   user_params, profile_params = params.require([:user, :profile])
+    #   # ActionController::ParameterMissing: param is missing or the value is empty: user
+    #
+    # Technically this method can be used to fetch terminal values:
+    #
+    #   # CAREFUL
+    #   params = ActionController::Parameters.new(person: { name: "Finn" })
+    #   name = params.require(:person).require(:name) # CAREFUL
+    #
+    # but take into account that at some point those ones have to be permitted:
+    #
+    #   def person_params
+    #     params.require(:person).permit(:name).tap do |person_params|
+    #       person_params.require(:name) # SAFER
+    #     end
+    #   end
+    #
+    # for example.
+    def require: (untyped key) -> untyped
+
+    # Alias of #require.
+    alias required require
+
+    # Returns a new <tt>ActionController::Parameters</tt> instance that
+    # includes only the given +filters+ and sets the +permitted+ attribute
+    # for the object to +true+. This is useful for limiting which attributes
+    # should be allowed for mass updating.
+    #
+    #   params = ActionController::Parameters.new(user: { name: "Francesco", age: 22, role: "admin" })
+    #   permitted = params.require(:user).permit(:name, :age)
+    #   permitted.permitted?      # => true
+    #   permitted.has_key?(:name) # => true
+    #   permitted.has_key?(:age)  # => true
+    #   permitted.has_key?(:role) # => false
+    #
+    # Only permitted scalars pass the filter. For example, given
+    #
+    #   params.permit(:name)
+    #
+    # +:name+ passes if it is a key of +params+ whose associated value is of type
+    # +String+, +Symbol+, +NilClass+, +Numeric+, +TrueClass+, +FalseClass+,
+    # +Date+, +Time+, +DateTime+, +StringIO+, +IO+,
+    # +ActionDispatch::Http::UploadedFile+ or +Rack::Test::UploadedFile+.
+    # Otherwise, the key +:name+ is filtered out.
+    #
+    # You may declare that the parameter should be an array of permitted scalars
+    # by mapping it to an empty array:
+    #
+    #   params = ActionController::Parameters.new(tags: ["rails", "parameters"])
+    #   params.permit(tags: [])
+    #
+    # Sometimes it is not possible or convenient to declare the valid keys of
+    # a hash parameter or its internal structure. Just map to an empty hash:
+    #
+    #   params.permit(preferences: {})
+    #
+    # Be careful because this opens the door to arbitrary input. In this
+    # case, +permit+ ensures values in the returned structure are permitted
+    # scalars and filters out anything else.
+    #
+    # You can also use +permit+ on nested parameters, like:
+    #
+    #   params = ActionController::Parameters.new({
+    #     person: {
+    #       name: "Francesco",
+    #       age:  22,
+    #       pets: [{
+    #         name: "Purplish",
+    #         category: "dogs"
+    #       }]
+    #     }
+    #   })
+    #
+    #   permitted = params.permit(person: [ :name, { pets: :name } ])
+    #   permitted.permitted?                    # => true
+    #   permitted[:person][:name]               # => "Francesco"
+    #   permitted[:person][:age]                # => nil
+    #   permitted[:person][:pets][0][:name]     # => "Purplish"
+    #   permitted[:person][:pets][0][:category] # => nil
+    #
+    # Note that if you use +permit+ in a key that points to a hash,
+    # it won't allow all the hash. You also need to specify which
+    # attributes inside the hash should be permitted.
+    #
+    #   params = ActionController::Parameters.new({
+    #     person: {
+    #       contact: {
+    #         email: "none@test.com",
+    #         phone: "555-1234"
+    #       }
+    #     }
+    #   })
+    #
+    #   params.require(:person).permit(:contact)
+    #   # => <ActionController::Parameters {} permitted: true>
+    #
+    #   params.require(:person).permit(contact: :phone)
+    #   # => <ActionController::Parameters {"contact"=><ActionController::Parameters {"phone"=>"555-1234"} permitted: true>} permitted: true>
+    #
+    #   params.require(:person).permit(contact: [ :email, :phone ])
+    #   # => <ActionController::Parameters {"contact"=><ActionController::Parameters {"email"=>"none@test.com", "phone"=>"555-1234"} permitted: true>} permitted: true>
+    def permit: (*untyped filters) -> untyped
+
+    # Returns a parameter for the given +key+. If not found,
+    # returns +nil+.
+    #
+    #   params = ActionController::Parameters.new(person: { name: "Francesco" })
+    #   params[:person] # => <ActionController::Parameters {"name"=>"Francesco"} permitted: false>
+    #   params[:none]   # => nil
+    def []: (untyped key) -> untyped
+
+    # Assigns a value to a given +key+. The given key may still get filtered out
+    # when +permit+ is called.
+    def []=: (untyped key, untyped value) -> untyped
+
+    # Returns a parameter for the given +key+. If the +key+
+    # can't be found, there are several options: With no other arguments,
+    # it will raise an <tt>ActionController::ParameterMissing</tt> error;
+    # if a second argument is given, then that is returned (converted to an
+    # instance of ActionController::Parameters if possible); if a block
+    # is given, then that will be run and its result returned.
+    #
+    #   params = ActionController::Parameters.new(person: { name: "Francesco" })
+    #   params.fetch(:person)               # => <ActionController::Parameters {"name"=>"Francesco"} permitted: false>
+    #   params.fetch(:none)                 # => ActionController::ParameterMissing: param is missing or the value is empty: none
+    #   params.fetch(:none, {})             # => <ActionController::Parameters {} permitted: false>
+    #   params.fetch(:none, "Francesco")    # => "Francesco"
+    #   params.fetch(:none) { "Francesco" } # => "Francesco"
+    def fetch: (untyped key, *untyped args) { () -> untyped } -> untyped
+
+    # Extracts the nested parameter from the given +keys+ by calling +dig+
+    # at each step. Returns +nil+ if any intermediate step is +nil+.
+    #
+    #   params = ActionController::Parameters.new(foo: { bar: { baz: 1 } })
+    #   params.dig(:foo, :bar, :baz) # => 1
+    #   params.dig(:foo, :zot, :xyz) # => nil
+    #
+    #   params2 = ActionController::Parameters.new(foo: [10, 11, 12])
+    #   params2.dig(:foo, 1) # => 11
+    def dig: (*untyped keys) -> untyped
+
+    # Returns a new <tt>ActionController::Parameters</tt> instance that
+    # includes only the given +keys+. If the given +keys+
+    # don't exist, returns an empty hash.
+    #
+    #   params = ActionController::Parameters.new(a: 1, b: 2, c: 3)
+    #   params.slice(:a, :b) # => <ActionController::Parameters {"a"=>1, "b"=>2} permitted: false>
+    #   params.slice(:d)     # => <ActionController::Parameters {} permitted: false>
+    def slice: (*untyped keys) -> untyped
+
+    # Returns current <tt>ActionController::Parameters</tt> instance which
+    # contains only the given +keys+.
+    def slice!: (*untyped keys) -> untyped
+
+    # Returns a new <tt>ActionController::Parameters</tt> instance that
+    # filters out the given +keys+.
+    #
+    #   params = ActionController::Parameters.new(a: 1, b: 2, c: 3)
+    #   params.except(:a, :b) # => <ActionController::Parameters {"c"=>3} permitted: false>
+    #   params.except(:d)     # => <ActionController::Parameters {"a"=>1, "b"=>2, "c"=>3} permitted: false>
+    def except: (*untyped keys) -> untyped
+
+    # Removes and returns the key/value pairs matching the given keys.
+    #
+    #   params = ActionController::Parameters.new(a: 1, b: 2, c: 3)
+    #   params.extract!(:a, :b) # => <ActionController::Parameters {"a"=>1, "b"=>2} permitted: false>
+    #   params                  # => <ActionController::Parameters {"c"=>3} permitted: false>
+    def extract!: (*untyped keys) -> untyped
+
+    # Returns a new <tt>ActionController::Parameters</tt> with the results of
+    # running +block+ once for every value. The keys are unchanged.
+    #
+    #   params = ActionController::Parameters.new(a: 1, b: 2, c: 3)
+    #   params.transform_values { |x| x * 2 }
+    #   # => <ActionController::Parameters {"a"=>2, "b"=>4, "c"=>6} permitted: false>
+    def transform_values: () { (untyped) -> untyped } -> untyped
+
+    # Performs values transformation and returns the altered
+    # <tt>ActionController::Parameters</tt> instance.
+    def transform_values!: () { (untyped) -> untyped } -> untyped
+
+    # Returns a new <tt>ActionController::Parameters</tt> instance with the
+    # results of running +block+ once for every key. The values are unchanged.
+    def transform_keys: () { () -> untyped } -> untyped
+
+    # Performs keys transformation and returns the altered
+    # <tt>ActionController::Parameters</tt> instance.
+    def transform_keys!: () { () -> untyped } -> untyped
+
+    # Deletes a key-value pair from +Parameters+ and returns the value. If
+    # +key+ is not found, returns +nil+ (or, with optional code block, yields
+    # +key+ and returns the result). Cf. +#extract!+, which returns the
+    # corresponding +ActionController::Parameters+ object.
+    def delete: (untyped key) { () -> untyped } -> untyped
+
+    # Returns a new instance of <tt>ActionController::Parameters</tt> with only
+    # items that the block evaluates to true.
+    def select: () { () -> untyped } -> untyped
+
+    # Equivalent to Hash#keep_if, but returns +nil+ if no changes were made.
+    def select!: () { () -> untyped } -> untyped
+
+    alias keep_if select!
+
+    # Returns a new instance of <tt>ActionController::Parameters</tt> with items
+    # that the block evaluates to true removed.
+    def reject: () { () -> untyped } -> untyped
+
+    # Removes items that the block evaluates to true and returns self.
+    def reject!: () { () -> untyped } -> untyped
+
+    alias delete_if reject!
+
+    # Returns values that were assigned to the given +keys+. Note that all the
+    # +Hash+ objects will be converted to <tt>ActionController::Parameters</tt>.
+    def values_at: (*untyped keys) -> untyped
+
+    # Returns a new <tt>ActionController::Parameters</tt> with all keys from
+    # +other_hash+ merged into current hash.
+    def merge: (untyped other_hash) -> untyped
+
+    # Returns current <tt>ActionController::Parameters</tt> instance with
+    # +other_hash+ merged into current hash.
+    def merge!: (untyped other_hash) -> untyped
+
+    # Returns a new <tt>ActionController::Parameters</tt> with all keys from
+    # current hash merged into +other_hash+.
+    def reverse_merge: (untyped other_hash) -> untyped
+
+    alias with_defaults reverse_merge
+
+    # Returns current <tt>ActionController::Parameters</tt> instance with
+    # current hash merged into +other_hash+.
+    def reverse_merge!: (untyped other_hash) -> untyped
+
+    alias with_defaults! reverse_merge!
+
+    def stringify_keys: () -> untyped
+
+    def inspect: () -> ::String
+
+    def self.hook_into_yaml_loading: () -> untyped
+
+    def init_with: (untyped coder) -> untyped
+
+    # Returns duplicate of object including all parameters.
+    def deep_dup: () -> untyped
+
+    attr_reader parameters: untyped
+
+    attr_writer permitted: untyped
+
+    def fields_for_style?: () -> untyped
+
+    def new_instance_with_inherited_permitted_status: (untyped hash) -> untyped
+
+    def convert_parameters_to_hashes: (untyped value, untyped using) -> untyped
+
+    def convert_hashes_to_parameters: (untyped key, untyped value) -> untyped
+
+    def convert_value_to_parameters: (untyped value) -> untyped
+
+    def each_element: (untyped object) { (untyped) -> untyped } -> untyped
+
+    def unpermitted_parameters!: (untyped params) -> untyped
+
+    def unpermitted_keys: (untyped params) -> untyped
+
+    # This is a white list of permitted scalar types that includes the ones
+    # supported in XML and JSON requests.
+    #
+    # This list is in particular used to filter ordinary requests, String goes
+    # as first element to quickly short-circuit the common case.
+    #
+    # If you modify this collection please update the API of +permit+ above.
+    PERMITTED_SCALAR_TYPES: ::Array[untyped]
+
+    def permitted_scalar?: (untyped value) -> untyped
+
+    # Adds existing keys to the params if their values are scalar.
+    #
+    # For example:
+    #
+    #   puts self.keys #=> ["zipcode(90210i)"]
+    #   params = {}
+    #
+    #   permitted_scalar_filter(params, "zipcode")
+    #
+    #   puts params.keys # => ["zipcode"]
+    def permitted_scalar_filter: (untyped params, untyped permitted_key) -> untyped
+
+    def array_of_permitted_scalars?: (untyped value) { (untyped) -> untyped } -> untyped
+
+    def non_scalar?: (untyped value) -> untyped
+
+    EMPTY_ARRAY: untyped
+
+    EMPTY_HASH: ::Hash[untyped, untyped]
+
+    def hash_filter: (untyped params, untyped filter) -> untyped
+
+    def permit_any_in_parameters: (untyped params) -> untyped
+
+    def permit_any_in_array: (untyped array) -> untyped
+
+    def initialize_copy: (untyped source) -> untyped
+  end
+
+  # == Strong \Parameters
+  #
+  # It provides an interface for protecting attributes from end-user
+  # assignment. This makes Action Controller parameters forbidden
+  # to be used in Active Model mass assignment until they have been explicitly
+  # enumerated.
+  #
+  # In addition, parameters can be marked as required and flow through a
+  # predefined raise/rescue flow to end up as a <tt>400 Bad Request</tt> with no
+  # effort.
+  #
+  #   class PeopleController < ActionController::Base
+  #     # Using "Person.create(params[:person])" would raise an
+  #     # ActiveModel::ForbiddenAttributesError exception because it'd
+  #     # be using mass assignment without an explicit permit step.
+  #     # This is the recommended form:
+  #     def create
+  #       Person.create(person_params)
+  #     end
+  #
+  #     # This will pass with flying colors as long as there's a person key in the
+  #     # parameters, otherwise it'll raise an ActionController::ParameterMissing
+  #     # exception, which will get caught by ActionController::Base and turned
+  #     # into a 400 Bad Request reply.
+  #     def update
+  #       redirect_to current_account.people.find(params[:id]).tap { |person|
+  #         person.update!(person_params)
+  #       }
+  #     end
+  #
+  #     private
+  #       # Using a private method to encapsulate the permissible parameters is
+  #       # a good pattern since you'll be able to reuse the same permit
+  #       # list between create and update. Also, you can specialize this method
+  #       # with per-user checking of permissible attributes.
+  #       def person_params
+  #         params.require(:person).permit(:name, :age)
+  #       end
+  #   end
+  #
+  # In order to use <tt>accepts_nested_attributes_for</tt> with Strong \Parameters, you
+  # will need to specify which nested attributes should be permitted. You might want
+  # to allow +:id+ and +:_destroy+, see ActiveRecord::NestedAttributes for more information.
+  #
+  #   class Person
+  #     has_many :pets
+  #     accepts_nested_attributes_for :pets
+  #   end
+  #
+  #   class PeopleController < ActionController::Base
+  #     def create
+  #       Person.create(person_params)
+  #     end
+  #
+  #     ...
+  #
+  #     private
+  #
+  #       def person_params
+  #         # It's mandatory to specify the nested attributes that should be permitted.
+  #         # If you use `permit` with just the key that points to the nested attributes hash,
+  #         # it will return an empty hash.
+  #         params.require(:person).permit(:name, :age, pets_attributes: [ :id, :name, :category ])
+  #       end
+  #   end
+  #
+  # See ActionController::Parameters.require and ActionController::Parameters.permit
+  # for more information.
+  module StrongParameters
+    # Returns a new ActionController::Parameters object that
+    # has been instantiated with the <tt>request.parameters</tt>.
+    def params: () -> untyped
+
+    # Assigns the given +value+ to the +params+ hash. If +value+
+    # is a Hash, this will create an ActionController::Parameters
+    # object that has been instantiated with the given +value+ hash.
+    def params=: (untyped value) -> untyped
+  end
+end
+
+module ActionController
+  module Testing
+    extend ActiveSupport::Concern
+
+    module Functional
+      # Behavior specific to functional tests
+      # :nodoc:
+      def recycle!: () -> untyped
+    end
+  end
+end
+
+module ActionController
+  # Includes +url_for+ into the host class. The class has to provide a +RouteSet+ by implementing
+  # the <tt>_routes</tt> method. Otherwise, an exception will be raised.
+  #
+  # In addition to <tt>AbstractController::UrlFor</tt>, this module accesses the HTTP layer to define
+  # URL options like the +host+. In order to do so, this module requires the host class
+  # to implement +env+ which needs to be Rack-compatible and +request+
+  # which is either an instance of +ActionDispatch::Request+ or an object
+  # that responds to the +host+, +optional_port+, +protocol+ and
+  # +symbolized_path_parameter+ methods.
+  #
+  #   class RootUrl
+  #     include ActionController::UrlFor
+  #     include Rails.application.routes.url_helpers
+  #
+  #     delegate :env, :request, to: :controller
+  #
+  #     def initialize(controller)
+  #       @controller = controller
+  #       @url        = root_path # named route from the application.
+  #     end
+  #   end
+  module UrlFor
+    extend ActiveSupport::Concern
+
+    include AbstractController::UrlFor
+
+    def url_options: () -> untyped
+  end
+end
+
+module ActionController
+  class MiddlewareStack < ActionDispatch::MiddlewareStack
+    class Middleware < ActionDispatch::MiddlewareStack::Middleware
+      # Extend ActionDispatch middleware stack to make it aware of options
+      # allowing the following syntax in controllers:
+      #
+      #   class PostsController < ApplicationController
+      #     use AuthenticationMiddleware, except: [:index, :show]
+      #   end
+      #
+      # nodoc:
+      # nodoc:
+      def initialize: (untyped klass, untyped args, untyped actions, untyped strategy, untyped block) -> untyped
+
+      def valid?: (untyped action) -> untyped
+    end
+
+    def build: (untyped action, ?untyped? app) { () -> untyped } -> untyped
+
+    INCLUDE: untyped
+
+    EXCLUDE: untyped
+
+    NULL: untyped
+
+    def build_middleware: (untyped klass, untyped args, untyped block) -> Middleware
+  end
+
+  # <tt>ActionController::Metal</tt> is the simplest possible controller, providing a
+  # valid Rack interface without the additional niceties provided by
+  # <tt>ActionController::Base</tt>.
+  #
+  # A sample metal controller might look like this:
+  #
+  #   class HelloController < ActionController::Metal
+  #     def index
+  #       self.response_body = "Hello World!"
+  #     end
+  #   end
+  #
+  # And then to route requests to your metal controller, you would add
+  # something like this to <tt>config/routes.rb</tt>:
+  #
+  #   get 'hello', to: HelloController.action(:index)
+  #
+  # The +action+ method returns a valid Rack application for the \Rails
+  # router to dispatch to.
+  #
+  # == Rendering Helpers
+  #
+  # <tt>ActionController::Metal</tt> by default provides no utilities for rendering
+  # views, partials, or other responses aside from explicitly calling of
+  # <tt>response_body=</tt>, <tt>content_type=</tt>, and <tt>status=</tt>. To
+  # add the render helpers you're used to having in a normal controller, you
+  # can do the following:
+  #
+  #   class HelloController < ActionController::Metal
+  #     include AbstractController::Rendering
+  #     include ActionView::Layouts
+  #     append_view_path "#{Rails.root}/app/views"
+  #
+  #     def index
+  #       render "hello/index"
+  #     end
+  #   end
+  #
+  # == Redirection Helpers
+  #
+  # To add redirection helpers to your metal controller, do the following:
+  #
+  #   class HelloController < ActionController::Metal
+  #     include ActionController::Redirecting
+  #     include Rails.application.routes.url_helpers
+  #
+  #     def index
+  #       redirect_to root_url
+  #     end
+  #   end
+  #
+  # == Other Helpers
+  #
+  # You can refer to the modules included in <tt>ActionController::Base</tt> to see
+  # other features you can bring into your metal controller.
+  #
+  class Metal < AbstractController::Base
+    # Returns the last part of the controller's name, underscored, without the ending
+    # <tt>Controller</tt>. For instance, PostsController returns <tt>posts</tt>.
+    # Namespaces are left out, so Admin::PostsController returns <tt>posts</tt> as well.
+    #
+    # ==== Returns
+    # * <tt>string</tt>
+    def self.controller_name: () -> untyped
+
+    def self.make_response!: (untyped request) -> untyped
+
+    def self.binary_params_for?: (untyped action) -> ::FalseClass
+
+    # Delegates to the class' <tt>controller_name</tt>.
+    def controller_name: () -> untyped
+
+    def initialize: () -> untyped
+
+    def params: () -> untyped
+
+    def params=: (untyped val) -> untyped
+
+    alias response_code status
+
+    # Basic url_for that can be overridden for more robust functionality.
+    def url_for: (untyped string) -> untyped
+
+    def response_body=: (untyped body) -> (nil | untyped)
+
+    # Tests if render or redirect has already happened.
+    def performed?: () -> untyped
+
+    def dispatch: (untyped name, untyped request, untyped response) -> untyped
+
+    def set_response!: (untyped response) -> untyped
+
+    def set_request!: (untyped request) -> untyped
+
+    def to_a: () -> untyped
+
+    def reset_session: () -> untyped
+
+    def self.inherited: (untyped base) -> untyped
+
+    # Pushes the given Rack middleware and its arguments to the bottom of the
+    # middleware stack.
+    def self.use: (*untyped args) { () -> untyped } -> untyped
+
+    # Alias for +middleware_stack+.
+    def self.middleware: () -> untyped
+
+    # Returns a Rack endpoint for the given action name.
+    def self.action: (untyped name) -> untyped
+
+    # Direct dispatch to the controller. Instantiates the controller, then
+    # executes the action named +name+.
+    def self.dispatch: (untyped name, untyped req, untyped res) -> untyped
+  end
+end
+
+module ActionController
+  class Railtie < Rails::Railtie
+    extend ::ActionController::Railties::Helpers
+  end
+end
+
+module ActionController
+  module Railties
+    module Helpers
+      def inherited: (untyped klass) -> (nil | untyped)
+    end
+  end
+end
+
+module ActionController
+  # ActionController::Renderer allows you to render arbitrary templates
+  # without requirement of being in controller actions.
+  #
+  # You get a concrete renderer class by invoking ActionController::Base#renderer.
+  # For example:
+  #
+  #   ApplicationController.renderer
+  #
+  # It allows you to call method #render directly.
+  #
+  #   ApplicationController.renderer.render template: '...'
+  #
+  # You can use this shortcut in a controller, instead of the previous example:
+  #
+  #   ApplicationController.render template: '...'
+  #
+  # #render allows you to use the same options that you can use when rendering in a controller.
+  # For example:
+  #
+  #   FooController.render :action, locals: { ... }, assigns: { ... }
+  #
+  # The template will be rendered in a Rack environment which is accessible through
+  # ActionController::Renderer#env. You can set it up in two ways:
+  #
+  # *  by changing renderer defaults, like
+  #
+  #       ApplicationController.renderer.defaults # => hash with default Rack environment
+  #
+  # *  by initializing an instance of renderer by passing it a custom environment.
+  #
+  #       ApplicationController.renderer.new(method: 'post', https: true)
+  #
+  class Renderer
+    attr_reader defaults: untyped
+
+    attr_reader controller: untyped
+
+    DEFAULTS: untyped
+
+    # Create a new renderer instance for a specific controller class.
+    def self.for: (untyped controller, ?::Hash[untyped, untyped] env, ?untyped defaults) -> untyped
+
+    # Create a new renderer for the same controller but with a new env.
+    def new: (?::Hash[untyped, untyped] env) -> untyped
+
+    # Create a new renderer for the same controller but with new defaults.
+    def with_defaults: (untyped defaults) -> untyped
+
+    # Accepts a custom Rack environment to render templates in.
+    # It will be merged with the default Rack environment defined by
+    # +ActionController::Renderer::DEFAULTS+.
+    def initialize: (untyped controller, untyped env, untyped defaults) -> untyped
+
+    # Render templates with any options from ActionController::Base#render_to_string.
+    #
+    # The primary options are:
+    # * <tt>:partial</tt> - See <tt>ActionView::PartialRenderer</tt> for details.
+    # * <tt>:file</tt> - Renders an explicit template file. Add <tt>:locals</tt> to pass in, if so desired.
+    #   It shouldn(trim non-ascii characters)t be used directly with unsanitized user input due to lack of validation.
+    # * <tt>:inline</tt> - Renders an ERB template string.
+    # * <tt>:plain</tt> - Renders provided text and sets the content type as <tt>text/plain</tt>.
+    # * <tt>:html</tt> - Renders the provided HTML safe string, otherwise
+    #   performs HTML escape on the string first. Sets the content type as <tt>text/html</tt>.
+    # * <tt>:json</tt> - Renders the provided hash or object in JSON. You don't
+    #   need to call <tt>.to_json</tt> on the object you want to render.
+    # * <tt>:body</tt> - Renders provided text and sets content type of <tt>text/plain</tt>.
+    #
+    # If no <tt>options</tt> hash is passed or if <tt>:update</tt> is specified, the default is
+    # to render a partial and use the second parameter as the locals hash.
+    def render: (*untyped args) -> untyped
+
+    def normalize_keys: (untyped env) -> untyped
+
+    RACK_KEY_TRANSLATION: ::Hash[untyped, untyped]
+
+    IDENTITY: untyped
+
+    RACK_VALUE_TRANSLATION: ::Hash[untyped, untyped]
+
+    def rack_key_for: (untyped key) -> untyped
+
+    def rack_value_for: (untyped key, untyped value) -> untyped
+  end
+end
+
+module ActionController
+  module TemplateAssertions
+    # :nodoc:
+    def assert_template: (?::Hash[untyped, untyped] options, ?untyped? message) -> untyped
+  end
+end
+
+module ActionController
+  class Metal
+    include Testing::Functional
+  end
+
+  module Live
+    def new_controller_thread: () { () -> untyped } -> untyped
+  end
+
+  class TestRequest < ActionDispatch::TestRequest
+    # ActionController::TestCase will be deprecated and moved to a gem in the future.
+    # Please use ActionDispatch::IntegrationTest going forward.
+    # nodoc:
+    DEFAULT_ENV: untyped
+
+    def self.new_session: () -> TestSession
+
+    attr_reader controller_class: untyped
+
+    # Create a new test request with default `env` values.
+    def self.create: (untyped controller_class) -> untyped
+
+    def self.default_env: () -> untyped
+
+    def initialize: (untyped env, untyped session, untyped controller_class) -> untyped
+
+    def query_string=: (untyped string) -> untyped
+
+    def content_type=: (untyped `type`) -> untyped
+
+    def assign_parameters: (untyped routes, untyped controller_path, untyped action, untyped parameters, untyped generated_path, untyped query_string_keys) -> untyped
+
+    ENCODER: untyped
+
+    def params_parsers: () -> untyped
+  end
+
+  class LiveTestResponse < Live::Response
+    # Was the response successful?
+    alias success? successful?
+
+    # Was the URL not found?
+    alias missing? not_found?
+
+    # Was there a server-side error?
+    alias error? server_error?
+  end
+
+  class TestSession < Rack::Session::Abstract::PersistedSecure::SecureSessionHash
+    # Methods #destroy and #load! are overridden to avoid calling methods on the
+    # @store object, which does not exist for the TestSession class.
+    # nodoc:
+    DEFAULT_OPTIONS: untyped
+
+    def initialize: (?::Hash[untyped, untyped] session) -> untyped
+
+    def exists?: () -> ::TrueClass
+
+    def keys: () -> untyped
+
+    def values: () -> untyped
+
+    def destroy: () -> untyped
+
+    def dig: (*untyped keys) -> untyped
+
+    def fetch: (untyped key, *untyped args) { () -> untyped } -> untyped
+
+    def load!: () -> untyped
+  end
+
+  # Superclass for ActionController functional tests. Functional tests allow you to
+  # test a single controller action per test method.
+  #
+  # == Use integration style controller tests over functional style controller tests.
+  #
+  # Rails discourages the use of functional tests in favor of integration tests
+  # (use ActionDispatch::IntegrationTest).
+  #
+  # New Rails applications no longer generate functional style controller tests and they should
+  # only be used for backward compatibility. Integration style controller tests perform actual
+  # requests, whereas functional style controller tests merely simulate a request. Besides,
+  # integration tests are as fast as functional tests and provide lot of helpers such as +as+,
+  # +parsed_body+ for effective testing of controller actions including even API endpoints.
+  #
+  # == Basic example
+  #
+  # Functional tests are written as follows:
+  # 1. First, one uses the +get+, +post+, +patch+, +put+, +delete+ or +head+ method to simulate
+  #    an HTTP request.
+  # 2. Then, one asserts whether the current state is as expected. "State" can be anything:
+  #    the controller's HTTP response, the database contents, etc.
+  #
+  # For example:
+  #
+  #   class BooksControllerTest < ActionController::TestCase
+  #     def test_create
+  #       # Simulate a POST response with the given HTTP parameters.
+  #       post(:create, params: { book: { title: "Love Hina" }})
+  #
+  #       # Asserts that the controller tried to redirect us to
+  #       # the created book's URI.
+  #       assert_response :found
+  #
+  #       # Asserts that the controller really put the book in the database.
+  #       assert_not_nil Book.find_by(title: "Love Hina")
+  #     end
+  #   end
+  #
+  # You can also send a real document in the simulated HTTP request.
+  #
+  #   def test_create
+  #     json = {book: { title: "Love Hina" }}.to_json
+  #     post :create, body: json
+  #   end
+  #
+  # == Special instance variables
+  #
+  # ActionController::TestCase will also automatically provide the following instance
+  # variables for use in the tests:
+  #
+  # <b>@controller</b>::
+  #      The controller instance that will be tested.
+  # <b>@request</b>::
+  #      An ActionController::TestRequest, representing the current HTTP
+  #      request. You can modify this object before sending the HTTP request. For example,
+  #      you might want to set some session properties before sending a GET request.
+  # <b>@response</b>::
+  #      An ActionDispatch::TestResponse object, representing the response
+  #      of the last HTTP response. In the above example, <tt>@response</tt> becomes valid
+  #      after calling +post+. If the various assert methods are not sufficient, then you
+  #      may use this object to inspect the HTTP response in detail.
+  #
+  # == Controller is automatically inferred
+  #
+  # ActionController::TestCase will automatically infer the controller under test
+  # from the test class name. If the controller cannot be inferred from the test
+  # class name, you can explicitly set it with +tests+.
+  #
+  #   class SpecialEdgeCaseWidgetsControllerTest < ActionController::TestCase
+  #     tests WidgetController
+  #   end
+  #
+  # == \Testing controller internals
+  #
+  # In addition to these specific assertions, you also have easy access to various collections that the regular test/unit assertions
+  # can be used against. These collections are:
+  #
+  # * session: Objects being saved in the session.
+  # * flash: The flash objects currently in the session.
+  # * cookies: \Cookies being sent to the user on this request.
+  #
+  # These collections can be used just like any other hash:
+  #
+  #   assert_equal "Dave", cookies[:name] # makes sure that a cookie called :name was set as "Dave"
+  #   assert flash.empty? # makes sure that there's nothing in the flash
+  #
+  # On top of the collections, you have the complete URL that a given action redirected to available in <tt>redirect_to_url</tt>.
+  #
+  # For redirects within the same controller, you can even call follow_redirect and the redirect will be followed, triggering another
+  # action call which can then be asserted against.
+  #
+  # == Manipulating session and cookie variables
+  #
+  # Sometimes you need to set up the session and cookie variables for a test.
+  # To do this just assign a value to the session or cookie collection:
+  #
+  #   session[:key] = "value"
+  #   cookies[:key] = "value"
+  #
+  # To clear the cookies for a test just clear the cookie collection:
+  #
+  #   cookies.clear
+  #
+  # == \Testing named routes
+  #
+  # If you're using named routes, they can be easily tested using the original named routes' methods straight in the test case.
+  #
+  #  assert_redirected_to page_url(title: 'foo')
+  class TestCase < ActiveSupport::TestCase
+    module Behavior
+      extend ActiveSupport::Concern
+
+      include ActionDispatch::TestProcess
+
+      include ActiveSupport::Testing::ConstantLookup
+
+      include Rails::Dom::Testing::Assertions
+
+      attr_reader response: untyped
+
+      attr_reader request: untyped
+
+      module ClassMethods
+        # Sets the controller class name. Useful if the name can't be inferred from test class.
+        # Normalizes +controller_class+ before using.
+        #
+        #   tests WidgetController
+        #   tests :widget
+        #   tests 'widget'
+        def tests: (untyped controller_class) -> untyped
+
+        def controller_class=: (untyped new_class) -> untyped
+
+        def controller_class: () -> untyped
+
+        def determine_default_controller_class: (untyped name) -> untyped
+      end
+
+      # Simulate a GET request with the given parameters.
+      #
+      # - +action+: The controller action to call.
+      # - +params+: The hash with HTTP parameters that you want to pass. This may be +nil+.
+      # - +body+: The request body with a string that is appropriately encoded
+      #   (<tt>application/x-www-form-urlencoded</tt> or <tt>multipart/form-data</tt>).
+      # - +session+: A hash of parameters to store in the session. This may be +nil+.
+      # - +flash+: A hash of parameters to store in the flash. This may be +nil+.
+      #
+      # You can also simulate POST, PATCH, PUT, DELETE, and HEAD requests with
+      # +post+, +patch+, +put+, +delete+, and +head+.
+      # Example sending parameters, session and setting a flash message:
+      #
+      #   get :show,
+      #     params: { id: 7 },
+      #     session: { user_id: 1 },
+      #     flash: { notice: 'This is flash message' }
+      #
+      # Note that the request method is not verified. The different methods are
+      # available to make the tests more expressive.
+      def get: (untyped action, **untyped args) -> untyped
+
+      # Simulate a POST request with the given parameters and set/volley the response.
+      # See +get+ for more details.
+      def post: (untyped action, **untyped args) -> untyped
+
+      # Simulate a PATCH request with the given parameters and set/volley the response.
+      # See +get+ for more details.
+      def patch: (untyped action, **untyped args) -> untyped
+
+      # Simulate a PUT request with the given parameters and set/volley the response.
+      # See +get+ for more details.
+      def put: (untyped action, **untyped args) -> untyped
+
+      # Simulate a DELETE request with the given parameters and set/volley the response.
+      # See +get+ for more details.
+      def delete: (untyped action, **untyped args) -> untyped
+
+      # Simulate a HEAD request with the given parameters and set/volley the response.
+      # See +get+ for more details.
+      def head: (untyped action, **untyped args) -> untyped
+
+      # Simulate an HTTP request to +action+ by specifying request method,
+      # parameters and set/volley the response.
+      #
+      # - +action+: The controller action to call.
+      # - +method+: Request method used to send the HTTP request. Possible values
+      #   are +GET+, +POST+, +PATCH+, +PUT+, +DELETE+, +HEAD+. Defaults to +GET+. Can be a symbol.
+      # - +params+: The hash with HTTP parameters that you want to pass. This may be +nil+.
+      # - +body+: The request body with a string that is appropriately encoded
+      #   (<tt>application/x-www-form-urlencoded</tt> or <tt>multipart/form-data</tt>).
+      # - +session+: A hash of parameters to store in the session. This may be +nil+.
+      # - +flash+: A hash of parameters to store in the flash. This may be +nil+.
+      # - +format+: Request format. Defaults to +nil+. Can be string or symbol.
+      # - +as+: Content type. Defaults to +nil+. Must be a symbol that corresponds
+      #   to a mime type.
+      #
+      # Example calling +create+ action and sending two params:
+      #
+      #   process :create,
+      #     method: 'POST',
+      #     params: {
+      #       user: { name: 'Gaurish Sharma', email: 'user@example.com' }
+      #     },
+      #     session: { user_id: 1 },
+      #     flash: { notice: 'This is flash message' }
+      #
+      # To simulate +GET+, +POST+, +PATCH+, +PUT+, +DELETE+ and +HEAD+ requests
+      # prefer using #get, #post, #patch, #put, #delete and #head methods
+      # respectively which will make tests more expressive.
+      #
+      # Note that the request method is not verified.
+      def process: (untyped action, ?as: untyped? as, ?xhr: bool xhr, ?format: untyped? format, ?flash: ::Hash[untyped, untyped] flash, ?body: untyped? body, ?session: untyped? session, ?params: untyped? params, ?method: ::String method) -> untyped
+
+      def controller_class_name: () -> untyped
+
+      def generated_path: (untyped generated_extras) -> untyped
+
+      def query_parameter_names: (untyped generated_extras) -> untyped
+
+      def setup_controller_request_and_response: () -> untyped
+
+      def build_response: (untyped klass) -> untyped
+
+      include ActionController::TemplateAssertions
+
+      include ActionDispatch::Assertions
+
+      def scrub_env!: (untyped env) -> untyped
+
+      def document_root_element: () -> untyped
+
+      def check_required_ivars: () -> untyped
+    end
+
+    include Behavior
+  end
+end
+
+module ActionController
+  extend ActiveSupport::Autoload
+end
+
+module ActionDispatch
+  module Http
+    module Cache
+      module Request
+        HTTP_IF_MODIFIED_SINCE: ::String
+
+        HTTP_IF_NONE_MATCH: ::String
+
+        def if_modified_since: () -> untyped
+
+        def if_none_match: () -> untyped
+
+        def if_none_match_etags: () -> untyped
+
+        def not_modified?: (untyped modified_at) -> untyped
+
+        def etag_matches?: (untyped etag) -> untyped
+
+        # Check response freshness (Last-Modified and ETag) against request
+        # If-Modified-Since and If-None-Match conditions. If both headers are
+        # supplied, both must match, or the request is not considered fresh.
+        def fresh?: (untyped response) -> (::FalseClass | untyped)
+      end
+
+      module Response
+        attr_reader cache_control: untyped
+
+        def last_modified: () -> untyped
+
+        def last_modified?: () -> untyped
+
+        def last_modified=: (untyped utc_time) -> untyped
+
+        def date: () -> untyped
+
+        def date?: () -> untyped
+
+        def date=: (untyped utc_time) -> untyped
+
+        # This method sets a weak ETag validator on the response so browsers
+        # and proxies may cache the response, keyed on the ETag. On subsequent
+        # requests, the If-None-Match header is set to the cached ETag. If it
+        # matches the current ETag, we can return a 304 Not Modified response
+        # with no body, letting the browser or proxy know that their cache is
+        # current. Big savings in request time and network bandwidth.
+        #
+        # Weak ETags are considered to be semantically equivalent but not
+        # byte-for-byte identical. This is perfect for browser caching of HTML
+        # pages where we don't care about exact equality, just what the user
+        # is viewing.
+        #
+        # Strong ETags are considered byte-for-byte identical. They allow a
+        # browser or proxy cache to support Range requests, useful for paging
+        # through a PDF file or scrubbing through a video. Some CDNs only
+        # support strong ETags and will ignore weak ETags entirely.
+        #
+        # Weak ETags are what we almost always need, so they're the default.
+        # Check out #strong_etag= to provide a strong ETag validator.
+        def etag=: (untyped weak_validators) -> untyped
+
+        def weak_etag=: (untyped weak_validators) -> untyped
+
+        def strong_etag=: (untyped strong_validators) -> untyped
+
+        def etag?: () -> untyped
+
+        # True if an ETag is set and it's a weak validator (preceded with W/)
+        def weak_etag?: () -> untyped
+
+        # True if an ETag is set and it isn't a weak validator (not preceded with W/)
+        def strong_etag?: () -> untyped
+
+        DATE: ::String
+
+        LAST_MODIFIED: ::String
+
+        SPECIAL_KEYS: untyped
+
+        def generate_weak_etag: (untyped validators) -> ::String
+
+        def generate_strong_etag: (untyped validators) -> ::String
+
+        def cache_control_segments: () -> untyped
+
+        def cache_control_headers: () -> untyped
+
+        def prepare_cache_control!: () -> untyped
+
+        DEFAULT_CACHE_CONTROL: ::String
+
+        NO_CACHE: ::String
+
+        PUBLIC: ::String
+
+        PRIVATE: ::String
+
+        MUST_REVALIDATE: ::String
+
+        def handle_conditional_get!: () -> untyped
+
+        def merge_and_normalize_cache_control!: (untyped cache_control) -> untyped
+      end
+    end
+  end
+end
+
+module ActionDispatch
+  module Http
+    class ContentDisposition
+      # :nodoc:
+      def self.format: (filename: untyped filename, disposition: untyped disposition) -> untyped
+
+      attr_reader disposition: untyped
+
+      attr_reader filename: untyped
+
+      def initialize: (filename: untyped filename, disposition: untyped disposition) -> untyped
+
+      TRADITIONAL_ESCAPED_CHAR: untyped
+
+      def ascii_filename: () -> untyped
+
+      RFC_5987_ESCAPED_CHAR: untyped
+
+      def utf8_filename: () -> untyped
+
+      def to_s: () -> untyped
+
+      def percent_escape: (untyped string, untyped pattern) -> untyped
+    end
+  end
+end
+
+module ActionDispatch
+  # nodoc:
+  class ContentSecurityPolicy
+    class Middleware
+      CONTENT_TYPE: ::String
+
+      POLICY: ::String
+
+      POLICY_REPORT_ONLY: ::String
+
+      def initialize: (untyped app) -> untyped
+
+      def call: (untyped env) -> untyped
+
+      def html_response?: (untyped headers) -> untyped
+
+      def header_name: (untyped request) -> untyped
+
+      def policy_present?: (untyped headers) -> untyped
+    end
+
+    module Request
+      POLICY: ::String
+
+      POLICY_REPORT_ONLY: ::String
+
+      NONCE_GENERATOR: ::String
+
+      NONCE: ::String
+
+      NONCE_DIRECTIVES: ::String
+
+      def content_security_policy: () -> untyped
+
+      def content_security_policy=: (untyped policy) -> untyped
+
+      def content_security_policy_report_only: () -> untyped
+
+      def content_security_policy_report_only=: (untyped value) -> untyped
+
+      def content_security_policy_nonce_generator: () -> untyped
+
+      def content_security_policy_nonce_generator=: (untyped generator) -> untyped
+
+      def content_security_policy_nonce_directives: () -> untyped
+
+      def content_security_policy_nonce_directives=: (untyped generator) -> untyped
+
+      def content_security_policy_nonce: () -> untyped
+
+      def generate_content_security_policy_nonce: () -> untyped
+    end
+
+    MAPPINGS: untyped
+
+    DIRECTIVES: untyped
+
+    DEFAULT_NONCE_DIRECTIVES: untyped
+
+    attr_reader directives: untyped
+
+    def initialize: () { (untyped) -> untyped } -> untyped
+
+    def initialize_copy: (untyped other) -> untyped
+
+    def block_all_mixed_content: (?bool enabled) -> untyped
+
+    def plugin_types: (*untyped types) -> untyped
+
+    def report_uri: (untyped uri) -> untyped
+
+    def require_sri_for: (*untyped types) -> untyped
+
+    def sandbox: (*untyped values) -> untyped
+
+    def upgrade_insecure_requests: (?bool enabled) -> untyped
+
+    def build: (?untyped? context, ?untyped? nonce, ?untyped? nonce_directives) -> untyped
+
+    def apply_mappings: (untyped sources) -> untyped
+
+    def apply_mapping: (untyped source) -> untyped
+
+    def build_directives: (untyped context, untyped nonce, untyped nonce_directives) -> untyped
+
+    def build_directive: (untyped sources, untyped context) -> untyped
+
+    def resolve_source: (untyped source, untyped context) -> untyped
+
+    def nonce_directive?: (untyped directive, untyped nonce_directives) -> untyped
+  end
+end
+
+module ActionDispatch
+  module Http
+    # Allows you to specify sensitive parameters which will be replaced from
+    # the request log by looking in the query string of the request and all
+    # sub-hashes of the params hash to filter. Filtering only certain sub-keys
+    # from a hash is possible by using the dot notation: 'credit_card.number'.
+    # If a block is given, each key and value of the params hash and all
+    # sub-hashes are passed to it, where the value or the key can be replaced using
+    # String#replace or similar methods.
+    #
+    #   env["action_dispatch.parameter_filter"] = [:password]
+    #   => replaces the value to all keys matching /password/i with "[FILTERED]"
+    #
+    #   env["action_dispatch.parameter_filter"] = [:foo, "bar"]
+    #   => replaces the value to all keys matching /foo|bar/i with "[FILTERED]"
+    #
+    #   env["action_dispatch.parameter_filter"] = [ "credit_card.code" ]
+    #   => replaces { credit_card: {code: "xxxx"} } with "[FILTERED]", does not
+    #   change { file: { code: "xxxx"} }
+    #
+    #   env["action_dispatch.parameter_filter"] = -> (k, v) do
+    #     v.reverse! if k =~ /secret/i
+    #   end
+    #   => reverses the value to all keys matching /secret/i
+    module FilterParameters
+      ENV_MATCH: ::Array[untyped]
+
+      NULL_PARAM_FILTER: untyped
+
+      NULL_ENV_FILTER: untyped
+
+      def initialize: () -> untyped
+
+      # Returns a hash of parameters with all sensitive data replaced.
+      def filtered_parameters: () -> untyped
+
+      # Returns a hash of request.env with all sensitive data replaced.
+      def filtered_env: () -> untyped
+
+      # Reconstructs a path with all sensitive GET parameters replaced.
+      def filtered_path: () -> untyped
+
+      def parameter_filter: () -> untyped
+
+      def env_filter: () -> untyped
+
+      def parameter_filter_for: (untyped filters) -> ActiveSupport::ParameterFilter
+
+      KV_RE: ::String
+
+      PAIR_RE: untyped
+
+      def filtered_query_string: () -> untyped
+    end
+  end
+end
+
+module ActionDispatch
+  module Http
+    module FilterRedirect
+      FILTERED: ::String
+
+      def filtered_location: () -> untyped
+
+      def location_filters: () -> untyped
+
+      def location_filter_match?: () -> untyped
+    end
+  end
+end
+
+module ActionDispatch
+  module Http
+    # Provides access to the request's HTTP headers from the environment.
+    #
+    #   env     = { "CONTENT_TYPE" => "text/plain", "HTTP_USER_AGENT" => "curl/7.43.0" }
+    #   headers = ActionDispatch::Http::Headers.from_hash(env)
+    #   headers["Content-Type"] # => "text/plain"
+    #   headers["User-Agent"] # => "curl/7.43.0"
+    #
+    # Also note that when headers are mapped to CGI-like variables by the Rack
+    # server, both dashes and underscores are converted to underscores. This
+    # ambiguity cannot be resolved at this stage anymore. Both underscores and
+    # dashes have to be interpreted as if they were originally sent as dashes.
+    #
+    #   # GET / HTTP/1.1
+    #   # ...
+    #   # User-Agent: curl/7.43.0
+    #   # X_Custom_Header: token
+    #
+    #   headers["X_Custom_Header"] # => nil
+    #   headers["X-Custom-Header"] # => "token"
+    class Headers
+      CGI_VARIABLES: untyped
+
+      HTTP_HEADER: untyped
+
+      include Enumerable[untyped]
+
+      def self.from_hash: (untyped hash) -> untyped
+
+      def initialize: (untyped request) -> untyped
+
+      # Returns the value for the given key mapped to @env.
+      def []: (untyped key) -> untyped
+
+      # Sets the given value for the key mapped to @env.
+      def []=: (untyped key, untyped value) -> untyped
+
+      # Add a value to a multivalued header like Vary or Accept-Encoding.
+      def add: (untyped key, untyped value) -> untyped
+
+      def key?: (untyped key) -> untyped
+
+      alias include? key?
+
+      DEFAULT: untyped
+
+      # Returns the value for the given key mapped to @env.
+      #
+      # If the key is not found and an optional code block is not provided,
+      # raises a <tt>KeyError</tt> exception.
+      #
+      # If the code block is provided, then it will be run and
+      # its result returned.
+      def fetch: (untyped key, ?untyped default) { () -> untyped } -> untyped
+
+      def each: () { () -> untyped } -> untyped
+
+      # Returns a new Http::Headers instance containing the contents of
+      # <tt>headers_or_env</tt> and the original instance.
+      def merge: (untyped headers_or_env) -> untyped
+
+      # Adds the contents of <tt>headers_or_env</tt> to original instance
+      # entries; duplicate keys are overwritten with the values from
+      # <tt>headers_or_env</tt>.
+      def merge!: (untyped headers_or_env) -> untyped
+
+      def env: () -> untyped
+
+      # Converts an HTTP header name to an environment variable name if it is
+      # not contained within the headers hash.
+      def env_name: (untyped key) -> untyped
+    end
+  end
+end
+
+module ActionDispatch
+  module Http
+    module MimeNegotiation
+      extend ActiveSupport::Concern
+
+      RESCUABLE_MIME_FORMAT_ERRORS: ::Array[untyped]
+
+      # The MIME type of the HTTP request, such as Mime[:xml].
+      def content_mime_type: () -> untyped
+
+      def content_type: () -> untyped
+
+      def has_content_type?: () -> untyped
+
+      # Returns the accepted MIME type for the request.
+      def accepts: () -> untyped
+
+      # Returns the MIME type for the \format used in the request.
+      #
+      #   GET /posts/5.xml   | request.format => Mime[:xml]
+      #   GET /posts/5.xhtml | request.format => Mime[:html]
+      #   GET /posts/5       | request.format => Mime[:html] or Mime[:js], or request.accepts.first
+      #
+      def format: (?untyped view_path) -> untyped
+
+      def formats: () -> untyped
+
+      # Sets the \variant for template.
+      def variant=: (untyped variant) -> untyped
+
+      def variant: () -> untyped
+
+      # Sets the \format by string extension, which can be used to force custom formats
+      # that are not controlled by the extension.
+      #
+      #   class ApplicationController < ActionController::Base
+      #     before_action :adjust_format_for_iphone
+      #
+      #     private
+      #       def adjust_format_for_iphone
+      #         request.format = :iphone if request.env["HTTP_USER_AGENT"][/iPhone/]
+      #       end
+      #   end
+      def format=: (untyped `extension`) -> untyped
+
+      # Sets the \formats by string extensions. This differs from #format= by allowing you
+      # to set multiple, ordered formats, which is useful when you want to have a fallback.
+      #
+      # In this example, the :iphone format will be used if it's available, otherwise it'll fallback
+      # to the :html format.
+      #
+      #   class ApplicationController < ActionController::Base
+      #     before_action :adjust_format_for_iphone_with_html_fallback
+      #
+      #     private
+      #       def adjust_format_for_iphone_with_html_fallback
+      #         request.formats = [ :iphone, :html ] if request.env["HTTP_USER_AGENT"][/iPhone/]
+      #       end
+      #   end
+      def formats=: (untyped extensions) -> untyped
+
+      # Returns the first MIME type that matches the provided array of MIME types.
+      def negotiate_mime: (untyped order) -> untyped
+
+      BROWSER_LIKE_ACCEPTS: untyped
+
+      def valid_accept_header: () -> untyped
+
+      def use_accept_header: () -> untyped
+
+      def format_from_path_extension: () -> untyped
+    end
+  end
+end
+
+module Mime
+  class Mimes
+    include Enumerable[untyped]
+
+    def initialize: () -> untyped
+
+    def each: () { (untyped) -> untyped } -> untyped
+
+    def <<: (untyped `type`) -> untyped
+
+    def delete_if: () { (untyped) -> untyped } -> untyped
+
+    def symbols: () -> untyped
+  end
+
+  SET: untyped
+
+  EXTENSION_LOOKUP: ::Hash[untyped, untyped]
+
+  LOOKUP: ::Hash[untyped, untyped]
+
+  def self.[]: (untyped `type`) -> untyped
+
+  def self.fetch: (untyped `type`) { (untyped) -> untyped } -> untyped
+
+  # Encapsulates the notion of a MIME type. Can be used at render time, for example, with:
+  #
+  #   class PostsController < ActionController::Base
+  #     def show
+  #       @post = Post.find(params[:id])
+  #
+  #       respond_to do |format|
+  #         format.html
+  #         format.ics { render body: @post.to_ics, mime_type: Mime::Type.lookup("text/calendar")  }
+  #         format.xml { render xml: @post }
+  #       end
+  #     end
+  #   end
+  class Type
+    attr_reader symbol: untyped
+
+    class AcceptItem
+      # A simple helper class used in parsing the accept header.
+      # nodoc:
+      attr_accessor index: untyped
+
+      # A simple helper class used in parsing the accept header.
+      # nodoc:
+      attr_accessor name: untyped
+
+      # A simple helper class used in parsing the accept header.
+      # nodoc:
+      attr_accessor q: untyped
+
+      alias to_s name
+
+      def initialize: (untyped index, untyped name, ?untyped? q) -> untyped
+
+      def <=>: (untyped item) -> untyped
+    end
+
+    class AcceptList
+      # nodoc:
+      def self.sort!: (untyped list) -> untyped
+
+      def self.find_item_by_name: (untyped array, untyped name) -> untyped
+    end
+
+    TRAILING_STAR_REGEXP: untyped
+
+    PARAMETER_SEPARATOR_REGEXP: untyped
+
+    def self.register_callback: () { () -> untyped } -> untyped
+
+    def self.lookup: (untyped string) -> untyped
+
+    def self.lookup_by_extension: (untyped `extension`) -> untyped
+
+    # Registers an alias that's not used on MIME type lookup, but can be referenced directly. Especially useful for
+    # rendering different HTML versions depending on the user agent, like an iPhone.
+    def self.register_alias: (untyped string, untyped symbol, ?untyped extension_synonyms) -> untyped
+
+    def self.register: (untyped string, untyped symbol, ?untyped mime_type_synonyms, ?untyped extension_synonyms, ?bool skip_lookup) -> untyped
+
+    def self.parse: (untyped accept_header) -> untyped
+
+    def self.parse_trailing_star: (untyped accept_header) -> untyped
+
+    # For an input of <tt>'text'</tt>, returns <tt>[Mime[:json], Mime[:xml], Mime[:ics],
+    # Mime[:html], Mime[:css], Mime[:csv], Mime[:js], Mime[:yaml], Mime[:text]</tt>.
+    #
+    # For an input of <tt>'application'</tt>, returns <tt>[Mime[:html], Mime[:js],
+    # Mime[:xml], Mime[:yaml], Mime[:atom], Mime[:json], Mime[:rss], Mime[:url_encoded_form]</tt>.
+    def self.parse_data_with_trailing_star: (untyped `type`) -> untyped
+
+    # This method is opposite of register method.
+    #
+    # To unregister a MIME type:
+    #
+    #   Mime::Type.unregister(:mobile)
+    def self.unregister: (untyped symbol) -> untyped
+
+    attr_reader hash: untyped
+
+    MIME_NAME: ::String
+
+    MIME_PARAMETER_KEY: ::String
+
+    MIME_PARAMETER_VALUE: ::String
+
+    MIME_PARAMETER: ::String
+
+    MIME_REGEXP: untyped
+
+    class InvalidMimeType < StandardError
+    end
+
+    def initialize: (untyped string, ?untyped? symbol, ?untyped synonyms) -> untyped
+
+    def to_s: () -> untyped
+
+    def to_str: () -> untyped
+
+    def to_sym: () -> untyped
+
+    def ref: () -> untyped
+
+    def ===: (untyped list) -> untyped
+
+    def ==: (untyped mime_type) -> (::FalseClass | untyped)
+
+    def eql?: (untyped other) -> untyped
+
+    def =~: (untyped mime_type) -> (::FalseClass | untyped)
+
+    def html?: () -> untyped
+
+    def all?: () -> ::FalseClass
+
+    attr_reader string: untyped
+
+    attr_reader synonyms: untyped
+
+    def to_ary: () -> nil
+
+    def to_a: () -> nil
+
+    def method_missing: (untyped method, *untyped args) -> untyped
+
+    def respond_to_missing?: (untyped method, ?bool include_private) -> untyped
+  end
+
+  class AllType < Type
+    include Singleton
+
+    def initialize: () -> untyped
+
+    def all?: () -> ::TrueClass
+
+    def html?: () -> ::TrueClass
+  end
+
+  # ALL isn't a real MIME type, so we don't register it for lookup with the
+  # other concrete types. It's a wildcard match that we use for `respond_to`
+  # negotiation internals.
+  ALL: untyped
+
+  class NullType
+    include Singleton
+
+    def nil?: () -> ::TrueClass
+
+    def ref: () -> nil
+
+    def respond_to_missing?: (untyped method, untyped _) -> untyped
+
+    def method_missing: (untyped method, *untyped args) -> untyped
+  end
+end
+
+module ActionDispatch
+  module Http
+    include ActiveSupport::Deprecation::DeprecatedConstantAccessor
+  end
+end
+
+module ActionDispatch
+  module Http
+    module Parameters
+      extend ActiveSupport::Concern
+
+      PARAMETERS_KEY: ::String
+
+      DEFAULT_PARSERS: ::Hash[untyped, untyped]
+
+      # Raised when raw data from the request cannot be parsed by the parser
+      # defined for request's content MIME type.
+      class ParseError < StandardError
+        def initialize: () -> untyped
+      end
+
+      # Returns the parameter parsers.
+      attr_reader parameter_parsers: untyped
+
+      module ClassMethods
+        # Configure the parameter parser for a given MIME type.
+        #
+        # It accepts a hash where the key is the symbol of the MIME type
+        # and the value is a proc.
+        #
+        #     original_parsers = ActionDispatch::Request.parameter_parsers
+        #     xml_parser = -> (raw_post) { Hash.from_xml(raw_post) || {} }
+        #     new_parsers = original_parsers.merge(xml: xml_parser)
+        #     ActionDispatch::Request.parameter_parsers = new_parsers
+        def parameter_parsers=: (untyped parsers) -> untyped
+      end
+
+      # Returns both GET and POST \parameters in a single hash.
+      def parameters: () -> untyped
+
+      alias params parameters
+
+      def path_parameters=: (untyped parameters) -> untyped
+
+      # Returns a hash with the \parameters used to form the \path of the request.
+      # Returned hash keys are strings:
+      #
+      #   {'action' => 'my_action', 'controller' => 'my_controller'}
+      def path_parameters: () -> untyped
+
+      def set_binary_encoding: (untyped params, untyped controller, untyped action) -> untyped
+
+      def binary_params_for?: (untyped controller, untyped action) -> untyped
+
+      def parse_formatted_parameters: (untyped parsers) { () -> untyped } -> untyped
+
+      def log_parse_error_once: () -> untyped
+
+      def params_parsers: () -> untyped
+    end
+  end
+end
+
+module ActionDispatch
+  class RailsMetaStore < Rack::Cache::MetaStore
+    def self.resolve: (untyped uri) -> untyped
+
+    def initialize: (?untyped store) -> untyped
+
+    def read: (untyped key) -> untyped
+
+    def write: (untyped key, untyped value) -> untyped
+
+    ::Rack::Cache::MetaStore::RAILS: untyped
+  end
+
+  class RailsEntityStore < Rack::Cache::EntityStore
+    def self.resolve: (untyped uri) -> untyped
+
+    def initialize: (?untyped store) -> untyped
+
+    def exist?: (untyped key) -> untyped
+
+    def open: (untyped key) -> untyped
+
+    def read: (untyped key) -> untyped
+
+    def write: (untyped body) -> ::Array[untyped]
+
+    ::Rack::Cache::EntityStore::RAILS: untyped
+  end
+end
+
+module ActionDispatch
+  class Request
+    include Rack::Request::Helpers
+
+    include ActionDispatch::Http::Cache::Request
+
+    include ActionDispatch::Http::MimeNegotiation
+
+    include ActionDispatch::Http::Parameters
+
+    include ActionDispatch::Http::FilterParameters
+
+    include ActionDispatch::Http::URL
+
+    include ActionDispatch::ContentSecurityPolicy::Request
+
+    include Rack::Request::Env
+
+    LOCALHOST: untyped
+
+    ENV_METHODS: untyped
+
+    def self.empty: () -> untyped
+
+    def initialize: (untyped env) -> untyped
+
+    def commit_cookie_jar!: () -> nil
+
+    PASS_NOT_FOUND: untyped
+
+    def controller_class: () -> untyped
+
+    def controller_class_for: (untyped name) -> untyped
+
+    # Returns true if the request has a header matching the given key parameter.
+    #
+    #    request.key? :ip_spoofing_check # => true
+    def key?: (untyped key) -> untyped
+
+    # List of HTTP request methods from the following RFCs:
+    # Hypertext Transfer Protocol -- HTTP/1.1 (https://www.ietf.org/rfc/rfc2616.txt)
+    # HTTP Extensions for Distributed Authoring -- WEBDAV (https://www.ietf.org/rfc/rfc2518.txt)
+    # Versioning Extensions to WebDAV (https://www.ietf.org/rfc/rfc3253.txt)
+    # Ordered Collections Protocol (WebDAV) (https://www.ietf.org/rfc/rfc3648.txt)
+    # Web Distributed Authoring and Versioning (WebDAV) Access Control Protocol (https://www.ietf.org/rfc/rfc3744.txt)
+    # Web Distributed Authoring and Versioning (WebDAV) SEARCH (https://www.ietf.org/rfc/rfc5323.txt)
+    # Calendar Extensions to WebDAV (https://www.ietf.org/rfc/rfc4791.txt)
+    # PATCH Method for HTTP (https://www.ietf.org/rfc/rfc5789.txt)
+    RFC2616: ::Array[untyped]
+
+    RFC2518: ::Array[untyped]
+
+    RFC3253: ::Array[untyped]
+
+    RFC3648: ::Array[untyped]
+
+    RFC3744: ::Array[untyped]
+
+    RFC5323: ::Array[untyped]
+
+    RFC4791: ::Array[untyped]
+
+    RFC5789: ::Array[untyped]
+
+    HTTP_METHODS: untyped
+
+    HTTP_METHOD_LOOKUP: ::Hash[untyped, untyped]
+
+    # Returns the HTTP \method that the application should see.
+    # In the case where the \method was overridden by a middleware
+    # (for instance, if a HEAD request was converted to a GET,
+    # or if a _method parameter was used to determine the \method
+    # the application should use), this \method returns the overridden
+    # value, not the original.
+    def request_method: () -> untyped
+
+    def routes: () -> untyped
+
+    def routes=: (untyped routes) -> untyped
+
+    def engine_script_name: (untyped _routes) -> untyped
+
+    def engine_script_name=: (untyped name) -> untyped
+
+    def request_method=: (untyped request_method) -> untyped
+
+    def controller_instance: () -> untyped
+
+    def controller_instance=: (untyped controller) -> untyped
+
+    def http_auth_salt: () -> untyped
+
+    def show_exceptions?: () -> untyped
+
+    # Returns a symbol form of the #request_method.
+    def request_method_symbol: () -> untyped
+
+    # Returns the original value of the environment's REQUEST_METHOD,
+    # even if it was overridden by middleware. See #request_method for
+    # more information.
+    def method: () -> untyped
+
+    # Returns a symbol form of the #method.
+    def method_symbol: () -> untyped
+
+    # Provides access to the request's HTTP headers, for example:
+    #
+    #   request.headers["Content-Type"] # => "text/plain"
+    def headers: () -> untyped
+
+    # Early Hints is an HTTP/2 status code that indicates hints to help a client start
+    # making preparations for processing the final response.
+    #
+    # If the env contains +rack.early_hints+ then the server accepts HTTP2 push for Link headers.
+    #
+    # The +send_early_hints+ method accepts a hash of links as follows:
+    #
+    #   send_early_hints("Link" => "</style.css>; rel=preload; as=style\n</script.js>; rel=preload")
+    #
+    # If you are using +javascript_include_tag+ or +stylesheet_link_tag+ the
+    # Early Hints headers are included by default if supported.
+    def send_early_hints: (untyped links) -> (nil | untyped)
+
+    # Returns a +String+ with the last requested path including their params.
+    #
+    #    # get '/foo'
+    #    request.original_fullpath # => '/foo'
+    #
+    #    # get '/foo?bar'
+    #    request.original_fullpath # => '/foo?bar'
+    def original_fullpath: () -> untyped
+
+    # Returns the +String+ full path including params of the last URL requested.
+    #
+    #    # get "/articles"
+    #    request.fullpath # => "/articles"
+    #
+    #    # get "/articles?page=2"
+    #    request.fullpath # => "/articles?page=2"
+    def fullpath: () -> untyped
+
+    # Returns the original request URL as a +String+.
+    #
+    #    # get "/articles?page=2"
+    #    request.original_url # => "http://www.example.com/articles?page=2"
+    def original_url: () -> untyped
+
+    # The +String+ MIME type of the request.
+    #
+    #    # get "/articles"
+    #    request.media_type # => "application/x-www-form-urlencoded"
+    def media_type: () -> untyped
+
+    # Returns the content length of the request as an integer.
+    def content_length: () -> untyped
+
+    # Returns true if the "X-Requested-With" header contains "XMLHttpRequest"
+    # (case-insensitive), which may need to be manually added depending on the
+    # choice of JavaScript libraries and frameworks.
+    def xml_http_request?: () -> untyped
+
+    alias xhr? xml_http_request?
+
+    # Returns the IP address of client as a +String+.
+    def ip: () -> untyped
+
+    # Returns the IP address of client as a +String+,
+    # usually set by the RemoteIp middleware.
+    def remote_ip: () -> untyped
+
+    def remote_ip=: (untyped remote_ip) -> untyped
+
+    ACTION_DISPATCH_REQUEST_ID: ::String
+
+    # Returns the unique request id, which is based on either the X-Request-Id header that can
+    # be generated by a firewall, load balancer, or web server or by the RequestId middleware
+    # (which sets the action_dispatch.request_id environment variable).
+    #
+    # This unique ID is useful for tracing a request from end-to-end as part of logging or debugging.
+    # This relies on the Rack variable set by the ActionDispatch::RequestId middleware.
+    def request_id: () -> untyped
+
+    def request_id=: (untyped id) -> untyped
+
+    alias uuid request_id
+
+    # Returns the lowercase name of the HTTP server software.
+    def server_software: () -> untyped
+
+    # Read the request \body. This is useful for web services that need to
+    # work with raw requests directly.
+    def raw_post: () -> untyped
+
+    # The request body is an IO input stream. If the RAW_POST_DATA environment
+    # variable is already set, wrap it in a StringIO.
+    def body: () -> untyped
+
+    # Determine whether the request body contains form-data by checking
+    # the request Content-Type for one of the media-types:
+    # "application/x-www-form-urlencoded" or "multipart/form-data". The
+    # list of form-data media types can be modified through the
+    # +FORM_DATA_MEDIA_TYPES+ array.
+    #
+    # A request body is not assumed to contain form-data when no
+    # Content-Type header is provided and the request_method is POST.
+    def form_data?: () -> untyped
+
+    def body_stream: () -> untyped
+
+    # TODO This should be broken apart into AD::Request::Session and probably
+    # be included by the session middleware.
+    def reset_session: () -> untyped
+
+    def session=: (untyped session) -> untyped
+
+    def session_options=: (untyped options) -> untyped
+
+    # Override Rack's GET method to support indifferent access.
+    def GET: () -> untyped
+
+    alias query_parameters GET
+
+    # Override Rack's POST method to support indifferent access.
+    def POST: () -> untyped
+
+    alias request_parameters POST
+
+    # Returns the authorization header regardless of whether it was specified directly or through one of the
+    # proxy alternatives.
+    def authorization: () -> untyped
+
+    # True if the request came from localhost, 127.0.0.1, or ::1.
+    def local?: () -> untyped
+
+    def request_parameters=: (untyped params) -> untyped
+
+    def logger: () -> untyped
+
+    def commit_flash: () -> nil
+
+    def ssl?: () -> untyped
+
+    def check_method: (untyped name) -> untyped
+  end
+end
+
+module ActionDispatch
+  # :nodoc:
+  # Represents an HTTP response generated by a controller action. Use it to
+  # retrieve the current state of the response, or customize the response. It can
+  # either represent a real HTTP response (i.e. one that is meant to be sent
+  # back to the web browser) or a TestResponse (i.e. one that is generated
+  # from integration tests).
+  #
+  # \Response is mostly a Ruby on \Rails framework implementation detail, and
+  # should never be used directly in controllers. Controllers should use the
+  # methods defined in ActionController::Base instead. For example, if you want
+  # to set the HTTP response's content MIME type, then use
+  # ActionControllerBase#headers instead of Response#headers.
+  #
+  # Nevertheless, integration tests may want to inspect controller responses in
+  # more detail, and that's when \Response can be useful for application
+  # developers. Integration test methods such as
+  # ActionDispatch::Integration::Session#get and
+  # ActionDispatch::Integration::Session#post return objects of type
+  # TestResponse (which are of course also of type \Response).
+  #
+  # For example, the following demo integration test prints the body of the
+  # controller response to the console:
+  #
+  #  class DemoControllerTest < ActionDispatch::IntegrationTest
+  #    def test_print_root_path_to_console
+  #      get('/')
+  #      puts response.body
+  #    end
+  #  end
+  class Response
+    class Header
+      # :nodoc:
+      def initialize: (untyped response, untyped header) -> untyped
+
+      def []=: (untyped k, untyped v) -> untyped
+
+      def merge: (untyped other) -> untyped
+
+      def to_hash: () -> untyped
+    end
+
+    # The request that the response is responding to.
+    attr_accessor request: untyped
+
+    # The HTTP status code.
+    attr_reader status: untyped
+
+    # Get headers for this response.
+    attr_reader header: untyped
+
+    alias headers header
+
+    def each: () { () -> untyped } -> untyped
+
+    CONTENT_TYPE: ::String
+
+    SET_COOKIE: ::String
+
+    LOCATION: ::String
+
+    NO_CONTENT_CODES: ::Array[untyped]
+
+    include Rack::Response::Helpers
+
+    # Aliasing these off because AD::Http::Cache::Response defines them.
+    alias _cache_control cache_control
+
+    alias _cache_control= cache_control=
+
+    include ActionDispatch::Http::FilterRedirect
+
+    include ActionDispatch::Http::Cache::Response
+
+    include MonitorMixin
+
+    class Buffer
+      # :nodoc:
+      def initialize: (untyped response, untyped buf) -> untyped
+
+      def body: () -> untyped
+
+      def write: (untyped string) -> untyped
+
+      def each: () { (untyped) -> untyped } -> untyped
+
+      def abort: () -> nil
+
+      def close: () -> untyped
+
+      def closed?: () -> untyped
+
+      def each_chunk: () { () -> untyped } -> untyped
+    end
+
+    def self.create: (?::Integer status, ?::Hash[untyped, untyped] header, ?untyped body, ?default_headers: untyped default_headers) -> untyped
+
+    def self.merge_default_headers: (untyped original, untyped default) -> untyped
+
+    # The underlying body, as a streamable object.
+    attr_reader stream: untyped
+
+    def initialize: (?::Integer status, ?::Hash[untyped, untyped] header, ?untyped body) { (untyped) -> untyped } -> untyped
+
+    def has_header?: (untyped key) -> untyped
+
+    def get_header: (untyped key) -> untyped
+
+    def set_header: (untyped key, untyped v) -> untyped
+
+    def delete_header: (untyped key) -> untyped
+
+    def await_commit: () -> untyped
+
+    def await_sent: () -> untyped
+
+    def commit!: () -> untyped
+
+    def sending!: () -> untyped
+
+    def sent!: () -> untyped
+
+    def sending?: () -> untyped
+
+    def committed?: () -> untyped
+
+    def sent?: () -> untyped
+
+    # Sets the HTTP status code.
+    def status=: (untyped status) -> untyped
+
+    # Sets the HTTP response's content MIME type. For example, in the controller
+    # you could write this:
+    #
+    #  response.content_type = "text/plain"
+    #
+    # If a character set has been defined for this response (see charset=) then
+    # the character set information will also be included in the content type
+    # information.
+    def content_type=: (untyped content_type) -> (nil | untyped)
+
+    # Content type of response.
+    def content_type: () -> untyped
+
+    # Media type of response.
+    def media_type: () -> untyped
+
+    def sending_file=: (untyped v) -> untyped
+
+    # Sets the HTTP character set. In case of +nil+ parameter
+    # it sets the charset to +default_charset+.
+    #
+    #   response.charset = 'utf-16' # => 'utf-16'
+    #   response.charset = nil      # => 'utf-8'
+    def charset=: (untyped charset) -> untyped
+
+    # The charset of the response. HTML wants to know the encoding of the
+    # content you're giving them, so we need to send that along.
+    def charset: () -> untyped
+
+    # The response code of the request.
+    def response_code: () -> untyped
+
+    # Returns a string to ensure compatibility with <tt>Net::HTTPResponse</tt>.
+    def code: () -> untyped
+
+    # Returns the corresponding message for the current HTTP status code:
+    #
+    #   response.status = 200
+    #   response.message # => "OK"
+    #
+    #   response.status = 404
+    #   response.message # => "Not Found"
+    #
+    def message: () -> untyped
+
+    alias status_message message
+
+    # Returns the content of the response as a string. This contains the contents
+    # of any calls to <tt>render</tt>.
+    def body: () -> untyped
+
+    def write: (untyped string) -> untyped
+
+    # Allows you to manually set or override the response body.
+    def body=: (untyped body) -> untyped
+
+    class FileBody
+      # Avoid having to pass an open file handle as the response body.
+      # Rack::Sendfile will usually intercept the response and uses
+      # the path directly, so there is no reason to open the file.
+      # nodoc:
+      attr_reader to_path: untyped
+
+      def initialize: (untyped path) -> untyped
+
+      def body: () -> untyped
+
+      # Stream the file's contents if Rack::Sendfile isn't present.
+      def each: () { (untyped) -> untyped } -> untyped
+    end
+
+    # Send the file stored at +path+ as the response body.
+    def send_file: (untyped path) -> untyped
+
+    def reset_body!: () -> untyped
+
+    def body_parts: () -> untyped
+
+    # The location header we'll be responding with.
+    alias redirect_url location
+
+    def close: () -> untyped
+
+    def abort: () -> untyped
+
+    # Turns the Response into a Rack-compatible array of the status, headers,
+    # and body. Allows explicit splatting:
+    #
+    #   status, headers, body = *response
+    def to_a: () -> untyped
+
+    alias prepare! to_a
+
+    # Returns the response cookies, converted to a Hash of (name => value) pairs
+    #
+    #   assert_equal 'AuthorOfNewPage', r.cookies['author']
+    def cookies: () -> untyped
+
+    class ContentTypeHeader[T] < ::Struct[T]
+      attr_accessor mime_type(): untyped
+
+      attr_accessor charset(): untyped
+    end
+
+    NullContentTypeHeader: untyped
+
+    CONTENT_TYPE_PARSER: untyped
+
+    def parse_content_type: (untyped content_type) -> untyped
+
+    # Small internal convenience method to get the parsed version of the current
+    # content type header.
+    def parsed_content_type_header: () -> untyped
+
+    def set_content_type: (untyped content_type, untyped charset) -> untyped
+
+    def before_committed: () -> (nil | untyped)
+
+    def before_sending: () -> untyped
+
+    def build_buffer: (untyped response, untyped body) -> Buffer
+
+    def munge_body_object: (untyped body) -> untyped
+
+    def assign_default_content_type_and_charset!: () -> (nil | untyped)
+
+    class RackBody
+      def initialize: (untyped response) -> untyped
+
+      def each: (*untyped args) { () -> untyped } -> untyped
+
+      def close: () -> untyped
+
+      def body: () -> untyped
+
+      def respond_to?: (untyped method, ?bool include_private) -> untyped
+
+      def to_path: () -> untyped
+
+      def to_ary: () -> nil
+    end
+
+    def handle_no_content!: () -> untyped
+
+    def rack_response: (untyped status, untyped header) -> untyped
+  end
+end
+
+module ActionDispatch
+  module Http
+    # Models uploaded files.
+    #
+    # The actual file is accessible via the +tempfile+ accessor, though some
+    # of its interface is available directly for convenience.
+    #
+    # Uploaded files are temporary files whose lifespan is one request. When
+    # the object is finalized Ruby unlinks the file, so there is no need to
+    # clean them with a separate maintenance task.
+    class UploadedFile
+      # The basename of the file in the client.
+      attr_accessor original_filename: untyped
+
+      # A string with the MIME type of the file.
+      attr_accessor content_type: untyped
+
+      # A +Tempfile+ object with the actual uploaded file. Note that some of
+      # its interface is available directly.
+      attr_accessor tempfile: untyped
+
+      # A string with the headers of the multipart request.
+      attr_accessor headers: untyped
+
+      def initialize: (untyped hash) -> untyped
+
+      # Shortcut for +tempfile.read+.
+      def read: (?untyped? length, ?untyped? buffer) -> untyped
+
+      # Shortcut for +tempfile.open+.
+      def open: () -> untyped
+
+      # Shortcut for +tempfile.close+.
+      def close: (?bool unlink_now) -> untyped
+
+      # Shortcut for +tempfile.path+.
+      def path: () -> untyped
+
+      # Shortcut for +tempfile.to_path+.
+      def to_path: () -> untyped
+
+      # Shortcut for +tempfile.rewind+.
+      def rewind: () -> untyped
+
+      # Shortcut for +tempfile.size+.
+      def size: () -> untyped
+
+      # Shortcut for +tempfile.eof?+.
+      def eof?: () -> untyped
+
+      def to_io: () -> untyped
+    end
+  end
+end
+
+module ActionDispatch
+  module Http
+    module URL
+      IP_HOST_REGEXP: untyped
+
+      HOST_REGEXP: untyped
+
+      PROTOCOL_REGEXP: untyped
+
+      # Returns the domain part of a host given the domain level.
+      #
+      #    # Top-level domain example
+      #    extract_domain('www.example.com', 1) # => "example.com"
+      #    # Second-level domain example
+      #    extract_domain('dev.www.example.co.uk', 2) # => "example.co.uk"
+      def self.extract_domain: (untyped host, untyped tld_length) -> untyped
+
+      # Returns the subdomains of a host as an Array given the domain level.
+      #
+      #    # Top-level domain example
+      #    extract_subdomains('www.example.com', 1) # => ["www"]
+      #    # Second-level domain example
+      #    extract_subdomains('dev.www.example.co.uk', 2) # => ["dev", "www"]
+      def self.extract_subdomains: (untyped host, untyped tld_length) -> untyped
+
+      # Returns the subdomains of a host as a String given the domain level.
+      #
+      #    # Top-level domain example
+      #    extract_subdomain('www.example.com', 1) # => "www"
+      #    # Second-level domain example
+      #    extract_subdomain('dev.www.example.co.uk', 2) # => "dev.www"
+      def self.extract_subdomain: (untyped host, untyped tld_length) -> untyped
+
+      def self.url_for: (untyped options) -> untyped
+
+      def self.full_url_for: (untyped options) -> untyped
+
+      def self.path_for: (untyped options) -> untyped
+
+      def self.add_params: (untyped path, untyped params) -> untyped
+
+      def self.add_anchor: (untyped path, untyped anchor) -> untyped
+
+      def self.extract_domain_from: (untyped host, untyped tld_length) -> untyped
+
+      def self.extract_subdomains_from: (untyped host, untyped tld_length) -> untyped
+
+      def self.add_trailing_slash: (untyped path) -> untyped
+
+      def self.build_host_url: (untyped host, untyped port, untyped protocol, untyped options, untyped path) -> untyped
+
+      def self.named_host?: (untyped host) -> untyped
+
+      def self.normalize_protocol: (untyped protocol) -> untyped
+
+      def self.normalize_host: (untyped _host, untyped options) -> untyped
+
+      def self.normalize_port: (untyped port, untyped protocol) { (untyped) -> untyped } -> (nil | untyped)
+
+      def initialize: () -> untyped
+
+      # Returns the complete URL used for this request.
+      #
+      #   req = ActionDispatch::Request.new 'HTTP_HOST' => 'example.com'
+      #   req.url # => "http://example.com"
+      def url: () -> untyped
+
+      # Returns 'https://' if this is an SSL request and 'http://' otherwise.
+      #
+      #   req = ActionDispatch::Request.new 'HTTP_HOST' => 'example.com'
+      #   req.protocol # => "http://"
+      #
+      #   req = ActionDispatch::Request.new 'HTTP_HOST' => 'example.com', 'HTTPS' => 'on'
+      #   req.protocol # => "https://"
+      def protocol: () -> untyped
+
+      # Returns the \host and port for this request, such as "example.com:8080".
+      #
+      #   req = ActionDispatch::Request.new 'HTTP_HOST' => 'example.com'
+      #   req.raw_host_with_port # => "example.com"
+      #
+      #   req = ActionDispatch::Request.new 'HTTP_HOST' => 'example.com:80'
+      #   req.raw_host_with_port # => "example.com:80"
+      #
+      #   req = ActionDispatch::Request.new 'HTTP_HOST' => 'example.com:8080'
+      #   req.raw_host_with_port # => "example.com:8080"
+      def raw_host_with_port: () -> untyped
+
+      # Returns the host for this request, such as "example.com".
+      #
+      #   req = ActionDispatch::Request.new 'HTTP_HOST' => 'example.com:8080'
+      #   req.host # => "example.com"
+      def host: () -> untyped
+
+      # Returns a \host:\port string for this request, such as "example.com" or
+      # "example.com:8080". Port is only included if it is not a default port
+      # (80 or 443)
+      #
+      #   req = ActionDispatch::Request.new 'HTTP_HOST' => 'example.com'
+      #   req.host_with_port # => "example.com"
+      #
+      #   req = ActionDispatch::Request.new 'HTTP_HOST' => 'example.com:80'
+      #   req.host_with_port # => "example.com"
+      #
+      #   req = ActionDispatch::Request.new 'HTTP_HOST' => 'example.com:8080'
+      #   req.host_with_port # => "example.com:8080"
+      def host_with_port: () -> ::String
+
+      # Returns the port number of this request as an integer.
+      #
+      #   req = ActionDispatch::Request.new 'HTTP_HOST' => 'example.com'
+      #   req.port # => 80
+      #
+      #   req = ActionDispatch::Request.new 'HTTP_HOST' => 'example.com:8080'
+      #   req.port # => 8080
+      def port: () -> untyped
+
+      # Returns the standard \port number for this request's protocol.
+      #
+      #   req = ActionDispatch::Request.new 'HTTP_HOST' => 'example.com:8080'
+      #   req.standard_port # => 80
+      def standard_port: () -> untyped
+
+      # Returns whether this request is using the standard port
+      #
+      #   req = ActionDispatch::Request.new 'HTTP_HOST' => 'example.com:80'
+      #   req.standard_port? # => true
+      #
+      #   req = ActionDispatch::Request.new 'HTTP_HOST' => 'example.com:8080'
+      #   req.standard_port? # => false
+      def standard_port?: () -> untyped
+
+      # Returns a number \port suffix like 8080 if the \port number of this request
+      # is not the default HTTP \port 80 or HTTPS \port 443.
+      #
+      #   req = ActionDispatch::Request.new 'HTTP_HOST' => 'example.com:80'
+      #   req.optional_port # => nil
+      #
+      #   req = ActionDispatch::Request.new 'HTTP_HOST' => 'example.com:8080'
+      #   req.optional_port # => 8080
+      def optional_port: () -> untyped
+
+      # Returns a string \port suffix, including colon, like ":8080" if the \port
+      # number of this request is not the default HTTP \port 80 or HTTPS \port 443.
+      #
+      #   req = ActionDispatch::Request.new 'HTTP_HOST' => 'example.com:80'
+      #   req.port_string # => ""
+      #
+      #   req = ActionDispatch::Request.new 'HTTP_HOST' => 'example.com:8080'
+      #   req.port_string # => ":8080"
+      def port_string: () -> untyped
+
+      # Returns the requested port, such as 8080, based on SERVER_PORT
+      #
+      #   req = ActionDispatch::Request.new 'SERVER_PORT' => '80'
+      #   req.server_port # => 80
+      #
+      #   req = ActionDispatch::Request.new 'SERVER_PORT' => '8080'
+      #   req.server_port # => 8080
+      def server_port: () -> untyped
+
+      # Returns the \domain part of a \host, such as "rubyonrails.org" in "www.rubyonrails.org". You can specify
+      # a different <tt>tld_length</tt>, such as 2 to catch rubyonrails.co.uk in "www.rubyonrails.co.uk".
+      def domain: (?untyped tld_length) -> untyped
+
+      # Returns all the \subdomains as an array, so <tt>["dev", "www"]</tt> would be
+      # returned for "dev.www.rubyonrails.org". You can specify a different <tt>tld_length</tt>,
+      # such as 2 to catch <tt>["www"]</tt> instead of <tt>["www", "rubyonrails"]</tt>
+      # in "www.rubyonrails.co.uk".
+      def subdomains: (?untyped tld_length) -> untyped
+
+      # Returns all the \subdomains as a string, so <tt>"dev.www"</tt> would be
+      # returned for "dev.www.rubyonrails.org". You can specify a different <tt>tld_length</tt>,
+      # such as 2 to catch <tt>"www"</tt> instead of <tt>"www.rubyonrails"</tt>
+      # in "www.rubyonrails.co.uk".
+      def subdomain: (?untyped tld_length) -> untyped
+    end
+  end
+end
+
+module ActionDispatch
+  # :stopdoc:
+  module Journey
+    # The Formatter class is used for formatting URLs. For example, parameters
+    # passed to +url_for+ in Rails will eventually call Formatter#generate.
+    class Formatter
+      attr_reader routes: untyped
+
+      def initialize: (untyped routes) -> untyped
+
+      def generate: (untyped name, untyped options, untyped path_parameters, ?untyped? parameterize) -> (::Array[untyped] | untyped)
+
+      def clear: () -> untyped
+
+      def extract_parameterized_parts: (untyped route, untyped options, untyped recall, ?untyped? parameterize) -> untyped
+
+      def named_routes: () -> untyped
+
+      def match_route: (untyped name, untyped options) { (untyped) -> untyped } -> untyped
+
+      def non_recursive: (untyped cache, untyped options) -> untyped
+
+      module RegexCaseComparator
+        DEFAULT_INPUT: untyped
+
+        DEFAULT_REGEX: untyped
+
+        def self.===: (untyped regex) -> untyped
+      end
+
+      # Returns an array populated with missing keys if any are present.
+      def missing_keys: (untyped route, untyped parts) -> untyped
+
+      def possibles: (untyped cache, untyped options, ?::Integer depth) -> untyped
+
+      def build_cache: () -> untyped
+
+      def cache: () -> untyped
+    end
+  end
+end
+
+module ActionDispatch
+  module Journey
+    module GTG
+      class Builder
+        # :nodoc:
+        # :nodoc:
+        # :nodoc:
+        DUMMY: untyped
+
+        attr_reader root: untyped
+
+        attr_reader ast: untyped
+
+        attr_reader endpoints: untyped
+
+        def initialize: (untyped root) -> untyped
+
+        def transition_table: () -> untyped
+
+        def nullable?: (untyped node) -> untyped
+
+        def firstpos: (untyped node) -> untyped
+
+        def lastpos: (untyped node) -> untyped
+
+        def followpos: (untyped node) -> untyped
+
+        def followpos_table: () -> untyped
+
+        def build_followpos: () -> untyped
+
+        def symbol: (untyped edge) -> untyped
+      end
+    end
+  end
+end
+
+module ActionDispatch
+  module Journey
+    module GTG
+      class MatchData
+        # :nodoc:
+        # :nodoc:
+        # :nodoc:
+        attr_reader memos: untyped
+
+        def initialize: (untyped memos) -> untyped
+      end
+
+      class Simulator
+        # :nodoc:
+        attr_reader tt: untyped
+
+        def initialize: (untyped transition_table) -> untyped
+
+        def memos: (untyped string) { () -> untyped } -> untyped
+      end
+    end
+  end
+end
+
+module ActionDispatch
+  module Journey
+    module GTG
+      class TransitionTable
+        # :nodoc:
+        # :nodoc:
+        # :nodoc:
+        include Journey::NFA::Dot
+
+        attr_reader memos: untyped
+
+        def initialize: () -> untyped
+
+        def add_accepting: (untyped state) -> untyped
+
+        def accepting_states: () -> untyped
+
+        def accepting?: (untyped state) -> untyped
+
+        def add_memo: (untyped idx, untyped memo) -> untyped
+
+        def memo: (untyped idx) -> untyped
+
+        def eclosure: (untyped t) -> untyped
+
+        def move: (untyped t, untyped a) -> (::Array[untyped] | untyped)
+
+        def as_json: (?untyped? options) -> { regexp_states: untyped, string_states: untyped, accepting: untyped }
+
+        def to_svg: () -> untyped
+
+        def visualizer: (untyped paths, ?::String title) -> untyped
+
+        def []=: (untyped from, untyped to, untyped sym) -> untyped
+
+        def states: () -> untyped
+
+        def transitions: () -> untyped
+
+        def states_hash_for: (untyped sym) -> untyped
+      end
+    end
+  end
+end
+
+module ActionDispatch
+  module Journey
+    module NFA
+      class Visitor < Visitors::Visitor
+        # :nodoc:
+        # :nodoc:
+        # :nodoc:
+        def initialize: (untyped tt) -> untyped
+
+        def visit_CAT: (untyped node) -> ::Array[untyped]
+
+        def visit_GROUP: (untyped node) -> ::Array[untyped]
+
+        def visit_OR: (untyped node) -> ::Array[untyped]
+
+        def terminal: (untyped node) -> ::Array[untyped]
+      end
+
+      class Builder
+        # :nodoc:
+        def initialize: (untyped ast) -> untyped
+
+        def transition_table: () -> untyped
+      end
+    end
+  end
+end
+
+module ActionDispatch
+  module Journey
+    module NFA
+      module Dot
+        # :nodoc:
+        # :nodoc:
+        # :nodoc:
+        def to_dot: () -> ::String
+      end
+    end
+  end
+end
+
+module ActionDispatch
+  module Journey
+    module NFA
+      class MatchData
+        # :nodoc:
+        # :nodoc:
+        # :nodoc:
+        attr_reader memos: untyped
+
+        def initialize: (untyped memos) -> untyped
+      end
+
+      class Simulator
+        # :nodoc:
+        attr_reader tt: untyped
+
+        def initialize: (untyped transition_table) -> untyped
+
+        def simulate: (untyped string) -> (nil | MatchData)
+
+        alias =~ simulate
+
+        alias match simulate
+      end
+    end
+  end
+end
+
+module ActionDispatch
+  module Journey
+    module NFA
+      class TransitionTable
+        # :nodoc:
+        # :nodoc:
+        # :nodoc:
+        include Journey::NFA::Dot
+
+        attr_accessor accepting: untyped
+
+        attr_reader memos: untyped
+
+        def initialize: () -> untyped
+
+        def accepting?: (untyped state) -> untyped
+
+        def accepting_states: () -> ::Array[untyped]
+
+        def add_memo: (untyped idx, untyped memo) -> untyped
+
+        def memo: (untyped idx) -> untyped
+
+        def []=: (untyped i, untyped f, untyped s) -> untyped
+
+        def merge: (untyped left, untyped right) -> untyped
+
+        def states: () -> untyped
+
+        # Returns set of NFA states to which there is a transition on ast symbol
+        # +a+ from some state +s+ in +t+.
+        def following_states: (untyped t, untyped a) -> untyped
+
+        # Returns set of NFA states to which there is a transition on ast symbol
+        # +a+ from some state +s+ in +t+.
+        def move: (untyped t, untyped a) -> untyped
+
+        def alphabet: () -> untyped
+
+        # Returns a set of NFA states reachable from some NFA state +s+ in set
+        # +t+ on nil-transitions alone.
+        def eclosure: (untyped t) -> untyped
+
+        def transitions: () -> untyped
+
+        def inverted: () -> untyped
+      end
+    end
+  end
+end
+
+module ActionDispatch
+  module Journey
+    module Nodes
+      class Node
+        # :nodoc:
+        # :nodoc:
+        # :nodoc:
+        include Enumerable[untyped]
+
+        attr_accessor left: untyped
+
+        attr_accessor memo: untyped
+
+        def initialize: (untyped left) -> untyped
+
+        def each: () { () -> untyped } -> untyped
+
+        def to_s: () -> untyped
+
+        def to_dot: () -> untyped
+
+        def to_sym: () -> untyped
+
+        def name: () -> untyped
+
+        def `type`: () -> untyped
+
+        def symbol?: () -> ::FalseClass
+
+        def literal?: () -> ::FalseClass
+
+        def terminal?: () -> ::FalseClass
+
+        def star?: () -> ::FalseClass
+
+        def cat?: () -> ::FalseClass
+
+        def group?: () -> ::FalseClass
+      end
+
+      class Terminal < Node
+        # :nodoc:
+        alias symbol left
+
+        def terminal?: () -> ::TrueClass
+      end
+
+      class Literal < Terminal
+        # :nodoc:
+        def literal?: () -> ::TrueClass
+
+        def `type`: () -> :LITERAL
+      end
+
+      class Dummy < Literal
+        # :nodoc:
+        def initialize: (?untyped x) -> untyped
+
+        def literal?: () -> ::FalseClass
+      end
+
+      class Slash < Terminal
+        # :nodoc:
+        def `type`: () -> :SLASH
+      end
+
+      class Dot < Terminal
+        # :nodoc:
+        def `type`: () -> :DOT
+      end
+
+      class Symbol < Terminal
+        # :nodoc:
+        attr_accessor regexp: untyped
+
+        alias symbol regexp
+
+        attr_reader name: untyped
+
+        DEFAULT_EXP: untyped
+
+        def initialize: (untyped left) -> untyped
+
+        def default_regexp?: () -> untyped
+
+        def `type`: () -> :SYMBOL
+
+        def symbol?: () -> ::TrueClass
+      end
+
+      class Unary < Node
+        # :nodoc:
+        def children: () -> ::Array[untyped]
+      end
+
+      class Group < Unary
+        # :nodoc:
+        def `type`: () -> :GROUP
+
+        def group?: () -> ::TrueClass
+      end
+
+      class Star < Unary
+        # :nodoc:
+        def star?: () -> ::TrueClass
+
+        def `type`: () -> :STAR
+
+        def name: () -> untyped
+      end
+
+      class Binary < Node
+        # :nodoc:
+        attr_accessor right: untyped
+
+        def initialize: (untyped left, untyped right) -> untyped
+
+        def children: () -> ::Array[untyped]
+      end
+
+      class Cat < Binary
+        # :nodoc:
+        def cat?: () -> ::TrueClass
+
+        def `type`: () -> :CAT
+      end
+
+      class Or < Node
+        # :nodoc:
+        attr_reader children: untyped
+
+        def initialize: (untyped children) -> untyped
+
+        def `type`: () -> :OR
+      end
+    end
+  end
+end
+
+module ActionDispatch
+  module Journey
+    class Parser < Racc::Parser
+      Racc_arg: ::Array[untyped]
+
+      Racc_token_to_s_table: ::Array[untyped]
+
+      Racc_debug_parser: bool
+
+      def _reduce_1: (untyped val, untyped _values) -> Nodes::Cat
+
+      def _reduce_2: (untyped val, untyped _values) -> untyped
+
+      def _reduce_7: (untyped val, untyped _values) -> Nodes::Group
+
+      def _reduce_8: (untyped val, untyped _values) -> Nodes::Or
+
+      def _reduce_9: (untyped val, untyped _values) -> Nodes::Or
+
+      def _reduce_10: (untyped val, untyped _values) -> Nodes::Star
+
+      def _reduce_15: (untyped val, untyped _values) -> Nodes::Slash
+
+      def _reduce_16: (untyped val, untyped _values) -> Nodes::Symbol
+
+      def _reduce_17: (untyped val, untyped _values) -> Nodes::Literal
+
+      def _reduce_18: (untyped val, untyped _values) -> Nodes::Dot
+
+      def _reduce_none: (untyped val, untyped _values) -> untyped
+    end
+  end
+end
+
+module ActionDispatch
+  # :stopdoc:
+  module Journey
+    class Parser < Racc::Parser
+      include Journey::Nodes
+
+      def self.parse: (untyped string) -> untyped
+
+      def initialize: () -> untyped
+
+      def parse: (untyped string) -> untyped
+
+      def next_token: () -> untyped
+    end
+  end
+end
+
+module ActionDispatch
+  module Journey
+    module Path
+      class Pattern
+        # :nodoc:
+        # :nodoc:
+        # :nodoc:
+        attr_reader spec: untyped
+
+        # :nodoc:
+        # :nodoc:
+        # :nodoc:
+        attr_reader requirements: untyped
+
+        # :nodoc:
+        # :nodoc:
+        # :nodoc:
+        attr_reader anchored: untyped
+
+        def self.from_string: (untyped string) -> untyped
+
+        def self.build: (untyped path, untyped requirements, untyped separators, untyped anchored) -> untyped
+
+        def initialize: (untyped ast, untyped requirements, untyped separators, untyped anchored) -> untyped
+
+        def build_formatter: () -> untyped
+
+        def eager_load!: () -> nil
+
+        def ast: () -> untyped
+
+        def names: () -> untyped
+
+        def required_names: () -> untyped
+
+        def optional_names: () -> untyped
+
+        class AnchoredRegexp < Journey::Visitors::Visitor
+          # :nodoc:
+          def initialize: (untyped separator, untyped matchers) -> untyped
+
+          def accept: (untyped node) -> ::Regexp
+
+          def visit_CAT: (untyped node) -> untyped
+
+          def visit_SYMBOL: (untyped node) -> (untyped | ::String)
+
+          def visit_GROUP: (untyped node) -> ::String
+
+          def visit_LITERAL: (untyped node) -> untyped
+
+          alias visit_DOT visit_LITERAL
+
+          def visit_SLASH: (untyped node) -> untyped
+
+          def visit_STAR: (untyped node) -> ::String
+
+          def visit_OR: (untyped node) -> ::String
+        end
+
+        class UnanchoredRegexp < AnchoredRegexp
+          # :nodoc:
+          def accept: (untyped node) -> untyped
+        end
+
+        class MatchData
+          # :nodoc:
+          attr_reader names: untyped
+
+          def initialize: (untyped names, untyped offsets, untyped match) -> untyped
+
+          def captures: () -> untyped
+
+          def named_captures: () -> untyped
+
+          def []: (untyped x) -> untyped
+
+          def length: () -> untyped
+
+          def post_match: () -> untyped
+
+          def to_s: () -> untyped
+        end
+
+        def match: (untyped other) -> (nil | MatchData)
+
+        alias =~ match
+
+        def source: () -> untyped
+
+        def to_regexp: () -> untyped
+
+        def regexp_visitor: () -> untyped
+
+        def offsets: () -> untyped
+      end
+    end
+  end
+end
+
+module ActionDispatch
+  # :stopdoc:
+  module Journey
+    class Route
+      attr_reader app: untyped
+
+      attr_reader path: untyped
+
+      attr_reader defaults: untyped
+
+      attr_reader name: untyped
+
+      attr_reader precedence: untyped
+
+      attr_reader constraints: untyped
+
+      attr_reader internal: untyped
+
+      attr_reader scope_options: untyped
+
+      alias conditions constraints
+
+      module VerbMatchers
+        VERBS: ::Array[untyped]
+
+        class Unknown
+          attr_reader verb: untyped
+
+          def initialize: (untyped verb) -> untyped
+
+          def call: (untyped request) -> untyped
+        end
+
+        class All
+          def self.call: (untyped _) -> ::TrueClass
+
+          def self.verb: () -> ::String
+        end
+
+        VERB_TO_CLASS: untyped
+      end
+
+      def self.verb_matcher: (untyped verb) -> untyped
+
+      def self.build: (untyped name, untyped app, untyped path, untyped constraints, untyped required_defaults, untyped defaults) -> untyped
+
+      #
+      # +path+ is a path constraint.
+      # +constraints+ is a hash of constraints to be applied to this route.
+      def initialize: (untyped name, untyped app, untyped path, untyped constraints, untyped required_defaults, untyped defaults, untyped request_method_match, untyped precedence, untyped scope_options, ?bool internal) -> untyped
+
+      def eager_load!: () -> nil
+
+      def ast: () -> untyped
+
+      # Needed for `rails routes`. Picks up succinctly defined requirements
+      # for a route, for example route
+      #
+      #   get 'photo/:id', :controller => 'photos', :action => 'show',
+      #     :id => /[A-Z]\d{5}/
+      #
+      # will have {:controller=>"photos", :action=>"show", :id=>/[A-Z]\d{5}/}
+      # as requirements.
+      def requirements: () -> untyped
+
+      def segments: () -> untyped
+
+      def required_keys: () -> untyped
+
+      def score: (untyped supplied_keys) -> (-1 | untyped)
+
+      def parts: () -> untyped
+
+      alias segment_keys parts
+
+      def format: (untyped path_options) -> untyped
+
+      def required_parts: () -> untyped
+
+      def required_default?: (untyped key) -> untyped
+
+      def required_defaults: () -> untyped
+
+      def glob?: () -> untyped
+
+      def dispatcher?: () -> untyped
+
+      def matches?: (untyped request) -> untyped
+
+      def ip: () -> untyped
+
+      def requires_matching_verb?: () -> untyped
+
+      def verb: () -> untyped
+
+      def verbs: () -> untyped
+
+      def match_verb: (untyped request) -> untyped
+    end
+  end
+end
+
+module ActionDispatch
+  module Journey
+    class Router
+      class Utils
+        # :nodoc:
+        # :nodoc:
+        # :nodoc:
+        # Normalizes URI path.
+        #
+        # Strips off trailing slash and ensures there is a leading slash.
+        # Also converts downcase URL encoded string to uppercase.
+        #
+        #   normalize_path("/foo")  # => "/foo"
+        #   normalize_path("/foo/") # => "/foo"
+        #   normalize_path("foo")   # => "/foo"
+        #   normalize_path("")      # => "/"
+        #   normalize_path("/%ab")  # => "/%AB"
+        def self.normalize_path: (untyped path) -> untyped
+
+        class UriEncoder
+          # URI path and fragment escaping
+          # https://tools.ietf.org/html/rfc3986
+          # :nodoc:
+          ENCODE: ::String
+
+          US_ASCII: untyped
+
+          UTF_8: untyped
+
+          EMPTY: untyped
+
+          DEC2HEX: untyped
+
+          ALPHA: ::String
+
+          DIGIT: ::String
+
+          UNRESERVED: ::String
+
+          SUB_DELIMS: ::String
+
+          ESCAPED: untyped
+
+          FRAGMENT: untyped
+
+          SEGMENT: untyped
+
+          PATH: untyped
+
+          def escape_fragment: (untyped fragment) -> untyped
+
+          def escape_path: (untyped path) -> untyped
+
+          def escape_segment: (untyped segment) -> untyped
+
+          def unescape_uri: (untyped uri) -> untyped
+
+          def escape: (untyped component, untyped pattern) -> untyped
+
+          def percent_encode: (untyped unsafe) -> untyped
+        end
+
+        ENCODER: untyped
+
+        def self.escape_path: (untyped path) -> untyped
+
+        def self.escape_segment: (untyped segment) -> untyped
+
+        def self.escape_fragment: (untyped fragment) -> untyped
+
+        # Replaces any escaped sequences with their unescaped representations.
+        #
+        #   uri = "/topics?title=Ruby%20on%20Rails"
+        #   unescape_uri(uri)  #=> "/topics?title=Ruby on Rails"
+        def self.unescape_uri: (untyped uri) -> untyped
+      end
+    end
+  end
+end
+
+module ActionDispatch
+  module Journey
+    class Router
+      # :nodoc:
+      # :nodoc:
+      attr_accessor routes: untyped
+
+      def initialize: (untyped routes) -> untyped
+
+      def eager_load!: () -> nil
+
+      def serve: (untyped req) -> (::Array[untyped] | ::Array[404 | ::Hash[::String, "pass"] | ::Array["Not Found"]])
+
+      def recognize: (untyped rails_req) { (untyped, untyped) -> untyped } -> untyped
+
+      def visualizer: () -> untyped
+
+      def partitioned_routes: () -> untyped
+
+      def ast: () -> untyped
+
+      def simulator: () -> untyped
+
+      def custom_routes: () -> untyped
+
+      def filter_routes: (untyped path) -> (::Array[untyped] | untyped)
+
+      def find_routes: (untyped req) -> untyped
+
+      def match_head_routes: (untyped routes, untyped req) -> untyped
+
+      def match_routes: (untyped routes, untyped req) -> untyped
+    end
+  end
+end
+
+module ActionDispatch
+  module Journey
+    class Routes
+      # :nodoc:
+      # The Routing table. Contains all routes for a system. Routes can be
+      # added to the table by calling Routes#add_route.
+      # :nodoc:
+      include Enumerable[untyped]
+
+      attr_reader routes: untyped
+
+      attr_reader custom_routes: untyped
+
+      attr_reader anchored_routes: untyped
+
+      def initialize: () -> untyped
+
+      def empty?: () -> untyped
+
+      def length: () -> untyped
+
+      alias size length
+
+      def last: () -> untyped
+
+      def each: () { () -> untyped } -> untyped
+
+      def clear: () -> untyped
+
+      def partition_route: (untyped route) -> untyped
+
+      def ast: () -> untyped
+
+      def simulator: () -> untyped
+
+      def add_route: (untyped name, untyped mapping) -> untyped
+
+      def clear_cache!: () -> untyped
+    end
+  end
+end
+
+module ActionDispatch
+  module Journey
+    class Scanner
+      # :nodoc:
+      # :nodoc:
+      def initialize: () -> untyped
+
+      def scan_setup: (untyped str) -> untyped
+
+      def eos?: () -> untyped
+
+      def pos: () -> untyped
+
+      def pre_match: () -> untyped
+
+      def next_token: () -> (nil | untyped)
+
+      # takes advantage of String @- deduping capabilities in Ruby 2.5 upwards
+      # see: https://bugs.ruby-lang.org/issues/13077
+      def dedup_scan: (untyped regex) -> untyped
+
+      def scan: () -> untyped
+    end
+  end
+end
+
+module ActionDispatch
+  # :stopdoc:
+  module Journey
+    class Format
+      ESCAPE_PATH: untyped
+
+      ESCAPE_SEGMENT: untyped
+
+      class Parameter[T] < ::Struct[T]
+        attr_accessor name(): untyped
+
+        attr_accessor escaper(): untyped
+
+        def escape: (untyped value) -> untyped
+      end
+
+      def self.required_path: (untyped symbol) -> Parameter[untyped]
+
+      def self.required_segment: (untyped symbol) -> Parameter[untyped]
+
+      def initialize: (untyped parts) -> untyped
+
+      def evaluate: (untyped hash) -> (::String | untyped)
+    end
+
+    module Visitors
+      class Visitor
+        # :nodoc:
+        # :nodoc:
+        DISPATCH_CACHE: ::Hash[untyped, untyped]
+
+        def accept: (untyped node) -> untyped
+
+        def visit: (untyped node) -> untyped
+
+        def binary: (untyped node) -> untyped
+
+        def visit_CAT: (untyped n) -> untyped
+
+        def nary: (untyped node) -> untyped
+
+        def visit_OR: (untyped n) -> untyped
+
+        def unary: (untyped node) -> untyped
+
+        def visit_GROUP: (untyped n) -> untyped
+
+        def visit_STAR: (untyped n) -> untyped
+
+        def terminal: (untyped node) -> nil
+
+        def visit_LITERAL: (untyped n) -> untyped
+
+        def visit_SYMBOL: (untyped n) -> untyped
+
+        def visit_SLASH: (untyped n) -> untyped
+
+        def visit_DOT: (untyped n) -> untyped
+      end
+
+      class FunctionalVisitor
+        # :nodoc:
+        DISPATCH_CACHE: ::Hash[untyped, untyped]
+
+        def accept: (untyped node, untyped seed) -> untyped
+
+        def visit: (untyped node, untyped seed) -> untyped
+
+        def binary: (untyped node, untyped seed) -> untyped
+
+        def visit_CAT: (untyped n, untyped seed) -> untyped
+
+        def nary: (untyped node, untyped seed) -> untyped
+
+        def visit_OR: (untyped n, untyped seed) -> untyped
+
+        def unary: (untyped node, untyped seed) -> untyped
+
+        def visit_GROUP: (untyped n, untyped seed) -> untyped
+
+        def visit_STAR: (untyped n, untyped seed) -> untyped
+
+        def terminal: (untyped node, untyped seed) -> untyped
+
+        def visit_LITERAL: (untyped n, untyped seed) -> untyped
+
+        def visit_SYMBOL: (untyped n, untyped seed) -> untyped
+
+        def visit_SLASH: (untyped n, untyped seed) -> untyped
+
+        def visit_DOT: (untyped n, untyped seed) -> untyped
+      end
+
+      class FormatBuilder < Visitor
+        # :nodoc:
+        def accept: (untyped node) -> Journey::Format
+
+        def terminal: (untyped node) -> ::Array[untyped]
+
+        def binary: (untyped node) -> untyped
+
+        def visit_GROUP: (untyped n) -> ::Array[Journey::Format]
+
+        def visit_STAR: (untyped n) -> ::Array[untyped]
+
+        def visit_SYMBOL: (untyped n) -> untyped
+      end
+
+      class Each < FunctionalVisitor
+        # Loop through the requirements AST.
+        # :nodoc:
+        def visit: (untyped node, untyped block) -> untyped
+
+        INSTANCE: untyped
+      end
+
+      class String < FunctionalVisitor
+        def binary: (untyped node, untyped seed) -> untyped
+
+        def nary: (untyped node, untyped seed) -> untyped
+
+        def terminal: (untyped node, untyped seed) -> untyped
+
+        def visit_GROUP: (untyped node, untyped seed) -> untyped
+
+        INSTANCE: untyped
+      end
+
+      class Dot < FunctionalVisitor
+        # :nodoc:
+        def initialize: () -> untyped
+
+        def accept: (untyped node, ?::Array[untyped] seed) -> ::String
+
+        def binary: (untyped node, untyped seed) -> untyped
+
+        def nary: (untyped node, untyped seed) -> untyped
+
+        def unary: (untyped node, untyped seed) -> untyped
+
+        def visit_GROUP: (untyped node, untyped seed) -> untyped
+
+        def visit_CAT: (untyped node, untyped seed) -> untyped
+
+        def visit_STAR: (untyped node, untyped seed) -> untyped
+
+        def visit_OR: (untyped node, untyped seed) -> untyped
+
+        def terminal: (untyped node, untyped seed) -> untyped
+
+        INSTANCE: untyped
+      end
+    end
+  end
+end
+
+module ActionDispatch
+  class ActionableExceptions
+    def initialize: (untyped app) -> untyped
+
+    def call: (untyped env) -> untyped
+
+    def actionable_request?: (untyped request) -> untyped
+
+    def redirect_to: (untyped location) -> ::Array[302 | ::Hash[::String, ::String | untyped] | ::Array[untyped]]
+  end
+end
+
+module ActionDispatch
+  # Provides callbacks to be executed before and after dispatching the request.
+  class Callbacks
+    include ActiveSupport::Callbacks
+
+    def self.before: (*untyped args) { () -> untyped } -> untyped
+
+    def self.after: (*untyped args) { () -> untyped } -> untyped
+
+    def initialize: (untyped app) -> untyped
+
+    def call: (untyped env) -> untyped
+  end
+end
+
+module ActionDispatch
+  class Request
+    def cookie_jar: () -> untyped
+
+    def commit_cookie_jar!: () -> untyped
+
+    def have_cookie_jar?: () -> untyped
+
+    def cookie_jar=: (untyped jar) -> untyped
+
+    def key_generator: () -> untyped
+
+    def signed_cookie_salt: () -> untyped
+
+    def encrypted_cookie_salt: () -> untyped
+
+    def encrypted_signed_cookie_salt: () -> untyped
+
+    def authenticated_encrypted_cookie_salt: () -> untyped
+
+    def use_authenticated_cookie_encryption: () -> untyped
+
+    def encrypted_cookie_cipher: () -> untyped
+
+    def signed_cookie_digest: () -> untyped
+
+    def secret_key_base: () -> untyped
+
+    def cookies_serializer: () -> untyped
+
+    def cookies_digest: () -> untyped
+
+    def cookies_rotations: () -> untyped
+
+    def use_cookies_with_metadata: () -> untyped
+  end
+
+  # \Cookies are read and written through ActionController#cookies.
+  #
+  # The cookies being read are the ones received along with the request, the cookies
+  # being written will be sent out with the response. Reading a cookie does not get
+  # the cookie object itself back, just the value it holds.
+  #
+  # Examples of writing:
+  #
+  #   # Sets a simple session cookie.
+  #   # This cookie will be deleted when the user's browser is closed.
+  #   cookies[:user_name] = "david"
+  #
+  #   # Cookie values are String based. Other data types need to be serialized.
+  #   cookies[:lat_lon] = JSON.generate([47.68, -122.37])
+  #
+  #   # Sets a cookie that expires in 1 hour.
+  #   cookies[:login] = { value: "XJ-122", expires: 1.hour }
+  #
+  #   # Sets a cookie that expires at a specific time.
+  #   cookies[:login] = { value: "XJ-122", expires: Time.utc(2020, 10, 15, 5) }
+  #
+  #   # Sets a signed cookie, which prevents users from tampering with its value.
+  #   # It can be read using the signed method `cookies.signed[:name]`
+  #   cookies.signed[:user_id] = current_user.id
+  #
+  #   # Sets an encrypted cookie value before sending it to the client which
+  #   # prevent users from reading and tampering with its value.
+  #   # It can be read using the encrypted method `cookies.encrypted[:name]`
+  #   cookies.encrypted[:discount] = 45
+  #
+  #   # Sets a "permanent" cookie (which expires in 20 years from now).
+  #   cookies.permanent[:login] = "XJ-122"
+  #
+  #   # You can also chain these methods:
+  #   cookies.signed.permanent[:login] = "XJ-122"
+  #
+  # Examples of reading:
+  #
+  #   cookies[:user_name]           # => "david"
+  #   cookies.size                  # => 2
+  #   JSON.parse(cookies[:lat_lon]) # => [47.68, -122.37]
+  #   cookies.signed[:login]        # => "XJ-122"
+  #   cookies.encrypted[:discount]  # => 45
+  #
+  # Example for deleting:
+  #
+  #   cookies.delete :user_name
+  #
+  # Please note that if you specify a :domain when setting a cookie, you must also specify the domain when deleting the cookie:
+  #
+  #  cookies[:name] = {
+  #    value: 'a yummy cookie',
+  #    expires: 1.year,
+  #    domain: 'domain.com'
+  #  }
+  #
+  #  cookies.delete(:name, domain: 'domain.com')
+  #
+  # The option symbols for setting cookies are:
+  #
+  # * <tt>:value</tt> - The cookie's value.
+  # * <tt>:path</tt> - The path for which this cookie applies. Defaults to the root
+  #   of the application.
+  # * <tt>:domain</tt> - The domain for which this cookie applies so you can
+  #   restrict to the domain level. If you use a schema like www.example.com
+  #   and want to share session with user.example.com set <tt>:domain</tt>
+  #   to <tt>:all</tt>. Make sure to specify the <tt>:domain</tt> option with
+  #   <tt>:all</tt> or <tt>Array</tt> again when deleting cookies.
+  #
+  #     domain: nil  # Does not set cookie domain. (default)
+  #     domain: :all # Allow the cookie for the top most level
+  #                  # domain and subdomains.
+  #     domain: %w(.example.com .example.org) # Allow the cookie
+  #                                           # for concrete domain names.
+  #
+  # * <tt>:tld_length</tt> - When using <tt>:domain => :all</tt>, this option can be used to explicitly
+  #   set the TLD length when using a short (<= 3 character) domain that is being interpreted as part of a TLD.
+  #   For example, to share cookies between user1.lvh.me and user2.lvh.me, set <tt>:tld_length</tt> to 2.
+  # * <tt>:expires</tt> - The time at which this cookie expires, as a \Time or ActiveSupport::Duration object.
+  # * <tt>:secure</tt> - Whether this cookie is only transmitted to HTTPS servers.
+  #   Default is +false+.
+  # * <tt>:httponly</tt> - Whether this cookie is accessible via scripting or
+  #   only HTTP. Defaults to +false+.
+  class Cookies
+    HTTP_HEADER: ::String
+
+    GENERATOR_KEY: ::String
+
+    SIGNED_COOKIE_SALT: ::String
+
+    ENCRYPTED_COOKIE_SALT: ::String
+
+    ENCRYPTED_SIGNED_COOKIE_SALT: ::String
+
+    AUTHENTICATED_ENCRYPTED_COOKIE_SALT: ::String
+
+    USE_AUTHENTICATED_COOKIE_ENCRYPTION: ::String
+
+    ENCRYPTED_COOKIE_CIPHER: ::String
+
+    SIGNED_COOKIE_DIGEST: ::String
+
+    SECRET_KEY_BASE: ::String
+
+    COOKIES_SERIALIZER: ::String
+
+    COOKIES_DIGEST: ::String
+
+    COOKIES_ROTATIONS: ::String
+
+    USE_COOKIES_WITH_METADATA: ::String
+
+    # Cookies can typically store 4096 bytes.
+    MAX_COOKIE_SIZE: ::Integer
+
+    # Raised when storing more than 4K of session data.
+    CookieOverflow: untyped
+
+    # Include in a cookie jar to allow chaining, e.g. cookies.permanent.signed.
+    module ChainedCookieJars
+      # Returns a jar that'll automatically set the assigned cookies to have an expiration date 20 years from now. Example:
+      #
+      #   cookies.permanent[:prefers_open_id] = true
+      #   # => Set-Cookie: prefers_open_id=true; path=/; expires=Sun, 16-Dec-2029 03:24:16 GMT
+      #
+      # This jar is only meant for writing. You'll read permanent cookies through the regular accessor.
+      #
+      # This jar allows chaining with the signed jar as well, so you can set permanent, signed cookies. Examples:
+      #
+      #   cookies.permanent.signed[:remember_me] = current_user.id
+      #   # => Set-Cookie: remember_me=BAhU--848956038e692d7046deab32b7131856ab20e14e; path=/; expires=Sun, 16-Dec-2029 03:24:16 GMT
+      def permanent: () -> untyped
+
+      # Returns a jar that'll automatically generate a signed representation of cookie value and verify it when reading from
+      # the cookie again. This is useful for creating cookies with values that the user is not supposed to change. If a signed
+      # cookie was tampered with by the user (or a 3rd party), +nil+ will be returned.
+      #
+      # This jar requires that you set a suitable secret for the verification on your app's +secret_key_base+.
+      #
+      # Example:
+      #
+      #   cookies.signed[:discount] = 45
+      #   # => Set-Cookie: discount=BAhpMg==--2c1c6906c90a3bc4fd54a51ffb41dffa4bf6b5f7; path=/
+      #
+      #   cookies.signed[:discount] # => 45
+      def signed: () -> untyped
+
+      # Returns a jar that'll automatically encrypt cookie values before sending them to the client and will decrypt them for read.
+      # If the cookie was tampered with by the user (or a 3rd party), +nil+ will be returned.
+      #
+      # If +config.action_dispatch.encrypted_cookie_salt+ and +config.action_dispatch.encrypted_signed_cookie_salt+
+      # are both set, legacy cookies encrypted with HMAC AES-256-CBC will be transparently upgraded.
+      #
+      # This jar requires that you set a suitable secret for the verification on your app's +secret_key_base+.
+      #
+      # Example:
+      #
+      #   cookies.encrypted[:discount] = 45
+      #   # => Set-Cookie: discount=DIQ7fw==--K3n//8vvnSbGq9dA--7Xh91HfLpwzbj1czhBiwOg==; path=/
+      #
+      #   cookies.encrypted[:discount] # => 45
+      def encrypted: () -> untyped
+
+      # Returns the +signed+ or +encrypted+ jar, preferring +encrypted+ if +secret_key_base+ is set.
+      # Used by ActionDispatch::Session::CookieStore to avoid the need to introduce new cookie stores.
+      def signed_or_encrypted: () -> untyped
+
+      def upgrade_legacy_hmac_aes_cbc_cookies?: () -> untyped
+
+      def encrypted_cookie_cipher: () -> untyped
+
+      def signed_cookie_digest: () -> untyped
+    end
+
+    class CookieJar
+      # nodoc:
+      include Enumerable[untyped]
+
+      # nodoc:
+      include ChainedCookieJars
+
+      # This regular expression is used to split the levels of a domain.
+      # The top level domain can be any string without a period or
+      # **.**, ***.** style TLDs like co.uk or com.au
+      #
+      # www.example.co.uk gives:
+      # $& => example.co.uk
+      #
+      # example.com gives:
+      # $& => example.com
+      #
+      # lots.of.subdomains.example.local gives:
+      # $& => example.local
+      DOMAIN_REGEXP: untyped
+
+      def self.build: (untyped req, untyped cookies) -> untyped
+
+      attr_reader request: untyped
+
+      def initialize: (untyped request) -> untyped
+
+      def committed?: () -> untyped
+
+      def commit!: () -> untyped
+
+      def each: () { () -> untyped } -> untyped
+
+      # Returns the value of the cookie by +name+, or +nil+ if no such cookie exists.
+      def []: (untyped name) -> untyped
+
+      def fetch: (untyped name, *untyped args) { () -> untyped } -> untyped
+
+      def key?: (untyped name) -> untyped
+
+      alias has_key? key?
+
+      # Returns the cookies as Hash.
+      alias to_hash to_h
+
+      def update: (untyped other_hash) -> untyped
+
+      def update_cookies_from_jar: () -> untyped
+
+      def to_header: () -> untyped
+
+      def handle_options: (untyped options) -> untyped
+
+      # Sets the cookie named +name+. The second argument may be the cookie's
+      # value or a hash of options as documented above.
+      def []=: (untyped name, untyped options) -> untyped
+
+      # Removes the cookie on the client machine by setting the value to an empty string
+      # and the expiration date in the past. Like <tt>[]=</tt>, you can pass in
+      # an options hash to delete cookies with extra data such as a <tt>:path</tt>.
+      def delete: (untyped name, ?::Hash[untyped, untyped] options) -> (nil | untyped)
+
+      # Whether the given cookie is to be deleted by this CookieJar.
+      # Like <tt>[]=</tt>, you can pass in an options hash to test if a
+      # deletion applies to a specific <tt>:path</tt>, <tt>:domain</tt> etc.
+      def deleted?: (untyped name, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Removes all cookies on the client machine by calling <tt>delete</tt> for each cookie.
+      def clear: (?::Hash[untyped, untyped] options) -> untyped
+
+      def write: (untyped headers) -> untyped
+
+      def escape: (untyped string) -> untyped
+
+      def make_set_cookie_header: (untyped header) -> untyped
+
+      def write_cookie?: (untyped cookie) -> untyped
+    end
+
+    class AbstractCookieJar
+      # :nodoc:
+      include ChainedCookieJars
+
+      def initialize: (untyped parent_jar) -> untyped
+
+      def []: (untyped name) -> untyped
+
+      def []=: (untyped name, untyped options) -> untyped
+
+      def request: () -> untyped
+
+      def expiry_options: (untyped options) -> untyped
+
+      def cookie_metadata: (untyped name, untyped options) -> untyped
+
+      def parse: (untyped name, untyped data, ?purpose: untyped? purpose) -> untyped
+
+      def commit: (untyped name, untyped options) -> nil
+    end
+
+    class PermanentCookieJar < AbstractCookieJar
+      def commit: (untyped name, untyped options) -> untyped
+    end
+
+    class JsonSerializer
+      # :nodoc:
+      def self.load: (untyped value) -> untyped
+
+      def self.dump: (untyped value) -> untyped
+    end
+
+    module SerializedCookieJars
+      # :nodoc:
+      MARSHAL_SIGNATURE: ::String
+
+      SERIALIZER: untyped
+
+      def needs_migration?: (untyped value) -> untyped
+
+      def serialize: (untyped value) -> untyped
+
+      def deserialize: (untyped name) { (untyped) -> untyped } -> untyped
+
+      def serializer: () -> untyped
+
+      def digest: () -> untyped
+    end
+
+    class SignedKeyRotatingCookieJar < AbstractCookieJar
+      # :nodoc:
+      include SerializedCookieJars
+
+      def initialize: (untyped parent_jar) -> untyped
+
+      def parse: (untyped name, untyped signed_message, ?purpose: untyped? purpose) -> untyped
+
+      def commit: (untyped name, untyped options) -> untyped
+    end
+
+    class EncryptedKeyRotatingCookieJar < AbstractCookieJar
+      # :nodoc:
+      include SerializedCookieJars
+
+      def initialize: (untyped parent_jar) -> untyped
+
+      def parse: (untyped name, untyped encrypted_message, ?purpose: untyped? purpose) -> untyped
+
+      def commit: (untyped name, untyped options) -> untyped
+    end
+
+    def initialize: (untyped app) -> untyped
+
+    def call: (untyped env) -> ::Array[untyped]
+  end
+end
+
+module ActionDispatch
+  # This middleware is responsible for logging exceptions and
+  # showing a debugging page in case the request is local.
+  class DebugExceptions
+    def self.register_interceptor: (?untyped? object) { () -> untyped } -> untyped
+
+    def initialize: (untyped app, ?untyped? routes_app, ?::Symbol response_format, ?untyped interceptors) -> untyped
+
+    def call: (untyped env) -> untyped
+
+    def invoke_interceptors: (untyped request, untyped exception) -> untyped
+
+    def render_exception: (untyped request, untyped exception) -> untyped
+
+    def render_for_browser_request: (untyped request, untyped wrapper) -> untyped
+
+    def render_for_api_request: (untyped content_type, untyped wrapper) -> untyped
+
+    def create_template: (untyped request, untyped wrapper) -> DebugView
+
+    def render: (untyped status, untyped body, untyped format) -> ::Array[untyped | ::Hash[::String, ::String | untyped] | ::Array[untyped]]
+
+    def log_error: (untyped request, untyped wrapper) -> (nil | untyped)
+
+    def log_array: (untyped logger, untyped array) -> (nil | untyped)
+
+    def logger: (untyped request) -> untyped
+
+    def stderr_logger: () -> untyped
+
+    def routes_inspector: (untyped exception) -> untyped
+
+    def api_request?: (untyped content_type) -> untyped
+  end
+end
+
+module ActionDispatch
+  # This middleware can be used to diagnose deadlocks in the autoload interlock.
+  #
+  # To use it, insert it near the top of the middleware stack, using
+  # <tt>config/application.rb</tt>:
+  #
+  #     config.middleware.insert_before Rack::Sendfile, ActionDispatch::DebugLocks
+  #
+  # After restarting the application and re-triggering the deadlock condition,
+  # <tt>/rails/locks</tt> will show a summary of all threads currently known to
+  # the interlock, which lock level they are holding or awaiting, and their
+  # current backtrace.
+  #
+  # Generally a deadlock will be caused by the interlock conflicting with some
+  # other external lock or blocking I/O call. These cannot be automatically
+  # identified, but should be visible in the displayed backtraces.
+  #
+  # NOTE: The formatting and content of this middleware's output is intended for
+  # human consumption, and should be expected to change between releases.
+  #
+  # This middleware exposes operational details of the server, with no access
+  # control. It should only be enabled when in use, and removed thereafter.
+  class DebugLocks
+    def initialize: (untyped app, ?::String path) -> untyped
+
+    def call: (untyped env) -> untyped
+
+    def render_details: (untyped req) -> ::Array[200 | ::Hash[::String, "text/plain" | untyped] | ::Array[untyped]]
+
+    def blocked_by?: (untyped victim, untyped blocker, untyped all_threads) -> (::FalseClass | untyped)
+  end
+end
+
+module ActionDispatch
+  class DebugView < ActionView::Base
+    # :nodoc:
+    RESCUES_TEMPLATE_PATH: untyped
+
+    def initialize: (untyped assigns) -> untyped
+
+    def compiled_method_container: () -> untyped
+
+    def debug_params: (untyped params) -> untyped
+
+    def debug_headers: (untyped headers) -> untyped
+
+    def debug_hash: (untyped object) -> untyped
+
+    def render: () -> untyped
+
+    def protect_against_forgery?: () -> ::FalseClass
+
+    def params_valid?: () -> untyped
+  end
+end
+
+module ActionDispatch
+  class ExceptionWrapper
+    attr_reader backtrace_cleaner: untyped
+
+    attr_reader exception: untyped
+
+    attr_reader wrapped_causes: untyped
+
+    attr_reader line_number: untyped
+
+    attr_reader file: untyped
+
+    def initialize: (untyped backtrace_cleaner, untyped exception) -> untyped
+
+    def unwrapped_exception: () -> untyped
+
+    def rescue_template: () -> untyped
+
+    def status_code: () -> untyped
+
+    def application_trace: () -> untyped
+
+    def framework_trace: () -> untyped
+
+    def full_trace: () -> untyped
+
+    def traces: () -> ::Hash[::String, untyped]
+
+    def self.status_code_for_exception: (untyped class_name) -> untyped
+
+    def source_extracts: () -> untyped
+
+    def trace_to_show: () -> untyped
+
+    def source_to_show_id: () -> untyped
+
+    def backtrace: () -> untyped
+
+    def causes_for: (untyped exception) { (untyped) -> untyped } -> untyped
+
+    def wrapped_causes_for: (untyped exception, untyped backtrace_cleaner) -> untyped
+
+    def clean_backtrace: (*untyped args) -> untyped
+
+    def source_fragment: (untyped path, untyped line) -> (nil | untyped)
+
+    def extract_file_and_line_number: (untyped trace) -> ::Array[untyped]
+
+    def expand_backtrace: () -> untyped
+  end
+end
+
+module ActionDispatch
+  class Executor
+    def initialize: (untyped app, untyped executor) -> untyped
+
+    def call: (untyped env) -> untyped
+  end
+end
+
+module ActionDispatch
+  # The flash provides a way to pass temporary primitive-types (String, Array, Hash) between actions. Anything you place in the flash will be exposed
+  # to the very next action and then cleared out. This is a great way of doing notices and alerts, such as a create
+  # action that sets <tt>flash[:notice] = "Post successfully created"</tt> before redirecting to a display action that can
+  # then expose the flash to its template. Actually, that exposure is automatically done.
+  #
+  #   class PostsController < ActionController::Base
+  #     def create
+  #       # save post
+  #       flash[:notice] = "Post successfully created"
+  #       redirect_to @post
+  #     end
+  #
+  #     def show
+  #       # doesn't need to assign the flash notice to the template, that's done automatically
+  #     end
+  #   end
+  #
+  #   show.html.erb
+  #     <% if flash[:notice] %>
+  #       <div class="notice"><%= flash[:notice] %></div>
+  #     <% end %>
+  #
+  # Since the +notice+ and +alert+ keys are a common idiom, convenience accessors are available:
+  #
+  #   flash.alert = "You must be logged in"
+  #   flash.notice = "Post successfully created"
+  #
+  # This example places a string in the flash. And of course, you can put as many as you like at a time too. If you want to pass
+  # non-primitive types, you will have to handle that in your application. Example: To show messages with links, you will have to
+  # use sanitize helper.
+  #
+  # Just remember: They'll be gone by the time the next action has been performed.
+  #
+  # See docs on the FlashHash class for more details about the flash.
+  class Flash
+    KEY: ::String
+
+    module RequestMethods
+      # Access the contents of the flash. Use <tt>flash["notice"]</tt> to
+      # read a notice you put there or <tt>flash["notice"] = "hello"</tt>
+      # to put a new one.
+      def flash: () -> untyped
+
+      def flash=: (untyped flash) -> untyped
+
+      def flash_hash: () -> untyped
+
+      def commit_flash: () -> untyped
+
+      def reset_session: () -> untyped
+    end
+
+    class FlashNow
+      # nodoc:
+      attr_accessor flash: untyped
+
+      def initialize: (untyped flash) -> untyped
+
+      def []=: (untyped k, untyped v) -> untyped
+
+      def []: (untyped k) -> untyped
+
+      # Convenience accessor for <tt>flash.now[:alert]=</tt>.
+      def alert=: (untyped message) -> untyped
+
+      # Convenience accessor for <tt>flash.now[:notice]=</tt>.
+      def notice=: (untyped message) -> untyped
+    end
+
+    class FlashHash
+      include Enumerable[untyped]
+
+      def self.from_session_value: (untyped value) -> untyped
+
+      def to_session_value: () -> (nil | ::Hash[::String, ::Array[untyped] | untyped])
+
+      def initialize: (?::Hash[untyped, untyped] flashes, ?untyped discard) -> untyped
+
+      def initialize_copy: (untyped other) -> untyped
+
+      def []=: (untyped k, untyped v) -> untyped
+
+      def []: (untyped k) -> untyped
+
+      def update: (untyped h) -> untyped
+
+      def keys: () -> untyped
+
+      def key?: (untyped name) -> untyped
+
+      def delete: (untyped key) -> untyped
+
+      def to_hash: () -> untyped
+
+      def empty?: () -> untyped
+
+      def clear: () -> untyped
+
+      def each: () { () -> untyped } -> untyped
+
+      alias merge! update
+
+      def replace: (untyped h) -> untyped
+
+      # Sets a flash that will not be available to the next action, only to the current.
+      #
+      #     flash.now[:message] = "Hello current action"
+      #
+      # This method enables you to use the flash as a central messaging system in your app.
+      # When you need to pass an object to the next action, you use the standard flash assign (<tt>[]=</tt>).
+      # When you need to pass an object to the current action, you use <tt>now</tt>, and your object will
+      # vanish when the current action is done.
+      #
+      # Entries set via <tt>now</tt> are accessed the same way as standard entries: <tt>flash['my-key']</tt>.
+      #
+      # Also, brings two convenience accessors:
+      #
+      #   flash.now.alert = "Beware now!"
+      #   # Equivalent to flash.now[:alert] = "Beware now!"
+      #
+      #   flash.now.notice = "Good luck now!"
+      #   # Equivalent to flash.now[:notice] = "Good luck now!"
+      def now: () -> untyped
+
+      # Keeps either the entire current flash or a specific flash entry available for the next action:
+      #
+      #    flash.keep            # keeps the entire flash
+      #    flash.keep(:notice)   # keeps only the "notice" entry, the rest of the flash is discarded
+      def keep: (?untyped? k) -> untyped
+
+      # Marks the entire flash or a single flash entry to be discarded by the end of the current action:
+      #
+      #     flash.discard              # discard the entire flash at the end of the current action
+      #     flash.discard(:warning)    # discard only the "warning" entry at the end of the current action
+      def discard: (?untyped? k) -> untyped
+
+      def sweep: () -> untyped
+
+      # Convenience accessor for <tt>flash[:alert]</tt>.
+      def alert: () -> untyped
+
+      # Convenience accessor for <tt>flash[:alert]=</tt>.
+      def alert=: (untyped message) -> untyped
+
+      # Convenience accessor for <tt>flash[:notice]</tt>.
+      def notice: () -> untyped
+
+      # Convenience accessor for <tt>flash[:notice]=</tt>.
+      def notice=: (untyped message) -> untyped
+
+      def now_is_loaded?: () -> untyped
+
+      def stringify_array: (untyped array) -> untyped
+    end
+
+    def self.new: (untyped app) -> untyped
+  end
+
+  class Request
+  end
+end
+
+module ActionDispatch
+  # This middleware guards from DNS rebinding attacks by explicitly permitting
+  # the hosts a request can be sent to.
+  #
+  # When a request comes to an unauthorized host, the +response_app+
+  # application will be executed and rendered. If no +response_app+ is given, a
+  # default one will run, which responds with +403 Forbidden+.
+  class HostAuthorization
+    class Permissions
+      # :nodoc:
+      def initialize: (untyped hosts) -> untyped
+
+      def empty?: () -> untyped
+
+      def allows?: (untyped host) -> untyped
+
+      def sanitize_hosts: (untyped hosts) -> untyped
+
+      def sanitize_regexp: (untyped host) -> ::Regexp
+
+      def sanitize_string: (untyped host) -> untyped
+    end
+
+    DEFAULT_RESPONSE_APP: untyped
+
+    def initialize: (untyped app, untyped hosts, ?untyped? response_app) -> untyped
+
+    def call: (untyped env) -> untyped
+
+    def authorized?: (untyped request) -> untyped
+
+    def mark_as_authorized: (untyped request) -> untyped
+  end
+end
+
+module ActionDispatch
+  # When called, this middleware renders an error page. By default if an HTML
+  # response is expected it will render static error pages from the <tt>/public</tt>
+  # directory. For example when this middleware receives a 500 response it will
+  # render the template found in <tt>/public/500.html</tt>.
+  # If an internationalized locale is set, this middleware will attempt to render
+  # the template in <tt>/public/500.<locale>.html</tt>. If an internationalized template
+  # is not found it will fall back on <tt>/public/500.html</tt>.
+  #
+  # When a request with a content type other than HTML is made, this middleware
+  # will attempt to convert error information into the appropriate response type.
+  class PublicExceptions
+    attr_accessor public_path: untyped
+
+    def initialize: (untyped public_path) -> untyped
+
+    def call: (untyped env) -> untyped
+
+    def render: (untyped status, untyped content_type, untyped body) -> untyped
+
+    def render_format: (untyped status, untyped content_type, untyped body) -> ::Array[untyped | ::Hash[::String, ::String | untyped] | ::Array[untyped]]
+
+    def render_html: (untyped status) -> untyped
+  end
+end
+
+module ActionDispatch
+  # ActionDispatch::Reloader wraps the request with callbacks provided by ActiveSupport::Reloader
+  # callbacks, intended to assist with code reloading during development.
+  #
+  # By default, ActionDispatch::Reloader is included in the middleware stack
+  # only in the development environment; specifically, when +config.cache_classes+
+  # is false.
+  class Reloader < Executor
+  end
+end
+
+module ActionDispatch
+  # This middleware calculates the IP address of the remote client that is
+  # making the request. It does this by checking various headers that could
+  # contain the address, and then picking the last-set address that is not
+  # on the list of trusted IPs. This follows the precedent set by e.g.
+  # {the Tomcat server}[https://issues.apache.org/bugzilla/show_bug.cgi?id=50453],
+  # with {reasoning explained at length}[https://blog.gingerlime.com/2012/rails-ip-spoofing-vulnerabilities-and-protection]
+  # by @gingerlime. A more detailed explanation of the algorithm is given
+  # at GetIp#calculate_ip.
+  #
+  # Some Rack servers concatenate repeated headers, like {HTTP RFC 2616}[https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2]
+  # requires. Some Rack servers simply drop preceding headers, and only report
+  # the value that was {given in the last header}[https://andre.arko.net/2011/12/26/repeated-headers-and-ruby-web-servers].
+  # If you are behind multiple proxy servers (like NGINX to HAProxy to Unicorn)
+  # then you should test your Rack server to make sure your data is good.
+  #
+  # IF YOU DON'T USE A PROXY, THIS MAKES YOU VULNERABLE TO IP SPOOFING.
+  # This middleware assumes that there is at least one proxy sitting around
+  # and setting headers with the client's remote IP address. If you don't use
+  # a proxy, because you are hosted on e.g. Heroku without SSL, any client can
+  # claim to have any IP address by setting the X-Forwarded-For header. If you
+  # care about that, then you need to explicitly drop or ignore those headers
+  # sometime before this middleware runs.
+  class RemoteIp
+    class IpSpoofAttackError < StandardError
+    end
+
+    # The default trusted IPs list simply includes IP addresses that are
+    # guaranteed by the IP specification to be private addresses. Those will
+    # not be the ultimate client IP in production, and so are discarded. See
+    # https://en.wikipedia.org/wiki/Private_network for details.
+    TRUSTED_PROXIES: untyped
+
+    attr_reader check_ip: untyped
+
+    attr_reader proxies: untyped
+
+    # Create a new +RemoteIp+ middleware instance.
+    #
+    # The +ip_spoofing_check+ option is on by default. When on, an exception
+    # is raised if it looks like the client is trying to lie about its own IP
+    # address. It makes sense to turn off this check on sites aimed at non-IP
+    # clients (like WAP devices), or behind proxies that set headers in an
+    # incorrect or confusing way (like AWS ELB).
+    #
+    # The +custom_proxies+ argument can take an Array of string, IPAddr, or
+    # Regexp objects which will be used instead of +TRUSTED_PROXIES+. If a
+    # single string, IPAddr, or Regexp object is provided, it will be used in
+    # addition to +TRUSTED_PROXIES+. Any proxy setup will put the value you
+    # want in the middle (or at the beginning) of the X-Forwarded-For list,
+    # with your proxy servers after it. If your proxies aren't removed, pass
+    # them in via the +custom_proxies+ parameter. That way, the middleware will
+    # ignore those IP addresses, and return the one that you want.
+    def initialize: (untyped app, ?bool ip_spoofing_check, ?untyped? custom_proxies) -> untyped
+
+    # Since the IP address may not be needed, we store the object here
+    # without calculating the IP to keep from slowing down the majority of
+    # requests. For those requests that do need to know the IP, the
+    # GetIp#calculate_ip method will calculate the memoized client IP address.
+    def call: (untyped env) -> untyped
+
+    # The GetIp class exists as a way to defer processing of the request data
+    # into an actual IP address. If the ActionDispatch::Request#remote_ip method
+    # is called, this class will calculate the value and then memoize it.
+    class GetIp
+      def initialize: (untyped req, untyped check_ip, untyped proxies) -> untyped
+
+      # Sort through the various IP address headers, looking for the IP most
+      # likely to be the address of the actual remote client making this
+      # request.
+      #
+      # REMOTE_ADDR will be correct if the request is made directly against the
+      # Ruby process, on e.g. Heroku. When the request is proxied by another
+      # server like HAProxy or NGINX, the IP address that made the original
+      # request will be put in an X-Forwarded-For header. If there are multiple
+      # proxies, that header may contain a list of IPs. Other proxy services
+      # set the Client-Ip header instead, so we check that too.
+      #
+      # As discussed in {this post about Rails IP Spoofing}[https://blog.gingerlime.com/2012/rails-ip-spoofing-vulnerabilities-and-protection/],
+      # while the first IP in the list is likely to be the "originating" IP,
+      # it could also have been set by the client maliciously.
+      #
+      # In order to find the first address that is (probably) accurate, we
+      # take the list of IPs, remove known and trusted proxies, and then take
+      # the last address left, which was presumably set by one of those proxies.
+      def calculate_ip: () -> untyped
+
+      # Memoizes the value returned by #calculate_ip and returns it for
+      # ActionDispatch::Request to use.
+      def to_s: () -> untyped
+
+      def ips_from: (untyped header) -> (::Array[untyped] | untyped)
+
+      def filter_proxies: (untyped ips) -> untyped
+    end
+  end
+end
+
+module ActionDispatch
+  # Makes a unique request id available to the +action_dispatch.request_id+ env variable (which is then accessible
+  # through <tt>ActionDispatch::Request#request_id</tt> or the alias <tt>ActionDispatch::Request#uuid</tt>) and sends
+  # the same id to the client via the X-Request-Id header.
+  #
+  # The unique request id is either based on the X-Request-Id header in the request, which would typically be generated
+  # by a firewall, load balancer, or the web server, or, if this header is not available, a random uuid. If the
+  # header is accepted from the outside world, we sanitize it to a max of 255 chars and alphanumeric and dashes only.
+  #
+  # The unique request id can be used to trace a request end-to-end and would typically end up being part of log files
+  # from multiple pieces of the stack.
+  class RequestId
+    X_REQUEST_ID: ::String
+
+    def initialize: (untyped app) -> untyped
+
+    def call: (untyped env) -> untyped
+
+    def make_request_id: (untyped request_id) -> untyped
+
+    def internal_request_id: () -> untyped
+  end
+end
+
+module ActionDispatch
+  module Session
+    class SessionRestoreError < StandardError
+      # nodoc:
+      def initialize: () -> untyped
+    end
+
+    module Compatibility
+      def initialize: (untyped app, ?::Hash[untyped, untyped] options) -> untyped
+
+      def generate_sid: () -> untyped
+
+      def initialize_sid: () -> untyped
+
+      def make_request: (untyped env) -> ActionDispatch::Request
+    end
+
+    module StaleSessionCheck
+      def load_session: (untyped env) -> untyped
+
+      def extract_session_id: (untyped env) -> untyped
+
+      def stale_session_check!: () { () -> untyped } -> untyped
+    end
+
+    module SessionObject
+      # :nodoc:
+      def prepare_session: (untyped req) -> untyped
+
+      def loaded_session?: (untyped session) -> untyped
+    end
+
+    class AbstractStore < Rack::Session::Abstract::Persisted
+      include Compatibility
+
+      include StaleSessionCheck
+
+      include SessionObject
+
+      def set_cookie: (untyped request, untyped session_id, untyped cookie) -> untyped
+    end
+
+    class AbstractSecureStore < Rack::Session::Abstract::PersistedSecure
+      include Compatibility
+
+      include StaleSessionCheck
+
+      include SessionObject
+
+      def generate_sid: () -> Rack::Session::SessionId
+
+      def set_cookie: (untyped request, untyped session_id, untyped cookie) -> untyped
+    end
+  end
+end
+
+module ActionDispatch
+  module Session
+    # A session store that uses an ActiveSupport::Cache::Store to store the sessions. This store is most useful
+    # if you don't store critical data in your sessions and you don't need them to live for extended periods
+    # of time.
+    #
+    # ==== Options
+    # * <tt>cache</tt>         - The cache to use. If it is not specified, <tt>Rails.cache</tt> will be used.
+    # * <tt>expire_after</tt>  - The length of time a session will be stored before automatically expiring.
+    #   By default, the <tt>:expires_in</tt> option of the cache is used.
+    class CacheStore < AbstractSecureStore
+      def initialize: (untyped app, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Get a session from the cache.
+      def find_session: (untyped env, untyped sid) -> ::Array[untyped]
+
+      # Set a session in the cache.
+      def write_session: (untyped env, untyped sid, untyped session, untyped options) -> untyped
+
+      # Remove a session from the cache.
+      def delete_session: (untyped env, untyped sid, untyped options) -> untyped
+
+      # Turn the session id into a cache key.
+      def cache_key: (untyped id) -> ::String
+
+      def get_session_with_fallback: (untyped sid) -> untyped
+    end
+  end
+end
+
+module ActionDispatch
+  module Session
+    # This cookie-based session store is the Rails default. It is
+    # dramatically faster than the alternatives.
+    #
+    # Sessions typically contain at most a user_id and flash message; both fit
+    # within the 4K cookie size limit. A CookieOverflow exception is raised if
+    # you attempt to store more than 4K of data.
+    #
+    # The cookie jar used for storage is automatically configured to be the
+    # best possible option given your application's configuration.
+    #
+    # Your cookies will be encrypted using your apps secret_key_base. This
+    # goes a step further than signed cookies in that encrypted cookies cannot
+    # be altered or read by users. This is the default starting in Rails 4.
+    #
+    # Configure your session store in an initializer:
+    #
+    #   Rails.application.config.session_store :cookie_store, key: '_your_app_session'
+    #
+    # In the development and test environments your application's secret key base is
+    # generated by Rails and stored in a temporary file in <tt>tmp/development_secret.txt</tt>.
+    # In all other environments, it is stored encrypted in the
+    # <tt>config/credentials.yml.enc</tt> file.
+    #
+    # If your application was not updated to Rails 5.2 defaults, the secret_key_base
+    # will be found in the old <tt>config/secrets.yml</tt> file.
+    #
+    # Note that changing your secret_key_base will invalidate all existing session.
+    # Additionally, you should take care to make sure you are not relying on the
+    # ability to decode signed cookies generated by your app in external
+    # applications or JavaScript before changing it.
+    #
+    # Because CookieStore extends Rack::Session::Abstract::Persisted, many of the
+    # options described there can be used to customize the session cookie that
+    # is generated. For example:
+    #
+    #   Rails.application.config.session_store :cookie_store, expire_after: 14.days
+    #
+    # would set the session cookie to expire automatically 14 days after creation.
+    # Other useful options include <tt>:key</tt>, <tt>:secure</tt> and
+    # <tt>:httponly</tt>.
+    class CookieStore < AbstractSecureStore
+      class SessionId
+        # Note: It inherits unnamed class, but omitted
+        attr_reader cookie_value: untyped
+
+        def initialize: (untyped session_id, ?::Hash[untyped, untyped] cookie_value) -> untyped
+      end
+
+      def initialize: (untyped app, ?::Hash[untyped, untyped] options) -> untyped
+
+      def delete_session: (untyped req, untyped session_id, untyped options) -> untyped
+
+      def load_session: (untyped req) -> untyped
+
+      def extract_session_id: (untyped req) -> untyped
+
+      def unpacked_cookie_data: (untyped req) -> untyped
+
+      def persistent_session_id!: (untyped data, ?untyped? sid) -> untyped
+
+      def write_session: (untyped req, untyped sid, untyped session_data, untyped options) -> SessionId
+
+      def set_cookie: (untyped request, untyped session_id, untyped cookie) -> untyped
+
+      def get_cookie: (untyped req) -> untyped
+
+      def cookie_jar: (untyped request) -> untyped
+    end
+  end
+end
+
+module ActionDispatch
+  module Session
+    # A session store that uses MemCache to implement storage.
+    #
+    # ==== Options
+    # * <tt>expire_after</tt>  - The length of time a session will be stored before automatically expiring.
+    class MemCacheStore < Rack::Session::Dalli
+      include Compatibility
+
+      include StaleSessionCheck
+
+      include SessionObject
+
+      def initialize: (untyped app, ?::Hash[untyped, untyped] options) -> untyped
+    end
+  end
+end
+
+module ActionDispatch
+  # This middleware rescues any exception returned by the application
+  # and calls an exceptions app that will wrap it in a format for the end user.
+  #
+  # The exceptions app should be passed as parameter on initialization
+  # of ShowExceptions. Every time there is an exception, ShowExceptions will
+  # store the exception in env["action_dispatch.exception"], rewrite the
+  # PATH_INFO to the exception status code and call the Rack app.
+  #
+  # If the application returns a "X-Cascade" pass response, this middleware
+  # will send an empty response as result with the correct status code.
+  # If any exception happens inside the exceptions app, this middleware
+  # catches the exceptions and returns a FAILSAFE_RESPONSE.
+  class ShowExceptions
+    FAILSAFE_RESPONSE: ::Array[untyped]
+
+    def initialize: (untyped app, untyped exceptions_app) -> untyped
+
+    def call: (untyped env) -> untyped
+
+    def render_exception: (untyped request, untyped exception) -> untyped
+
+    def pass_response: (untyped status) -> ::Array[untyped | ::Hash[::String, ::String | "0"] | ::Array[untyped]]
+  end
+end
+
+module ActionDispatch
+  # This middleware is added to the stack when <tt>config.force_ssl = true</tt>, and is passed
+  # the options set in +config.ssl_options+. It does three jobs to enforce secure HTTP
+  # requests:
+  #
+  # 1. <b>TLS redirect</b>: Permanently redirects +http://+ requests to +https://+
+  #    with the same URL host, path, etc. Enabled by default. Set +config.ssl_options+
+  #    to modify the destination URL
+  #    (e.g. <tt>redirect: { host: "secure.widgets.com", port: 8080 }</tt>), or set
+  #    <tt>redirect: false</tt> to disable this feature.
+  #
+  #    Requests can opt-out of redirection with +exclude+:
+  #
+  #      config.ssl_options = { redirect: { exclude: -> request { request.path =~ /healthcheck/ } } }
+  #
+  #    Cookies will not be flagged as secure for excluded requests.
+  #
+  # 2. <b>Secure cookies</b>: Sets the +secure+ flag on cookies to tell browsers they
+  #    must not be sent along with +http://+ requests. Enabled by default. Set
+  #    +config.ssl_options+ with <tt>secure_cookies: false</tt> to disable this feature.
+  #
+  # 3. <b>HTTP Strict Transport Security (HSTS)</b>: Tells the browser to remember
+  #    this site as TLS-only and automatically redirect non-TLS requests.
+  #    Enabled by default. Configure +config.ssl_options+ with <tt>hsts: false</tt> to disable.
+  #
+  #    Set +config.ssl_options+ with <tt>hsts: { ... }</tt> to configure HSTS:
+  #
+  #    * +expires+: How long, in seconds, these settings will stick. The minimum
+  #      required to qualify for browser preload lists is 1 year. Defaults to
+  #      1 year (recommended).
+  #
+  #    * +subdomains+: Set to +true+ to tell the browser to apply these settings
+  #      to all subdomains. This protects your cookies from interception by a
+  #      vulnerable site on a subdomain. Defaults to +true+.
+  #
+  #    * +preload+: Advertise that this site may be included in browsers'
+  #      preloaded HSTS lists. HSTS protects your site on every visit <i>except the
+  #      first visit</i> since it hasn't seen your HSTS header yet. To close this
+  #      gap, browser vendors include a baked-in list of HSTS-enabled sites.
+  #      Go to https://hstspreload.org to submit your site for inclusion.
+  #      Defaults to +false+.
+  #
+  #    To turn off HSTS, omitting the header is not enough. Browsers will remember the
+  #    original HSTS directive until it expires. Instead, use the header to tell browsers to
+  #    expire HSTS immediately. Setting <tt>hsts: false</tt> is a shortcut for
+  #    <tt>hsts: { expires: 0 }</tt>.
+  class SSL
+    # Default to 1 year, the minimum for browser preload lists.
+    HSTS_EXPIRES_IN: ::Integer
+
+    def self.default_hsts_options: () -> { expires: untyped, subdomains: ::TrueClass, preload: ::FalseClass }
+
+    def initialize: (untyped app, ?secure_cookies: bool secure_cookies, ?hsts: ::Hash[untyped, untyped] hsts, ?redirect: ::Hash[untyped, untyped] redirect) -> untyped
+
+    def call: (untyped env) -> untyped
+
+    def set_hsts_header!: (untyped headers) -> untyped
+
+    def normalize_hsts_options: (untyped options) -> untyped
+
+    # https://tools.ietf.org/html/rfc6797#section-6.1
+    def build_hsts_header: (untyped hsts) -> untyped
+
+    def flag_cookies_as_secure!: (untyped headers) -> untyped
+
+    def redirect_to_https: (untyped request) -> ::Array[untyped | ::Hash[::String, "text/html" | untyped]]
+
+    def redirection_status: (untyped request) -> untyped
+
+    def https_location_for: (untyped request) -> untyped
+  end
+end
+
+module ActionDispatch
+  class MiddlewareStack
+    class Middleware
+      attr_reader args: untyped
+
+      attr_reader block: untyped
+
+      attr_reader klass: untyped
+
+      def initialize: (untyped klass, untyped args, untyped block) -> untyped
+
+      def name: () -> untyped
+
+      def ==: (untyped middleware) -> untyped
+
+      def inspect: () -> untyped
+
+      def build: (untyped app) -> untyped
+
+      def build_instrumented: (untyped app) -> InstrumentationProxy
+    end
+
+    # This class is used to instrument the execution of a single middleware.
+    # It proxies the `call` method transparently and instruments the method
+    # call.
+    class InstrumentationProxy
+      EVENT_NAME: ::String
+
+      def initialize: (untyped middleware, untyped class_name) -> untyped
+
+      def call: (untyped env) -> untyped
+    end
+
+    include Enumerable[untyped]
+
+    attr_accessor middlewares: untyped
+
+    def initialize: (*untyped args) { (untyped) -> untyped } -> untyped
+
+    def each: () { (untyped) -> untyped } -> untyped
+
+    def size: () -> untyped
+
+    def last: () -> untyped
+
+    def []: (untyped i) -> untyped
+
+    def unshift: (untyped klass, *untyped args) { () -> untyped } -> untyped
+
+    def initialize_copy: (untyped other) -> untyped
+
+    def insert: (untyped index, untyped klass, *untyped args) { () -> untyped } -> untyped
+
+    alias insert_before insert
+
+    def insert_after: (untyped index, *untyped args) { () -> untyped } -> untyped
+
+    def swap: (untyped target, *untyped args) { () -> untyped } -> untyped
+
+    def delete: (untyped target) -> untyped
+
+    def use: (untyped klass, *untyped args) { () -> untyped } -> untyped
+
+    def build: (?untyped? app) { () -> untyped } -> untyped
+
+    def assert_index: (untyped index, untyped where) -> untyped
+
+    def build_middleware: (untyped klass, untyped args, untyped block) -> Middleware
+  end
+end
+
+module ActionDispatch
+  # This middleware returns a file's contents from disk in the body response.
+  # When initialized, it can accept optional HTTP headers, which will be set
+  # when a response containing a file's contents is delivered.
+  #
+  # This middleware will render the file specified in <tt>env["PATH_INFO"]</tt>
+  # where the base path is in the +root+ directory. For example, if the +root+
+  # is set to +public/+, then a request with <tt>env["PATH_INFO"]</tt> of
+  # +assets/application.js+ will return a response with the contents of a file
+  # located at +public/assets/application.js+ if the file exists. If the file
+  # does not exist, a 404 "File not Found" response will be returned.
+  class FileHandler
+    def initialize: (untyped root, ?headers: ::Hash[untyped, untyped] headers, ?index: ::String index) -> untyped
+
+    # Takes a path to a file. If the file is found, has valid encoding, and has
+    # correct read permissions, the return value is a URI-escaped string
+    # representing the filename. Otherwise, false is returned.
+    #
+    # Used by the +Static+ class to check the existence of a valid file
+    # in the server's +public/+ directory (see Static#call).
+    def match?: (untyped path) -> (::FalseClass | untyped)
+
+    def call: (untyped env) -> untyped
+
+    def serve: (untyped request) -> untyped
+
+    def ext: () -> untyped
+
+    def content_type: (untyped path) -> untyped
+
+    def gzip_encoding_accepted?: (untyped request) -> untyped
+
+    def gzip_file_path: (untyped path) -> untyped
+  end
+
+  # This middleware will attempt to return the contents of a file's body from
+  # disk in the response. If a file is not found on disk, the request will be
+  # delegated to the application stack. This middleware is commonly initialized
+  # to serve assets from a server's +public/+ directory.
+  #
+  # This middleware verifies the path to ensure that only files
+  # living in the root directory can be rendered. A request cannot
+  # produce a directory traversal using this middleware. Only 'GET' and 'HEAD'
+  # requests will result in a file being returned.
+  class Static
+    def initialize: (untyped app, untyped path, ?headers: ::Hash[untyped, untyped] headers, ?index: ::String index) -> untyped
+
+    def call: (untyped env) -> untyped
+  end
+end
+
+module ActionDispatch
+  class Railtie < Rails::Railtie
+  end
+end
+
+module ActionDispatch
+  class Request
+    class Session
+      ENV_SESSION_KEY: untyped
+
+      ENV_SESSION_OPTIONS_KEY: untyped
+
+      # Singleton object used to determine if an optional param wasn't specified.
+      Unspecified: untyped
+
+      # Creates a session hash, merging the properties of the previous session if any.
+      def self.create: (untyped store, untyped req, untyped default_options) -> untyped
+
+      def self.find: (untyped req) -> untyped
+
+      def self.set: (untyped req, untyped session) -> untyped
+
+      class Options
+        # nodoc:
+        def self.set: (untyped req, untyped options) -> untyped
+
+        def self.find: (untyped req) -> untyped
+
+        def initialize: (untyped by, untyped default_options) -> untyped
+
+        def []: (untyped key) -> untyped
+
+        def id: (untyped req) -> untyped
+
+        def []=: (untyped k, untyped v) -> untyped
+
+        def to_hash: () -> untyped
+
+        def values_at: (*untyped args) -> untyped
+      end
+
+      def initialize: (untyped by, untyped req) -> untyped
+
+      def id: () -> untyped
+
+      def options: () -> untyped
+
+      def destroy: () -> untyped
+
+      # Returns value of the key stored in the session or
+      # +nil+ if the given key is not found in the session.
+      def []: (untyped key) -> untyped
+
+      # Returns the nested value specified by the sequence of keys, returning
+      # +nil+ if any intermediate step is +nil+.
+      def dig: (*untyped keys) -> untyped
+
+      # Returns true if the session has the given key or false.
+      def has_key?: (untyped key) -> untyped
+
+      alias key? has_key?
+
+      alias include? has_key?
+
+      # Returns keys of the session as Array.
+      def keys: () -> untyped
+
+      # Returns values of the session as Array.
+      def values: () -> untyped
+
+      # Writes given value to given key of the session.
+      def []=: (untyped key, untyped value) -> untyped
+
+      # Clears the session.
+      def clear: () -> untyped
+
+      # Returns the session as Hash.
+      def to_hash: () -> untyped
+
+      alias to_h to_hash
+
+      # Updates the session with given Hash.
+      #
+      #   session.to_hash
+      #   # => {"session_id"=>"e29b9ea315edf98aad94cc78c34cc9b2"}
+      #
+      #   session.update({ "foo" => "bar" })
+      #   # => {"session_id"=>"e29b9ea315edf98aad94cc78c34cc9b2", "foo" => "bar"}
+      #
+      #   session.to_hash
+      #   # => {"session_id"=>"e29b9ea315edf98aad94cc78c34cc9b2", "foo" => "bar"}
+      def update: (untyped hash) -> untyped
+
+      # Deletes given key from the session.
+      def delete: (untyped key) -> untyped
+
+      # Returns value of the given key from the session, or raises +KeyError+
+      # if can't find the given key and no default value is set.
+      # Returns default value if specified.
+      #
+      #   session.fetch(:foo)
+      #   # => KeyError: key not found: "foo"
+      #
+      #   session.fetch(:foo, :bar)
+      #   # => :bar
+      #
+      #   session.fetch(:foo) do
+      #     :bar
+      #   end
+      #   # => :bar
+      def fetch: (untyped key, ?untyped default) { () -> untyped } -> untyped
+
+      def inspect: () -> untyped
+
+      def exists?: () -> untyped
+
+      def loaded?: () -> untyped
+
+      def empty?: () -> untyped
+
+      def merge!: (untyped other) -> untyped
+
+      def each: () { () -> untyped } -> untyped
+
+      def load_for_read!: () -> untyped
+
+      def load_for_write!: () -> untyped
+
+      def load!: () -> untyped
+
+      def stringify_keys: (untyped other) -> untyped
+    end
+  end
+end
+
+module ActionDispatch
+  class Request
+    class Utils
+      def self.each_param_value: (untyped params) { () -> untyped } -> untyped
+
+      def self.normalize_encode_params: (untyped params) -> untyped
+
+      def self.check_param_encoding: (untyped params) -> untyped
+
+      class ParamEncoder
+        # :nodoc:
+        # Convert nested Hash to HashWithIndifferentAccess.
+        def self.normalize_encode_params: (untyped params) -> untyped
+
+        def self.handle_array: (untyped params) -> untyped
+      end
+
+      class NoNilParamEncoder < ParamEncoder
+        # Remove nils from the params hash.
+        # :nodoc:
+        def self.handle_array: (untyped params) -> untyped
+      end
+    end
+  end
+end
+
+module ActionDispatch
+  module Routing
+    class Endpoint
+      # :nodoc:
+      def dispatcher?: () -> ::FalseClass
+
+      def redirect?: () -> ::FalseClass
+
+      def matches?: (untyped req) -> ::TrueClass
+
+      def app: () -> untyped
+
+      def rack_app: () -> untyped
+
+      def engine?: () -> untyped
+    end
+  end
+end
+
+module ActionDispatch
+  module Routing
+    class RouteWrapper < SimpleDelegator
+      def endpoint: () -> untyped
+
+      def constraints: () -> untyped
+
+      def rack_app: () -> untyped
+
+      def path: () -> untyped
+
+      def name: () -> untyped
+
+      def reqs: () -> untyped
+
+      def controller: () -> untyped
+
+      def action: () -> untyped
+
+      def internal?: () -> untyped
+
+      def engine?: () -> untyped
+    end
+
+    class RoutesInspector
+      #
+      # This class is just used for displaying route information when someone
+      # executes `rails routes` or looks at the RoutingError page.
+      # People should not use this class.
+      # :nodoc:
+      def initialize: (untyped routes) -> untyped
+
+      def format: (untyped formatter, ?::Hash[untyped, untyped] filter) -> untyped
+
+      def normalize_filter: (untyped filter) -> untyped
+
+      def filter_routes: (untyped filter) -> untyped
+
+      def collect_routes: (untyped routes) -> untyped
+
+      def collect_engine_routes: (untyped route) -> (nil | untyped)
+    end
+
+    module ConsoleFormatter
+      class Base
+        def initialize: () -> untyped
+
+        def result: () -> untyped
+
+        def section_title: (untyped title) -> nil
+
+        def section: (untyped routes) -> nil
+
+        def header: (untyped routes) -> nil
+
+        def no_routes: (untyped routes, untyped filter) -> untyped
+      end
+
+      class Sheet < Base
+        def section_title: (untyped title) -> untyped
+
+        def section: (untyped routes) -> untyped
+
+        def header: (untyped routes) -> untyped
+
+        def draw_section: (untyped routes) -> untyped
+
+        def draw_header: (untyped routes) -> ::String
+
+        def widths: (untyped routes) -> ::Array[untyped]
+      end
+
+      class Expanded < Base
+        def section_title: (untyped title) -> untyped
+
+        def section: (untyped routes) -> untyped
+
+        def draw_expanded_section: (untyped routes) -> untyped
+
+        def route_header: (index: untyped index) -> ::String
+      end
+    end
+
+    class HtmlTableFormatter
+      def initialize: (untyped view) -> untyped
+
+      def section_title: (untyped title) -> untyped
+
+      def section: (untyped routes) -> untyped
+
+      # The header is part of the HTML page, so we don't construct it here.
+      def header: (untyped routes) -> nil
+
+      def no_routes: () -> untyped
+
+      def result: () -> untyped
+    end
+  end
+end
+
+module ActionDispatch
+  module Routing
+    class Mapper
+      URL_OPTIONS: ::Array[untyped]
+
+      class Constraints < Routing::Endpoint
+        # nodoc:
+        attr_reader app: untyped
+
+        # nodoc:
+        attr_reader constraints: untyped
+
+        SERVE: untyped
+
+        CALL: untyped
+
+        def initialize: (untyped app, untyped constraints, untyped strategy) -> untyped
+
+        def dispatcher?: () -> untyped
+
+        def matches?: (untyped req) -> untyped
+
+        def serve: (untyped req) -> (::Array[404 | ::Hash[::String, "pass"] | ::Array[untyped]] | untyped)
+
+        def constraint_args: (untyped constraint, untyped request) -> untyped
+      end
+
+      class Mapping
+        # nodoc:
+        ANCHOR_CHARACTERS_REGEX: untyped
+
+        OPTIONAL_FORMAT_REGEX: untyped
+
+        attr_reader requirements: untyped
+
+        attr_reader defaults: untyped
+
+        attr_reader to: untyped
+
+        attr_reader default_controller: untyped
+
+        attr_reader default_action: untyped
+
+        attr_reader required_defaults: untyped
+
+        attr_reader ast: untyped
+
+        attr_reader scope_options: untyped
+
+        def self.build: (untyped scope, untyped set, untyped ast, untyped controller, untyped default_action, untyped to, untyped via, untyped formatted, untyped options_constraints, untyped anchor, untyped options) -> untyped
+
+        def self.check_via: (untyped via) -> untyped
+
+        def self.normalize_path: (untyped path, untyped format) -> untyped
+
+        def self.optional_format?: (untyped path, untyped format) -> untyped
+
+        def initialize: (untyped set, untyped ast, untyped defaults, untyped controller, untyped default_action, untyped modyoule, untyped to, untyped formatted, untyped scope_constraints, untyped scope_options, untyped blocks, untyped via, untyped options_constraints, untyped anchor, untyped options) -> untyped
+
+        def make_route: (untyped name, untyped precedence) -> Journey::Route
+
+        def application: () -> untyped
+
+        def path: () -> untyped
+
+        def conditions: () -> untyped
+
+        def build_conditions: (untyped current_conditions, untyped request_class) -> untyped
+
+        def request_method: () -> untyped
+
+        JOINED_SEPARATORS: untyped
+
+        def build_path: (untyped ast, untyped requirements, untyped anchor) -> untyped
+
+        def intern: (untyped object) -> untyped
+
+        def add_wildcard_options: (untyped options, untyped formatted, untyped path_ast) -> untyped
+
+        def normalize_options!: (untyped options, untyped path_params, untyped modyoule) -> untyped
+
+        def split_constraints: (untyped path_params, untyped constraints) -> untyped
+
+        def normalize_format: (untyped formatted) -> untyped
+
+        def verify_regexp_requirements: (untyped requirements) -> untyped
+
+        def normalize_defaults: (untyped options) -> untyped
+
+        def app: (untyped blocks) -> untyped
+
+        def check_controller_and_action: (untyped path_params, untyped controller, untyped action) -> untyped
+
+        def check_part: (untyped name, untyped part, untyped path_params, untyped hash) { (untyped) -> untyped } -> untyped
+
+        def split_to: (untyped to) -> untyped
+
+        def add_controller_module: (untyped controller, untyped modyoule) -> untyped
+
+        def translate_controller: (untyped controller) { () -> untyped } -> untyped
+
+        def blocks: (untyped callable_constraint) -> ::Array[untyped]
+
+        def constraints: (untyped options, untyped path_params) -> untyped
+
+        def dispatcher: (untyped raise_on_name_error) -> Routing::RouteSet::Dispatcher
+      end
+
+      # Invokes Journey::Router::Utils.normalize_path and ensure that
+      # (:locale) becomes (/:locale) instead of /(:locale). Except
+      # for root cases, where the latter is the correct one.
+      def self.normalize_path: (untyped path) -> untyped
+
+      def self.normalize_name: (untyped name) -> untyped
+
+      module Base
+        # Matches a URL pattern to one or more routes.
+        #
+        # You should not use the +match+ method in your router
+        # without specifying an HTTP method.
+        #
+        # If you want to expose your action to both GET and POST, use:
+        #
+        #   # sets :controller, :action and :id in params
+        #   match ':controller/:action/:id', via: [:get, :post]
+        #
+        # Note that +:controller+, +:action+ and +:id+ are interpreted as URL
+        # query parameters and thus available through +params+ in an action.
+        #
+        # If you want to expose your action to GET, use +get+ in the router:
+        #
+        # Instead of:
+        #
+        #   match ":controller/:action/:id"
+        #
+        # Do:
+        #
+        #   get ":controller/:action/:id"
+        #
+        # Two of these symbols are special, +:controller+ maps to the controller
+        # and +:action+ to the controller's action. A pattern can also map
+        # wildcard segments (globs) to params:
+        #
+        #   get 'songs/*category/:title', to: 'songs#show'
+        #
+        #   # 'songs/rock/classic/stairway-to-heaven' sets
+        #   #  params[:category] = 'rock/classic'
+        #   #  params[:title] = 'stairway-to-heaven'
+        #
+        # To match a wildcard parameter, it must have a name assigned to it.
+        # Without a variable name to attach the glob parameter to, the route
+        # can't be parsed.
+        #
+        # When a pattern points to an internal route, the route's +:action+ and
+        # +:controller+ should be set in options or hash shorthand. Examples:
+        #
+        #   match 'photos/:id' => 'photos#show', via: :get
+        #   match 'photos/:id', to: 'photos#show', via: :get
+        #   match 'photos/:id', controller: 'photos', action: 'show', via: :get
+        #
+        # A pattern can also point to a +Rack+ endpoint i.e. anything that
+        # responds to +call+:
+        #
+        #   match 'photos/:id', to: -> (hash) { [200, {}, ["Coming soon"]] }, via: :get
+        #   match 'photos/:id', to: PhotoRackApp, via: :get
+        #   # Yes, controller actions are just rack endpoints
+        #   match 'photos/:id', to: PhotosController.action(:show), via: :get
+        #
+        # Because requesting various HTTP verbs with a single action has security
+        # implications, you must either specify the actions in
+        # the via options or use one of the HttpHelpers[rdoc-ref:HttpHelpers]
+        # instead +match+
+        #
+        # === Options
+        #
+        # Any options not seen here are passed on as params with the URL.
+        #
+        # [:controller]
+        #   The route's controller.
+        #
+        # [:action]
+        #   The route's action.
+        #
+        # [:param]
+        #   Overrides the default resource identifier +:id+ (name of the
+        #   dynamic segment used to generate the routes).
+        #   You can access that segment from your controller using
+        #   <tt>params[<:param>]</tt>.
+        #   In your router:
+        #
+        #      resources :users, param: :name
+        #
+        #   The +users+ resource here will have the following routes generated for it:
+        #
+        #      GET       /users(.:format)
+        #      POST      /users(.:format)
+        #      GET       /users/new(.:format)
+        #      GET       /users/:name/edit(.:format)
+        #      GET       /users/:name(.:format)
+        #      PATCH/PUT /users/:name(.:format)
+        #      DELETE    /users/:name(.:format)
+        #
+        #   You can override <tt>ActiveRecord::Base#to_param</tt> of a related
+        #   model to construct a URL:
+        #
+        #      class User < ActiveRecord::Base
+        #        def to_param
+        #          name
+        #        end
+        #      end
+        #
+        #      user = User.find_by(name: 'Phusion')
+        #      user_path(user)  # => "/users/Phusion"
+        #
+        # [:path]
+        #   The path prefix for the routes.
+        #
+        # [:module]
+        #   The namespace for :controller.
+        #
+        #     match 'path', to: 'c#a', module: 'sekret', controller: 'posts', via: :get
+        #     # => Sekret::PostsController
+        #
+        #   See <tt>Scoping#namespace</tt> for its scope equivalent.
+        #
+        # [:as]
+        #   The name used to generate routing helpers.
+        #
+        # [:via]
+        #   Allowed HTTP verb(s) for route.
+        #
+        #      match 'path', to: 'c#a', via: :get
+        #      match 'path', to: 'c#a', via: [:get, :post]
+        #      match 'path', to: 'c#a', via: :all
+        #
+        # [:to]
+        #   Points to a +Rack+ endpoint. Can be an object that responds to
+        #   +call+ or a string representing a controller's action.
+        #
+        #      match 'path', to: 'controller#action', via: :get
+        #      match 'path', to: -> (env) { [200, {}, ["Success!"]] }, via: :get
+        #      match 'path', to: RackApp, via: :get
+        #
+        # [:on]
+        #   Shorthand for wrapping routes in a specific RESTful context. Valid
+        #   values are +:member+, +:collection+, and +:new+. Only use within
+        #   <tt>resource(s)</tt> block. For example:
+        #
+        #      resource :bar do
+        #        match 'foo', to: 'c#a', on: :member, via: [:get, :post]
+        #      end
+        #
+        #   Is equivalent to:
+        #
+        #      resource :bar do
+        #        member do
+        #          match 'foo', to: 'c#a', via: [:get, :post]
+        #        end
+        #      end
+        #
+        # [:constraints]
+        #   Constrains parameters with a hash of regular expressions
+        #   or an object that responds to <tt>matches?</tt>. In addition, constraints
+        #   other than path can also be specified with any object
+        #   that responds to <tt>===</tt> (eg. String, Array, Range, etc.).
+        #
+        #     match 'path/:id', constraints: { id: /[A-Z]\d{5}/ }, via: :get
+        #
+        #     match 'json_only', constraints: { format: 'json' }, via: :get
+        #
+        #     class PermitList
+        #       def matches?(request) request.remote_ip == '1.2.3.4' end
+        #     end
+        #     match 'path', to: 'c#a', constraints: PermitList.new, via: :get
+        #
+        #   See <tt>Scoping#constraints</tt> for more examples with its scope
+        #   equivalent.
+        #
+        # [:defaults]
+        #   Sets defaults for parameters
+        #
+        #     # Sets params[:format] to 'jpg' by default
+        #     match 'path', to: 'c#a', defaults: { format: 'jpg' }, via: :get
+        #
+        #   See <tt>Scoping#defaults</tt> for its scope equivalent.
+        #
+        # [:anchor]
+        #   Boolean to anchor a <tt>match</tt> pattern. Default is true. When set to
+        #   false, the pattern matches any request prefixed with the given path.
+        #
+        #     # Matches any request starting with 'path'
+        #     match 'path', to: 'c#a', anchor: false, via: :get
+        #
+        # [:format]
+        #   Allows you to specify the default value for optional +format+
+        #   segment or disable it by supplying +false+.
+        def match: (untyped path, ?untyped? options) -> nil
+
+        # Mount a Rack-based application to be used within the application.
+        #
+        #   mount SomeRackApp, at: "some_route"
+        #
+        # Alternatively:
+        #
+        #   mount(SomeRackApp => "some_route")
+        #
+        # For options, see +match+, as +mount+ uses it internally.
+        #
+        # All mounted applications come with routing helpers to access them.
+        # These are named after the class specified, so for the above example
+        # the helper is either +some_rack_app_path+ or +some_rack_app_url+.
+        # To customize this helper's name, use the +:as+ option:
+        #
+        #   mount(SomeRackApp => "some_route", as: "exciting")
+        #
+        # This will generate the +exciting_path+ and +exciting_url+ helpers
+        # which can be used to navigate to this mounted app.
+        def mount: (untyped app, ?untyped? options) -> untyped
+
+        def default_url_options=: (untyped options) -> untyped
+
+        alias default_url_options default_url_options=
+
+        def with_default_scope: (untyped scope) { () -> untyped } -> untyped
+
+        # Query if the following named route was already defined.
+        def has_named_route?: (untyped name) -> untyped
+
+        def rails_app?: (untyped app) -> untyped
+
+        def app_name: (untyped app, untyped rails_app) -> untyped
+
+        def define_generate_prefix: (untyped app, untyped name) -> untyped
+      end
+
+      module HttpHelpers
+        # Define a route that only recognizes HTTP GET.
+        # For supported arguments, see match[rdoc-ref:Base#match]
+        #
+        #   get 'bacon', to: 'food#bacon'
+        def get: (*untyped args) { () -> untyped } -> untyped
+
+        # Define a route that only recognizes HTTP POST.
+        # For supported arguments, see match[rdoc-ref:Base#match]
+        #
+        #   post 'bacon', to: 'food#bacon'
+        def post: (*untyped args) { () -> untyped } -> untyped
+
+        # Define a route that only recognizes HTTP PATCH.
+        # For supported arguments, see match[rdoc-ref:Base#match]
+        #
+        #   patch 'bacon', to: 'food#bacon'
+        def patch: (*untyped args) { () -> untyped } -> untyped
+
+        # Define a route that only recognizes HTTP PUT.
+        # For supported arguments, see match[rdoc-ref:Base#match]
+        #
+        #   put 'bacon', to: 'food#bacon'
+        def put: (*untyped args) { () -> untyped } -> untyped
+
+        # Define a route that only recognizes HTTP DELETE.
+        # For supported arguments, see match[rdoc-ref:Base#match]
+        #
+        #   delete 'broccoli', to: 'food#broccoli'
+        def delete: (*untyped args) { () -> untyped } -> untyped
+
+        def map_method: (untyped method, untyped args) { () -> untyped } -> untyped
+      end
+
+      # You may wish to organize groups of controllers under a namespace.
+      # Most commonly, you might group a number of administrative controllers
+      # under an +admin+ namespace. You would place these controllers under
+      # the <tt>app/controllers/admin</tt> directory, and you can group them
+      # together in your router:
+      #
+      #   namespace "admin" do
+      #     resources :posts, :comments
+      #   end
+      #
+      # This will create a number of routes for each of the posts and comments
+      # controller. For <tt>Admin::PostsController</tt>, Rails will create:
+      #
+      #   GET       /admin/posts
+      #   GET       /admin/posts/new
+      #   POST      /admin/posts
+      #   GET       /admin/posts/1
+      #   GET       /admin/posts/1/edit
+      #   PATCH/PUT /admin/posts/1
+      #   DELETE    /admin/posts/1
+      #
+      # If you want to route /posts (without the prefix /admin) to
+      # <tt>Admin::PostsController</tt>, you could use
+      #
+      #   scope module: "admin" do
+      #     resources :posts
+      #   end
+      #
+      # or, for a single case
+      #
+      #   resources :posts, module: "admin"
+      #
+      # If you want to route /admin/posts to +PostsController+
+      # (without the <tt>Admin::</tt> module prefix), you could use
+      #
+      #   scope "/admin" do
+      #     resources :posts
+      #   end
+      #
+      # or, for a single case
+      #
+      #   resources :posts, path: "/admin/posts"
+      #
+      # In each of these cases, the named routes remain the same as if you did
+      # not use scope. In the last case, the following paths map to
+      # +PostsController+:
+      #
+      #   GET       /admin/posts
+      #   GET       /admin/posts/new
+      #   POST      /admin/posts
+      #   GET       /admin/posts/1
+      #   GET       /admin/posts/1/edit
+      #   PATCH/PUT /admin/posts/1
+      #   DELETE    /admin/posts/1
+      module Scoping
+        # Scopes a set of routes to the given default options.
+        #
+        # Take the following route definition as an example:
+        #
+        #   scope path: ":account_id", as: "account" do
+        #     resources :projects
+        #   end
+        #
+        # This generates helpers such as +account_projects_path+, just like +resources+ does.
+        # The difference here being that the routes generated are like /:account_id/projects,
+        # rather than /accounts/:account_id/projects.
+        #
+        # === Options
+        #
+        # Takes same options as <tt>Base#match</tt> and <tt>Resources#resources</tt>.
+        #
+        #   # route /posts (without the prefix /admin) to <tt>Admin::PostsController</tt>
+        #   scope module: "admin" do
+        #     resources :posts
+        #   end
+        #
+        #   # prefix the posts resource's requests with '/admin'
+        #   scope path: "/admin" do
+        #     resources :posts
+        #   end
+        #
+        #   # prefix the routing helper name: +sekret_posts_path+ instead of +posts_path+
+        #   scope as: "sekret" do
+        #     resources :posts
+        #   end
+        def scope: (*untyped args) { () -> untyped } -> untyped
+
+        POISON: untyped
+
+        # Scopes routes to a specific controller
+        #
+        #   controller "food" do
+        #     match "bacon", action: :bacon, via: :get
+        #   end
+        def controller: (untyped controller) { () -> untyped } -> untyped
+
+        # Scopes routes to a specific namespace. For example:
+        #
+        #   namespace :admin do
+        #     resources :posts
+        #   end
+        #
+        # This generates the following routes:
+        #
+        #       admin_posts GET       /admin/posts(.:format)          admin/posts#index
+        #       admin_posts POST      /admin/posts(.:format)          admin/posts#create
+        #    new_admin_post GET       /admin/posts/new(.:format)      admin/posts#new
+        #   edit_admin_post GET       /admin/posts/:id/edit(.:format) admin/posts#edit
+        #        admin_post GET       /admin/posts/:id(.:format)      admin/posts#show
+        #        admin_post PATCH/PUT /admin/posts/:id(.:format)      admin/posts#update
+        #        admin_post DELETE    /admin/posts/:id(.:format)      admin/posts#destroy
+        #
+        # === Options
+        #
+        # The +:path+, +:as+, +:module+, +:shallow_path+ and +:shallow_prefix+
+        # options all default to the name of the namespace.
+        #
+        # For options, see <tt>Base#match</tt>. For +:shallow_path+ option, see
+        # <tt>Resources#resources</tt>.
+        #
+        #   # accessible through /sekret/posts rather than /admin/posts
+        #   namespace :admin, path: "sekret" do
+        #     resources :posts
+        #   end
+        #
+        #   # maps to <tt>Sekret::PostsController</tt> rather than <tt>Admin::PostsController</tt>
+        #   namespace :admin, module: "sekret" do
+        #     resources :posts
+        #   end
+        #
+        #   # generates +sekret_posts_path+ rather than +admin_posts_path+
+        #   namespace :admin, as: "sekret" do
+        #     resources :posts
+        #   end
+        def namespace: (untyped path, ?::Hash[untyped, untyped] options) { () -> untyped } -> untyped
+
+        # === Parameter Restriction
+        # Allows you to constrain the nested routes based on a set of rules.
+        # For instance, in order to change the routes to allow for a dot character in the +id+ parameter:
+        #
+        #   constraints(id: /\d+\.\d+/) do
+        #     resources :posts
+        #   end
+        #
+        # Now routes such as +/posts/1+ will no longer be valid, but +/posts/1.1+ will be.
+        # The +id+ parameter must match the constraint passed in for this example.
+        #
+        # You may use this to also restrict other parameters:
+        #
+        #   resources :posts do
+        #     constraints(post_id: /\d+\.\d+/) do
+        #       resources :comments
+        #     end
+        #   end
+        #
+        # === Restricting based on IP
+        #
+        # Routes can also be constrained to an IP or a certain range of IP addresses:
+        #
+        #   constraints(ip: /192\.168\.\d+\.\d+/) do
+        #     resources :posts
+        #   end
+        #
+        # Any user connecting from the 192.168.* range will be able to see this resource,
+        # where as any user connecting outside of this range will be told there is no such route.
+        #
+        # === Dynamic request matching
+        #
+        # Requests to routes can be constrained based on specific criteria:
+        #
+        #    constraints(-> (req) { req.env["HTTP_USER_AGENT"] =~ /iPhone/ }) do
+        #      resources :iphones
+        #    end
+        #
+        # You are able to move this logic out into a class if it is too complex for routes.
+        # This class must have a +matches?+ method defined on it which either returns +true+
+        # if the user should be given access to that route, or +false+ if the user should not.
+        #
+        #    class Iphone
+        #      def self.matches?(request)
+        #        request.env["HTTP_USER_AGENT"] =~ /iPhone/
+        #      end
+        #    end
+        #
+        # An expected place for this code would be +lib/constraints+.
+        #
+        # This class is then used like this:
+        #
+        #    constraints(Iphone) do
+        #      resources :iphones
+        #    end
+        def constraints: (?::Hash[untyped, untyped] constraints) { () -> untyped } -> untyped
+
+        # Allows you to set default parameters for a route, such as this:
+        #   defaults id: 'home' do
+        #     match 'scoped_pages/(:id)', to: 'pages#show'
+        #   end
+        # Using this, the +:id+ parameter here will default to 'home'.
+        def defaults: (?::Hash[untyped, untyped] defaults) { () -> untyped } -> untyped
+
+        def merge_path_scope: (untyped parent, untyped child) -> untyped
+
+        def merge_shallow_path_scope: (untyped parent, untyped child) -> untyped
+
+        def merge_as_scope: (untyped parent, untyped child) -> untyped
+
+        def merge_shallow_prefix_scope: (untyped parent, untyped child) -> untyped
+
+        def merge_module_scope: (untyped parent, untyped child) -> untyped
+
+        def merge_controller_scope: (untyped parent, untyped child) -> untyped
+
+        def merge_action_scope: (untyped parent, untyped child) -> untyped
+
+        def merge_via_scope: (untyped parent, untyped child) -> untyped
+
+        def merge_format_scope: (untyped parent, untyped child) -> untyped
+
+        def merge_path_names_scope: (untyped parent, untyped child) -> untyped
+
+        def merge_constraints_scope: (untyped parent, untyped child) -> untyped
+
+        def merge_defaults_scope: (untyped parent, untyped child) -> untyped
+
+        def merge_blocks_scope: (untyped parent, untyped child) -> untyped
+
+        def merge_options_scope: (untyped parent, untyped child) -> untyped
+
+        def merge_shallow_scope: (untyped parent, untyped child) -> untyped
+
+        def merge_to_scope: (untyped parent, untyped child) -> untyped
+      end
+
+      # Resource routing allows you to quickly declare all of the common routes
+      # for a given resourceful controller. Instead of declaring separate routes
+      # for your +index+, +show+, +new+, +edit+, +create+, +update+ and +destroy+
+      # actions, a resourceful route declares them in a single line of code:
+      #
+      #  resources :photos
+      #
+      # Sometimes, you have a resource that clients always look up without
+      # referencing an ID. A common example, /profile always shows the profile of
+      # the currently logged in user. In this case, you can use a singular resource
+      # to map /profile (rather than /profile/:id) to the show action.
+      #
+      #  resource :profile
+      #
+      # It's common to have resources that are logically children of other
+      # resources:
+      #
+      #   resources :magazines do
+      #     resources :ads
+      #   end
+      #
+      # You may wish to organize groups of controllers under a namespace. Most
+      # commonly, you might group a number of administrative controllers under
+      # an +admin+ namespace. You would place these controllers under the
+      # <tt>app/controllers/admin</tt> directory, and you can group them together
+      # in your router:
+      #
+      #   namespace "admin" do
+      #     resources :posts, :comments
+      #   end
+      #
+      # By default the +:id+ parameter doesn't accept dots. If you need to
+      # use dots as part of the +:id+ parameter add a constraint which
+      # overrides this restriction, e.g:
+      #
+      #   resources :articles, id: /[^\/]+/
+      #
+      # This allows any character other than a slash as part of your +:id+.
+      #
+      module Resources
+        # CANONICAL_ACTIONS holds all actions that does not need a prefix or
+        # a path appended since they fit properly in their scope level.
+        VALID_ON_OPTIONS: ::Array[untyped]
+
+        RESOURCE_OPTIONS: ::Array[untyped]
+
+        CANONICAL_ACTIONS: ::Array[untyped]
+
+        class Resource
+          # nodoc:
+          attr_reader controller: untyped
+
+          # nodoc:
+          attr_reader path: untyped
+
+          # nodoc:
+          attr_reader param: untyped
+
+          def initialize: (untyped entities, untyped api_only, untyped shallow, ?::Hash[untyped, untyped] options) -> untyped
+
+          def default_actions: () -> untyped
+
+          def actions: () -> untyped
+
+          def available_actions: () -> untyped
+
+          def name: () -> untyped
+
+          def plural: () -> untyped
+
+          def singular: () -> untyped
+
+          alias member_name singular
+
+          # Checks for uncountable plurals, and appends "_index" if the plural
+          # and singular form are the same.
+          def collection_name: () -> untyped
+
+          def resource_scope: () -> untyped
+
+          alias collection_scope path
+
+          def member_scope: () -> ::String
+
+          alias shallow_scope member_scope
+
+          def new_scope: (untyped new_path) -> ::String
+
+          def nested_param: () -> ::Symbol
+
+          def nested_scope: () -> ::String
+
+          def shallow?: () -> untyped
+
+          def singleton?: () -> ::FalseClass
+        end
+
+        class SingletonResource < Resource
+          # nodoc:
+          def initialize: (untyped entities, untyped api_only, untyped shallow, untyped options) -> untyped
+
+          def default_actions: () -> untyped
+
+          def plural: () -> untyped
+
+          def singular: () -> untyped
+
+          alias member_name singular
+
+          alias collection_name singular
+
+          alias member_scope path
+
+          alias nested_scope path
+
+          def singleton?: () -> ::TrueClass
+        end
+
+        def resources_path_names: (untyped options) -> untyped
+
+        # Sometimes, you have a resource that clients always look up without
+        # referencing an ID. A common example, /profile always shows the
+        # profile of the currently logged in user. In this case, you can use
+        # a singular resource to map /profile (rather than /profile/:id) to
+        # the show action:
+        #
+        #   resource :profile
+        #
+        # This creates six different routes in your application, all mapping to
+        # the +Profiles+ controller (note that the controller is named after
+        # the plural):
+        #
+        #   GET       /profile/new
+        #   GET       /profile
+        #   GET       /profile/edit
+        #   PATCH/PUT /profile
+        #   DELETE    /profile
+        #   POST      /profile
+        #
+        # === Options
+        # Takes same options as resources[rdoc-ref:#resources]
+        def resource: (*untyped resources) { () -> untyped } -> untyped
+
+        # In Rails, a resourceful route provides a mapping between HTTP verbs
+        # and URLs and controller actions. By convention, each action also maps
+        # to particular CRUD operations in a database. A single entry in the
+        # routing file, such as
+        #
+        #   resources :photos
+        #
+        # creates seven different routes in your application, all mapping to
+        # the +Photos+ controller:
+        #
+        #   GET       /photos
+        #   GET       /photos/new
+        #   POST      /photos
+        #   GET       /photos/:id
+        #   GET       /photos/:id/edit
+        #   PATCH/PUT /photos/:id
+        #   DELETE    /photos/:id
+        #
+        # Resources can also be nested infinitely by using this block syntax:
+        #
+        #   resources :photos do
+        #     resources :comments
+        #   end
+        #
+        # This generates the following comments routes:
+        #
+        #   GET       /photos/:photo_id/comments
+        #   GET       /photos/:photo_id/comments/new
+        #   POST      /photos/:photo_id/comments
+        #   GET       /photos/:photo_id/comments/:id
+        #   GET       /photos/:photo_id/comments/:id/edit
+        #   PATCH/PUT /photos/:photo_id/comments/:id
+        #   DELETE    /photos/:photo_id/comments/:id
+        #
+        # === Options
+        # Takes same options as match[rdoc-ref:Base#match] as well as:
+        #
+        # [:path_names]
+        #   Allows you to change the segment component of the +edit+ and +new+ actions.
+        #   Actions not specified are not changed.
+        #
+        #     resources :posts, path_names: { new: "brand_new" }
+        #
+        #   The above example will now change /posts/new to /posts/brand_new.
+        #
+        # [:path]
+        #   Allows you to change the path prefix for the resource.
+        #
+        #     resources :posts, path: 'postings'
+        #
+        #   The resource and all segments will now route to /postings instead of /posts.
+        #
+        # [:only]
+        #   Only generate routes for the given actions.
+        #
+        #     resources :cows, only: :show
+        #     resources :cows, only: [:show, :index]
+        #
+        # [:except]
+        #   Generate all routes except for the given actions.
+        #
+        #     resources :cows, except: :show
+        #     resources :cows, except: [:show, :index]
+        #
+        # [:shallow]
+        #   Generates shallow routes for nested resource(s). When placed on a parent resource,
+        #   generates shallow routes for all nested resources.
+        #
+        #     resources :posts, shallow: true do
+        #       resources :comments
+        #     end
+        #
+        #   Is the same as:
+        #
+        #     resources :posts do
+        #       resources :comments, except: [:show, :edit, :update, :destroy]
+        #     end
+        #     resources :comments, only: [:show, :edit, :update, :destroy]
+        #
+        #   This allows URLs for resources that otherwise would be deeply nested such
+        #   as a comment on a blog post like <tt>/posts/a-long-permalink/comments/1234</tt>
+        #   to be shortened to just <tt>/comments/1234</tt>.
+        #
+        #   Set <tt>shallow: false</tt> on a child resource to ignore a parent's shallow parameter.
+        #
+        # [:shallow_path]
+        #   Prefixes nested shallow routes with the specified path.
+        #
+        #     scope shallow_path: "sekret" do
+        #       resources :posts do
+        #         resources :comments, shallow: true
+        #       end
+        #     end
+        #
+        #   The +comments+ resource here will have the following routes generated for it:
+        #
+        #     post_comments    GET       /posts/:post_id/comments(.:format)
+        #     post_comments    POST      /posts/:post_id/comments(.:format)
+        #     new_post_comment GET       /posts/:post_id/comments/new(.:format)
+        #     edit_comment     GET       /sekret/comments/:id/edit(.:format)
+        #     comment          GET       /sekret/comments/:id(.:format)
+        #     comment          PATCH/PUT /sekret/comments/:id(.:format)
+        #     comment          DELETE    /sekret/comments/:id(.:format)
+        #
+        # [:shallow_prefix]
+        #   Prefixes nested shallow route names with specified prefix.
+        #
+        #     scope shallow_prefix: "sekret" do
+        #       resources :posts do
+        #         resources :comments, shallow: true
+        #       end
+        #     end
+        #
+        #   The +comments+ resource here will have the following routes generated for it:
+        #
+        #     post_comments           GET       /posts/:post_id/comments(.:format)
+        #     post_comments           POST      /posts/:post_id/comments(.:format)
+        #     new_post_comment        GET       /posts/:post_id/comments/new(.:format)
+        #     edit_sekret_comment     GET       /comments/:id/edit(.:format)
+        #     sekret_comment          GET       /comments/:id(.:format)
+        #     sekret_comment          PATCH/PUT /comments/:id(.:format)
+        #     sekret_comment          DELETE    /comments/:id(.:format)
+        #
+        # [:format]
+        #   Allows you to specify the default value for optional +format+
+        #   segment or disable it by supplying +false+.
+        #
+        # [:param]
+        #   Allows you to override the default param name of +:id+ in the URL.
+        #
+        # === Examples
+        #
+        #   # routes call <tt>Admin::PostsController</tt>
+        #   resources :posts, module: "admin"
+        #
+        #   # resource actions are at /admin/posts.
+        #   resources :posts, path: "admin/posts"
+        def resources: (*untyped resources) { () -> untyped } -> untyped
+
+        # To add a route to the collection:
+        #
+        #   resources :photos do
+        #     collection do
+        #       get 'search'
+        #     end
+        #   end
+        #
+        # This will enable Rails to recognize paths such as <tt>/photos/search</tt>
+        # with GET, and route to the search action of +PhotosController+. It will also
+        # create the <tt>search_photos_url</tt> and <tt>search_photos_path</tt>
+        # route helpers.
+        def collection: () { () -> untyped } -> untyped
+
+        # To add a member route, add a member block into the resource block:
+        #
+        #   resources :photos do
+        #     member do
+        #       get 'preview'
+        #     end
+        #   end
+        #
+        # This will recognize <tt>/photos/1/preview</tt> with GET, and route to the
+        # preview action of +PhotosController+. It will also create the
+        # <tt>preview_photo_url</tt> and <tt>preview_photo_path</tt> helpers.
+        def member: () { () -> untyped } -> untyped
+
+        def new: () { () -> untyped } -> untyped
+
+        def nested: () { () -> untyped } -> untyped
+
+        # See ActionDispatch::Routing::Mapper::Scoping#namespace.
+        def namespace: (untyped path, ?::Hash[untyped, untyped] options) -> untyped
+
+        def shallow: () { () -> untyped } -> untyped
+
+        def shallow?: () -> untyped
+
+        # Matches a URL pattern to one or more routes.
+        # For more information, see match[rdoc-ref:Base#match].
+        #
+        #   match 'path' => 'controller#action', via: :patch
+        #   match 'path', to: 'controller#action', via: :post
+        #   match 'path', 'otherpath', on: :member, via: :get
+        def match: (untyped path, *untyped rest) { () -> untyped } -> untyped
+
+        # You can specify what Rails should route "/" to with the root method:
+        #
+        #   root to: 'pages#main'
+        #
+        # For options, see +match+, as +root+ uses it internally.
+        #
+        # You can also pass a string which will expand
+        #
+        #   root 'pages#main'
+        #
+        # You should put the root route at the top of <tt>config/routes.rb</tt>,
+        # because this means it will be matched first. As this is the most popular route
+        # of most Rails applications, this is beneficial.
+        def root: (untyped path, ?::Hash[untyped, untyped] options) -> untyped
+
+        def parent_resource: () -> untyped
+
+        def apply_common_behavior_for: (untyped method, untyped resources, untyped options) { () -> untyped } -> (::TrueClass | ::FalseClass)
+
+        def apply_action_options: (untyped options) -> untyped
+
+        def action_options?: (untyped options) -> untyped
+
+        def scope_action_options: () -> untyped
+
+        def resource_scope?: () -> untyped
+
+        def resource_method_scope?: () -> untyped
+
+        def nested_scope?: () -> untyped
+
+        def with_scope_level: (untyped kind) { () -> untyped } -> untyped
+
+        def resource_scope: (untyped resource) { () -> untyped } -> untyped
+
+        def nested_options: () -> untyped
+
+        def shallow_nesting_depth: () -> untyped
+
+        def param_constraint?: () -> untyped
+
+        def param_constraint: () -> untyped
+
+        def canonical_action?: (untyped action) -> untyped
+
+        def shallow_scope: () { () -> untyped } -> untyped
+
+        def path_for_action: (untyped action, untyped path) -> (::String | untyped)
+
+        def action_path: (untyped name) -> untyped
+
+        def prefix_name_for_action: (untyped as, untyped action) -> untyped
+
+        def name_for_action: (untyped as, untyped action) -> (nil | untyped)
+
+        def set_member_mappings_for_resource: () -> untyped
+
+        def api_only?: () -> untyped
+
+        def path_scope: (untyped path) { () -> untyped } -> untyped
+
+        def map_match: (untyped paths, untyped options) -> untyped
+
+        def get_to_from_path: (untyped path, untyped to, untyped action) -> untyped
+
+        def using_match_shorthand?: (untyped path) -> untyped
+
+        def decomposed_match: (untyped path, untyped controller, untyped options, untyped _path, untyped to, untyped via, untyped formatted, untyped anchor, untyped options_constraints) -> untyped
+
+        def add_route: (untyped action, untyped controller, untyped options, untyped _path, untyped to, untyped via, untyped formatted, untyped anchor, untyped options_constraints) -> untyped
+
+        def match_root_route: (untyped options) -> untyped
+      end
+
+      # Routing Concerns allow you to declare common routes that can be reused
+      # inside others resources and routes.
+      #
+      #   concern :commentable do
+      #     resources :comments
+      #   end
+      #
+      #   concern :image_attachable do
+      #     resources :images, only: :index
+      #   end
+      #
+      # These concerns are used in Resources routing:
+      #
+      #   resources :messages, concerns: [:commentable, :image_attachable]
+      #
+      # or in a scope or namespace:
+      #
+      #   namespace :posts do
+      #     concerns :commentable
+      #   end
+      module Concerns
+        # Define a routing concern using a name.
+        #
+        # Concerns may be defined inline, using a block, or handled by
+        # another object, by passing that object as the second parameter.
+        #
+        # The concern object, if supplied, should respond to <tt>call</tt>,
+        # which will receive two parameters:
+        #
+        #   * The current mapper
+        #   * A hash of options which the concern object may use
+        #
+        # Options may also be used by concerns defined in a block by accepting
+        # a block parameter. So, using a block, you might do something as
+        # simple as limit the actions available on certain resources, passing
+        # standard resource options through the concern:
+        #
+        #   concern :commentable do |options|
+        #     resources :comments, options
+        #   end
+        #
+        #   resources :posts, concerns: :commentable
+        #   resources :archived_posts do
+        #     # Don't allow comments on archived posts
+        #     concerns :commentable, only: [:index, :show]
+        #   end
+        #
+        # Or, using a callable object, you might implement something more
+        # specific to your application, which would be out of place in your
+        # routes file.
+        #
+        #   # purchasable.rb
+        #   class Purchasable
+        #     def initialize(defaults = {})
+        #       @defaults = defaults
+        #     end
+        #
+        #     def call(mapper, options = {})
+        #       options = @defaults.merge(options)
+        #       mapper.resources :purchases
+        #       mapper.resources :receipts
+        #       mapper.resources :returns if options[:returnable]
+        #     end
+        #   end
+        #
+        #   # routes.rb
+        #   concern :purchasable, Purchasable.new(returnable: true)
+        #
+        #   resources :toys, concerns: :purchasable
+        #   resources :electronics, concerns: :purchasable
+        #   resources :pets do
+        #     concerns :purchasable, returnable: false
+        #   end
+        #
+        # Any routing helpers can be used inside a concern. If using a
+        # callable, they're accessible from the Mapper that's passed to
+        # <tt>call</tt>.
+        def concern: (untyped name, ?untyped? callable) { () -> untyped } -> untyped
+
+        # Use the named concerns
+        #
+        #   resources :posts do
+        #     concerns :commentable
+        #   end
+        #
+        # Concerns also work in any routes helper that you want to use:
+        #
+        #   namespace :posts do
+        #     concerns :commentable
+        #   end
+        def concerns: (*untyped args) -> untyped
+      end
+
+      module CustomUrls
+        # Define custom URL helpers that will be added to the application's
+        # routes. This allows you to override and/or replace the default behavior
+        # of routing helpers, e.g:
+        #
+        #   direct :homepage do
+        #     "https://rubyonrails.org"
+        #   end
+        #
+        #   direct :commentable do |model|
+        #     [ model, anchor: model.dom_id ]
+        #   end
+        #
+        #   direct :main do
+        #     { controller: "pages", action: "index", subdomain: "www" }
+        #   end
+        #
+        # The return value from the block passed to +direct+ must be a valid set of
+        # arguments for +url_for+ which will actually build the URL string. This can
+        # be one of the following:
+        #
+        # * A string, which is treated as a generated URL
+        # * A hash, e.g. <tt>{ controller: "pages", action: "index" }</tt>
+        # * An array, which is passed to +polymorphic_url+
+        # * An Active Model instance
+        # * An Active Model class
+        #
+        # NOTE: Other URL helpers can be called in the block but be careful not to invoke
+        # your custom URL helper again otherwise it will result in a stack overflow error.
+        #
+        # You can also specify default options that will be passed through to
+        # your URL helper definition, e.g:
+        #
+        #   direct :browse, page: 1, size: 10 do |options|
+        #     [ :products, options.merge(params.permit(:page, :size).to_h.symbolize_keys) ]
+        #   end
+        #
+        # In this instance the +params+ object comes from the context in which the
+        # block is executed, e.g. generating a URL inside a controller action or a view.
+        # If the block is executed where there isn't a +params+ object such as this:
+        #
+        #   Rails.application.routes.url_helpers.browse_path
+        #
+        # then it will raise a +NameError+. Because of this you need to be aware of the
+        # context in which you will use your custom URL helper when defining it.
+        #
+        # NOTE: The +direct+ method can't be used inside of a scope block such as
+        # +namespace+ or +scope+ and will raise an error if it detects that it is.
+        def direct: (untyped name, ?::Hash[untyped, untyped] options) { () -> untyped } -> untyped
+
+        # Define custom polymorphic mappings of models to URLs. This alters the
+        # behavior of +polymorphic_url+ and consequently the behavior of
+        # +link_to+ and +form_for+ when passed a model instance, e.g:
+        #
+        #   resource :basket
+        #
+        #   resolve "Basket" do
+        #     [:basket]
+        #   end
+        #
+        # This will now generate "/basket" when a +Basket+ instance is passed to
+        # +link_to+ or +form_for+ instead of the standard "/baskets/:id".
+        #
+        # NOTE: This custom behavior only applies to simple polymorphic URLs where
+        # a single model instance is passed and not more complicated forms, e.g:
+        #
+        #   # config/routes.rb
+        #   resource :profile
+        #   namespace :admin do
+        #     resources :users
+        #   end
+        #
+        #   resolve("User") { [:profile] }
+        #
+        #   # app/views/application/_menu.html.erb
+        #   link_to "Profile", @current_user
+        #   link_to "Profile", [:admin, @current_user]
+        #
+        # The first +link_to+ will generate "/profile" but the second will generate
+        # the standard polymorphic URL of "/admin/users/1".
+        #
+        # You can pass options to a polymorphic mapping - the arity for the block
+        # needs to be two as the instance is passed as the first argument, e.g:
+        #
+        #   resolve "Basket", anchor: "items" do |basket, options|
+        #     [:basket, options]
+        #   end
+        #
+        # This generates the URL "/basket#items" because when the last item in an
+        # array passed to +polymorphic_url+ is a hash then it's treated as options
+        # to the URL helper that gets called.
+        #
+        # NOTE: The +resolve+ method can't be used inside of a scope block such as
+        # +namespace+ or +scope+ and will raise an error if it detects that it is.
+        def resolve: (*untyped args) { () -> untyped } -> untyped
+      end
+
+      class Scope
+        # :nodoc:
+        OPTIONS: ::Array[untyped]
+
+        RESOURCE_SCOPES: ::Array[untyped]
+
+        RESOURCE_METHOD_SCOPES: ::Array[untyped]
+
+        attr_reader parent: untyped
+
+        attr_reader scope_level: untyped
+
+        def initialize: (untyped hash, ?untyped parent, ?untyped? scope_level) -> untyped
+
+        def nested?: () -> untyped
+
+        def null?: () -> untyped
+
+        def root?: () -> untyped
+
+        def resources?: () -> untyped
+
+        def resource_method_scope?: () -> untyped
+
+        def action_name: (untyped name_prefix, untyped prefix, untyped collection_name, untyped member_name) -> untyped
+
+        def resource_scope?: () -> untyped
+
+        def options: () -> untyped
+
+        def new: (untyped hash) -> untyped
+
+        def new_level: (untyped level) -> untyped
+
+        def []: (untyped key) -> untyped
+
+        include Enumerable[untyped]
+
+        def each: () { (untyped) -> untyped } -> untyped
+
+        def frame: () -> untyped
+
+        NULL: untyped
+      end
+
+      def initialize: (untyped set) -> untyped
+
+      include Base
+
+      include HttpHelpers
+
+      include Redirection
+
+      include Scoping
+
+      include Concerns
+
+      include Resources
+
+      include CustomUrls
+    end
+  end
+end
+
+module ActionDispatch
+  module Routing
+    # Polymorphic URL helpers are methods for smart resolution to a named route call when
+    # given an Active Record model instance. They are to be used in combination with
+    # ActionController::Resources.
+    #
+    # These methods are useful when you want to generate the correct URL or path to a RESTful
+    # resource without having to know the exact type of the record in question.
+    #
+    # Nested resources and/or namespaces are also supported, as illustrated in the example:
+    #
+    #   polymorphic_url([:admin, @article, @comment])
+    #
+    # results in:
+    #
+    #   admin_article_comment_url(@article, @comment)
+    #
+    # == Usage within the framework
+    #
+    # Polymorphic URL helpers are used in a number of places throughout the \Rails framework:
+    #
+    # * <tt>url_for</tt>, so you can use it with a record as the argument, e.g.
+    #   <tt>url_for(@article)</tt>;
+    # * ActionView::Helpers::FormHelper uses <tt>polymorphic_path</tt>, so you can write
+    #   <tt>form_for(@article)</tt> without having to specify <tt>:url</tt> parameter for the form
+    #   action;
+    # * <tt>redirect_to</tt> (which, in fact, uses <tt>url_for</tt>) so you can write
+    #   <tt>redirect_to(post)</tt> in your controllers;
+    # * ActionView::Helpers::AtomFeedHelper, so you don't have to explicitly specify URLs
+    #   for feed entries.
+    #
+    # == Prefixed polymorphic helpers
+    #
+    # In addition to <tt>polymorphic_url</tt> and <tt>polymorphic_path</tt> methods, a
+    # number of prefixed helpers are available as a shorthand to <tt>action: "..."</tt>
+    # in options. Those are:
+    #
+    # * <tt>edit_polymorphic_url</tt>, <tt>edit_polymorphic_path</tt>
+    # * <tt>new_polymorphic_url</tt>, <tt>new_polymorphic_path</tt>
+    #
+    # Example usage:
+    #
+    #   edit_polymorphic_path(@post)           # => "/posts/1/edit"
+    #   polymorphic_path(@post, format: :pdf)  # => "/posts/1.pdf"
+    #
+    # == Usage with mounted engines
+    #
+    # If you are using a mounted engine and you need to use a polymorphic_url
+    # pointing at the engine's routes, pass in the engine's route proxy as the first
+    # argument to the method. For example:
+    #
+    #   polymorphic_url([blog, @post])  # calls blog.post_path(@post)
+    #   form_for([blog, @post])         # => "/blog/posts/1"
+    #
+    module PolymorphicRoutes
+      # Constructs a call to a named RESTful route for the given record and returns the
+      # resulting URL string. For example:
+      #
+      #   # calls post_url(post)
+      #   polymorphic_url(post) # => "http://example.com/posts/1"
+      #   polymorphic_url([blog, post]) # => "http://example.com/blogs/1/posts/1"
+      #   polymorphic_url([:admin, blog, post]) # => "http://example.com/admin/blogs/1/posts/1"
+      #   polymorphic_url([user, :blog, post]) # => "http://example.com/users/1/blog/posts/1"
+      #   polymorphic_url(Comment) # => "http://example.com/comments"
+      #
+      # ==== Options
+      #
+      # * <tt>:action</tt> - Specifies the action prefix for the named route:
+      #   <tt>:new</tt> or <tt>:edit</tt>. Default is no prefix.
+      # * <tt>:routing_type</tt> - Allowed values are <tt>:path</tt> or <tt>:url</tt>.
+      #   Default is <tt>:url</tt>.
+      #
+      # Also includes all the options from <tt>url_for</tt>. These include such
+      # things as <tt>:anchor</tt> or <tt>:trailing_slash</tt>. Example usage
+      # is given below:
+      #
+      #   polymorphic_url([blog, post], anchor: 'my_anchor')
+      #     # => "http://example.com/blogs/1/posts/1#my_anchor"
+      #   polymorphic_url([blog, post], anchor: 'my_anchor', script_name: "/my_app")
+      #     # => "http://example.com/my_app/blogs/1/posts/1#my_anchor"
+      #
+      # For all of these options, see the documentation for {url_for}[rdoc-ref:ActionDispatch::Routing::UrlFor].
+      #
+      # ==== Functionality
+      #
+      #   # an Article record
+      #   polymorphic_url(record)  # same as article_url(record)
+      #
+      #   # a Comment record
+      #   polymorphic_url(record)  # same as comment_url(record)
+      #
+      #   # it recognizes new records and maps to the collection
+      #   record = Comment.new
+      #   polymorphic_url(record)  # same as comments_url()
+      #
+      #   # the class of a record will also map to the collection
+      #   polymorphic_url(Comment) # same as comments_url()
+      #
+      def polymorphic_url: (untyped record_or_hash_or_array, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Returns the path component of a URL for the given record.
+      def polymorphic_path: (untyped record_or_hash_or_array, ?::Hash[untyped, untyped] options) -> untyped
+
+      def polymorphic_url_for_action: (untyped action, untyped record_or_hash, untyped options) -> untyped
+
+      def polymorphic_path_for_action: (untyped action, untyped record_or_hash, untyped options) -> untyped
+
+      def polymorphic_mapping: (untyped record) -> untyped
+
+      class HelperMethodBuilder
+        # :nodoc:
+        CACHE: ::Hash[untyped, untyped]
+
+        def self.get: (untyped action, untyped `type`) -> untyped
+
+        def self.url: () -> untyped
+
+        def self.path: () -> untyped
+
+        def self.build: (untyped action, untyped `type`) -> untyped
+
+        def self.singular: (untyped prefix, untyped suffix) -> untyped
+
+        def self.plural: (untyped prefix, untyped suffix) -> untyped
+
+        def self.polymorphic_method: (untyped recipient, untyped record_or_hash_or_array, untyped action, untyped `type`, untyped options) -> untyped
+
+        attr_reader suffix: untyped
+
+        attr_reader prefix: untyped
+
+        def initialize: (untyped key_strategy, untyped prefix, untyped suffix) -> untyped
+
+        def handle_string: (untyped record) -> ::Array[untyped | ::Array[untyped]]
+
+        def handle_string_call: (untyped target, untyped str) -> untyped
+
+        def handle_class: (untyped klass) -> ::Array[untyped | ::Array[untyped]]
+
+        def handle_class_call: (untyped target, untyped klass) -> untyped
+
+        def handle_model: (untyped record) -> ::Array[untyped]
+
+        def handle_model_call: (untyped target, untyped record) -> untyped
+
+        def handle_list: (untyped list) -> ::Array[untyped]
+
+        def polymorphic_mapping: (untyped target, untyped record) -> untyped
+
+        def get_method_for_class: (untyped klass) -> untyped
+
+        def get_method_for_string: (untyped str) -> ::String
+      end
+    end
+  end
+end
+
+module ActionDispatch
+  module Routing
+    class Redirect < Endpoint
+      # :nodoc:
+      attr_reader status: untyped
+
+      # :nodoc:
+      attr_reader block: untyped
+
+      def initialize: (untyped status, untyped block) -> untyped
+
+      def redirect?: () -> ::TrueClass
+
+      def call: (untyped env) -> untyped
+
+      def serve: (untyped req) -> ::Array[untyped | ::Array[untyped]]
+
+      def path: (untyped params, untyped request) -> untyped
+
+      def inspect: () -> ::String
+
+      def relative_path?: (untyped path) -> untyped
+
+      def escape: (untyped params) -> untyped
+
+      def escape_fragment: (untyped params) -> untyped
+
+      def escape_path: (untyped params) -> untyped
+    end
+
+    class PathRedirect < Redirect
+      URL_PARTS: untyped
+
+      def path: (untyped params, untyped request) -> untyped
+
+      def inspect: () -> ::String
+
+      def interpolation_required?: (untyped string, untyped params) -> untyped
+    end
+
+    class OptionRedirect < Redirect
+      # :nodoc:
+      alias options block
+
+      def path: (untyped params, untyped request) -> untyped
+
+      def inspect: () -> ::String
+    end
+
+    module Redirection
+      # Redirect any path to another path:
+      #
+      #   get "/stories" => redirect("/posts")
+      #
+      # This will redirect the user, while ignoring certain parts of the request, including query string, etc.
+      # <tt>/stories</tt>, <tt>/stories?foo=bar</tt>, etc all redirect to <tt>/posts</tt>.
+      #
+      # You can also use interpolation in the supplied redirect argument:
+      #
+      #   get 'docs/:article', to: redirect('/wiki/%{article}')
+      #
+      # Note that if you return a path without a leading slash then the URL is prefixed with the
+      # current SCRIPT_NAME environment variable. This is typically '/' but may be different in
+      # a mounted engine or where the application is deployed to a subdirectory of a website.
+      #
+      # Alternatively you can use one of the other syntaxes:
+      #
+      # The block version of redirect allows for the easy encapsulation of any logic associated with
+      # the redirect in question. Either the params and request are supplied as arguments, or just
+      # params, depending of how many arguments your block accepts. A string is required as a
+      # return value.
+      #
+      #   get 'jokes/:number', to: redirect { |params, request|
+      #     path = (params[:number].to_i.even? ? "wheres-the-beef" : "i-love-lamp")
+      #     "http://#{request.host_with_port}/#{path}"
+      #   }
+      #
+      # Note that the +do end+ syntax for the redirect block wouldn't work, as Ruby would pass
+      # the block to +get+ instead of +redirect+. Use <tt>{ ... }</tt> instead.
+      #
+      # The options version of redirect allows you to supply only the parts of the URL which need
+      # to change, it also supports interpolation of the path similar to the first example.
+      #
+      #   get 'stores/:name',       to: redirect(subdomain: 'stores', path: '/%{name}')
+      #   get 'stores/:name(*all)', to: redirect(subdomain: 'stores', path: '/%{name}%{all}')
+      #   get '/stories', to: redirect(path: '/posts')
+      #
+      # This will redirect the user, while changing only the specified parts of the request,
+      # for example the +path+ option in the last example.
+      # <tt>/stories</tt>, <tt>/stories?foo=bar</tt>, redirect to <tt>/posts</tt> and <tt>/posts?foo=bar</tt> respectively.
+      #
+      # Finally, an object which responds to call can be supplied to redirect, allowing you to reuse
+      # common redirect routes. The call method must accept two arguments, params and request, and return
+      # a string.
+      #
+      #   get 'accounts/:name' => redirect(SubdomainRedirector.new('api'))
+      #
+      def redirect: (*untyped args) { () -> untyped } -> (OptionRedirect | PathRedirect | Redirect)
+    end
+  end
+end
+
+module ActionDispatch
+  module Routing
+    # :stopdoc:
+    class RouteSet
+      # Since the router holds references to many parts of the system
+      # like engines, controllers and the application itself, inspecting
+      # the route set can actually be really slow, therefore we default
+      # alias inspect to to_s.
+      alias inspect to_s
+
+      class Dispatcher < Routing::Endpoint
+        def initialize: (untyped raise_on_name_error) -> untyped
+
+        def dispatcher?: () -> ::TrueClass
+
+        def serve: (untyped req) -> untyped
+
+        def controller: (untyped req) -> untyped
+
+        def dispatch: (untyped controller, untyped action, untyped req, untyped res) -> untyped
+      end
+
+      class StaticDispatcher < Dispatcher
+        def initialize: (untyped controller_class) -> untyped
+
+        def controller: (untyped _) -> untyped
+      end
+
+      # A NamedRouteCollection instance is a collection of named routes, and also
+      # maintains an anonymous module that can be used to install helpers for the
+      # named routes.
+      class NamedRouteCollection
+        include Enumerable[untyped]
+
+        attr_reader routes: untyped
+
+        attr_reader url_helpers_module: untyped
+
+        attr_reader path_helpers_module: untyped
+
+        def initialize: () -> untyped
+
+        def route_defined?: (untyped name) -> untyped
+
+        def helper_names: () -> untyped
+
+        def clear!: () -> untyped
+
+        def add: (untyped name, untyped route) -> untyped
+
+        def get: (untyped name) -> untyped
+
+        def key?: (untyped name) -> (nil | untyped)
+
+        alias []= add
+
+        alias [] get
+
+        alias clear clear!
+
+        def each: () { (untyped, untyped) -> untyped } -> untyped
+
+        def names: () -> untyped
+
+        def length: () -> untyped
+
+        # Given a +name+, defines name_path and name_url helpers.
+        # Used by 'direct', 'resolve', and 'polymorphic' route helpers.
+        def add_url_helper: (untyped name, untyped defaults) { () -> untyped } -> untyped
+
+        class UrlHelper
+          def self.create: (untyped route, untyped options, untyped route_name, untyped url_strategy) -> untyped
+
+          def self.optimize_helper?: (untyped route) -> untyped
+
+          attr_reader url_strategy: untyped
+
+          attr_reader route_name: untyped
+
+          class OptimizedUrlHelper < UrlHelper
+            attr_reader arg_size: untyped
+
+            def initialize: (untyped route, untyped options, untyped route_name, untyped url_strategy) -> untyped
+
+            def call: (untyped t, untyped args, untyped inner_options) -> untyped
+
+            def optimized_helper: (untyped args) -> untyped
+
+            def optimize_routes_generation?: (untyped t) -> untyped
+
+            def parameterize_args: (untyped args) { (untyped) -> untyped } -> untyped
+
+            def raise_generation_error: (untyped args) -> untyped
+          end
+
+          def initialize: (untyped route, untyped options, untyped route_name, untyped url_strategy) -> untyped
+
+          def call: (untyped t, untyped args, untyped inner_options) -> untyped
+
+          def handle_positional_args: (untyped controller_options, untyped inner_options, untyped args, untyped result, untyped path_params) -> untyped
+        end
+
+        # Create a URL helper allowing ordered parameters to be associated
+        # with corresponding dynamic segments, so you can do:
+        #
+        #   foo_url(bar, baz, bang)
+        #
+        # Instead of:
+        #
+        #   foo_url(bar: bar, baz: baz, bang: bang)
+        #
+        # Also allow options hash, so you can do:
+        #
+        #   foo_url(bar, baz, bang, sort_by: 'baz')
+        #
+        def define_url_helper: (untyped mod, untyped route, untyped name, untyped opts, untyped route_key, untyped url_strategy) -> untyped
+      end
+
+      # strategy for building URLs to send to the client
+      PATH: untyped
+
+      UNKNOWN: untyped
+
+      attr_accessor formatter: untyped
+
+      attr_accessor set: untyped
+
+      attr_accessor named_routes: untyped
+
+      attr_accessor default_scope: untyped
+
+      attr_accessor router: untyped
+
+      attr_accessor disable_clear_and_finalize: untyped
+
+      attr_accessor resources_path_names: untyped
+
+      attr_accessor default_url_options: untyped
+
+      attr_reader env_key: untyped
+
+      attr_reader polymorphic_mappings: untyped
+
+      alias routes set
+
+      def self.default_resources_path_names: () -> { new: "new", edit: "edit" }
+
+      def self.new_with_config: (untyped config) -> untyped
+
+      class Config[T] < ::Struct[T]
+        attr_accessor relative_url_root(): untyped
+
+        attr_accessor api_only(): untyped
+      end
+
+      DEFAULT_CONFIG: untyped
+
+      def initialize: (?untyped config) -> untyped
+
+      def eager_load!: () -> nil
+
+      def relative_url_root: () -> untyped
+
+      def api_only?: () -> untyped
+
+      def request_class: () -> untyped
+
+      def make_request: (untyped env) -> untyped
+
+      def draw: () { () -> untyped } -> nil
+
+      def append: () { () -> untyped } -> untyped
+
+      def `prepend`: () { () -> untyped } -> untyped
+
+      def eval_block: (untyped block) -> untyped
+
+      def finalize!: () -> (nil | untyped)
+
+      def clear!: () -> untyped
+
+      module MountedHelpers
+        extend ActiveSupport::Concern
+
+        include UrlFor
+      end
+
+      # Contains all the mounted helpers across different
+      # engines and the `main_app` helper for the application.
+      # You can include this in your classes if you want to
+      # access routes for other engines.
+      def mounted_helpers: () -> untyped
+
+      def define_mounted_helper: (untyped name, ?untyped? script_namer) -> (nil | untyped)
+
+      def url_helpers: (?bool supports_path) -> untyped
+
+      def empty?: () -> untyped
+
+      def add_route: (untyped mapping, untyped name) -> untyped
+
+      def add_polymorphic_mapping: (untyped klass, untyped options) { () -> untyped } -> untyped
+
+      def add_url_helper: (untyped name, untyped options) { () -> untyped } -> untyped
+
+      class CustomUrlHelper
+        attr_reader name: untyped
+
+        attr_reader defaults: untyped
+
+        attr_reader block: untyped
+
+        def initialize: (untyped name, untyped defaults) { () -> untyped } -> untyped
+
+        def call: (untyped t, untyped args, ?bool only_path) -> untyped
+
+        def eval_block: (untyped t, untyped args, untyped options) -> untyped
+
+        def merge_defaults: (untyped options) -> untyped
+      end
+
+      class Generator
+        PARAMETERIZE: untyped
+
+        attr_reader options: untyped
+
+        attr_reader recall: untyped
+
+        attr_reader set: untyped
+
+        attr_reader named_route: untyped
+
+        def initialize: (untyped named_route, untyped options, untyped recall, untyped set) -> untyped
+
+        def controller: () -> untyped
+
+        def current_controller: () -> untyped
+
+        def use_recall_for: (untyped key) -> untyped
+
+        def normalize_options!: () -> untyped
+
+        # This pulls :controller, :action, and :id out of the recall.
+        # The recall key is only used if there is no key in the options
+        # or if the key in the options is identical. If any of
+        # :controller, :action or :id is not found, don't pull any
+        # more keys from the recall.
+        def normalize_controller_action_id!: () -> (nil | untyped)
+
+        # if the current controller is "foo/bar/baz" and controller: "baz/bat"
+        # is specified, the controller becomes "foo/baz/bat"
+        def use_relative_controller!: () -> untyped
+
+        # Remove leading slashes from controllers
+        def normalize_controller!: () -> untyped
+
+        # Generates a path from routes, returns [path, params].
+        # If no route is generated the formatter will raise ActionController::UrlGenerationError
+        def generate: () -> untyped
+
+        def different_controller?: () -> (::FalseClass | untyped)
+
+        def named_route_exists?: () -> untyped
+
+        def segment_keys: () -> untyped
+      end
+
+      # Generate the path indicated by the arguments, and return an array of
+      # the keys that were not used to generate it.
+      def extra_keys: (untyped options, ?::Hash[untyped, untyped] recall) -> untyped
+
+      def generate_extras: (untyped options, ?::Hash[untyped, untyped] recall) -> untyped
+
+      def generate: (untyped route_key, untyped options, ?::Hash[untyped, untyped] recall) -> untyped
+
+      RESERVED_OPTIONS: ::Array[untyped]
+
+      def optimize_routes_generation?: () -> untyped
+
+      def find_script_name: (untyped options) -> untyped
+
+      def find_relative_url_root: (untyped options) -> untyped
+
+      def path_for: (untyped options, ?untyped? route_name) -> untyped
+
+      # The +options+ argument must be a hash whose keys are *symbols*.
+      def url_for: (untyped options, ?untyped? route_name, ?untyped url_strategy) -> untyped
+
+      def call: (untyped env) -> untyped
+
+      def recognize_path: (untyped path, ?::Hash[untyped, untyped] environment) -> untyped
+
+      def recognize_path_with_request: (untyped req, untyped path, untyped extras, ?raise_on_missing: bool raise_on_missing) -> untyped
+    end
+  end
+end
+
+module ActionDispatch
+  module Routing
+    class RoutesProxy
+      # nodoc:
+      include ActionDispatch::Routing::UrlFor
+
+      attr_accessor scope: untyped
+
+      attr_accessor routes: untyped
+
+      alias _routes routes
+
+      def initialize: (untyped routes, untyped scope, untyped helpers, ?untyped? script_namer) -> untyped
+
+      def url_options: () -> untyped
+
+      def respond_to_missing?: (untyped method, untyped _) -> untyped
+
+      def method_missing: (untyped method, *untyped args) -> untyped
+
+      # Keeps the part of the script name provided by the global
+      # context via ENV["SCRIPT_NAME"], which `mount` doesn't know
+      # about since it depends on the specific request, but use our
+      # script name resolver for the mount point dependent part.
+      def merge_script_names: (untyped previous_script_name, untyped new_script_name) -> untyped
+    end
+  end
+end
+
+module ActionDispatch
+  module Routing
+    # In <tt>config/routes.rb</tt> you define URL-to-controller mappings, but the reverse
+    # is also possible: a URL can be generated from one of your routing definitions.
+    # URL generation functionality is centralized in this module.
+    #
+    # See ActionDispatch::Routing for general information about routing and routes.rb.
+    #
+    # <b>Tip:</b> If you need to generate URLs from your models or some other place,
+    # then ActionController::UrlFor is what you're looking for. Read on for
+    # an introduction. In general, this module should not be included on its own,
+    # as it is usually included by url_helpers (as in Rails.application.routes.url_helpers).
+    #
+    # == URL generation from parameters
+    #
+    # As you may know, some functions, such as ActionController::Base#url_for
+    # and ActionView::Helpers::UrlHelper#link_to, can generate URLs given a set
+    # of parameters. For example, you've probably had the chance to write code
+    # like this in one of your views:
+    #
+    #   <%= link_to('Click here', controller: 'users',
+    #           action: 'new', message: 'Welcome!') %>
+    #   # => <a href="/users/new?message=Welcome%21">Click here</a>
+    #
+    # link_to, and all other functions that require URL generation functionality,
+    # actually use ActionController::UrlFor under the hood. And in particular,
+    # they use the ActionController::UrlFor#url_for method. One can generate
+    # the same path as the above example by using the following code:
+    #
+    #   include UrlFor
+    #   url_for(controller: 'users',
+    #           action: 'new',
+    #           message: 'Welcome!',
+    #           only_path: true)
+    #   # => "/users/new?message=Welcome%21"
+    #
+    # Notice the <tt>only_path: true</tt> part. This is because UrlFor has no
+    # information about the website hostname that your Rails app is serving. So if you
+    # want to include the hostname as well, then you must also pass the <tt>:host</tt>
+    # argument:
+    #
+    #   include UrlFor
+    #   url_for(controller: 'users',
+    #           action: 'new',
+    #           message: 'Welcome!',
+    #           host: 'www.example.com')
+    #   # => "http://www.example.com/users/new?message=Welcome%21"
+    #
+    # By default, all controllers and views have access to a special version of url_for,
+    # that already knows what the current hostname is. So if you use url_for in your
+    # controllers or your views, then you don't need to explicitly pass the <tt>:host</tt>
+    # argument.
+    #
+    # For convenience reasons, mailers provide a shortcut for ActionController::UrlFor#url_for.
+    # So within mailers, you only have to type +url_for+ instead of 'ActionController::UrlFor#url_for'
+    # in full. However, mailers don't have hostname information, and you still have to provide
+    # the +:host+ argument or set the default host that will be used in all mailers using the
+    # configuration option +config.action_mailer.default_url_options+. For more information on
+    # url_for in mailers read the ActionMailer#Base documentation.
+    #
+    #
+    # == URL generation for named routes
+    #
+    # UrlFor also allows one to access methods that have been auto-generated from
+    # named routes. For example, suppose that you have a 'users' resource in your
+    # <tt>config/routes.rb</tt>:
+    #
+    #   resources :users
+    #
+    # This generates, among other things, the method <tt>users_path</tt>. By default,
+    # this method is accessible from your controllers, views and mailers. If you need
+    # to access this auto-generated method from other places (such as a model), then
+    # you can do that by including Rails.application.routes.url_helpers in your class:
+    #
+    #   class User < ActiveRecord::Base
+    #     include Rails.application.routes.url_helpers
+    #
+    #     def base_uri
+    #       user_path(self)
+    #     end
+    #   end
+    #
+    #   User.find(1).base_uri # => "/users/1"
+    #
+    module UrlFor
+      extend ActiveSupport::Concern
+
+      include PolymorphicRoutes
+
+      def initialize: () -> untyped
+
+      # Hook overridden in controller to add request information
+      # with +default_url_options+. Application logic should not
+      # go into url_options.
+      def url_options: () -> untyped
+
+      # Generate a URL based on the options provided, default_url_options and the
+      # routes defined in routes.rb. The following options are supported:
+      #
+      # * <tt>:only_path</tt> - If true, the relative URL is returned. Defaults to +false+.
+      # * <tt>:protocol</tt> - The protocol to connect to. Defaults to 'http'.
+      # * <tt>:host</tt> - Specifies the host the link should be targeted at.
+      #   If <tt>:only_path</tt> is false, this option must be
+      #   provided either explicitly, or via +default_url_options+.
+      # * <tt>:subdomain</tt> - Specifies the subdomain of the link, using the +tld_length+
+      #   to split the subdomain from the host.
+      #   If false, removes all subdomains from the host part of the link.
+      # * <tt>:domain</tt> - Specifies the domain of the link, using the +tld_length+
+      #   to split the domain from the host.
+      # * <tt>:tld_length</tt> - Number of labels the TLD id composed of, only used if
+      #   <tt>:subdomain</tt> or <tt>:domain</tt> are supplied. Defaults to
+      #   <tt>ActionDispatch::Http::URL.tld_length</tt>, which in turn defaults to 1.
+      # * <tt>:port</tt> - Optionally specify the port to connect to.
+      # * <tt>:anchor</tt> - An anchor name to be appended to the path.
+      # * <tt>:params</tt> - The query parameters to be appended to the path.
+      # * <tt>:trailing_slash</tt> - If true, adds a trailing slash, as in "/archive/2009/"
+      # * <tt>:script_name</tt> - Specifies application path relative to domain root. If provided, prepends application path.
+      #
+      # Any other key (<tt>:controller</tt>, <tt>:action</tt>, etc.) given to
+      # +url_for+ is forwarded to the Routes module.
+      #
+      #    url_for controller: 'tasks', action: 'testing', host: 'somehost.org', port: '8080'
+      #    # => 'http://somehost.org:8080/tasks/testing'
+      #    url_for controller: 'tasks', action: 'testing', host: 'somehost.org', anchor: 'ok', only_path: true
+      #    # => '/tasks/testing#ok'
+      #    url_for controller: 'tasks', action: 'testing', trailing_slash: true
+      #    # => 'http://somehost.org/tasks/testing/'
+      #    url_for controller: 'tasks', action: 'testing', host: 'somehost.org', number: '33'
+      #    # => 'http://somehost.org/tasks/testing?number=33'
+      #    url_for controller: 'tasks', action: 'testing', host: 'somehost.org', script_name: "/myapp"
+      #    # => 'http://somehost.org/myapp/tasks/testing'
+      #    url_for controller: 'tasks', action: 'testing', host: 'somehost.org', script_name: "/myapp", only_path: true
+      #    # => '/myapp/tasks/testing'
+      #
+      # Missing routes keys may be filled in from the current request's parameters
+      # (e.g. +:controller+, +:action+, +:id+ and any other parameters that are
+      # placed in the path). Given that the current action has been reached
+      # through <tt>GET /users/1</tt>:
+      #
+      #   url_for(only_path: true)                        # => '/users/1'
+      #   url_for(only_path: true, action: 'edit')        # => '/users/1/edit'
+      #   url_for(only_path: true, action: 'edit', id: 2) # => '/users/2/edit'
+      #
+      # Notice that no +:id+ parameter was provided to the first +url_for+ call
+      # and the helper used the one from the route's path. Any path parameter
+      # implicitly used by +url_for+ can always be overwritten like shown on the
+      # last +url_for+ calls.
+      def url_for: (?untyped? options) -> untyped
+
+      def full_url_for: (?untyped? options) -> untyped
+
+      # Allows calling direct or regular named route.
+      #
+      #   resources :buckets
+      #
+      #   direct :recordable do |recording|
+      #     route_for(:bucket, recording.bucket)
+      #   end
+      #
+      #   direct :threadable do |threadable|
+      #     route_for(:recordable, threadable.parent)
+      #   end
+      #
+      # This maintains the context of the original caller on
+      # whether to return a path or full URL, e.g:
+      #
+      #   threadable_path(threadable)  # => "/buckets/1"
+      #   threadable_url(threadable)   # => "http://example.com/buckets/1"
+      #
+      def route_for: (untyped name, *untyped args) -> untyped
+
+      def optimize_routes_generation?: () -> untyped
+
+      def _with_routes: (untyped routes) { () -> untyped } -> untyped
+
+      def _routes_context: () -> untyped
+    end
+  end
+end
+
+module ActionDispatch
+  # The routing module provides URL rewriting in native Ruby. It's a way to
+  # redirect incoming requests to controllers and actions. This replaces
+  # mod_rewrite rules. Best of all, Rails' \Routing works with any web server.
+  # Routes are defined in <tt>config/routes.rb</tt>.
+  #
+  # Think of creating routes as drawing a map for your requests. The map tells
+  # them where to go based on some predefined pattern:
+  #
+  #   Rails.application.routes.draw do
+  #     Pattern 1 tells some request to go to one place
+  #     Pattern 2 tell them to go to another
+  #     ...
+  #   end
+  #
+  # The following symbols are special:
+  #
+  #   :controller maps to your controller name
+  #   :action     maps to an action with your controllers
+  #
+  # Other names simply map to a parameter as in the case of <tt>:id</tt>.
+  #
+  # == Resources
+  #
+  # Resource routing allows you to quickly declare all of the common routes
+  # for a given resourceful controller. Instead of declaring separate routes
+  # for your +index+, +show+, +new+, +edit+, +create+, +update+ and +destroy+
+  # actions, a resourceful route declares them in a single line of code:
+  #
+  #  resources :photos
+  #
+  # Sometimes, you have a resource that clients always look up without
+  # referencing an ID. A common example, /profile always shows the profile of
+  # the currently logged in user. In this case, you can use a singular resource
+  # to map /profile (rather than /profile/:id) to the show action.
+  #
+  #  resource :profile
+  #
+  # It's common to have resources that are logically children of other
+  # resources:
+  #
+  #   resources :magazines do
+  #     resources :ads
+  #   end
+  #
+  # You may wish to organize groups of controllers under a namespace. Most
+  # commonly, you might group a number of administrative controllers under
+  # an +admin+ namespace. You would place these controllers under the
+  # <tt>app/controllers/admin</tt> directory, and you can group them together
+  # in your router:
+  #
+  #   namespace "admin" do
+  #     resources :posts, :comments
+  #   end
+  #
+  # Alternatively, you can add prefixes to your path without using a separate
+  # directory by using +scope+. +scope+ takes additional options which
+  # apply to all enclosed routes.
+  #
+  #   scope path: "/cpanel", as: 'admin' do
+  #     resources :posts, :comments
+  #   end
+  #
+  # For more, see <tt>Routing::Mapper::Resources#resources</tt>,
+  # <tt>Routing::Mapper::Scoping#namespace</tt>, and
+  # <tt>Routing::Mapper::Scoping#scope</tt>.
+  #
+  # == Non-resourceful routes
+  #
+  # For routes that don't fit the <tt>resources</tt> mold, you can use the HTTP helper
+  # methods <tt>get</tt>, <tt>post</tt>, <tt>patch</tt>, <tt>put</tt> and <tt>delete</tt>.
+  #
+  #   get 'post/:id', to: 'posts#show'
+  #   post 'post/:id', to: 'posts#create_comment'
+  #
+  # Now, if you POST to <tt>/posts/:id</tt>, it will route to the <tt>create_comment</tt> action. A GET on the same
+  # URL will route to the <tt>show</tt> action.
+  #
+  # If your route needs to respond to more than one HTTP method (or all methods) then using the
+  # <tt>:via</tt> option on <tt>match</tt> is preferable.
+  #
+  #   match 'post/:id', to: 'posts#show', via: [:get, :post]
+  #
+  # == Named routes
+  #
+  # Routes can be named by passing an <tt>:as</tt> option,
+  # allowing for easy reference within your source as +name_of_route_url+
+  # for the full URL and +name_of_route_path+ for the URI path.
+  #
+  # Example:
+  #
+  #   # In config/routes.rb
+  #   get '/login', to: 'accounts#login', as: 'login'
+  #
+  #   # With render, redirect_to, tests, etc.
+  #   redirect_to login_url
+  #
+  # Arguments can be passed as well.
+  #
+  #   redirect_to show_item_path(id: 25)
+  #
+  # Use <tt>root</tt> as a shorthand to name a route for the root path "/".
+  #
+  #   # In config/routes.rb
+  #   root to: 'blogs#index'
+  #
+  #   # would recognize http://www.example.com/ as
+  #   params = { controller: 'blogs', action: 'index' }
+  #
+  #   # and provide these named routes
+  #   root_url   # => 'http://www.example.com/'
+  #   root_path  # => '/'
+  #
+  # Note: when using +controller+, the route is simply named after the
+  # method you call on the block parameter rather than map.
+  #
+  #   # In config/routes.rb
+  #   controller :blog do
+  #     get 'blog/show',    to: :list
+  #     get 'blog/delete',  to: :delete
+  #     get 'blog/edit',    to: :edit
+  #   end
+  #
+  #   # provides named routes for show, delete, and edit
+  #   link_to @article.title, blog_show_path(id: @article.id)
+  #
+  # == Pretty URLs
+  #
+  # Routes can generate pretty URLs. For example:
+  #
+  #   get '/articles/:year/:month/:day', to: 'articles#find_by_id', constraints: {
+  #     year:       /\d{4}/,
+  #     month:      /\d{1,2}/,
+  #     day:        /\d{1,2}/
+  #   }
+  #
+  # Using the route above, the URL "http://localhost:3000/articles/2005/11/06"
+  # maps to
+  #
+  #   params = {year: '2005', month: '11', day: '06'}
+  #
+  # == Regular Expressions and parameters
+  # You can specify a regular expression to define a format for a parameter.
+  #
+  #   controller 'geocode' do
+  #     get 'geocode/:postalcode', to: :show, constraints: {
+  #       postalcode: /\d{5}(-\d{4})?/
+  #     }
+  #   end
+  #
+  # Constraints can include the 'ignorecase' and 'extended syntax' regular
+  # expression modifiers:
+  #
+  #   controller 'geocode' do
+  #     get 'geocode/:postalcode', to: :show, constraints: {
+  #       postalcode: /hx\d\d\s\d[a-z]{2}/i
+  #     }
+  #   end
+  #
+  #   controller 'geocode' do
+  #     get 'geocode/:postalcode', to: :show, constraints: {
+  #       postalcode: /# Postalcode format
+  #          \d{5} #Prefix
+  #          (-\d{4})? #Suffix
+  #          /x
+  #     }
+  #   end
+  #
+  # Using the multiline modifier will raise an +ArgumentError+.
+  # Encoding regular expression modifiers are silently ignored. The
+  # match will always use the default encoding or ASCII.
+  #
+  # == External redirects
+  #
+  # You can redirect any path to another path using the redirect helper in your router:
+  #
+  #   get "/stories", to: redirect("/posts")
+  #
+  # == Unicode character routes
+  #
+  # You can specify unicode character routes in your router:
+  #
+  #   get "(trim non-ascii characters)", to: "welcome#index"
+  #
+  # == Routing to Rack Applications
+  #
+  # Instead of a String, like <tt>posts#index</tt>, which corresponds to the
+  # index action in the PostsController, you can specify any Rack application
+  # as the endpoint for a matcher:
+  #
+  #   get "/application.js", to: Sprockets
+  #
+  # == Reloading routes
+  #
+  # You can reload routes if you feel you must:
+  #
+  #   Rails.application.reload_routes!
+  #
+  # This will clear all named routes and reload config/routes.rb if the file has been modified from
+  # last load. To absolutely force reloading, use <tt>reload!</tt>.
+  #
+  # == Testing Routes
+  #
+  # The two main methods for testing your routes:
+  #
+  # === +assert_routing+
+  #
+  #   def test_movie_route_properly_splits
+  #     opts = {controller: "plugin", action: "checkout", id: "2"}
+  #     assert_routing "plugin/checkout/2", opts
+  #   end
+  #
+  # +assert_routing+ lets you test whether or not the route properly resolves into options.
+  #
+  # === +assert_recognizes+
+  #
+  #   def test_route_has_options
+  #     opts = {controller: "plugin", action: "show", id: "12"}
+  #     assert_recognizes opts, "/plugins/show/12"
+  #   end
+  #
+  # Note the subtle difference between the two: +assert_routing+ tests that
+  # a URL fits options while +assert_recognizes+ tests that a URL
+  # breaks into parameters properly.
+  #
+  # In tests you can simply pass the URL or named route to +get+ or +post+.
+  #
+  #   def send_to_jail
+  #     get '/jail'
+  #     assert_response :success
+  #   end
+  #
+  #   def goes_to_login
+  #     get login_url
+  #     #...
+  #   end
+  #
+  # == View a list of all your routes
+  #
+  #   rails routes
+  #
+  # Target a specific controller with <tt>-c</tt>, or grep routes
+  # using <tt>-g</tt>. Useful in conjunction with <tt>--expanded</tt>
+  # which displays routes vertically.
+  module Routing
+    extend ActiveSupport::Autoload
+
+    SEPARATORS: ::Array[untyped]
+
+    HTTP_METHODS: ::Array[untyped]
+  end
+end
+
+module ActionDispatch
+  # = System Testing
+  #
+  # System tests let you test applications in the browser. Because system
+  # tests use a real browser experience, you can test all of your JavaScript
+  # easily from your test suite.
+  #
+  # To create a system test in your application, extend your test class
+  # from <tt>ApplicationSystemTestCase</tt>. System tests use Capybara as a
+  # base and allow you to configure the settings through your
+  # <tt>application_system_test_case.rb</tt> file that is generated with a new
+  # application or scaffold.
+  #
+  # Here is an example system test:
+  #
+  #   require 'application_system_test_case'
+  #
+  #   class Users::CreateTest < ApplicationSystemTestCase
+  #     test "adding a new user" do
+  #       visit users_path
+  #       click_on 'New User'
+  #
+  #       fill_in 'Name', with: 'Arya'
+  #       click_on 'Create User'
+  #
+  #       assert_text 'Arya'
+  #     end
+  #   end
+  #
+  # When generating an application or scaffold, an +application_system_test_case.rb+
+  # file will also be generated containing the base class for system testing.
+  # This is where you can change the driver, add Capybara settings, and other
+  # configuration for your system tests.
+  #
+  #   require "test_helper"
+  #
+  #   class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
+  #     driven_by :selenium, using: :chrome, screen_size: [1400, 1400]
+  #   end
+  #
+  # By default, <tt>ActionDispatch::SystemTestCase</tt> is driven by the
+  # Selenium driver, with the Chrome browser, and a browser size of 1400x1400.
+  #
+  # Changing the driver configuration options is easy. Let's say you want to use
+  # the Firefox browser instead of Chrome. In your +application_system_test_case.rb+
+  # file add the following:
+  #
+  #   require "test_helper"
+  #
+  #   class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
+  #     driven_by :selenium, using: :firefox
+  #   end
+  #
+  # +driven_by+ has a required argument for the driver name. The keyword
+  # arguments are +:using+ for the browser and +:screen_size+ to change the
+  # size of the browser screen. These two options are not applicable for
+  # headless drivers and will be silently ignored if passed.
+  #
+  # Headless browsers such as headless Chrome and headless Firefox are also supported.
+  # You can use these browsers by setting the +:using+ argument to +:headless_chrome+ or +:headless_firefox+.
+  #
+  # To use a headless driver, like Poltergeist, update your Gemfile to use
+  # Poltergeist instead of Selenium and then declare the driver name in the
+  # +application_system_test_case.rb+ file. In this case, you would leave out
+  # the +:using+ option because the driver is headless, but you can still use
+  # +:screen_size+ to change the size of the browser screen, also you can use
+  # +:options+ to pass options supported by the driver. Please refer to your
+  # driver documentation to learn about supported options.
+  #
+  #   require "test_helper"
+  #   require "capybara/poltergeist"
+  #
+  #   class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
+  #     driven_by :poltergeist, screen_size: [1400, 1400], options:
+  #       { js_errors: true }
+  #   end
+  #
+  # Some drivers require browser capabilities to be passed as a block instead
+  # of through the +options+ hash.
+  #
+  # As an example, if you want to add mobile emulation on chrome, you'll have to
+  # create an instance of selenium's +Chrome::Options+ object and add
+  # capabilities with a block.
+  #
+  # The block will be passed an instance of <tt><Driver>::Options</tt> where you can
+  # define the capabilities you want. Please refer to your driver documentation
+  # to learn about supported options.
+  #
+  #   class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
+  #     driven_by :selenium, using: :chrome, screen_size: [1024, 768] do |driver_option|
+  #       driver_option.add_emulation(device_name: 'iPhone 6')
+  #       driver_option.add_extension('path/to/chrome_extension.crx')
+  #     end
+  #   end
+  #
+  # Because <tt>ActionDispatch::SystemTestCase</tt> is a shim between Capybara
+  # and Rails, any driver that is supported by Capybara is supported by system
+  # tests as long as you include the required gems and files.
+  class SystemTestCase < ActiveSupport::TestCase
+    include Capybara::DSL
+
+    include Capybara::Minitest::Assertions
+
+    include SystemTesting::TestHelpers::SetupAndTeardown
+
+    include SystemTesting::TestHelpers::ScreenshotHelper
+
+    def initialize: () -> untyped
+
+    def self.start_application: () -> untyped
+
+    # System Test configuration options
+    #
+    # The default settings are Selenium, using Chrome, with a screen size
+    # of 1400x1400.
+    #
+    # Examples:
+    #
+    #   driven_by :poltergeist
+    #
+    #   driven_by :selenium, screen_size: [800, 800]
+    #
+    #   driven_by :selenium, using: :chrome
+    #
+    #   driven_by :selenium, using: :headless_chrome
+    #
+    #   driven_by :selenium, using: :firefox
+    #
+    #   driven_by :selenium, using: :headless_firefox
+    def self.driven_by: (untyped driver, ?options: ::Hash[untyped, untyped] options, ?screen_size: ::Array[untyped] screen_size, ?using: ::Symbol using) { () -> untyped } -> untyped
+
+    def method_missing: (untyped method, *untyped args) { () -> untyped } -> untyped
+  end
+end
+
+module ActionDispatch
+  module SystemTesting
+    class Browser
+      # :nodoc:
+      attr_reader name: untyped
+
+      def initialize: (untyped name) -> untyped
+
+      def `type`: () -> untyped
+
+      def options: () -> untyped
+
+      def capabilities: () -> untyped
+
+      # driver_path can be configured as a proc. The webdrivers gem uses this
+      # proc to update web drivers. Running this proc early allows us to only
+      # update the webdriver once and avoid race conditions when using
+      # parallel tests.
+      def preload: () -> untyped
+
+      def headless_chrome_browser_options: () -> untyped
+
+      def headless_firefox_browser_options: () -> untyped
+    end
+  end
+end
+
+module ActionDispatch
+  module SystemTesting
+    class Driver
+      # :nodoc:
+      def initialize: (untyped name, **untyped options) { () -> untyped } -> untyped
+
+      def use: () -> untyped
+
+      def registerable?: () -> untyped
+
+      def register: () -> untyped
+
+      def define_browser_capabilities: (untyped capabilities) -> untyped
+
+      def browser_options: () -> untyped
+
+      def register_selenium: (untyped app) -> untyped
+
+      def register_poltergeist: (untyped app) -> Capybara::Poltergeist::Driver
+
+      def register_webkit: (untyped app) -> untyped
+
+      def setup: () -> untyped
+    end
+  end
+end
+
+module ActionDispatch
+  module SystemTesting
+    class Server
+      attr_accessor silence_puma: untyped
+
+      def run: () -> untyped
+
+      def setup: () -> untyped
+
+      def set_server: () -> untyped
+
+      def set_port: () -> untyped
+    end
+  end
+end
+
+module ActionDispatch
+  module SystemTesting
+    module TestHelpers
+      # Screenshot helper for system testing.
+      module ScreenshotHelper
+        # Takes a screenshot of the current page in the browser.
+        #
+        # +take_screenshot+ can be used at any point in your system tests to take
+        # a screenshot of the current state. This can be useful for debugging or
+        # automating visual testing.
+        #
+        # The screenshot will be displayed in your console, if supported.
+        #
+        # You can set the +RAILS_SYSTEM_TESTING_SCREENSHOT+ environment variable to
+        # control the output. Possible values are:
+        # * [+simple+ (default)]    Only displays the screenshot path.
+        #                           This is the default value.
+        # * [+inline+]              Display the screenshot in the terminal using the
+        #                           iTerm image protocol (https://iterm2.com/documentation-images.html).
+        # * [+artifact+]            Display the screenshot in the terminal, using the terminal
+        #                           artifact format (https://buildkite.github.io/terminal-to-html/inline-images/).
+        def take_screenshot: () -> untyped
+
+        # Takes a screenshot of the current page in the browser if the test
+        # failed.
+        #
+        # +take_failed_screenshot+ is included in <tt>application_system_test_case.rb</tt>
+        # that is generated with the application. To take screenshots when a test
+        # fails add +take_failed_screenshot+ to the teardown block before clearing
+        # sessions.
+        def take_failed_screenshot: () -> untyped
+
+        def image_name: () -> untyped
+
+        def image_path: () -> untyped
+
+        def absolute_image_path: () -> untyped
+
+        def save_image: () -> untyped
+
+        def output_type: () -> untyped
+
+        def display_image: () -> untyped
+
+        def inline_base64: (untyped path) -> untyped
+
+        def failed?: () -> untyped
+
+        def supports_screenshot?: () -> untyped
+      end
+    end
+  end
+end
+
+module ActionDispatch
+  module SystemTesting
+    module TestHelpers
+      module SetupAndTeardown
+        # :nodoc:
+        DEFAULT_HOST: ::String
+
+        def host!: (untyped host) -> untyped
+
+        def before_setup: () -> untyped
+
+        def before_teardown: () -> untyped
+
+        def after_teardown: () -> untyped
+      end
+    end
+  end
+end
+
+module ActionDispatch
+  # This is a class that abstracts away an asserted response. It purposely
+  # does not inherit from Response because it doesn't need it. That means it
+  # does not have headers or a body.
+  class AssertionResponse
+    attr_reader code: untyped
+
+    attr_reader name: untyped
+
+    GENERIC_RESPONSE_CODES: ::Hash[untyped, untyped]
+
+    # Accepts a specific response status code as an Integer (404) or String
+    # ('404') or a response status range as a Symbol pseudo-code (:success,
+    # indicating any 200-299 status code).
+    def initialize: (untyped code_or_name) -> untyped
+
+    def code_and_name: () -> ::String
+
+    def code_from_name: (untyped name) -> untyped
+
+    def name_from_code: (untyped code) -> untyped
+  end
+end
+
+module ActionDispatch
+  module Assertions
+    # A small suite of assertions that test responses from \Rails applications.
+    module ResponseAssertions
+      RESPONSE_PREDICATES: ::Hash[untyped, untyped]
+
+      # Asserts that the response is one of the following types:
+      #
+      # * <tt>:success</tt>   - Status code was in the 200-299 range
+      # * <tt>:redirect</tt>  - Status code was in the 300-399 range
+      # * <tt>:missing</tt>   - Status code was 404
+      # * <tt>:error</tt>     - Status code was in the 500-599 range
+      #
+      # You can also pass an explicit status number like <tt>assert_response(501)</tt>
+      # or its symbolic equivalent <tt>assert_response(:not_implemented)</tt>.
+      # See Rack::Utils::SYMBOL_TO_STATUS_CODE for a full list.
+      #
+      #   # Asserts that the response was a redirection
+      #   assert_response :redirect
+      #
+      #   # Asserts that the response code was status code 401 (unauthorized)
+      #   assert_response 401
+      def assert_response: (untyped `type`, ?untyped? message) -> untyped
+
+      # Asserts that the redirection options passed in match those of the redirect called in the latest action.
+      # This match can be partial, such that <tt>assert_redirected_to(controller: "weblog")</tt> will also
+      # match the redirection of <tt>redirect_to(controller: "weblog", action: "show")</tt> and so on.
+      #
+      #   # Asserts that the redirection was to the "index" action on the WeblogController
+      #   assert_redirected_to controller: "weblog", action: "index"
+      #
+      #   # Asserts that the redirection was to the named route login_url
+      #   assert_redirected_to login_url
+      #
+      #   # Asserts that the redirection was to the URL for @customer
+      #   assert_redirected_to @customer
+      #
+      #   # Asserts that the redirection matches the regular expression
+      #   assert_redirected_to %r(\Ahttp://example.org)
+      def assert_redirected_to: (?::Hash[untyped, untyped] options, ?untyped? message) -> (::TrueClass | untyped)
+
+      # Proxy to to_param if the object will respond to it.
+      def parameterize: (untyped value) -> untyped
+
+      def normalize_argument_to_redirection: (untyped fragment) -> untyped
+
+      def generate_response_message: (untyped expected, ?untyped actual) -> untyped
+
+      def response_body_if_short: () -> ::String
+
+      def location_if_redirected: () -> ::String
+
+      def code_with_name: (untyped code_or_name) -> untyped
+    end
+  end
+end
+
+module ActionDispatch
+  module Assertions
+    # Suite of assertions to test routes generated by \Rails and the handling of requests made to them.
+    module RoutingAssertions
+      def setup: () -> untyped
+
+      # Asserts that the routing of the given +path+ was handled correctly and that the parsed options (given in the +expected_options+ hash)
+      # match +path+. Basically, it asserts that \Rails recognizes the route given by +expected_options+.
+      #
+      # Pass a hash in the second argument (+path+) to specify the request method. This is useful for routes
+      # requiring a specific HTTP method. The hash should contain a :path with the incoming request path
+      # and a :method containing the required HTTP verb.
+      #
+      #   # Asserts that POSTing to /items will call the create action on ItemsController
+      #   assert_recognizes({controller: 'items', action: 'create'}, {path: 'items', method: :post})
+      #
+      # You can also pass in +extras+ with a hash containing URL parameters that would normally be in the query string. This can be used
+      # to assert that values in the query string will end up in the params hash correctly. To test query strings you must use the extras
+      # argument because appending the query string on the path directly will not work. For example:
+      #
+      #   # Asserts that a path of '/items/list/1?view=print' returns the correct options
+      #   assert_recognizes({controller: 'items', action: 'list', id: '1', view: 'print'}, 'items/list/1', { view: "print" })
+      #
+      # The +message+ parameter allows you to pass in an error message that is displayed upon failure.
+      #
+      #   # Check the default route (i.e., the index action)
+      #   assert_recognizes({controller: 'items', action: 'index'}, 'items')
+      #
+      #   # Test a specific action
+      #   assert_recognizes({controller: 'items', action: 'list'}, 'items/list')
+      #
+      #   # Test an action with a parameter
+      #   assert_recognizes({controller: 'items', action: 'destroy', id: '1'}, 'items/destroy/1')
+      #
+      #   # Test a custom route
+      #   assert_recognizes({controller: 'items', action: 'show', id: '1'}, 'view/item1')
+      def assert_recognizes: (untyped expected_options, untyped path, ?::Hash[untyped, untyped] extras, ?untyped? msg) -> untyped
+
+      # Asserts that the provided options can be used to generate the provided path. This is the inverse of +assert_recognizes+.
+      # The +extras+ parameter is used to tell the request the names and values of additional request parameters that would be in
+      # a query string. The +message+ parameter allows you to specify a custom error message for assertion failures.
+      #
+      # The +defaults+ parameter is unused.
+      #
+      #   # Asserts that the default action is generated for a route with no action
+      #   assert_generates "/items", controller: "items", action: "index"
+      #
+      #   # Tests that the list action is properly routed
+      #   assert_generates "/items/list", controller: "items", action: "list"
+      #
+      #   # Tests the generation of a route with a parameter
+      #   assert_generates "/items/list/1", { controller: "items", action: "list", id: "1" }
+      #
+      #   # Asserts that the generated route gives us our custom route
+      #   assert_generates "changesets/12", { controller: 'scm', action: 'show_diff', revision: "12" }
+      def assert_generates: (untyped expected_path, untyped options, ?::Hash[untyped, untyped] defaults, ?::Hash[untyped, untyped] extras, ?untyped? message) -> untyped
+
+      # Asserts that path and options match both ways; in other words, it verifies that <tt>path</tt> generates
+      # <tt>options</tt> and then that <tt>options</tt> generates <tt>path</tt>. This essentially combines +assert_recognizes+
+      # and +assert_generates+ into one step.
+      #
+      # The +extras+ hash allows you to specify options that would normally be provided as a query string to the action. The
+      # +message+ parameter allows you to specify a custom error message to display upon failure.
+      #
+      #  # Asserts a basic route: a controller with the default action (index)
+      #  assert_routing '/home', controller: 'home', action: 'index'
+      #
+      #  # Test a route generated with a specific controller, action, and parameter (id)
+      #  assert_routing '/entries/show/23', controller: 'entries', action: 'show', id: 23
+      #
+      #  # Asserts a basic route (controller + default action), with an error message if it fails
+      #  assert_routing '/store', { controller: 'store', action: 'index' }, {}, {}, 'Route for store index not generated properly'
+      #
+      #  # Tests a route, providing a defaults hash
+      #  assert_routing 'controller/action/9', {id: "9", item: "square"}, {controller: "controller", action: "action"}, {}, {item: "square"}
+      #
+      #  # Tests a route with an HTTP method
+      #  assert_routing({ method: 'put', path: '/product/321' }, { controller: "product", action: "update", id: "321" })
+      def assert_routing: (untyped path, untyped options, ?::Hash[untyped, untyped] defaults, ?::Hash[untyped, untyped] extras, ?untyped? message) -> untyped
+
+      # A helper to make it easier to test different route configurations.
+      # This method temporarily replaces @routes with a new RouteSet instance.
+      #
+      # The new instance is yielded to the passed block. Typically the block
+      # will create some routes using <tt>set.draw { match ... }</tt>:
+      #
+      #   with_routing do |set|
+      #     set.draw do
+      #       resources :users
+      #     end
+      #     assert_equal "/users", users_path
+      #   end
+      #
+      def with_routing: () { (untyped) -> untyped } -> untyped
+
+      # ROUTES TODO: These assertions should really work in an integration context
+      def method_missing: (untyped selector, *untyped args) { () -> untyped } -> untyped
+
+      # Recognizes the route for a given path.
+      def recognized_request_for: (untyped path, ?::Hash[untyped, untyped] extras, untyped msg) -> untyped
+
+      def fail_on: (untyped exception_class, untyped message) { () -> untyped } -> untyped
+    end
+  end
+end
+
+module ActionDispatch
+  module Assertions
+    extend ActiveSupport::Concern
+
+    include ResponseAssertions
+
+    include RoutingAssertions
+
+    include Rails::Dom::Testing::Assertions
+
+    def html_document: () -> untyped
+  end
+end
+
+module ActionDispatch
+  module Integration
+    # nodoc:
+    module RequestHelpers
+      # Performs a GET request with the given parameters. See ActionDispatch::Integration::Session#process
+      # for more details.
+      def get: (untyped path, **untyped args) -> untyped
+
+      # Performs a POST request with the given parameters. See ActionDispatch::Integration::Session#process
+      # for more details.
+      def post: (untyped path, **untyped args) -> untyped
+
+      # Performs a PATCH request with the given parameters. See ActionDispatch::Integration::Session#process
+      # for more details.
+      def patch: (untyped path, **untyped args) -> untyped
+
+      # Performs a PUT request with the given parameters. See ActionDispatch::Integration::Session#process
+      # for more details.
+      def put: (untyped path, **untyped args) -> untyped
+
+      # Performs a DELETE request with the given parameters. See ActionDispatch::Integration::Session#process
+      # for more details.
+      def delete: (untyped path, **untyped args) -> untyped
+
+      # Performs a HEAD request with the given parameters. See ActionDispatch::Integration::Session#process
+      # for more details.
+      def head: (untyped path, **untyped args) -> untyped
+
+      # Follow a single redirect response. If the last response was not a
+      # redirect, an exception will be raised. Otherwise, the redirect is
+      # performed on the location header. Any arguments are passed to the
+      # underlying call to `get`.
+      def follow_redirect!: (**untyped args) -> untyped
+    end
+
+    # An instance of this class represents a set of requests and responses
+    # performed sequentially by a test process. Because you can instantiate
+    # multiple sessions and run them side-by-side, you can also mimic (to some
+    # limited extent) multiple simultaneous users interacting with your system.
+    #
+    # Typically, you will instantiate a new session using
+    # IntegrationTest#open_session, rather than instantiating
+    # Integration::Session directly.
+    class Session
+      DEFAULT_HOST: ::String
+
+      include Minitest::Assertions
+
+      include TestProcess
+
+      include RequestHelpers
+
+      include Assertions
+
+      # The hostname used in the last request.
+      def host: () -> untyped
+
+      attr_writer host: untyped
+
+      # The remote_addr used in the last request.
+      attr_accessor remote_addr: untyped
+
+      # The Accept header to send.
+      attr_accessor accept: untyped
+
+      # A map of the cookies returned by the last response, and which will be
+      # sent with the next request.
+      def cookies: () -> untyped
+
+      # A reference to the controller instance used by the last request.
+      attr_reader controller: untyped
+
+      # A reference to the request instance used by the last request.
+      attr_reader request: untyped
+
+      # A reference to the response instance used by the last request.
+      attr_reader response: untyped
+
+      # A running counter of the number of requests processed.
+      attr_accessor request_count: untyped
+
+      include ActionDispatch::Routing::UrlFor
+
+      # Create and initialize a new Session instance.
+      def initialize: (untyped app) -> untyped
+
+      def url_options: () -> untyped
+
+      # Resets the instance. This can be used to reset the state information
+      # in an existing session instance, so it can be used from a clean-slate
+      # condition.
+      #
+      #   session.reset!
+      def reset!: () -> untyped
+
+      # Specify whether or not the session should mimic a secure HTTPS request.
+      #
+      #   session.https!
+      #   session.https!(false)
+      def https!: (?bool flag) -> untyped
+
+      # Returns +true+ if the session is mimicking a secure HTTPS request.
+      #
+      #   if session.https?
+      #     ...
+      #   end
+      def https?: () -> untyped
+
+      # Performs the actual request.
+      #
+      # - +method+: The HTTP method (GET, POST, PATCH, PUT, DELETE, HEAD, OPTIONS)
+      #   as a symbol.
+      # - +path+: The URI (as a String) on which you want to perform the
+      #   request.
+      # - +params+: The HTTP parameters that you want to pass. This may
+      #   be +nil+,
+      #   a Hash, or a String that is appropriately encoded
+      #   (<tt>application/x-www-form-urlencoded</tt> or
+      #   <tt>multipart/form-data</tt>).
+      # - +headers+: Additional headers to pass, as a Hash. The headers will be
+      #   merged into the Rack env hash.
+      # - +env+: Additional env to pass, as a Hash. The headers will be
+      #   merged into the Rack env hash.
+      # - +xhr+: Set to `true` if you want to make and Ajax request.
+      #   Adds request headers characteristic of XMLHttpRequest e.g. HTTP_X_REQUESTED_WITH.
+      #   The headers will be merged into the Rack env hash.
+      # - +as+: Used for encoding the request with different content type.
+      #   Supports `:json` by default and will set the appropriate request headers.
+      #   The headers will be merged into the Rack env hash.
+      #
+      # This method is rarely used directly. Use +#get+, +#post+, or other standard
+      # HTTP methods in integration tests. +#process+ is only required when using a
+      # request method that doesn't have a method defined in the integration tests.
+      #
+      # This method returns the response status, after performing the request.
+      # Furthermore, if this method was called from an ActionDispatch::IntegrationTest object,
+      # then that object's <tt>@response</tt> instance variable will point to a Response object
+      # which one can use to inspect the details of the response.
+      #
+      # Example:
+      #   process :get, '/author', params: { since: 201501011400 }
+      def process: (untyped method, untyped path, ?as: untyped? as, ?xhr: bool xhr, ?env: untyped? env, ?headers: untyped? headers, ?params: untyped? params) -> untyped
+
+      # Set the host name to use in the next request.
+      #
+      #   session.host! "www.example.com"
+      alias host! host=
+
+      def _mock_session: () -> untyped
+
+      def build_full_uri: (untyped path, untyped env) -> ::String
+
+      def build_expanded_path: (untyped path) { (untyped) -> untyped } -> untyped
+    end
+
+    module Runner
+      include ActionDispatch::Assertions
+
+      APP_SESSIONS: ::Hash[untyped, untyped]
+
+      attr_reader app: untyped
+
+      attr_accessor root_session: untyped
+
+      def initialize: (*untyped args) { () -> untyped } -> untyped
+
+      def before_setup: () -> untyped
+
+      def integration_session: () -> untyped
+
+      # Reset the current session. This is useful for testing multiple sessions
+      # in a single test case.
+      def reset!: () -> untyped
+
+      def create_session: (untyped app) -> untyped
+
+      def remove!: () -> untyped
+
+      # Open a new session instance. If a block is given, the new session is
+      # yielded to the block before being returned.
+      #
+      #   session = open_session do |sess|
+      #     sess.extend(CustomAssertions)
+      #   end
+      #
+      # By default, a single session is automatically created for you, but you
+      # can use this method to open multiple sessions that ought to be tested
+      # simultaneously.
+      def open_session: () { (untyped) -> untyped } -> untyped
+
+      def assertions: () -> untyped
+
+      def assertions=: (untyped assertions) -> untyped
+
+      def copy_session_variables!: () -> untyped
+
+      def default_url_options: () -> untyped
+
+      def default_url_options=: (untyped options) -> untyped
+
+      def respond_to_missing?: (untyped method, untyped _) -> untyped
+
+      # Delegate unhandled messages to the current session instance.
+      def method_missing: (untyped method, *untyped args) { () -> untyped } -> untyped
+    end
+  end
+
+  class IntegrationTest < ActiveSupport::TestCase
+    include TestProcess::FixtureFile
+
+    module UrlOptions
+      extend ActiveSupport::Concern
+
+      def url_options: () -> untyped
+    end
+
+    module Behavior
+      extend ActiveSupport::Concern
+
+      include Integration::Runner
+
+      include ActionController::TemplateAssertions
+
+      include ActionDispatch::Routing::UrlFor
+
+      include UrlOptions
+
+      module ClassMethods
+        def app: () -> untyped
+
+        def app=: (untyped app) -> untyped
+
+        def register_encoder: (*untyped args, **untyped options) -> untyped
+      end
+
+      def app: () -> untyped
+
+      def document_root_element: () -> untyped
+    end
+
+    include Behavior
+  end
+end
+
+module ActionDispatch
+  class RequestEncoder
+    # :nodoc:
+    class IdentityEncoder
+      def content_type: () -> nil
+
+      def accept_header: () -> nil
+
+      def encode_params: (untyped params) -> untyped
+
+      def response_parser: () -> untyped
+    end
+
+    attr_reader response_parser: untyped
+
+    def initialize: (untyped mime_name, untyped param_encoder, untyped response_parser) -> untyped
+
+    def content_type: () -> untyped
+
+    def accept_header: () -> untyped
+
+    def encode_params: (untyped params) -> untyped
+
+    def self.parser: (untyped content_type) -> untyped
+
+    def self.encoder: (untyped name) -> untyped
+
+    def self.register_encoder: (untyped mime_name, ?response_parser: untyped? response_parser, ?param_encoder: untyped? param_encoder) -> untyped
+  end
+end
+
+module ActionDispatch
+  module TestProcess
+    module FixtureFile
+      # Shortcut for <tt>Rack::Test::UploadedFile.new(File.join(ActionDispatch::IntegrationTest.fixture_path, path), type)</tt>:
+      #
+      #   post :change_avatar, params: { avatar: fixture_file_upload('files/spongebob.png', 'image/png') }
+      #
+      # To upload binary files on Windows, pass <tt>:binary</tt> as the last parameter.
+      # This will not affect other platforms:
+      #
+      #   post :change_avatar, params: { avatar: fixture_file_upload('files/spongebob.png', 'image/png', :binary) }
+      def fixture_file_upload: (untyped path, ?untyped? mime_type, ?bool binary) -> Rack::Test::UploadedFile
+    end
+
+    include FixtureFile
+
+    def assigns: (?untyped? key) -> untyped
+
+    def session: () -> untyped
+
+    def flash: () -> untyped
+
+    def cookies: () -> untyped
+
+    def redirect_to_url: () -> untyped
+  end
+end
+
+module ActionDispatch
+  class TestRequest < Request
+    DEFAULT_ENV: untyped
+
+    # Create a new test request with default +env+ values.
+    def self.create: (?::Hash[untyped, untyped] env) -> untyped
+
+    def self.default_env: () -> untyped
+
+    def request_method=: (untyped method) -> untyped
+
+    def host=: (untyped host) -> untyped
+
+    def port=: (untyped number) -> untyped
+
+    def request_uri=: (untyped uri) -> untyped
+
+    def path=: (untyped path) -> untyped
+
+    def action=: (untyped action_name) -> untyped
+
+    def if_modified_since=: (untyped last_modified) -> untyped
+
+    def if_none_match=: (untyped etag) -> untyped
+
+    def remote_addr=: (untyped addr) -> untyped
+
+    def user_agent=: (untyped user_agent) -> untyped
+
+    def accept=: (untyped mime_types) -> untyped
+  end
+end
+
+module ActionDispatch
+  # Integration test methods such as ActionDispatch::Integration::Session#get
+  # and ActionDispatch::Integration::Session#post return objects of class
+  # TestResponse, which represent the HTTP response results of the requested
+  # controller actions.
+  #
+  # See Response for more information on controller response objects.
+  class TestResponse < Response
+    def self.from_response: (untyped response) -> untyped
+
+    def parsed_body: () -> untyped
+
+    def response_parser: () -> untyped
+  end
+end
+
+module Rack
+end
+
+module ActionDispatch
+  extend ActiveSupport::Autoload
+
+  class IllegalStateError < StandardError
+  end
+
+  class MissingController[T] < NameError[T]
+  end
+
+  module Http
+    extend ActiveSupport::Autoload
+  end
+
+  module Session
+  end
+end
+
+module ActionPack
+  # Returns the version of the currently loaded Action Pack as a <tt>Gem::Version</tt>
+  def self.gem_version: () -> Gem::Version
+
+  module VERSION
+    MAJOR: ::Integer
+
+    MINOR: ::Integer
+
+    TINY: ::Integer
+
+    PRE: ::String
+
+    STRING: untyped
+  end
+end
+
+module ActionPack
+  # Returns the version of the currently loaded ActionPack as a <tt>Gem::Version</tt>
+  def self.version: () -> untyped
+end
+

--- a/gems/actionpack/6.0.3.2/actionpack-generated.rbs
+++ b/gems/actionpack/6.0.3.2/actionpack-generated.rbs
@@ -39,6 +39,18 @@ module AbstractController
   # expected to provide their own +render+ method, since rendering means
   # different things depending on the context.
   class Base
+    #
+    # Returns the body of the HTTP response sent by the controller.
+    attr_accessor response_body(@_response_body): untyped
+
+    #
+    # Returns the name of the action this controller is processing.
+    attr_accessor action_name(@_action_name): untyped
+
+    #
+    # Returns the formats that can be processed by the controller.
+    attr_accessor formats(@_formats): untyped
+
     include ActiveSupport::Configurable
 
     extend ActiveSupport::DescendantsTracker
@@ -2067,6 +2079,8 @@ module ActionController
     extend ActiveSupport::Concern
 
     include AbstractController::Logger
+
+    attr_accessor view_runtime(@_view_runtime): untyped
 
     def process_action: (*untyped args) -> untyped
 
@@ -4205,6 +4219,10 @@ module ActionController
 
     # Delegates to the class' <tt>controller_name</tt>.
     def controller_name: () -> untyped
+
+    attr_accessor response(@_response): untyped
+
+    attr_accessor request(@_request): untyped
 
     def initialize: () -> untyped
 

--- a/gems/actionpack/6.0.3.2/actionpack-generated.rbs
+++ b/gems/actionpack/6.0.3.2/actionpack-generated.rbs
@@ -130,6 +130,8 @@ module AbstractController
     # support paths, only full URLs.
     def self.supports_path?: () -> ::TrueClass
 
+    private
+
     # Returns true if the name can be considered an action because
     # it has a method defined in the controller.
     #
@@ -302,6 +304,8 @@ module AbstractController
 
       def cache_store=: (untyped store) -> untyped
 
+      private
+
       def cache_configured?: () -> untyped
     end
 
@@ -316,6 +320,8 @@ module AbstractController
     end
 
     def view_cache_dependencies: () -> untyped
+
+    private
 
     def cache: (untyped key, ?::Hash[untyped, untyped] options) { () -> untyped } -> untyped
   end
@@ -398,6 +404,8 @@ end
 module AbstractController
   module Collector
     def self.generate_method_for_mime: (untyped mime) -> untyped
+
+    private
 
     def method_missing: (untyped symbol) { () -> untyped } -> untyped
   end
@@ -504,6 +512,8 @@ module AbstractController
       #   helpers provided.
       def modules_for_helpers: (untyped args) -> untyped
 
+      private
+
       # Makes all the (instance) methods in the helper module available to templates
       # rendered through this controller.
       #
@@ -573,6 +583,8 @@ module AbstractController
     # This method should return a hash with assigns.
     # You can overwrite this configuration per controller.
     def view_assigns: () -> untyped
+
+    private
 
     def _normalize_args: (?untyped? action, ?::Hash[untyped, untyped] options) -> untyped
 
@@ -965,6 +977,8 @@ module ActionController
 
     include AbstractController::Caching
 
+    private
+
     def instrument_payload: (untyped key) -> { controller: untyped, action: untyped, key: untyped }
 
     def instrument_name: () -> "action_controller"
@@ -1270,6 +1284,8 @@ module ActionController
     #   indicate that they can serve the cached response to all users.
     def http_cache_forever: (?public: bool `public`) { () -> untyped } -> untyped
 
+    private
+
     def combine_etags: (untyped validator, untyped options) -> untyped
   end
 end
@@ -1290,6 +1306,8 @@ module ActionController
       def content_security_policy_report_only: (?bool report_only, **untyped options) -> untyped
     end
 
+    private
+
     def content_security_policy?: () -> untyped
 
     def content_security_policy_nonce: () -> untyped
@@ -1302,6 +1320,8 @@ module ActionController
   # nodoc:
   module Cookies
     extend ActiveSupport::Concern
+
+    private
 
     def cookies: () -> untyped
   end
@@ -1319,6 +1339,8 @@ module ActionController
     DEFAULT_SEND_FILE_TYPE: ::String
 
     DEFAULT_SEND_FILE_DISPOSITION: ::String
+
+    private
 
     def send_file: (untyped path, ?::Hash[untyped, untyped] options) -> untyped
 
@@ -1375,6 +1397,8 @@ module ActionController
     extend ActiveSupport::Concern
 
     include ActionController::ConditionalGet
+
+    private
 
     def determine_template_etag: (untyped options) -> untyped
 
@@ -1480,6 +1504,8 @@ module ActionController
       def add_flash_types: (*untyped types) -> untyped
     end
 
+    private
+
     def redirect_to: (?::Hash[untyped, untyped] options, ?::Hash[untyped, untyped] response_options_and_flash) -> untyped
   end
 end
@@ -1528,6 +1554,8 @@ module ActionController
     #
     # See Rack::Utils::SYMBOL_TO_STATUS_CODE for a full list of valid +status+ symbols.
     def head: (untyped status, ?::Hash[untyped, untyped] options) -> ::TrueClass
+
+    private
 
     def include_content?: (untyped status) -> untyped
   end
@@ -1618,6 +1646,8 @@ module ActionController
       #   # => ["application", "chart", "rubygems"]
       def all_helpers_from_path: (untyped path) -> untyped
 
+      private
+
       # Extract helper names from files in <tt>app/helpers/**/*_helper.rb</tt>
       def all_application_helpers: () -> untyped
     end
@@ -1687,6 +1717,8 @@ module ActionController
     #     assert_equal 200, status
     #   end
     module Basic
+      extend ::ActionController::HttpAuthentication::Basic
+
       module ControllerMethods
         extend ActiveSupport::Concern
 
@@ -1763,6 +1795,8 @@ module ActionController
     # they reach your application. You can debug this situation by logging all environment
     # variables, and check for HTTP_AUTHORIZATION, amongst others.
     module Digest
+      extend ::ActionController::HttpAuthentication::Digest
+
       module ControllerMethods
         def authenticate_or_request_with_http_digest: (?::String realm, ?untyped? message) { () -> untyped } -> untyped
 
@@ -1926,6 +1960,8 @@ module ActionController
 
       AUTHN_PAIR_DELIMITERS: untyped
 
+      extend ::ActionController::HttpAuthentication::Token
+
       module ControllerMethods
         def authenticate_or_request_with_http_token: (?::String realm, ?untyped? message) { () -> untyped } -> untyped
 
@@ -2015,6 +2051,8 @@ module ActionController
 
     def method_for_action: (untyped action_name) -> untyped
 
+    private
+
     def interactive_browser_request?: () -> untyped
   end
 end
@@ -2039,6 +2077,8 @@ module ActionController
     def send_data: (untyped data, ?::Hash[untyped, untyped] options) -> untyped
 
     def redirect_to: (*untyped args) -> untyped
+
+    private
 
     # A hook invoked every time a before callback is halted.
     def halted_callback_hook: (untyped filter) -> untyped
@@ -2135,6 +2175,8 @@ module ActionController
 
       def write: (untyped object, ?::Hash[untyped, untyped] options) -> untyped
 
+      private
+
       def perform_write: (untyped json, untyped options) -> untyped
     end
 
@@ -2180,10 +2222,14 @@ module ActionController
 
       def call_on_error: () -> untyped
 
+      private
+
       def each_chunk: () { (untyped) -> untyped } -> untyped
     end
 
     class Response < ActionDispatch::Response
+      private
+
       def before_committed: () -> untyped
 
       def build_buffer: (untyped response, untyped body) -> untyped
@@ -2192,6 +2238,8 @@ module ActionController
     def process: (untyped name) -> untyped
 
     def response_body=: (untyped body) -> untyped
+
+    private
 
     def new_controller_thread: () { () -> untyped } -> untyped
 
@@ -2449,6 +2497,8 @@ module ActionController
 
         def variant: () -> untyped
 
+        private
+
         def variant_key: () -> untyped
       end
     end
@@ -2578,6 +2628,8 @@ module ActionController
 
       def name: () -> untyped
 
+      private
+
       # Determine the wrapper model from the controller's name. By convention,
       # this could be done by trying to find the defined model that has the
       # same singular name as the controller. For example, +UsersController+
@@ -2629,6 +2681,8 @@ module ActionController
     # Performs parameters wrapping upon the request. Called automatically
     # by the metal call stack.
     def process_action: (*untyped args) -> untyped
+
+    private
 
     # Returns the wrapper key which will be used to store wrapped parameters.
     def _wrapper_key: () -> untyped
@@ -2731,7 +2785,9 @@ module ActionController
     # options and the behavior is identical.
     def redirect_back: (fallback_location: untyped fallback_location, ?allow_other_host: bool allow_other_host, **untyped args) -> untyped
 
-    def _compute_redirect_to_location: (untyped request, untyped options) -> untyped
+    def self?._compute_redirect_to_location: (untyped request, untyped options) -> untyped
+
+    private
 
     def _extract_redirect_to_status: (untyped options, untyped response_options) -> untyped
 
@@ -2882,6 +2938,8 @@ module ActionController
 
     def render_to_body: (?::Hash[untyped, untyped] options) -> untyped
 
+    private
+
     def _process_variant: (untyped options) -> untyped
 
     def _render_in_priorities: (untyped options) -> (untyped | nil)
@@ -3007,6 +3065,8 @@ module ActionController
       # See +skip_before_action+ for allowed options.
       def skip_forgery_protection: (?::Hash[untyped, untyped] options) -> untyped
 
+      private
+
       def protection_method_class: (untyped name) -> untyped
     end
 
@@ -3016,6 +3076,8 @@ module ActionController
 
         # This is the method that defines the application behavior when a request is found to be unverified.
         def handle_unverified_request: () -> untyped
+
+        private
 
         class NullSessionHash < Rack::Session::Abstract::SessionHash
           # nodoc:
@@ -3045,6 +3107,8 @@ module ActionController
         def handle_unverified_request: () -> untyped
       end
     end
+
+    private
 
     def verify_authenticity_token: () -> untyped
 
@@ -3126,6 +3190,8 @@ module ActionController
     # +false+, but someone may set it to <tt>request.local?</tt> so local
     # requests in production still show the detailed exception pages.
     def show_detailed_exceptions?: () -> ::FalseClass
+
+    private
 
     def process_action: (*untyped args) -> untyped
   end
@@ -3324,6 +3390,8 @@ module ActionController
   #
   module Streaming
     extend ActiveSupport::Concern
+
+    private
 
     # Set proper cache control and transfer encoding when streaming
     def _process_options: (untyped options) -> untyped
@@ -3857,6 +3925,8 @@ module ActionController
 
     def fields_for_style?: () -> untyped
 
+    private
+
     def new_instance_with_inherited_permitted_status: (untyped hash) -> untyped
 
     def convert_parameters_to_hashes: (untyped value, untyped using) -> untyped
@@ -4052,6 +4122,8 @@ module ActionController
     end
 
     def build: (untyped action, ?untyped? app) { () -> untyped } -> untyped
+
+    private
 
     INCLUDE: untyped
 
@@ -4264,6 +4336,8 @@ module ActionController
     # to render a partial and use the second parameter as the locals hash.
     def render: (*untyped args) -> untyped
 
+    private
+
     def normalize_keys: (untyped env) -> untyped
 
     RACK_KEY_TRANSLATION: ::Hash[untyped, untyped]
@@ -4290,10 +4364,6 @@ module ActionController
     include Testing::Functional
   end
 
-  module Live
-    def new_controller_thread: () { () -> untyped } -> untyped
-  end
-
   class TestRequest < ActionDispatch::TestRequest
     # ActionController::TestCase will be deprecated and moved to a gem in the future.
     # Please use ActionDispatch::IntegrationTest going forward.
@@ -4318,6 +4388,8 @@ module ActionController
     def assign_parameters: (untyped routes, untyped controller_path, untyped action, untyped parameters, untyped generated_path, untyped query_string_keys) -> untyped
 
     ENCODER: untyped
+
+    private
 
     def params_parsers: () -> untyped
   end
@@ -4352,6 +4424,8 @@ module ActionController
     def dig: (*untyped keys) -> untyped
 
     def fetch: (untyped key, *untyped args) { () -> untyped } -> untyped
+
+    private
 
     def load!: () -> untyped
   end
@@ -4582,6 +4656,8 @@ module ActionController
 
       include ActionDispatch::Assertions
 
+      private
+
       def scrub_env!: (untyped env) -> untyped
 
       def document_root_element: () -> untyped
@@ -4669,6 +4745,8 @@ module ActionDispatch
         # True if an ETag is set and it isn't a weak validator (not preceded with W/)
         def strong_etag?: () -> untyped
 
+        private
+
         DATE: ::String
 
         LAST_MODIFIED: ::String
@@ -4725,6 +4803,8 @@ module ActionDispatch
 
       def to_s: () -> untyped
 
+      private
+
       def percent_escape: (untyped string, untyped pattern) -> untyped
     end
   end
@@ -4743,6 +4823,8 @@ module ActionDispatch
       def initialize: (untyped app) -> untyped
 
       def call: (untyped env) -> untyped
+
+      private
 
       def html_response?: (untyped headers) -> untyped
 
@@ -4780,6 +4862,8 @@ module ActionDispatch
 
       def content_security_policy_nonce: () -> untyped
 
+      private
+
       def generate_content_security_policy_nonce: () -> untyped
     end
 
@@ -4808,6 +4892,8 @@ module ActionDispatch
     def upgrade_insecure_requests: (?bool enabled) -> untyped
 
     def build: (?untyped? context, ?untyped? nonce, ?untyped? nonce_directives) -> untyped
+
+    private
 
     def apply_mappings: (untyped sources) -> untyped
 
@@ -4865,6 +4951,8 @@ module ActionDispatch
       # Reconstructs a path with all sensitive GET parameters replaced.
       def filtered_path: () -> untyped
 
+      private
+
       def parameter_filter: () -> untyped
 
       def env_filter: () -> untyped
@@ -4886,6 +4974,8 @@ module ActionDispatch
       FILTERED: ::String
 
       def filtered_location: () -> untyped
+
+      private
 
       def location_filters: () -> untyped
 
@@ -4963,6 +5053,8 @@ module ActionDispatch
 
       def env: () -> untyped
 
+      private
+
       # Converts an HTTP header name to an environment variable name if it is
       # not contained within the headers hash.
       def env_name: (untyped key) -> untyped
@@ -5033,6 +5125,8 @@ module ActionDispatch
 
       # Returns the first MIME type that matches the provided array of MIME types.
       def negotiate_mime: (untyped order) -> untyped
+
+      private
 
       BROWSER_LIKE_ACCEPTS: untyped
 
@@ -5188,6 +5282,8 @@ module Mime
 
     attr_reader synonyms: untyped
 
+    private
+
     def to_ary: () -> nil
 
     def to_a: () -> nil
@@ -5218,6 +5314,8 @@ module Mime
     def nil?: () -> ::TrueClass
 
     def ref: () -> nil
+
+    private
 
     def respond_to_missing?: (untyped method, untyped _) -> untyped
 
@@ -5274,6 +5372,8 @@ module ActionDispatch
       #
       #   {'action' => 'my_action', 'controller' => 'my_controller'}
       def path_parameters: () -> untyped
+
+      private
 
       def set_binary_encoding: (untyped params, untyped controller, untyped action) -> untyped
 
@@ -5560,6 +5660,8 @@ module ActionDispatch
 
     def ssl?: () -> untyped
 
+    private
+
     def check_method: (untyped name) -> untyped
   end
 end
@@ -5655,6 +5757,8 @@ module ActionDispatch
       def close: () -> untyped
 
       def closed?: () -> untyped
+
+      private
 
       def each_chunk: () { () -> untyped } -> untyped
     end
@@ -5792,6 +5896,8 @@ module ActionDispatch
     #
     #   assert_equal 'AuthorOfNewPage', r.cookies['author']
     def cookies: () -> untyped
+
+    private
 
     class ContentTypeHeader[T] < ::Struct[T]
       attr_accessor mime_type(): untyped
@@ -5936,6 +6042,8 @@ module ActionDispatch
       def self.full_url_for: (untyped options) -> untyped
 
       def self.path_for: (untyped options) -> untyped
+
+      private
 
       def self.add_params: (untyped path, untyped params) -> untyped
 
@@ -6092,6 +6200,8 @@ module ActionDispatch
 
       def clear: () -> untyped
 
+      private
+
       def extract_parameterized_parts: (untyped route, untyped options, untyped recall, ?untyped? parameterize) -> untyped
 
       def named_routes: () -> untyped
@@ -6146,6 +6256,8 @@ module ActionDispatch
         def lastpos: (untyped node) -> untyped
 
         def followpos: (untyped node) -> untyped
+
+        private
 
         def followpos_table: () -> untyped
 
@@ -6219,6 +6331,8 @@ module ActionDispatch
         def states: () -> untyped
 
         def transitions: () -> untyped
+
+        private
 
         def states_hash_for: (untyped sym) -> untyped
       end
@@ -6339,6 +6453,8 @@ module ActionDispatch
         def eclosure: (untyped t) -> untyped
 
         def transitions: () -> untyped
+
+        private
 
         def inverted: () -> untyped
       end
@@ -6628,6 +6744,8 @@ module ActionDispatch
 
         def to_regexp: () -> untyped
 
+        private
+
         def regexp_visitor: () -> untyped
 
         def offsets: () -> untyped
@@ -6731,6 +6849,8 @@ module ActionDispatch
 
       def verb: () -> untyped
 
+      private
+
       def verbs: () -> untyped
 
       def match_verb: (untyped request) -> untyped
@@ -6795,6 +6915,8 @@ module ActionDispatch
 
           def unescape_uri: (untyped uri) -> untyped
 
+          private
+
           def escape: (untyped component, untyped pattern) -> untyped
 
           def percent_encode: (untyped unsafe) -> untyped
@@ -6834,6 +6956,8 @@ module ActionDispatch
       def recognize: (untyped rails_req) { (untyped, untyped) -> untyped } -> untyped
 
       def visualizer: () -> untyped
+
+      private
 
       def partitioned_routes: () -> untyped
 
@@ -6891,6 +7015,8 @@ module ActionDispatch
 
       def add_route: (untyped name, untyped mapping) -> untyped
 
+      private
+
       def clear_cache!: () -> untyped
     end
   end
@@ -6912,6 +7038,8 @@ module ActionDispatch
       def pre_match: () -> untyped
 
       def next_token: () -> (nil | untyped)
+
+      private
 
       # takes advantage of String @- deduping capabilities in Ruby 2.5 upwards
       # see: https://bugs.ruby-lang.org/issues/13077
@@ -6954,6 +7082,8 @@ module ActionDispatch
         DISPATCH_CACHE: ::Hash[untyped, untyped]
 
         def accept: (untyped node) -> untyped
+
+        private
 
         def visit: (untyped node) -> untyped
 
@@ -7039,6 +7169,8 @@ module ActionDispatch
       end
 
       class String < FunctionalVisitor
+        private
+
         def binary: (untyped node, untyped seed) -> untyped
 
         def nary: (untyped node, untyped seed) -> untyped
@@ -7055,6 +7187,8 @@ module ActionDispatch
         def initialize: () -> untyped
 
         def accept: (untyped node, ?::Array[untyped] seed) -> ::String
+
+        private
 
         def binary: (untyped node, untyped seed) -> untyped
 
@@ -7083,6 +7217,8 @@ module ActionDispatch
     def initialize: (untyped app) -> untyped
 
     def call: (untyped env) -> untyped
+
+    private
 
     def actionable_request?: (untyped request) -> untyped
 
@@ -7309,6 +7445,8 @@ module ActionDispatch
       # Used by ActionDispatch::Session::CookieStore to avoid the need to introduce new cookie stores.
       def signed_or_encrypted: () -> untyped
 
+      private
+
       def upgrade_legacy_hmac_aes_cbc_cookies?: () -> untyped
 
       def encrypted_cookie_cipher: () -> untyped
@@ -7388,6 +7526,8 @@ module ActionDispatch
 
       def write: (untyped headers) -> untyped
 
+      private
+
       def escape: (untyped string) -> untyped
 
       def make_set_cookie_header: (untyped header) -> untyped
@@ -7407,6 +7547,8 @@ module ActionDispatch
 
       def request: () -> untyped
 
+      private
+
       def expiry_options: (untyped options) -> untyped
 
       def cookie_metadata: (untyped name, untyped options) -> untyped
@@ -7417,6 +7559,8 @@ module ActionDispatch
     end
 
     class PermanentCookieJar < AbstractCookieJar
+      private
+
       def commit: (untyped name, untyped options) -> untyped
     end
 
@@ -7450,6 +7594,8 @@ module ActionDispatch
 
       def initialize: (untyped parent_jar) -> untyped
 
+      private
+
       def parse: (untyped name, untyped signed_message, ?purpose: untyped? purpose) -> untyped
 
       def commit: (untyped name, untyped options) -> untyped
@@ -7460,6 +7606,8 @@ module ActionDispatch
       include SerializedCookieJars
 
       def initialize: (untyped parent_jar) -> untyped
+
+      private
 
       def parse: (untyped name, untyped encrypted_message, ?purpose: untyped? purpose) -> untyped
 
@@ -7481,6 +7629,8 @@ module ActionDispatch
     def initialize: (untyped app, ?untyped? routes_app, ?::Symbol response_format, ?untyped interceptors) -> untyped
 
     def call: (untyped env) -> untyped
+
+    private
 
     def invoke_interceptors: (untyped request, untyped exception) -> untyped
 
@@ -7534,6 +7684,8 @@ module ActionDispatch
     def initialize: (untyped app, ?::String path) -> untyped
 
     def call: (untyped env) -> untyped
+
+    private
 
     def render_details: (untyped req) -> ::Array[200 | ::Hash[::String, "text/plain" | untyped] | ::Array[untyped]]
 
@@ -7599,6 +7751,8 @@ module ActionDispatch
     def trace_to_show: () -> untyped
 
     def source_to_show_id: () -> untyped
+
+    private
 
     def backtrace: () -> untyped
 
@@ -7777,6 +7931,8 @@ module ActionDispatch
 
       def now_is_loaded?: () -> untyped
 
+      private
+
       def stringify_array: (untyped array) -> untyped
     end
 
@@ -7803,6 +7959,8 @@ module ActionDispatch
 
       def allows?: (untyped host) -> untyped
 
+      private
+
       def sanitize_hosts: (untyped hosts) -> untyped
 
       def sanitize_regexp: (untyped host) -> ::Regexp
@@ -7815,6 +7973,8 @@ module ActionDispatch
     def initialize: (untyped app, untyped hosts, ?untyped? response_app) -> untyped
 
     def call: (untyped env) -> untyped
+
+    private
 
     def authorized?: (untyped request) -> untyped
 
@@ -7839,6 +7999,8 @@ module ActionDispatch
     def initialize: (untyped public_path) -> untyped
 
     def call: (untyped env) -> untyped
+
+    private
 
     def render: (untyped status, untyped content_type, untyped body) -> untyped
 
@@ -7950,6 +8112,8 @@ module ActionDispatch
       # ActionDispatch::Request to use.
       def to_s: () -> untyped
 
+      private
+
       def ips_from: (untyped header) -> (::Array[untyped] | untyped)
 
       def filter_proxies: (untyped ips) -> untyped
@@ -7975,6 +8139,8 @@ module ActionDispatch
 
     def call: (untyped env) -> untyped
 
+    private
+
     def make_request_id: (untyped request_id) -> untyped
 
     def internal_request_id: () -> untyped
@@ -7992,6 +8158,8 @@ module ActionDispatch
       def initialize: (untyped app, ?::Hash[untyped, untyped] options) -> untyped
 
       def generate_sid: () -> untyped
+
+      private
 
       def initialize_sid: () -> untyped
 
@@ -8020,6 +8188,8 @@ module ActionDispatch
 
       include SessionObject
 
+      private
+
       def set_cookie: (untyped request, untyped session_id, untyped cookie) -> untyped
     end
 
@@ -8031,6 +8201,8 @@ module ActionDispatch
       include SessionObject
 
       def generate_sid: () -> Rack::Session::SessionId
+
+      private
 
       def set_cookie: (untyped request, untyped session_id, untyped cookie) -> untyped
     end
@@ -8058,6 +8230,8 @@ module ActionDispatch
 
       # Remove a session from the cache.
       def delete_session: (untyped env, untyped sid, untyped options) -> untyped
+
+      private
 
       # Turn the session id into a cache key.
       def cache_key: (untyped id) -> ::String
@@ -8123,6 +8297,8 @@ module ActionDispatch
 
       def load_session: (untyped req) -> untyped
 
+      private
+
       def extract_session_id: (untyped req) -> untyped
 
       def unpacked_cookie_data: (untyped req) -> untyped
@@ -8177,6 +8353,8 @@ module ActionDispatch
     def initialize: (untyped app, untyped exceptions_app) -> untyped
 
     def call: (untyped env) -> untyped
+
+    private
 
     def render_exception: (untyped request, untyped exception) -> untyped
 
@@ -8239,6 +8417,8 @@ module ActionDispatch
     def initialize: (untyped app, ?secure_cookies: bool secure_cookies, ?hsts: ::Hash[untyped, untyped] hsts, ?redirect: ::Hash[untyped, untyped] redirect) -> untyped
 
     def call: (untyped env) -> untyped
+
+    private
 
     def set_hsts_header!: (untyped headers) -> untyped
 
@@ -8322,6 +8502,8 @@ module ActionDispatch
 
     def build: (?untyped? app) { () -> untyped } -> untyped
 
+    private
+
     def assert_index: (untyped index, untyped where) -> untyped
 
     def build_middleware: (untyped klass, untyped args, untyped block) -> Middleware
@@ -8353,6 +8535,8 @@ module ActionDispatch
     def call: (untyped env) -> untyped
 
     def serve: (untyped request) -> untyped
+
+    private
 
     def ext: () -> untyped
 
@@ -8503,6 +8687,8 @@ module ActionDispatch
 
       def each: () { () -> untyped } -> untyped
 
+      private
+
       def load_for_read!: () -> untyped
 
       def load_for_write!: () -> untyped
@@ -8593,6 +8779,8 @@ module ActionDispatch
 
       def format: (untyped formatter, ?::Hash[untyped, untyped] filter) -> untyped
 
+      private
+
       def normalize_filter: (untyped filter) -> untyped
 
       def filter_routes: (untyped filter) -> untyped
@@ -8624,6 +8812,8 @@ module ActionDispatch
 
         def header: (untyped routes) -> untyped
 
+        private
+
         def draw_section: (untyped routes) -> untyped
 
         def draw_header: (untyped routes) -> ::String
@@ -8635,6 +8825,8 @@ module ActionDispatch
         def section_title: (untyped title) -> untyped
 
         def section: (untyped routes) -> untyped
+
+        private
 
         def draw_expanded_section: (untyped routes) -> untyped
 
@@ -8683,6 +8875,8 @@ module ActionDispatch
 
         def serve: (untyped req) -> (::Array[404 | ::Hash[::String, "pass"] | ::Array[untyped]] | untyped)
 
+        private
+
         def constraint_args: (untyped constraint, untyped request) -> untyped
       end
 
@@ -8726,11 +8920,17 @@ module ActionDispatch
 
         def conditions: () -> untyped
 
+        private
+
         def build_conditions: (untyped current_conditions, untyped request_class) -> untyped
 
         def request_method: () -> untyped
 
+        public
+
         JOINED_SEPARATORS: untyped
+
+        private
 
         def build_path: (untyped ast, untyped requirements, untyped anchor) -> untyped
 
@@ -8987,6 +9187,8 @@ module ActionDispatch
         # Query if the following named route was already defined.
         def has_named_route?: (untyped name) -> untyped
 
+        private
+
         def rails_app?: (untyped app) -> untyped
 
         def app_name: (untyped app, untyped rails_app) -> untyped
@@ -9024,6 +9226,8 @@ module ActionDispatch
         #
         #   delete 'broccoli', to: 'food#broccoli'
         def delete: (*untyped args) { () -> untyped } -> untyped
+
+        private
 
         def map_method: (untyped method, untyped args) { () -> untyped } -> untyped
       end
@@ -9227,6 +9431,8 @@ module ActionDispatch
         #   end
         # Using this, the +:id+ parameter here will default to 'home'.
         def defaults: (?::Hash[untyped, untyped] defaults) { () -> untyped } -> untyped
+
+        private
 
         def merge_path_scope: (untyped parent, untyped child) -> untyped
 
@@ -9603,6 +9809,8 @@ module ActionDispatch
         # because this means it will be matched first. As this is the most popular route
         # of most Rails applications, this is beneficial.
         def root: (untyped path, ?::Hash[untyped, untyped] options) -> untyped
+
+        private
 
         def parent_resource: () -> untyped
 
@@ -10020,6 +10228,8 @@ module ActionDispatch
       # Returns the path component of a URL for the given record.
       def polymorphic_path: (untyped record_or_hash_or_array, ?::Hash[untyped, untyped] options) -> untyped
 
+      private
+
       def polymorphic_url_for_action: (untyped action, untyped record_or_hash, untyped options) -> untyped
 
       def polymorphic_path_for_action: (untyped action, untyped record_or_hash, untyped options) -> untyped
@@ -10064,6 +10274,8 @@ module ActionDispatch
 
         def handle_list: (untyped list) -> ::Array[untyped]
 
+        private
+
         def polymorphic_mapping: (untyped target, untyped record) -> untyped
 
         def get_method_for_class: (untyped klass) -> untyped
@@ -10095,6 +10307,8 @@ module ActionDispatch
 
       def inspect: () -> ::String
 
+      private
+
       def relative_path?: (untyped path) -> untyped
 
       def escape: (untyped params) -> untyped
@@ -10110,6 +10324,8 @@ module ActionDispatch
       def path: (untyped params, untyped request) -> untyped
 
       def inspect: () -> ::String
+
+      private
 
       def interpolation_required?: (untyped string, untyped params) -> untyped
     end
@@ -10193,6 +10409,8 @@ module ActionDispatch
 
         def serve: (untyped req) -> untyped
 
+        private
+
         def controller: (untyped req) -> untyped
 
         def dispatch: (untyped controller, untyped action, untyped req, untyped res) -> untyped
@@ -10200,6 +10418,8 @@ module ActionDispatch
 
       class StaticDispatcher < Dispatcher
         def initialize: (untyped controller_class) -> untyped
+
+        private
 
         def controller: (untyped _) -> untyped
       end
@@ -10210,7 +10430,11 @@ module ActionDispatch
       class NamedRouteCollection
         include Enumerable[untyped]
 
+        private
+
         attr_reader routes: untyped
+
+        public
 
         attr_reader url_helpers_module: untyped
 
@@ -10262,6 +10486,8 @@ module ActionDispatch
 
             def call: (untyped t, untyped args, untyped inner_options) -> untyped
 
+            private
+
             def optimized_helper: (untyped args) -> untyped
 
             def optimize_routes_generation?: (untyped t) -> untyped
@@ -10277,6 +10503,8 @@ module ActionDispatch
 
           def handle_positional_args: (untyped controller_options, untyped inner_options, untyped args, untyped result, untyped path_params) -> untyped
         end
+
+        private
 
         # Create a URL helper allowing ordered parameters to be associated
         # with corresponding dynamic segments, so you can do:
@@ -10343,7 +10571,11 @@ module ActionDispatch
 
       def request_class: () -> untyped
 
+      private
+
       def make_request: (untyped env) -> untyped
+
+      public
 
       def draw: () { () -> untyped } -> nil
 
@@ -10351,7 +10583,11 @@ module ActionDispatch
 
       def `prepend`: () { () -> untyped } -> untyped
 
+      private
+
       def eval_block: (untyped block) -> untyped
+
+      public
 
       def finalize!: () -> (nil | untyped)
 
@@ -10391,6 +10627,8 @@ module ActionDispatch
         def initialize: (untyped name, untyped defaults) { () -> untyped } -> untyped
 
         def call: (untyped t, untyped args, ?bool only_path) -> untyped
+
+        private
 
         def eval_block: (untyped t, untyped args, untyped options) -> untyped
 
@@ -10438,6 +10676,8 @@ module ActionDispatch
 
         def different_controller?: () -> (::FalseClass | untyped)
 
+        private
+
         def named_route_exists?: () -> untyped
 
         def segment_keys: () -> untyped
@@ -10449,7 +10689,11 @@ module ActionDispatch
 
       def generate_extras: (untyped options, ?::Hash[untyped, untyped] recall) -> untyped
 
+      private
+
       def generate: (untyped route_key, untyped options, ?::Hash[untyped, untyped] recall) -> untyped
+
+      public
 
       RESERVED_OPTIONS: ::Array[untyped]
 
@@ -10488,6 +10732,8 @@ module ActionDispatch
       def initialize: (untyped routes, untyped scope, untyped helpers, ?untyped? script_namer) -> untyped
 
       def url_options: () -> untyped
+
+      private
 
       def respond_to_missing?: (untyped method, untyped _) -> untyped
 
@@ -10674,6 +10920,8 @@ module ActionDispatch
       def route_for: (untyped name, *untyped args) -> untyped
 
       def optimize_routes_generation?: () -> untyped
+
+      private
 
       def _with_routes: (untyped routes) { () -> untyped } -> untyped
 
@@ -11090,6 +11338,8 @@ module ActionDispatch
       # parallel tests.
       def preload: () -> untyped
 
+      private
+
       def headless_chrome_browser_options: () -> untyped
 
       def headless_firefox_browser_options: () -> untyped
@@ -11104,6 +11354,8 @@ module ActionDispatch
       def initialize: (untyped name, **untyped options) { () -> untyped } -> untyped
 
       def use: () -> untyped
+
+      private
 
       def registerable?: () -> untyped
 
@@ -11130,6 +11382,8 @@ module ActionDispatch
       attr_accessor silence_puma: untyped
 
       def run: () -> untyped
+
+      private
 
       def setup: () -> untyped
 
@@ -11171,6 +11425,8 @@ module ActionDispatch
         # fails add +take_failed_screenshot+ to the teardown block before clearing
         # sessions.
         def take_failed_screenshot: () -> untyped
+
+        private
 
         def image_name: () -> untyped
 
@@ -11231,6 +11487,8 @@ module ActionDispatch
 
     def code_and_name: () -> ::String
 
+    private
+
     def code_from_name: (untyped name) -> untyped
 
     def name_from_code: (untyped code) -> untyped
@@ -11277,6 +11535,8 @@ module ActionDispatch
       #   # Asserts that the redirection matches the regular expression
       #   assert_redirected_to %r(\Ahttp://example.org)
       def assert_redirected_to: (?::Hash[untyped, untyped] options, ?untyped? message) -> (::TrueClass | untyped)
+
+      private
 
       # Proxy to to_param if the object will respond to it.
       def parameterize: (untyped value) -> untyped
@@ -11391,6 +11651,8 @@ module ActionDispatch
 
       # ROUTES TODO: These assertions should really work in an integration context
       def method_missing: (untyped selector, *untyped args) { () -> untyped } -> untyped
+
+      private
 
       # Recognizes the route for a given path.
       def recognized_request_for: (untyped path, ?::Hash[untyped, untyped] extras, untyped msg) -> untyped
@@ -11562,6 +11824,8 @@ module ActionDispatch
       #   session.host! "www.example.com"
       alias host! host=
 
+      private
+
       def _mock_session: () -> untyped
 
       def build_full_uri: (untyped path, untyped env) -> ::String
@@ -11613,6 +11877,8 @@ module ActionDispatch
       def default_url_options: () -> untyped
 
       def default_url_options=: (untyped options) -> untyped
+
+      private
 
       def respond_to_missing?: (untyped method, untyped _) -> untyped
 

--- a/gems/actionpack/6.0.3.2/patch.rbs
+++ b/gems/actionpack/6.0.3.2/patch.rbs
@@ -1,0 +1,73 @@
+module AbstractController
+  class Base
+    # alias bug: https://github.com/ruby/rbs/issues/458
+    def send: (String | Symbol name, *untyped args) ?{ (*untyped) -> untyped } -> untyped
+
+    # bug: rbs prototype rb isn't aware of `class << self` for attr_reader
+    # https://github.com/rails/rails/blob/fbe2433be6e052a1acac63c7faf287c52ed3c5ba/actionpack/lib/abstract_controller/base.rb#L34-L35
+    def self.abstract: () -> untyped
+  end
+end
+
+module ActionController
+  class Metal
+    # alias bug?: https://github.com/ruby/rbs/issues/458
+    def status: -> untyped
+  end
+
+  class LiveTestResponse < Live::Response
+    # alias bug?: https://github.com/ruby/rbs/issues/458
+    def successful?: -> untyped
+    def not_found?: -> untyped
+    def server_error?: -> untyped
+  end
+end
+
+module ActionDispatch
+  class Response
+    # alias bug: https://github.com/ruby/rbs/issues/458
+    attr_accessor cache_control: untyped
+
+    # alias bug: https://github.com/ruby/rbs/issues/458
+    def location: () -> untyped
+  end
+
+  class Cookies
+    class CookieJar
+      # alias bug: https://github.com/ruby/rbs/issues/458
+      def to_h: () -> ::Hash[untyped, untyped]
+              | [T, U] () { (untyped) -> [T, U] } -> ::Hash[T, U]
+    end
+  end
+
+  module Journey
+    module Nodes
+      class Terminal < Node
+        # alias bug: https://github.com/ruby/rbs/issues/458
+        def left: () -> untyped
+      end
+    end
+  end
+
+  module Routing
+    class Mapper
+      module Resources
+        class SingletonResource < Resource
+          # alias bug: https://github.com/ruby/rbs/issues/458
+          attr_reader path: untyped
+        end
+      end
+    end
+
+    class OptionRedirect < Redirect
+      # alias bug: https://github.com/ruby/rbs/issues/458
+      attr_reader block: untyped
+    end
+
+    class RouteSet
+      # alias bug: https://github.com/ruby/rbs/issues/458
+      def to_s: () -> String
+    end
+  end
+end
+

--- a/gems/actionview/6.0.3.2/actionview-generated.rbs
+++ b/gems/actionview/6.0.3.2/actionview-generated.rbs
@@ -173,6 +173,10 @@ module ActionView
 
     attr_reader lookup_context: untyped
 
+    attr_accessor config(@_config): untyped
+
+    attr_accessor assigns(@_assigns): untyped
+
     def assign: (untyped new_assigns) -> untyped
 
     def self.build_lookup_context: (untyped context) -> untyped
@@ -1737,6 +1741,18 @@ end
 module ActionView
   module Helpers
     module ControllerHelper
+      # nodoc:
+      # This module keeps all methods and behavior in ActionView
+      # that simply delegates to the controller.
+      # nodoc:
+      attr_accessor controller(@_controller): untyped
+
+      # nodoc:
+      # This module keeps all methods and behavior in ActionView
+      # that simply delegates to the controller.
+      # nodoc:
+      attr_accessor request(@_request): untyped
+
       CONTROLLER_DELEGATES: ::Array[untyped]
 
       def assign_controller: (untyped controller) -> untyped
@@ -2716,6 +2732,8 @@ module ActionView
       include ModelNaming
 
       include RecordIdentifier
+
+      attr_accessor default_form_builder(@_default_form_builder): untyped
 
       # Creates a form that allows the user to create or update the attributes
       # of a specific model object.
@@ -8829,6 +8847,8 @@ module ActionView
     end
 
     def _normalize_options: (untyped options) -> untyped
+
+    attr_writer action_has_layout(@_action_has_layout): untyped
 
     def initialize: () -> untyped
 

--- a/gems/actionview/6.0.3.2/actionview-generated.rbs
+++ b/gems/actionview/6.0.3.2/actionview-generated.rbs
@@ -1,3 +1,27 @@
+# The generated code is based on Ruby on Rails source code
+# You can find the license of Ruby on Rails from following.
+
+#Copyright (c) 2005-2019 David Heinemeier Hansson
+#
+#Permission is hereby granted, free of charge, to any person obtaining
+#a copy of this software and associated documentation files (the
+#"Software"), to deal in the Software without restriction, including
+#without limitation the rights to use, copy, modify, merge, publish,
+#distribute, sublicense, and/or sell copies of the Software, and to
+#permit persons to whom the Software is furnished to do so, subject to
+#the following conditions:
+#
+#The above copyright notice and this permission notice shall be
+#included in all copies or substantial portions of the Software.
+#
+#THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+#EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+#MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+#LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+#OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+#WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 module ActionView
   # nodoc:
   # = Action View Base

--- a/gems/actionview/6.0.3.2/actionview-generated.rbs
+++ b/gems/actionview/6.0.3.2/actionview-generated.rbs
@@ -1,0 +1,10572 @@
+module ActionView
+  # nodoc:
+  # = Action View Base
+  #
+  # Action View templates can be written in several ways.
+  # If the template file has a <tt>.erb</tt> extension, then it uses the erubi[https://rubygems.org/gems/erubi]
+  # template system which can embed Ruby into an HTML document.
+  # If the template file has a <tt>.builder</tt> extension, then Jim Weirich's Builder::XmlMarkup library is used.
+  #
+  # == ERB
+  #
+  # You trigger ERB by using embeddings such as <tt><% %></tt>, <tt><% -%></tt>, and <tt><%= %></tt>. The <tt><%= %></tt> tag set is used when you want output. Consider the
+  # following loop for names:
+  #
+  #   <b>Names of all the people</b>
+  #   <% @people.each do |person| %>
+  #     Name: <%= person.name %><br/>
+  #   <% end %>
+  #
+  # The loop is setup in regular embedding tags <tt><% %></tt>, and the name is written using the output embedding tag <tt><%= %></tt>. Note that this
+  # is not just a usage suggestion. Regular output functions like print or puts won't work with ERB templates. So this would be wrong:
+  #
+  #   <%# WRONG %>
+  #   Hi, Mr. <% puts "Frodo" %>
+  #
+  # If you absolutely must write from within a function use +concat+.
+  #
+  # When on a line that only contains whitespaces except for the tag, <tt><% %></tt> suppresses leading and trailing whitespace,
+  # including the trailing newline. <tt><% %></tt> and <tt><%- -%></tt> are the same.
+  # Note however that <tt><%= %></tt> and <tt><%= -%></tt> are different: only the latter removes trailing whitespaces.
+  #
+  # === Using sub templates
+  #
+  # Using sub templates allows you to sidestep tedious replication and extract common display structures in shared templates. The
+  # classic example is the use of a header and footer (even though the Action Pack-way would be to use Layouts):
+  #
+  #   <%= render "shared/header" %>
+  #   Something really specific and terrific
+  #   <%= render "shared/footer" %>
+  #
+  # As you see, we use the output embeddings for the render methods. The render call itself will just return a string holding the
+  # result of the rendering. The output embedding writes it to the current template.
+  #
+  # But you don't have to restrict yourself to static includes. Templates can share variables amongst themselves by using instance
+  # variables defined using the regular embedding tags. Like this:
+  #
+  #   <% @page_title = "A Wonderful Hello" %>
+  #   <%= render "shared/header" %>
+  #
+  # Now the header can pick up on the <tt>@page_title</tt> variable and use it for outputting a title tag:
+  #
+  #   <title><%= @page_title %></title>
+  #
+  # === Passing local variables to sub templates
+  #
+  # You can pass local variables to sub templates by using a hash with the variable names as keys and the objects as values:
+  #
+  #   <%= render "shared/header", { headline: "Welcome", person: person } %>
+  #
+  # These can now be accessed in <tt>shared/header</tt> with:
+  #
+  #   Headline: <%= headline %>
+  #   First name: <%= person.first_name %>
+  #
+  # The local variables passed to sub templates can be accessed as a hash using the <tt>local_assigns</tt> hash. This lets you access the
+  # variables as:
+  #
+  #   Headline: <%= local_assigns[:headline] %>
+  #
+  # This is useful in cases where you aren't sure if the local variable has been assigned. Alternatively, you could also use
+  # <tt>defined? headline</tt> to first check if the variable has been assigned before using it.
+  #
+  # === Template caching
+  #
+  # By default, Rails will compile each template to a method in order to render it. When you alter a template,
+  # Rails will check the file's modification time and recompile it in development mode.
+  #
+  # == Builder
+  #
+  # Builder templates are a more programmatic alternative to ERB. They are especially useful for generating XML content. An XmlMarkup object
+  # named +xml+ is automatically made available to templates with a <tt>.builder</tt> extension.
+  #
+  # Here are some basic examples:
+  #
+  #   xml.em("emphasized")                                 # => <em>emphasized</em>
+  #   xml.em { xml.b("emph & bold") }                      # => <em><b>emph &amp; bold</b></em>
+  #   xml.a("A Link", "href" => "http://onestepback.org")  # => <a href="http://onestepback.org">A Link</a>
+  #   xml.target("name" => "compile", "option" => "fast")  # => <target option="fast" name="compile"\>
+  #                                                        # NOTE: order of attributes is not specified.
+  #
+  # Any method with a block will be treated as an XML markup tag with nested markup in the block. For example, the following:
+  #
+  #   xml.div do
+  #     xml.h1(@person.name)
+  #     xml.p(@person.bio)
+  #   end
+  #
+  # would produce something like:
+  #
+  #   <div>
+  #     <h1>David Heinemeier Hansson</h1>
+  #     <p>A product of Danish Design during the Winter of '79...</p>
+  #   </div>
+  #
+  # Here is a full-length RSS example actually used on Basecamp:
+  #
+  #   xml.rss("version" => "2.0", "xmlns:dc" => "http://purl.org/dc/elements/1.1/") do
+  #     xml.channel do
+  #       xml.title(@feed_title)
+  #       xml.link(@url)
+  #       xml.description "Basecamp: Recent items"
+  #       xml.language "en-us"
+  #       xml.ttl "40"
+  #
+  #       @recent_items.each do |item|
+  #         xml.item do
+  #           xml.title(item_title(item))
+  #           xml.description(item_description(item)) if item_description(item)
+  #           xml.pubDate(item_pubDate(item))
+  #           xml.guid(@person.firm.account.url + @recent_items.url(item))
+  #           xml.link(@person.firm.account.url + @recent_items.url(item))
+  #
+  #           xml.tag!("dc:creator", item.author_name) if item_has_creator?(item)
+  #         end
+  #       end
+  #     end
+  #   end
+  #
+  # For more information on Builder please consult the {source
+  # code}[https://github.com/jimweirich/builder].
+  class Base
+    include Helpers
+
+    include ::ERB::Util
+
+    include Context
+
+    def self.cache_template_loading: () -> untyped
+
+    def self.cache_template_loading=: (untyped value) -> untyped
+
+    def self.xss_safe?: () -> ::TrueClass
+
+    def self.with_empty_template_cache: () -> untyped
+
+    def self.changed?: (untyped other) -> untyped
+
+    attr_reader view_renderer: untyped
+
+    attr_reader lookup_context: untyped
+
+    def assign: (untyped new_assigns) -> untyped
+
+    def self.build_lookup_context: (untyped context) -> untyped
+
+    def self.empty: () -> untyped
+
+    def self.with_view_paths: (untyped view_paths, ?::Hash[untyped, untyped] assigns, ?untyped? controller) -> untyped
+
+    def self.with_context: (untyped context, ?::Hash[untyped, untyped] assigns, ?untyped? controller) -> untyped
+
+    NULL: untyped
+
+    def initialize: (?untyped? lookup_context, ?::Hash[untyped, untyped] assigns, ?untyped? controller, ?untyped formats) -> untyped
+
+    def _run: (untyped method, untyped template, untyped locals, untyped buffer) { () -> untyped } -> untyped
+
+    def compiled_method_container: () -> untyped
+
+    def in_rendering_context: (untyped options) { (untyped) -> untyped } -> untyped
+  end
+end
+
+module ActionView
+  class OutputBuffer < ActiveSupport::SafeBuffer
+    # Used as a buffer for views
+    #
+    # The main difference between this and ActiveSupport::SafeBuffer
+    # is for the methods `<<` and `safe_expr_append=` the inputs are
+    # checked for nil before they are assigned and `to_s` is called on
+    # the input. For example:
+    #
+    #   obuf = ActionView::OutputBuffer.new "hello"
+    #   obuf << 5
+    #   puts obuf # => "hello5"
+    #
+    #   sbuf = ActiveSupport::SafeBuffer.new "hello"
+    #   sbuf << 5
+    #   puts sbuf # => "hello\u0005"
+    #
+    # nodoc:
+    def initialize: () -> untyped
+
+    def <<: (untyped value) -> untyped
+
+    alias append= <<
+
+    def safe_expr_append=: (untyped val) -> untyped
+
+    alias safe_append= safe_concat
+  end
+
+  class StreamingBuffer
+    # nodoc:
+    def initialize: (untyped block) -> untyped
+
+    def <<: (untyped value) -> untyped
+
+    alias concat <<
+
+    alias append= <<
+
+    def safe_concat: (untyped value) -> untyped
+
+    alias safe_append= safe_concat
+
+    def html_safe?: () -> ::TrueClass
+
+    def html_safe: () -> untyped
+  end
+end
+
+module ActionView
+  class CacheExpiry
+    class Executor
+      def initialize: (watcher: untyped watcher) -> untyped
+
+      def before: (untyped target) -> untyped
+    end
+
+    def initialize: (watcher: untyped watcher) -> untyped
+
+    def clear_cache_if_necessary: () -> untyped
+
+    def clear_cache: () -> untyped
+
+    def dirs_to_watch: () -> untyped
+
+    def all_view_paths: () -> untyped
+  end
+end
+
+module ActionView
+  # = Action View Context
+  #
+  # Action View contexts are supplied to Action Controller to render a template.
+  # The default Action View context is ActionView::Base.
+  #
+  # In order to work with Action Controller, a Context must just include this
+  # module. The initialization of the variables used by the context
+  # (@output_buffer, @view_flow, and @virtual_path) is responsibility of the
+  # object that includes this module (although you can call _prepare_context
+  # defined below).
+  module Context
+    attr_accessor output_buffer: untyped
+
+    attr_accessor view_flow: untyped
+
+    # Prepares the context by setting the appropriate instance variables.
+    def _prepare_context: () -> untyped
+
+    # Encapsulates the interaction with the view flow so it
+    # returns the correct buffer on +yield+. This is usually
+    # overwritten by helpers to add more behavior.
+    def _layout_for: (?untyped? name) -> untyped
+  end
+end
+
+module ActionView
+  class DependencyTracker
+    def self.find_dependencies: (untyped name, untyped template, ?untyped? view_paths) -> (::Array[untyped] | untyped)
+
+    def self.register_tracker: (untyped `extension`, untyped tracker) -> untyped
+
+    def self.remove_tracker: (untyped handler) -> untyped
+
+    class ERBTracker
+      # :nodoc:
+      EXPLICIT_DEPENDENCY: untyped
+
+      # A valid ruby identifier - suitable for class, method and specially variable names
+      IDENTIFIER: untyped
+
+      # Any kind of variable name. e.g. @instance, @@class, $global or local.
+      # Possibly following a method call chain
+      VARIABLE_OR_METHOD_CHAIN: untyped
+
+      # A simple string literal. e.g. "School's out!"
+      STRING: untyped
+
+      # Part of any hash containing the :partial key
+      PARTIAL_HASH_KEY: untyped
+
+      # Part of any hash containing the :layout key
+      LAYOUT_HASH_KEY: untyped
+
+      # Matches:
+      #   partial: "comments/comment", collection: @all_comments => "comments/comment"
+      #   (object: @single_comment, partial: "comments/comment") => "comments/comment"
+      #
+      #   "comments/comments"
+      #   'comments/comments'
+      #   ('comments/comments')
+      #
+      #   (@topic)         => "topics/topic"
+      #    topics          => "topics/topic"
+      #   (message.topics) => "topics/topic"
+      RENDER_ARGUMENTS: untyped
+
+      LAYOUT_DEPENDENCY: untyped
+
+      def self.supports_view_paths?: () -> ::TrueClass
+
+      def self.call: (untyped name, untyped template, ?untyped? view_paths) -> untyped
+
+      def initialize: (untyped name, untyped template, ?untyped? view_paths) -> untyped
+
+      def dependencies: () -> untyped
+
+      attr_reader name: untyped
+
+      attr_reader template: untyped
+
+      def source: () -> untyped
+
+      def directory: () -> untyped
+
+      def render_dependencies: () -> untyped
+
+      def add_dependencies: (untyped render_dependencies, untyped arguments, untyped pattern) -> untyped
+
+      def add_dynamic_dependency: (untyped dependencies, untyped dependency) -> untyped
+
+      def add_static_dependency: (untyped dependencies, untyped dependency) -> untyped
+
+      def resolve_directories: (untyped wildcard_dependencies) -> (::Array[untyped] | untyped)
+
+      def explicit_dependencies: () -> untyped
+    end
+  end
+end
+
+module ActionView
+  class Digestor
+    # Supported options:
+    #
+    # * <tt>name</tt>         - Template name
+    # * <tt>format</tt>       - Template format
+    # * <tt>finder</tt>       - An instance of <tt>ActionView::LookupContext</tt>
+    # * <tt>dependencies</tt> - An array of dependent views
+    def self.digest: (finder: untyped finder, name: untyped name, ?dependencies: untyped? dependencies, ?format: untyped? format) -> untyped
+
+    def self.logger: () -> untyped
+
+    # Create a dependency tree for template named +name+.
+    def self.tree: (untyped name, untyped finder, ?bool partial, ?::Hash[untyped, untyped] seen) -> untyped
+
+    def self.find_template: (untyped finder, untyped name, untyped prefixes, untyped partial, untyped keys) -> untyped
+
+    class Node
+      attr_reader name: untyped
+
+      attr_reader logical_name: untyped
+
+      attr_reader template: untyped
+
+      attr_reader children: untyped
+
+      def self.create: (untyped name, untyped logical_name, untyped template, untyped partial) -> untyped
+
+      def initialize: (untyped name, untyped logical_name, untyped template, ?untyped children) -> untyped
+
+      def digest: (untyped finder, ?untyped stack) -> untyped
+
+      def dependency_digest: (untyped finder, untyped stack) -> untyped
+
+      def to_dep_map: () -> untyped
+    end
+
+    class Partial < Node
+    end
+
+    class Missing < Node
+      def digest: (untyped finder, ?untyped _) -> ::String
+    end
+
+    class Injected < Node
+      def digest: (untyped finder, ?untyped _) -> untyped
+    end
+
+    class NullLogger
+      def self.debug: (untyped _) -> nil
+
+      def self.error: (untyped _) -> nil
+    end
+  end
+end
+
+module ActionView
+  class OutputFlow
+    # nodoc:
+    attr_reader content: untyped
+
+    def initialize: () -> untyped
+
+    # Called by _layout_for to read stored values.
+    def get: (untyped key) -> untyped
+
+    # Called by each renderer object to set the layout contents.
+    def set: (untyped key, untyped value) -> untyped
+
+    # Called by content_for
+    def append: (untyped key, untyped value) -> untyped
+
+    alias append! append
+  end
+
+  class StreamingFlow < OutputFlow
+    # nodoc:
+    def initialize: (untyped view, untyped fiber) -> untyped
+
+    # Try to get stored content. If the content
+    # is not available and we're inside the layout fiber,
+    # then it will begin waiting for the given key and yield.
+    def get: (untyped key) -> untyped
+
+    # Appends the contents for the given key. This is called
+    # by providing and resuming back to the fiber,
+    # if that's the key it's waiting for.
+    def append!: (untyped key, untyped value) -> untyped
+
+    def inside_fiber?: () -> untyped
+  end
+end
+
+module ActionView
+  # Returns the version of the currently loaded Action View as a <tt>Gem::Version</tt>
+  def self.gem_version: () -> Gem::Version
+
+  module VERSION
+    MAJOR: ::Integer
+
+    MINOR: ::Integer
+
+    TINY: ::Integer
+
+    PRE: ::String
+
+    STRING: untyped
+  end
+end
+
+module ActionView
+  module Helpers
+    # = Active Model Helpers
+    # nodoc:
+    module ActiveModelHelper
+    end
+
+    module ActiveModelInstanceTag
+      def object: () -> untyped
+
+      def content_tag: (untyped `type`, untyped options) -> untyped
+
+      def tag: (untyped `type`, untyped options) -> untyped
+
+      def error_wrapping: (untyped html_tag) -> untyped
+
+      def error_message: () -> untyped
+
+      def object_has_errors?: () -> untyped
+
+      def select_markup_helper?: (untyped `type`) -> untyped
+
+      def tag_generate_errors?: (untyped options) -> untyped
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    # = Action View Asset Tag Helpers
+    # nodoc:
+    # This module provides methods for generating HTML that links views to assets such
+    # as images, JavaScripts, stylesheets, and feeds. These methods do not verify
+    # the assets exist before linking to them:
+    #
+    #   image_tag("rails.png")
+    #   # => <img src="/assets/rails.png" />
+    #   stylesheet_link_tag("application")
+    #   # => <link href="/assets/application.css?body=1" media="screen" rel="stylesheet" />
+    module AssetTagHelper
+      extend ActiveSupport::Concern
+
+      include AssetUrlHelper
+
+      include TagHelper
+
+      # Returns an HTML script tag for each of the +sources+ provided.
+      #
+      # Sources may be paths to JavaScript files. Relative paths are assumed to be relative
+      # to <tt>assets/javascripts</tt>, full paths are assumed to be relative to the document
+      # root. Relative paths are idiomatic, use absolute paths only when needed.
+      #
+      # When passing paths, the ".js" extension is optional.  If you do not want ".js"
+      # appended to the path <tt>extname: false</tt> can be set on the options.
+      #
+      # You can modify the HTML attributes of the script tag by passing a hash as the
+      # last argument.
+      #
+      # When the Asset Pipeline is enabled, you can pass the name of your manifest as
+      # source, and include other JavaScript or CoffeeScript files inside the manifest.
+      #
+      # If the server supports Early Hints header links for these assets will be
+      # automatically pushed.
+      #
+      # ==== Options
+      #
+      # When the last parameter is a hash you can add HTML attributes using that
+      # parameter. The following options are supported:
+      #
+      # * <tt>:extname</tt>  - Append an extension to the generated URL unless the extension
+      #   already exists. This only applies for relative URLs.
+      # * <tt>:protocol</tt>  - Sets the protocol of the generated URL. This option only
+      #   applies when a relative URL and +host+ options are provided.
+      # * <tt>:host</tt>  - When a relative URL is provided the host is added to the
+      #   that path.
+      # * <tt>:skip_pipeline</tt>  - This option is used to bypass the asset pipeline
+      #   when it is set to true.
+      # * <tt>:nonce</tt>  - When set to true, adds an automatic nonce value if
+      #   you have Content Security Policy enabled.
+      #
+      # ==== Examples
+      #
+      #   javascript_include_tag "xmlhr"
+      #   # => <script src="/assets/xmlhr.debug-1284139606.js"></script>
+      #
+      #   javascript_include_tag "xmlhr", host: "localhost", protocol: "https"
+      #   # => <script src="https://localhost/assets/xmlhr.debug-1284139606.js"></script>
+      #
+      #   javascript_include_tag "template.jst", extname: false
+      #   # => <script src="/assets/template.debug-1284139606.jst"></script>
+      #
+      #   javascript_include_tag "xmlhr.js"
+      #   # => <script src="/assets/xmlhr.debug-1284139606.js"></script>
+      #
+      #   javascript_include_tag "common.javascript", "/elsewhere/cools"
+      #   # => <script src="/assets/common.javascript.debug-1284139606.js"></script>
+      #   #    <script src="/elsewhere/cools.debug-1284139606.js"></script>
+      #
+      #   javascript_include_tag "http://www.example.com/xmlhr"
+      #   # => <script src="http://www.example.com/xmlhr"></script>
+      #
+      #   javascript_include_tag "http://www.example.com/xmlhr.js"
+      #   # => <script src="http://www.example.com/xmlhr.js"></script>
+      #
+      #   javascript_include_tag "http://www.example.com/xmlhr.js", nonce: true
+      #   # => <script src="http://www.example.com/xmlhr.js" nonce="..."></script>
+      def javascript_include_tag: (*untyped sources) -> untyped
+
+      # Returns a stylesheet link tag for the sources specified as arguments. If
+      # you don't specify an extension, <tt>.css</tt> will be appended automatically.
+      # You can modify the link attributes by passing a hash as the last argument.
+      # For historical reasons, the 'media' attribute will always be present and defaults
+      # to "screen", so you must explicitly set it to "all" for the stylesheet(s) to
+      # apply to all media types.
+      #
+      # If the server supports Early Hints header links for these assets will be
+      # automatically pushed.
+      #
+      #   stylesheet_link_tag "style"
+      #   # => <link href="/assets/style.css" media="screen" rel="stylesheet" />
+      #
+      #   stylesheet_link_tag "style.css"
+      #   # => <link href="/assets/style.css" media="screen" rel="stylesheet" />
+      #
+      #   stylesheet_link_tag "http://www.example.com/style.css"
+      #   # => <link href="http://www.example.com/style.css" media="screen" rel="stylesheet" />
+      #
+      #   stylesheet_link_tag "style", media: "all"
+      #   # => <link href="/assets/style.css" media="all" rel="stylesheet" />
+      #
+      #   stylesheet_link_tag "style", media: "print"
+      #   # => <link href="/assets/style.css" media="print" rel="stylesheet" />
+      #
+      #   stylesheet_link_tag "random.styles", "/css/stylish"
+      #   # => <link href="/assets/random.styles" media="screen" rel="stylesheet" />
+      #   #    <link href="/css/stylish.css" media="screen" rel="stylesheet" />
+      def stylesheet_link_tag: (*untyped sources) -> untyped
+
+      # Returns a link tag that browsers and feed readers can use to auto-detect
+      # an RSS, Atom, or JSON feed. The +type+ can be <tt>:rss</tt> (default),
+      # <tt>:atom</tt>, or <tt>:json</tt>. Control the link options in url_for format
+      # using the +url_options+. You can modify the LINK tag itself in +tag_options+.
+      #
+      # ==== Options
+      #
+      # * <tt>:rel</tt>  - Specify the relation of this link, defaults to "alternate"
+      # * <tt>:type</tt>  - Override the auto-generated mime type
+      # * <tt>:title</tt>  - Specify the title of the link, defaults to the +type+
+      #
+      # ==== Examples
+      #
+      #   auto_discovery_link_tag
+      #   # => <link rel="alternate" type="application/rss+xml" title="RSS" href="http://www.currenthost.com/controller/action" />
+      #   auto_discovery_link_tag(:atom)
+      #   # => <link rel="alternate" type="application/atom+xml" title="ATOM" href="http://www.currenthost.com/controller/action" />
+      #   auto_discovery_link_tag(:json)
+      #   # => <link rel="alternate" type="application/json" title="JSON" href="http://www.currenthost.com/controller/action" />
+      #   auto_discovery_link_tag(:rss, {action: "feed"})
+      #   # => <link rel="alternate" type="application/rss+xml" title="RSS" href="http://www.currenthost.com/controller/feed" />
+      #   auto_discovery_link_tag(:rss, {action: "feed"}, {title: "My RSS"})
+      #   # => <link rel="alternate" type="application/rss+xml" title="My RSS" href="http://www.currenthost.com/controller/feed" />
+      #   auto_discovery_link_tag(:rss, {controller: "news", action: "feed"})
+      #   # => <link rel="alternate" type="application/rss+xml" title="RSS" href="http://www.currenthost.com/news/feed" />
+      #   auto_discovery_link_tag(:rss, "http://www.example.com/feed.rss", {title: "Example RSS"})
+      #   # => <link rel="alternate" type="application/rss+xml" title="Example RSS" href="http://www.example.com/feed.rss" />
+      def auto_discovery_link_tag: (?::Symbol `type`, ?::Hash[untyped, untyped] url_options, ?::Hash[untyped, untyped] tag_options) -> untyped
+
+      # Returns a link tag for a favicon managed by the asset pipeline.
+      #
+      # If a page has no link like the one generated by this helper, browsers
+      # ask for <tt>/favicon.ico</tt> automatically, and cache the file if the
+      # request succeeds. If the favicon changes it is hard to get it updated.
+      #
+      # To have better control applications may let the asset pipeline manage
+      # their favicon storing the file under <tt>app/assets/images</tt>, and
+      # using this helper to generate its corresponding link tag.
+      #
+      # The helper gets the name of the favicon file as first argument, which
+      # defaults to "favicon.ico", and also supports +:rel+ and +:type+ options
+      # to override their defaults, "shortcut icon" and "image/x-icon"
+      # respectively:
+      #
+      #   favicon_link_tag
+      #   # => <link href="/assets/favicon.ico" rel="shortcut icon" type="image/x-icon" />
+      #
+      #   favicon_link_tag 'myicon.ico'
+      #   # => <link href="/assets/myicon.ico" rel="shortcut icon" type="image/x-icon" />
+      #
+      # Mobile Safari looks for a different link tag, pointing to an image that
+      # will be used if you add the page to the home screen of an iOS device.
+      # The following call would generate such a tag:
+      #
+      #   favicon_link_tag 'mb-icon.png', rel: 'apple-touch-icon', type: 'image/png'
+      #   # => <link href="/assets/mb-icon.png" rel="apple-touch-icon" type="image/png" />
+      def favicon_link_tag: (?::String source, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Returns a link tag that browsers can use to preload the +source+.
+      # The +source+ can be the path of a resource managed by asset pipeline,
+      # a full path, or an URI.
+      #
+      # ==== Options
+      #
+      # * <tt>:type</tt>  - Override the auto-generated mime type, defaults to the mime type for +source+ extension.
+      # * <tt>:as</tt>  - Override the auto-generated value for as attribute, calculated using +source+ extension and mime type.
+      # * <tt>:crossorigin</tt>  - Specify the crossorigin attribute, required to load cross-origin resources.
+      # * <tt>:nopush</tt>  - Specify if the use of server push is not desired for the resource. Defaults to +false+.
+      #
+      # ==== Examples
+      #
+      #   preload_link_tag("custom_theme.css")
+      #   # => <link rel="preload" href="/assets/custom_theme.css" as="style" type="text/css" />
+      #
+      #   preload_link_tag("/videos/video.webm")
+      #   # => <link rel="preload" href="/videos/video.mp4" as="video" type="video/webm" />
+      #
+      #   preload_link_tag(post_path(format: :json), as: "fetch")
+      #   # => <link rel="preload" href="/posts.json" as="fetch" type="application/json" />
+      #
+      #   preload_link_tag("worker.js", as: "worker")
+      #   # => <link rel="preload" href="/assets/worker.js" as="worker" type="text/javascript" />
+      #
+      #   preload_link_tag("//example.com/font.woff2")
+      #   # => <link rel="preload" href="//example.com/font.woff2" as="font" type="font/woff2" crossorigin="anonymous"/>
+      #
+      #   preload_link_tag("//example.com/font.woff2", crossorigin: "use-credentials")
+      #   # => <link rel="preload" href="//example.com/font.woff2" as="font" type="font/woff2" crossorigin="use-credentials" />
+      #
+      #   preload_link_tag("/media/audio.ogg", nopush: true)
+      #   # => <link rel="preload" href="/media/audio.ogg" as="audio" type="audio/ogg" />
+      #
+      def preload_link_tag: (untyped source, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Returns an HTML image tag for the +source+. The +source+ can be a full
+      # path, a file, or an Active Storage attachment.
+      #
+      # ==== Options
+      #
+      # You can add HTML attributes using the +options+. The +options+ supports
+      # additional keys for convenience and conformance:
+      #
+      # * <tt>:size</tt> - Supplied as "{Width}x{Height}" or "{Number}", so "30x45" becomes
+      #   width="30" and height="45", and "50" becomes width="50" and height="50".
+      #   <tt>:size</tt> will be ignored if the value is not in the correct format.
+      # * <tt>:srcset</tt> - If supplied as a hash or array of <tt>[source, descriptor]</tt>
+      #   pairs, each image path will be expanded before the list is formatted as a string.
+      #
+      # ==== Examples
+      #
+      # Assets (images that are part of your app):
+      #
+      #   image_tag("icon")
+      #   # => <img src="/assets/icon" />
+      #   image_tag("icon.png")
+      #   # => <img src="/assets/icon.png" />
+      #   image_tag("icon.png", size: "16x10", alt: "Edit Entry")
+      #   # => <img src="/assets/icon.png" width="16" height="10" alt="Edit Entry" />
+      #   image_tag("/icons/icon.gif", size: "16")
+      #   # => <img src="/icons/icon.gif" width="16" height="16" />
+      #   image_tag("/icons/icon.gif", height: '32', width: '32')
+      #   # => <img height="32" src="/icons/icon.gif" width="32" />
+      #   image_tag("/icons/icon.gif", class: "menu_icon")
+      #   # => <img class="menu_icon" src="/icons/icon.gif" />
+      #   image_tag("/icons/icon.gif", data: { title: 'Rails Application' })
+      #   # => <img data-title="Rails Application" src="/icons/icon.gif" />
+      #   image_tag("icon.png", srcset: { "icon_2x.png" => "2x", "icon_4x.png" => "4x" })
+      #   # => <img src="/assets/icon.png" srcset="/assets/icon_2x.png 2x, /assets/icon_4x.png 4x">
+      #   image_tag("pic.jpg", srcset: [["pic_1024.jpg", "1024w"], ["pic_1980.jpg", "1980w"]], sizes: "100vw")
+      #   # => <img src="/assets/pic.jpg" srcset="/assets/pic_1024.jpg 1024w, /assets/pic_1980.jpg 1980w" sizes="100vw">
+      #
+      # Active Storage blobs (images that are uploaded by the users of your app):
+      #
+      #   image_tag(user.avatar)
+      #   # => <img src="/rails/active_storage/blobs/.../tiger.jpg" />
+      #   image_tag(user.avatar.variant(resize_to_limit: [100, 100]))
+      #   # => <img src="/rails/active_storage/representations/.../tiger.jpg" />
+      #   image_tag(user.avatar.variant(resize_to_limit: [100, 100]), size: '100')
+      #   # => <img width="100" height="100" src="/rails/active_storage/representations/.../tiger.jpg" />
+      def image_tag: (untyped source, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Returns an HTML video tag for the +sources+. If +sources+ is a string,
+      # a single video tag will be returned. If +sources+ is an array, a video
+      # tag with nested source tags for each source will be returned. The
+      # +sources+ can be full paths or files that exist in your public videos
+      # directory.
+      #
+      # ==== Options
+      #
+      # When the last parameter is a hash you can add HTML attributes using that
+      # parameter. The following options are supported:
+      #
+      # * <tt>:poster</tt> - Set an image (like a screenshot) to be shown
+      #   before the video loads. The path is calculated like the +src+ of +image_tag+.
+      # * <tt>:size</tt> - Supplied as "{Width}x{Height}" or "{Number}", so "30x45" becomes
+      #   width="30" and height="45", and "50" becomes width="50" and height="50".
+      #   <tt>:size</tt> will be ignored if the value is not in the correct format.
+      # * <tt>:poster_skip_pipeline</tt> will bypass the asset pipeline when using
+      #   the <tt>:poster</tt> option instead using an asset in the public folder.
+      #
+      # ==== Examples
+      #
+      #   video_tag("trailer")
+      #   # => <video src="/videos/trailer"></video>
+      #   video_tag("trailer.ogg")
+      #   # => <video src="/videos/trailer.ogg"></video>
+      #   video_tag("trailer.ogg", controls: true, preload: 'none')
+      #   # => <video preload="none" controls="controls" src="/videos/trailer.ogg"></video>
+      #   video_tag("trailer.m4v", size: "16x10", poster: "screenshot.png")
+      #   # => <video src="/videos/trailer.m4v" width="16" height="10" poster="/assets/screenshot.png"></video>
+      #   video_tag("trailer.m4v", size: "16x10", poster: "screenshot.png", poster_skip_pipeline: true)
+      #   # => <video src="/videos/trailer.m4v" width="16" height="10" poster="screenshot.png"></video>
+      #   video_tag("/trailers/hd.avi", size: "16x16")
+      #   # => <video src="/trailers/hd.avi" width="16" height="16"></video>
+      #   video_tag("/trailers/hd.avi", size: "16")
+      #   # => <video height="16" src="/trailers/hd.avi" width="16"></video>
+      #   video_tag("/trailers/hd.avi", height: '32', width: '32')
+      #   # => <video height="32" src="/trailers/hd.avi" width="32"></video>
+      #   video_tag("trailer.ogg", "trailer.flv")
+      #   # => <video><source src="/videos/trailer.ogg" /><source src="/videos/trailer.flv" /></video>
+      #   video_tag(["trailer.ogg", "trailer.flv"])
+      #   # => <video><source src="/videos/trailer.ogg" /><source src="/videos/trailer.flv" /></video>
+      #   video_tag(["trailer.ogg", "trailer.flv"], size: "160x120")
+      #   # => <video height="120" width="160"><source src="/videos/trailer.ogg" /><source src="/videos/trailer.flv" /></video>
+      def video_tag: (*untyped sources) -> untyped
+
+      # Returns an HTML audio tag for the +sources+. If +sources+ is a string,
+      # a single audio tag will be returned. If +sources+ is an array, an audio
+      # tag with nested source tags for each source will be returned. The
+      # +sources+ can be full paths or files that exist in your public audios
+      # directory.
+      #
+      # When the last parameter is a hash you can add HTML attributes using that
+      # parameter.
+      #
+      #   audio_tag("sound")
+      #   # => <audio src="/audios/sound"></audio>
+      #   audio_tag("sound.wav")
+      #   # => <audio src="/audios/sound.wav"></audio>
+      #   audio_tag("sound.wav", autoplay: true, controls: true)
+      #   # => <audio autoplay="autoplay" controls="controls" src="/audios/sound.wav"></audio>
+      #   audio_tag("sound.wav", "sound.mid")
+      #   # => <audio><source src="/audios/sound.wav" /><source src="/audios/sound.mid" /></audio>
+      def audio_tag: (*untyped sources) -> untyped
+
+      def multiple_sources_tag_builder: (untyped `type`, untyped sources) { (untyped) -> untyped } -> untyped
+
+      def resolve_image_source: (untyped source, untyped skip_pipeline) -> untyped
+
+      def extract_dimensions: (untyped size) -> untyped
+
+      def check_for_image_tag_errors: (untyped options) -> untyped
+
+      def resolve_link_as: (untyped extname, untyped mime_type) -> untyped
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    # = Action View Asset URL Helpers
+    # nodoc:
+    # This module provides methods for generating asset paths and
+    # URLs.
+    #
+    #   image_path("rails.png")
+    #   # => "/assets/rails.png"
+    #
+    #   image_url("rails.png")
+    #   # => "http://www.example.com/assets/rails.png"
+    #
+    # === Using asset hosts
+    #
+    # By default, Rails links to these assets on the current host in the public
+    # folder, but you can direct Rails to link to assets from a dedicated asset
+    # server by setting <tt>ActionController::Base.asset_host</tt> in the application
+    # configuration, typically in <tt>config/environments/production.rb</tt>.
+    # For example, you'd define <tt>assets.example.com</tt> to be your asset
+    # host this way, inside the <tt>configure</tt> block of your environment-specific
+    # configuration files or <tt>config/application.rb</tt>:
+    #
+    #   config.action_controller.asset_host = "assets.example.com"
+    #
+    # Helpers take that into account:
+    #
+    #   image_tag("rails.png")
+    #   # => <img src="http://assets.example.com/assets/rails.png" />
+    #   stylesheet_link_tag("application")
+    #   # => <link href="http://assets.example.com/assets/application.css" media="screen" rel="stylesheet" />
+    #
+    # Browsers open a limited number of simultaneous connections to a single
+    # host. The exact number varies by browser and version. This limit may cause
+    # some asset downloads to wait for previous assets to finish before they can
+    # begin. You can use the <tt>%d</tt> wildcard in the +asset_host+ to
+    # distribute the requests over four hosts. For example,
+    # <tt>assets%d.example.com</tt> will spread the asset requests over
+    # "assets0.example.com", ..., "assets3.example.com".
+    #
+    #   image_tag("rails.png")
+    #   # => <img src="http://assets0.example.com/assets/rails.png" />
+    #   stylesheet_link_tag("application")
+    #   # => <link href="http://assets2.example.com/assets/application.css" media="screen" rel="stylesheet" />
+    #
+    # This may improve the asset loading performance of your application.
+    # It is also possible the combination of additional connection overhead
+    # (DNS, SSL) and the overall browser connection limits may result in this
+    # solution being slower. You should be sure to measure your actual
+    # performance across targeted browsers both before and after this change.
+    #
+    # To implement the corresponding hosts you can either setup four actual
+    # hosts or use wildcard DNS to CNAME the wildcard to a single asset host.
+    # You can read more about setting up your DNS CNAME records from your ISP.
+    #
+    # Note: This is purely a browser performance optimization and is not meant
+    # for server load balancing. See https://www.die.net/musings/page_load_time/
+    # for background and https://www.browserscope.org/?category=network for
+    # connection limit data.
+    #
+    # Alternatively, you can exert more control over the asset host by setting
+    # +asset_host+ to a proc like this:
+    #
+    #   ActionController::Base.asset_host = Proc.new { |source|
+    #     "http://assets#{Digest::MD5.hexdigest(source).to_i(16) % 2 + 1}.example.com"
+    #   }
+    #   image_tag("rails.png")
+    #   # => <img src="http://assets1.example.com/assets/rails.png" />
+    #   stylesheet_link_tag("application")
+    #   # => <link href="http://assets2.example.com/assets/application.css" media="screen" rel="stylesheet" />
+    #
+    # The example above generates "http://assets1.example.com" and
+    # "http://assets2.example.com". This option is useful for example if
+    # you need fewer/more than four hosts, custom host names, etc.
+    #
+    # As you see the proc takes a +source+ parameter. That's a string with the
+    # absolute path of the asset, for example "/assets/rails.png".
+    #
+    #    ActionController::Base.asset_host = Proc.new { |source|
+    #      if source.ends_with?('.css')
+    #        "http://stylesheets.example.com"
+    #      else
+    #        "http://assets.example.com"
+    #      end
+    #    }
+    #   image_tag("rails.png")
+    #   # => <img src="http://assets.example.com/assets/rails.png" />
+    #   stylesheet_link_tag("application")
+    #   # => <link href="http://stylesheets.example.com/assets/application.css" media="screen" rel="stylesheet" />
+    #
+    # Alternatively you may ask for a second parameter +request+. That one is
+    # particularly useful for serving assets from an SSL-protected page. The
+    # example proc below disables asset hosting for HTTPS connections, while
+    # still sending assets for plain HTTP requests from asset hosts. If you don't
+    # have SSL certificates for each of the asset hosts this technique allows you
+    # to avoid warnings in the client about mixed media.
+    # Note that the +request+ parameter might not be supplied, e.g. when the assets
+    # are precompiled with the command `rails assets:precompile`. Make sure to use a
+    # +Proc+ instead of a lambda, since a +Proc+ allows missing parameters and sets them
+    # to +nil+.
+    #
+    #   config.action_controller.asset_host = Proc.new { |source, request|
+    #     if request && request.ssl?
+    #       "#{request.protocol}#{request.host_with_port}"
+    #     else
+    #       "#{request.protocol}assets.example.com"
+    #     end
+    #   }
+    #
+    # You can also implement a custom asset host object that responds to +call+
+    # and takes either one or two parameters just like the proc.
+    #
+    #   config.action_controller.asset_host = AssetHostingWithMinimumSsl.new(
+    #     "http://asset%d.example.com", "https://asset1.example.com"
+    #   )
+    #
+    module AssetUrlHelper
+      URI_REGEXP: untyped
+
+      # This is the entry point for all assets.
+      # When using the asset pipeline (i.e. sprockets and sprockets-rails), the
+      # behavior is "enhanced". You can bypass the asset pipeline by passing in
+      # <tt>skip_pipeline: true</tt> to the options.
+      #
+      # All other asset *_path helpers delegate through this method.
+      #
+      # === With the asset pipeline
+      #
+      # All options passed to +asset_path+ will be passed to +compute_asset_path+
+      # which is implemented by sprockets-rails.
+      #
+      #   asset_path("application.js") # => "/assets/application-60aa4fdc5cea14baf5400fba1abf4f2a46a5166bad4772b1effe341570f07de9.js"
+      #
+      # === Without the asset pipeline (<tt>skip_pipeline: true</tt>)
+      #
+      # Accepts a <tt>type</tt> option that can specify the asset's extension. No error
+      # checking is done to verify the source passed into +asset_path+ is valid
+      # and that the file exists on disk.
+      #
+      #   asset_path("application.js", skip_pipeline: true)                 # => "application.js"
+      #   asset_path("filedoesnotexist.png", skip_pipeline: true)           # => "filedoesnotexist.png"
+      #   asset_path("application", type: :javascript, skip_pipeline: true) # => "/javascripts/application.js"
+      #   asset_path("application", type: :stylesheet, skip_pipeline: true) # => "/stylesheets/application.css"
+      #
+      # === Options applying to all assets
+      #
+      # Below lists scenarios that apply to +asset_path+ whether or not you're
+      # using the asset pipeline.
+      #
+      # - All fully qualified URLs are returned immediately. This bypasses the
+      #   asset pipeline and all other behavior described.
+      #
+      #     asset_path("http://www.example.com/js/xmlhr.js") # => "http://www.example.com/js/xmlhr.js"
+      #
+      # - All assets that begin with a forward slash are assumed to be full
+      #   URLs and will not be expanded. This will bypass the asset pipeline.
+      #
+      #     asset_path("/foo.png") # => "/foo.png"
+      #
+      # - All blank strings will be returned immediately. This bypasses the
+      #   asset pipeline and all other behavior described.
+      #
+      #     asset_path("") # => ""
+      #
+      # - If <tt>config.relative_url_root</tt> is specified, all assets will have that
+      #   root prepended.
+      #
+      #     Rails.application.config.relative_url_root = "bar"
+      #     asset_path("foo.js", skip_pipeline: true) # => "bar/foo.js"
+      #
+      # - A different asset host can be specified via <tt>config.action_controller.asset_host</tt>
+      #   this is commonly used in conjunction with a CDN.
+      #
+      #     Rails.application.config.action_controller.asset_host = "assets.example.com"
+      #     asset_path("foo.js", skip_pipeline: true) # => "http://assets.example.com/foo.js"
+      #
+      # - An extension name can be specified manually with <tt>extname</tt>.
+      #
+      #     asset_path("foo", skip_pipeline: true, extname: ".js")     # => "/foo.js"
+      #     asset_path("foo.css", skip_pipeline: true, extname: ".js") # => "/foo.css.js"
+      def asset_path: (untyped source, ?::Hash[untyped, untyped] options) -> (::String | untyped)
+
+      alias path_to_asset asset_path
+
+      # Computes the full URL to an asset in the public directory. This
+      # will use +asset_path+ internally, so most of their behaviors
+      # will be the same. If :host options is set, it overwrites global
+      # +config.action_controller.asset_host+ setting.
+      #
+      # All other options provided are forwarded to +asset_path+ call.
+      #
+      #   asset_url "application.js"                                 # => http://example.com/assets/application.js
+      #   asset_url "application.js", host: "http://cdn.example.com" # => http://cdn.example.com/assets/application.js
+      #
+      def asset_url: (untyped source, ?::Hash[untyped, untyped] options) -> untyped
+
+      alias url_to_asset asset_url
+
+      ASSET_EXTENSIONS: ::Hash[untyped, untyped]
+
+      # Compute extname to append to asset path. Returns +nil+ if
+      # nothing should be added.
+      def compute_asset_extname: (untyped source, ?::Hash[untyped, untyped] options) -> (nil | untyped)
+
+      # Maps asset types to public directory.
+      ASSET_PUBLIC_DIRECTORIES: ::Hash[untyped, untyped]
+
+      # Computes asset path to public directory. Plugins and
+      # extensions can override this method to point to custom assets
+      # or generate digested paths or query strings.
+      def compute_asset_path: (untyped source, ?::Hash[untyped, untyped] options) -> untyped
+
+      alias public_compute_asset_path compute_asset_path
+
+      # Pick an asset host for this source. Returns +nil+ if no host is set,
+      # the host if no wildcard is set, the host interpolated with the
+      # numbers 0-3 if it contains <tt>%d</tt> (the number is the source hash mod 4),
+      # or the value returned from invoking call on an object responding to call
+      # (proc or otherwise).
+      def compute_asset_host: (?::String source, ?::Hash[untyped, untyped] options) -> (nil | untyped)
+
+      # Computes the path to a JavaScript asset in the public javascripts directory.
+      # If the +source+ filename has no extension, .js will be appended (except for explicit URIs)
+      # Full paths from the document root will be passed through.
+      # Used internally by +javascript_include_tag+ to build the script path.
+      #
+      #   javascript_path "xmlhr"                              # => /assets/xmlhr.js
+      #   javascript_path "dir/xmlhr.js"                       # => /assets/dir/xmlhr.js
+      #   javascript_path "/dir/xmlhr"                         # => /dir/xmlhr.js
+      #   javascript_path "http://www.example.com/js/xmlhr"    # => http://www.example.com/js/xmlhr
+      #   javascript_path "http://www.example.com/js/xmlhr.js" # => http://www.example.com/js/xmlhr.js
+      def javascript_path: (untyped source, ?::Hash[untyped, untyped] options) -> untyped
+
+      alias path_to_javascript javascript_path
+
+      # Computes the full URL to a JavaScript asset in the public javascripts directory.
+      # This will use +javascript_path+ internally, so most of their behaviors will be the same.
+      # Since +javascript_url+ is based on +asset_url+ method you can set :host options. If :host
+      # options is set, it overwrites global +config.action_controller.asset_host+ setting.
+      #
+      #   javascript_url "js/xmlhr.js", host: "http://stage.example.com" # => http://stage.example.com/assets/js/xmlhr.js
+      #
+      def javascript_url: (untyped source, ?::Hash[untyped, untyped] options) -> untyped
+
+      alias url_to_javascript javascript_url
+
+      # Computes the path to a stylesheet asset in the public stylesheets directory.
+      # If the +source+ filename has no extension, .css will be appended (except for explicit URIs).
+      # Full paths from the document root will be passed through.
+      # Used internally by +stylesheet_link_tag+ to build the stylesheet path.
+      #
+      #   stylesheet_path "style"                                  # => /assets/style.css
+      #   stylesheet_path "dir/style.css"                          # => /assets/dir/style.css
+      #   stylesheet_path "/dir/style.css"                         # => /dir/style.css
+      #   stylesheet_path "http://www.example.com/css/style"       # => http://www.example.com/css/style
+      #   stylesheet_path "http://www.example.com/css/style.css"   # => http://www.example.com/css/style.css
+      def stylesheet_path: (untyped source, ?::Hash[untyped, untyped] options) -> untyped
+
+      alias path_to_stylesheet stylesheet_path
+
+      # Computes the full URL to a stylesheet asset in the public stylesheets directory.
+      # This will use +stylesheet_path+ internally, so most of their behaviors will be the same.
+      # Since +stylesheet_url+ is based on +asset_url+ method you can set :host options. If :host
+      # options is set, it overwrites global +config.action_controller.asset_host+ setting.
+      #
+      #   stylesheet_url "css/style.css", host: "http://stage.example.com" # => http://stage.example.com/assets/css/style.css
+      #
+      def stylesheet_url: (untyped source, ?::Hash[untyped, untyped] options) -> untyped
+
+      alias url_to_stylesheet stylesheet_url
+
+      # Computes the path to an image asset.
+      # Full paths from the document root will be passed through.
+      # Used internally by +image_tag+ to build the image path:
+      #
+      #   image_path("edit")                                         # => "/assets/edit"
+      #   image_path("edit.png")                                     # => "/assets/edit.png"
+      #   image_path("icons/edit.png")                               # => "/assets/icons/edit.png"
+      #   image_path("/icons/edit.png")                              # => "/icons/edit.png"
+      #   image_path("http://www.example.com/img/edit.png")          # => "http://www.example.com/img/edit.png"
+      #
+      # If you have images as application resources this method may conflict with their named routes.
+      # The alias +path_to_image+ is provided to avoid that. Rails uses the alias internally, and
+      # plugin authors are encouraged to do so.
+      def image_path: (untyped source, ?::Hash[untyped, untyped] options) -> untyped
+
+      alias path_to_image image_path
+
+      # Computes the full URL to an image asset.
+      # This will use +image_path+ internally, so most of their behaviors will be the same.
+      # Since +image_url+ is based on +asset_url+ method you can set :host options. If :host
+      # options is set, it overwrites global +config.action_controller.asset_host+ setting.
+      #
+      #   image_url "edit.png", host: "http://stage.example.com" # => http://stage.example.com/assets/edit.png
+      #
+      def image_url: (untyped source, ?::Hash[untyped, untyped] options) -> untyped
+
+      alias url_to_image image_url
+
+      # Computes the path to a video asset in the public videos directory.
+      # Full paths from the document root will be passed through.
+      # Used internally by +video_tag+ to build the video path.
+      #
+      #   video_path("hd")                                            # => /videos/hd
+      #   video_path("hd.avi")                                        # => /videos/hd.avi
+      #   video_path("trailers/hd.avi")                               # => /videos/trailers/hd.avi
+      #   video_path("/trailers/hd.avi")                              # => /trailers/hd.avi
+      #   video_path("http://www.example.com/vid/hd.avi")             # => http://www.example.com/vid/hd.avi
+      def video_path: (untyped source, ?::Hash[untyped, untyped] options) -> untyped
+
+      alias path_to_video video_path
+
+      # Computes the full URL to a video asset in the public videos directory.
+      # This will use +video_path+ internally, so most of their behaviors will be the same.
+      # Since +video_url+ is based on +asset_url+ method you can set :host options. If :host
+      # options is set, it overwrites global +config.action_controller.asset_host+ setting.
+      #
+      #   video_url "hd.avi", host: "http://stage.example.com" # => http://stage.example.com/videos/hd.avi
+      #
+      def video_url: (untyped source, ?::Hash[untyped, untyped] options) -> untyped
+
+      alias url_to_video video_url
+
+      # Computes the path to an audio asset in the public audios directory.
+      # Full paths from the document root will be passed through.
+      # Used internally by +audio_tag+ to build the audio path.
+      #
+      #   audio_path("horse")                                            # => /audios/horse
+      #   audio_path("horse.wav")                                        # => /audios/horse.wav
+      #   audio_path("sounds/horse.wav")                                 # => /audios/sounds/horse.wav
+      #   audio_path("/sounds/horse.wav")                                # => /sounds/horse.wav
+      #   audio_path("http://www.example.com/sounds/horse.wav")          # => http://www.example.com/sounds/horse.wav
+      def audio_path: (untyped source, ?::Hash[untyped, untyped] options) -> untyped
+
+      alias path_to_audio audio_path
+
+      # Computes the full URL to an audio asset in the public audios directory.
+      # This will use +audio_path+ internally, so most of their behaviors will be the same.
+      # Since +audio_url+ is based on +asset_url+ method you can set :host options. If :host
+      # options is set, it overwrites global +config.action_controller.asset_host+ setting.
+      #
+      #   audio_url "horse.wav", host: "http://stage.example.com" # => http://stage.example.com/audios/horse.wav
+      #
+      def audio_url: (untyped source, ?::Hash[untyped, untyped] options) -> untyped
+
+      alias url_to_audio audio_url
+
+      # Computes the path to a font asset.
+      # Full paths from the document root will be passed through.
+      #
+      #   font_path("font")                                           # => /fonts/font
+      #   font_path("font.ttf")                                       # => /fonts/font.ttf
+      #   font_path("dir/font.ttf")                                   # => /fonts/dir/font.ttf
+      #   font_path("/dir/font.ttf")                                  # => /dir/font.ttf
+      #   font_path("http://www.example.com/dir/font.ttf")            # => http://www.example.com/dir/font.ttf
+      def font_path: (untyped source, ?::Hash[untyped, untyped] options) -> untyped
+
+      alias path_to_font font_path
+
+      # Computes the full URL to a font asset.
+      # This will use +font_path+ internally, so most of their behaviors will be the same.
+      # Since +font_url+ is based on +asset_url+ method you can set :host options. If :host
+      # options is set, it overwrites global +config.action_controller.asset_host+ setting.
+      #
+      #   font_url "font.ttf", host: "http://stage.example.com" # => http://stage.example.com/fonts/font.ttf
+      #
+      def font_url: (untyped source, ?::Hash[untyped, untyped] options) -> untyped
+
+      alias url_to_font font_url
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    # = Action View Atom Feed Helpers
+    # nodoc:
+    module AtomFeedHelper
+      # Adds easy defaults to writing Atom feeds with the Builder template engine (this does not work on ERB or any other
+      # template languages).
+      #
+      # Full usage example:
+      #
+      #   config/routes.rb:
+      #     Rails.application.routes.draw do
+      #       resources :posts
+      #       root to: "posts#index"
+      #     end
+      #
+      #   app/controllers/posts_controller.rb:
+      #     class PostsController < ApplicationController
+      #       # GET /posts.html
+      #       # GET /posts.atom
+      #       def index
+      #         @posts = Post.all
+      #
+      #         respond_to do |format|
+      #           format.html
+      #           format.atom
+      #         end
+      #       end
+      #     end
+      #
+      #   app/views/posts/index.atom.builder:
+      #     atom_feed do |feed|
+      #       feed.title("My great blog!")
+      #       feed.updated(@posts[0].created_at) if @posts.length > 0
+      #
+      #       @posts.each do |post|
+      #         feed.entry(post) do |entry|
+      #           entry.title(post.title)
+      #           entry.content(post.body, type: 'html')
+      #
+      #           entry.author do |author|
+      #             author.name("DHH")
+      #           end
+      #         end
+      #       end
+      #     end
+      #
+      # The options for atom_feed are:
+      #
+      # * <tt>:language</tt>: Defaults to "en-US".
+      # * <tt>:root_url</tt>: The HTML alternative that this feed is doubling for. Defaults to / on the current host.
+      # * <tt>:url</tt>: The URL for this feed. Defaults to the current URL.
+      # * <tt>:id</tt>: The id for this feed. Defaults to "tag:localhost,2005:/posts", in this case.
+      # * <tt>:schema_date</tt>: The date at which the tag scheme for the feed was first used. A good default is the year you
+      #   created the feed. See http://feedvalidator.org/docs/error/InvalidTAG.html for more information. If not specified,
+      #   2005 is used (as an "I don't care" value).
+      # * <tt>:instruct</tt>: Hash of XML processing instructions in the form {target => {attribute => value, }} or {target => [{attribute => value, }, ]}
+      #
+      # Other namespaces can be added to the root element:
+      #
+      #   app/views/posts/index.atom.builder:
+      #     atom_feed({'xmlns:app' => 'http://www.w3.org/2007/app',
+      #         'xmlns:openSearch' => 'http://a9.com/-/spec/opensearch/1.1/'}) do |feed|
+      #       feed.title("My great blog!")
+      #       feed.updated((@posts.first.created_at))
+      #       feed.tag!('openSearch:totalResults', 10)
+      #
+      #       @posts.each do |post|
+      #         feed.entry(post) do |entry|
+      #           entry.title(post.title)
+      #           entry.content(post.body, type: 'html')
+      #           entry.tag!('app:edited', Time.now)
+      #
+      #           entry.author do |author|
+      #             author.name("DHH")
+      #           end
+      #         end
+      #       end
+      #     end
+      #
+      # The Atom spec defines five elements (content rights title subtitle
+      # summary) which may directly contain xhtml content if type: 'xhtml'
+      # is specified as an attribute. If so, this helper will take care of
+      # the enclosing div and xhtml namespace declaration. Example usage:
+      #
+      #    entry.summary type: 'xhtml' do |xhtml|
+      #      xhtml.p pluralize(order.line_items.count, "line item")
+      #      xhtml.p "Shipped to #{order.address}"
+      #      xhtml.p "Paid by #{order.pay_type}"
+      #    end
+      #
+      #
+      # <tt>atom_feed</tt> yields an +AtomFeedBuilder+ instance. Nested elements yield
+      # an +AtomBuilder+ instance.
+      def atom_feed: (?::Hash[untyped, untyped] options) { (untyped) -> untyped } -> untyped
+
+      class AtomBuilder
+        # nodoc:
+        XHTML_TAG_NAMES: untyped
+
+        def initialize: (untyped xml) -> untyped
+
+        # Delegate to xml builder, first wrapping the element in an xhtml
+        # namespaced div element if the method and arguments indicate
+        # that an xhtml_block? is desired.
+        def method_missing: (untyped method, *untyped arguments) { () -> untyped } -> untyped
+
+        # True if the method name matches one of the five elements defined
+        # in the Atom spec as potentially containing XHTML content and
+        # if type: 'xhtml' is, in fact, specified.
+        def xhtml_block?: (untyped method, untyped arguments) -> untyped
+      end
+
+      class AtomFeedBuilder < AtomBuilder
+        # nodoc:
+        def initialize: (untyped xml, untyped view, ?::Hash[untyped, untyped] feed_options) -> untyped
+
+        # Accepts a Date or Time object and inserts it in the proper format. If +nil+ is passed, current time in UTC is used.
+        def updated: (?untyped? date_or_time) -> untyped
+
+        # Creates an entry tag for a specific record and prefills the id using class and id.
+        #
+        # Options:
+        #
+        # * <tt>:published</tt>: Time first published. Defaults to the created_at attribute on the record if one such exists.
+        # * <tt>:updated</tt>: Time of update. Defaults to the updated_at attribute on the record if one such exists.
+        # * <tt>:url</tt>: The URL for this entry or +false+ or +nil+ for not having a link tag. Defaults to the +polymorphic_url+ for the record.
+        # * <tt>:id</tt>: The ID for this entry. Defaults to "tag:#{@view.request.host},#{@feed_options[:schema_date]}:#{record.class}/#{record.id}"
+        # * <tt>:type</tt>: The TYPE for this entry. Defaults to "text/html".
+        def entry: (untyped record, ?::Hash[untyped, untyped] options) { (untyped) -> untyped } -> untyped
+      end
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    # = Action View Cache Helper
+    # nodoc:
+    module CacheHelper
+      # This helper exposes a method for caching fragments of a view
+      # rather than an entire action or page. This technique is useful
+      # caching pieces like menus, lists of new topics, static HTML
+      # fragments, and so on. This method takes a block that contains
+      # the content you wish to cache.
+      #
+      # The best way to use this is by doing recyclable key-based cache expiration
+      # on top of a cache store like Memcached or Redis that'll automatically
+      # kick out old entries.
+      #
+      # When using this method, you list the cache dependency as the name of the cache, like so:
+      #
+      #   <% cache project do %>
+      #     <b>All the topics on this project</b>
+      #     <%= render project.topics %>
+      #   <% end %>
+      #
+      # This approach will assume that when a new topic is added, you'll touch
+      # the project. The cache key generated from this call will be something like:
+      #
+      #   views/template/action.html.erb:7a1156131a6928cb0026877f8b749ac9/projects/123
+      #         ^template path           ^template tree digest            ^class   ^id
+      #
+      # This cache key is stable, but it's combined with a cache version derived from the project
+      # record. When the project updated_at is touched, the #cache_version changes, even
+      # if the key stays stable. This means that unlike a traditional key-based cache expiration
+      # approach, you won't be generating cache trash, unused keys, simply because the dependent
+      # record is updated.
+      #
+      # If your template cache depends on multiple sources (try to avoid this to keep things simple),
+      # you can name all these dependencies as part of an array:
+      #
+      #   <% cache [ project, current_user ] do %>
+      #     <b>All the topics on this project</b>
+      #     <%= render project.topics %>
+      #   <% end %>
+      #
+      # This will include both records as part of the cache key and updating either of them will
+      # expire the cache.
+      #
+      # ==== \Template digest
+      #
+      # The template digest that's added to the cache key is computed by taking an MD5 of the
+      # contents of the entire template file. This ensures that your caches will automatically
+      # expire when you change the template file.
+      #
+      # Note that the MD5 is taken of the entire template file, not just what's within the
+      # cache do/end call. So it's possible that changing something outside of that call will
+      # still expire the cache.
+      #
+      # Additionally, the digestor will automatically look through your template file for
+      # explicit and implicit dependencies, and include those as part of the digest.
+      #
+      # The digestor can be bypassed by passing skip_digest: true as an option to the cache call:
+      #
+      #   <% cache project, skip_digest: true do %>
+      #     <b>All the topics on this project</b>
+      #     <%= render project.topics %>
+      #   <% end %>
+      #
+      # ==== Implicit dependencies
+      #
+      # Most template dependencies can be derived from calls to render in the template itself.
+      # Here are some examples of render calls that Cache Digests knows how to decode:
+      #
+      #   render partial: "comments/comment", collection: commentable.comments
+      #   render "comments/comments"
+      #   render 'comments/comments'
+      #   render('comments/comments')
+      #
+      #   render "header" translates to render("comments/header")
+      #
+      #   render(@topic)         translates to render("topics/topic")
+      #   render(topics)         translates to render("topics/topic")
+      #   render(message.topics) translates to render("topics/topic")
+      #
+      # It's not possible to derive all render calls like that, though.
+      # Here are a few examples of things that can't be derived:
+      #
+      #   render group_of_attachments
+      #   render @project.documents.where(published: true).order('created_at')
+      #
+      # You will have to rewrite those to the explicit form:
+      #
+      #   render partial: 'attachments/attachment', collection: group_of_attachments
+      #   render partial: 'documents/document', collection: @project.documents.where(published: true).order('created_at')
+      #
+      # === Explicit dependencies
+      #
+      # Sometimes you'll have template dependencies that can't be derived at all. This is typically
+      # the case when you have template rendering that happens in helpers. Here's an example:
+      #
+      #   <%= render_sortable_todolists @project.todolists %>
+      #
+      # You'll need to use a special comment format to call those out:
+      #
+      #   <%# Template Dependency: todolists/todolist %>
+      #   <%= render_sortable_todolists @project.todolists %>
+      #
+      # In some cases, like a single table inheritance setup, you might have
+      # a bunch of explicit dependencies. Instead of writing every template out,
+      # you can use a wildcard to match any template in a directory:
+      #
+      #   <%# Template Dependency: events/* %>
+      #   <%= render_categorizable_events @person.events %>
+      #
+      # This marks every template in the directory as a dependency. To find those
+      # templates, the wildcard path must be absolutely defined from <tt>app/views</tt> or paths
+      # otherwise added with +prepend_view_path+ or +append_view_path+.
+      # This way the wildcard for <tt>app/views/recordings/events</tt> would be <tt>recordings/events/*</tt> etc.
+      #
+      # The pattern used to match explicit dependencies is <tt>/# Template Dependency: (\S+)/</tt>,
+      # so it's important that you type it out just so.
+      # You can only declare one template dependency per line.
+      #
+      # === External dependencies
+      #
+      # If you use a helper method, for example, inside a cached block and
+      # you then update that helper, you'll have to bump the cache as well.
+      # It doesn't really matter how you do it, but the MD5 of the template file
+      # must change. One recommendation is to simply be explicit in a comment, like:
+      #
+      #   <%# Helper Dependency Updated: May 6, 2012 at 6pm %>
+      #   <%= some_helper_method(person) %>
+      #
+      # Now all you have to do is change that timestamp when the helper method changes.
+      #
+      # === Collection Caching
+      #
+      # When rendering a collection of objects that each use the same partial, a <tt>:cached</tt>
+      # option can be passed.
+      #
+      # For collections rendered such:
+      #
+      #   <%= render partial: 'projects/project', collection: @projects, cached: true %>
+      #
+      # The <tt>cached: true</tt> will make Action View's rendering read several templates
+      # from cache at once instead of one call per template.
+      #
+      # Templates in the collection not already cached are written to cache.
+      #
+      # Works great alongside individual template fragment caching.
+      # For instance if the template the collection renders is cached like:
+      #
+      #   # projects/_project.html.erb
+      #   <% cache project do %>
+      #     <%# ... %>
+      #   <% end %>
+      #
+      # Any collection renders will find those cached templates when attempting
+      # to read multiple templates at once.
+      #
+      # If your collection cache depends on multiple sources (try to avoid this to keep things simple),
+      # you can name all these dependencies as part of a block that returns an array:
+      #
+      #   <%= render partial: 'projects/project', collection: @projects, cached: -> project { [ project, current_user ] } %>
+      #
+      # This will include both records as part of the cache key and updating either of them will
+      # expire the cache.
+      def cache: (?::Hash[untyped, untyped] name, ?::Hash[untyped, untyped] options) { () -> untyped } -> nil
+
+      # Cache fragments of a view if +condition+ is true
+      #
+      #   <% cache_if admin?, project do %>
+      #     <b>All the topics on this project</b>
+      #     <%= render project.topics %>
+      #   <% end %>
+      def cache_if: (untyped condition, ?::Hash[untyped, untyped] name, ?::Hash[untyped, untyped] options) { () -> untyped } -> nil
+
+      # Cache fragments of a view unless +condition+ is true
+      #
+      #   <% cache_unless admin?, project do %>
+      #     <b>All the topics on this project</b>
+      #     <%= render project.topics %>
+      #   <% end %>
+      def cache_unless: (untyped condition, ?::Hash[untyped, untyped] name, ?::Hash[untyped, untyped] options) { () -> untyped } -> untyped
+
+      # This helper returns the name of a cache key for a given fragment cache
+      # call. By supplying <tt>skip_digest: true</tt> to cache, the digestion of cache
+      # fragments can be manually bypassed. This is useful when cache fragments
+      # cannot be manually expired unless you know the exact key which is the
+      # case when using memcached.
+      #
+      # The digest will be generated using +virtual_path:+ if it is provided.
+      #
+      def cache_fragment_name: (?::Hash[untyped, untyped] name, ?digest_path: untyped? digest_path, ?virtual_path: untyped? virtual_path, ?skip_digest: untyped? skip_digest) -> untyped
+
+      def digest_path_from_template: (untyped template) -> untyped
+
+      def fragment_name_with_digest: (untyped name, untyped virtual_path, untyped digest_path) -> untyped
+
+      def fragment_for: (?::Hash[untyped, untyped] name, ?untyped? options) { () -> untyped } -> untyped
+
+      def read_fragment_for: (untyped name, untyped options) -> untyped
+
+      def write_fragment_for: (untyped name, untyped options) { () -> untyped } -> untyped
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    # = Action View Capture Helper
+    # nodoc:
+    # CaptureHelper exposes methods to let you extract generated markup which
+    # can be used in other parts of a template or layout file.
+    #
+    # It provides a method to capture blocks into variables through capture and
+    # a way to capture a block of markup for use in a layout through {content_for}[rdoc-ref:ActionView::Helpers::CaptureHelper#content_for].
+    module CaptureHelper
+      # The capture method extracts part of a template as a String object.
+      # You can then use this object anywhere in your templates, layout, or helpers.
+      #
+      # The capture method can be used in ERB templates...
+      #
+      #   <% @greeting = capture do %>
+      #     Welcome to my shiny new web page!  The date and time is
+      #     <%= Time.now %>
+      #   <% end %>
+      #
+      # ...and Builder (RXML) templates.
+      #
+      #   @timestamp = capture do
+      #     "The current timestamp is #{Time.now}."
+      #   end
+      #
+      # You can then use that variable anywhere else. For example:
+      #
+      #   <html>
+      #   <head><title><%= @greeting %></title></head>
+      #   <body>
+      #   <b><%= @greeting %></b>
+      #   </body>
+      #   </html>
+      #
+      # The return of capture is the string generated by the block. For Example:
+      #
+      #   @greeting # => "Welcome to my shiny new web page! The date and time is 2018-09-06 11:09:16 -0500"
+      #
+      def capture: (*untyped args) { (untyped) -> untyped } -> untyped
+
+      # Calling <tt>content_for</tt> stores a block of markup in an identifier for later use.
+      # In order to access this stored content in other templates, helper modules
+      # or the layout, you would pass the identifier as an argument to <tt>content_for</tt>.
+      #
+      # Note: <tt>yield</tt> can still be used to retrieve the stored content, but calling
+      # <tt>yield</tt> doesn't work in helper modules, while <tt>content_for</tt> does.
+      #
+      #   <% content_for :not_authorized do %>
+      #     alert('You are not authorized to do that!')
+      #   <% end %>
+      #
+      # You can then use <tt>content_for :not_authorized</tt> anywhere in your templates.
+      #
+      #   <%= content_for :not_authorized if current_user.nil? %>
+      #
+      # This is equivalent to:
+      #
+      #   <%= yield :not_authorized if current_user.nil? %>
+      #
+      # <tt>content_for</tt>, however, can also be used in helper modules.
+      #
+      #   module StorageHelper
+      #     def stored_content
+      #       content_for(:storage) || "Your storage is empty"
+      #     end
+      #   end
+      #
+      # This helper works just like normal helpers.
+      #
+      #   <%= stored_content %>
+      #
+      # You can also use the <tt>yield</tt> syntax alongside an existing call to
+      # <tt>yield</tt> in a layout. For example:
+      #
+      #   <%# This is the layout %>
+      #   <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+      #   <head>
+      #     <title>My Website</title>
+      #     <%= yield :script %>
+      #   </head>
+      #   <body>
+      #     <%= yield %>
+      #   </body>
+      #   </html>
+      #
+      # And now, we'll create a view that has a <tt>content_for</tt> call that
+      # creates the <tt>script</tt> identifier.
+      #
+      #   <%# This is our view %>
+      #   Please login!
+      #
+      #   <% content_for :script do %>
+      #     <script>alert('You are not authorized to view this page!')</script>
+      #   <% end %>
+      #
+      # Then, in another view, you could to do something like this:
+      #
+      #   <%= link_to 'Logout', action: 'logout', remote: true %>
+      #
+      #   <% content_for :script do %>
+      #     <%= javascript_include_tag :defaults %>
+      #   <% end %>
+      #
+      # That will place +script+ tags for your default set of JavaScript files on the page;
+      # this technique is useful if you'll only be using these scripts in a few views.
+      #
+      # Note that <tt>content_for</tt> concatenates (default) the blocks it is given for a particular
+      # identifier in order. For example:
+      #
+      #   <% content_for :navigation do %>
+      #     <li><%= link_to 'Home', action: 'index' %></li>
+      #   <% end %>
+      #
+      #  And in another place:
+      #
+      #   <% content_for :navigation do %>
+      #     <li><%= link_to 'Login', action: 'login' %></li>
+      #   <% end %>
+      #
+      # Then, in another template or layout, this code would render both links in order:
+      #
+      #   <ul><%= content_for :navigation %></ul>
+      #
+      # If the flush parameter is +true+ <tt>content_for</tt> replaces the blocks it is given. For example:
+      #
+      #   <% content_for :navigation do %>
+      #     <li><%= link_to 'Home', action: 'index' %></li>
+      #   <% end %>
+      #
+      #   <%#  Add some other content, or use a different template: %>
+      #
+      #   <% content_for :navigation, flush: true do %>
+      #     <li><%= link_to 'Login', action: 'login' %></li>
+      #   <% end %>
+      #
+      # Then, in another template or layout, this code would render only the last link:
+      #
+      #   <ul><%= content_for :navigation %></ul>
+      #
+      # Lastly, simple content can be passed as a parameter:
+      #
+      #   <% content_for :script, javascript_include_tag(:defaults) %>
+      #
+      # WARNING: <tt>content_for</tt> is ignored in caches. So you shouldn't use it for elements that will be fragment cached.
+      def content_for: (untyped name, ?untyped? content, ?::Hash[untyped, untyped] options) { () -> untyped } -> untyped
+
+      # The same as +content_for+ but when used with streaming flushes
+      # straight back to the layout. In other words, if you want to
+      # concatenate several times to the same buffer when rendering a given
+      # template, you should use +content_for+, if not, use +provide+ to tell
+      # the layout to stop looking for more contents.
+      def provide: (untyped name, ?untyped? content) { () -> untyped } -> untyped
+
+      # <tt>content_for?</tt> checks whether any content has been captured yet using <tt>content_for</tt>.
+      # Useful to render parts of your layout differently based on what is in your views.
+      #
+      #   <%# This is the layout %>
+      #   <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+      #   <head>
+      #     <title>My Website</title>
+      #     <%= yield :script %>
+      #   </head>
+      #   <body class="<%= content_for?(:right_col) ? 'two-column' : 'one-column' %>">
+      #     <%= yield %>
+      #     <%= yield :right_col %>
+      #   </body>
+      #   </html>
+      def content_for?: (untyped name) -> untyped
+
+      def with_output_buffer: (?untyped? buf) { () -> untyped } -> untyped
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    module ControllerHelper
+      CONTROLLER_DELEGATES: ::Array[untyped]
+
+      def assign_controller: (untyped controller) -> untyped
+
+      def logger: () -> untyped
+
+      def respond_to?: (untyped method_name, ?bool include_private) -> untyped
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    # = Action View CSP Helper
+    # nodoc:
+    module CspHelper
+      # Returns a meta tag "csp-nonce" with the per-session nonce value
+      # for allowing inline <script> tags.
+      #
+      #   <head>
+      #     <%= csp_meta_tag %>
+      #   </head>
+      #
+      # This is used by the Rails UJS helper to create dynamically
+      # loaded inline <script> elements.
+      #
+      def csp_meta_tag: (**untyped options) -> untyped
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    # = Action View CSRF Helper
+    # nodoc:
+    module CsrfHelper
+      # Returns meta tags "csrf-param" and "csrf-token" with the name of the cross-site
+      # request forgery protection parameter and token, respectively.
+      #
+      #   <head>
+      #     <%= csrf_meta_tags %>
+      #   </head>
+      #
+      # These are used to generate the dynamic forms that implement non-remote links with
+      # <tt>:method</tt>.
+      #
+      # You don't need to use these tags for regular forms as they generate their own hidden fields.
+      #
+      # For AJAX requests other than GETs, extract the "csrf-token" from the meta-tag and send as the
+      # "X-CSRF-Token" HTTP header. If you are using rails-ujs this happens automatically.
+      #
+      def csrf_meta_tags: () -> untyped
+
+      # For backwards compatibility.
+      alias csrf_meta_tag csrf_meta_tags
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    # nodoc:
+    # = Action View Date Helpers
+    #
+    # The Date Helper primarily creates select/option tags for different kinds of dates and times or date and time
+    # elements. All of the select-type methods share a number of common options that are as follows:
+    #
+    # * <tt>:prefix</tt> - overwrites the default prefix of "date" used for the select names. So specifying "birthday"
+    #   would give \birthday[month] instead of \date[month] if passed to the <tt>select_month</tt> method.
+    # * <tt>:include_blank</tt> - set to true if it should be possible to set an empty date.
+    # * <tt>:discard_type</tt> - set to true if you want to discard the type part of the select name. If set to true,
+    #   the <tt>select_month</tt> method would use simply "date" (which can be overwritten using <tt>:prefix</tt>) instead
+    #   of \date[month].
+    module DateHelper
+      MINUTES_IN_YEAR: ::Integer
+
+      MINUTES_IN_QUARTER_YEAR: ::Integer
+
+      MINUTES_IN_THREE_QUARTERS_YEAR: ::Integer
+
+      # Reports the approximate distance in time between two Time, Date or DateTime objects or integers as seconds.
+      # Pass <tt>include_seconds: true</tt> if you want more detailed approximations when distance < 1 min, 29 secs.
+      # Distances are reported based on the following table:
+      #
+      #   0 <-> 29 secs                                                             # => less than a minute
+      #   30 secs <-> 1 min, 29 secs                                                # => 1 minute
+      #   1 min, 30 secs <-> 44 mins, 29 secs                                       # => [2..44] minutes
+      #   44 mins, 30 secs <-> 89 mins, 29 secs                                     # => about 1 hour
+      #   89 mins, 30 secs <-> 23 hrs, 59 mins, 29 secs                             # => about [2..24] hours
+      #   23 hrs, 59 mins, 30 secs <-> 41 hrs, 59 mins, 29 secs                     # => 1 day
+      #   41 hrs, 59 mins, 30 secs  <-> 29 days, 23 hrs, 59 mins, 29 secs           # => [2..29] days
+      #   29 days, 23 hrs, 59 mins, 30 secs <-> 44 days, 23 hrs, 59 mins, 29 secs   # => about 1 month
+      #   44 days, 23 hrs, 59 mins, 30 secs <-> 59 days, 23 hrs, 59 mins, 29 secs   # => about 2 months
+      #   59 days, 23 hrs, 59 mins, 30 secs <-> 1 yr minus 1 sec                    # => [2..12] months
+      #   1 yr <-> 1 yr, 3 months                                                   # => about 1 year
+      #   1 yr, 3 months <-> 1 yr, 9 months                                         # => over 1 year
+      #   1 yr, 9 months <-> 2 yr minus 1 sec                                       # => almost 2 years
+      #   2 yrs <-> max time or date                                                # => (same rules as 1 yr)
+      #
+      # With <tt>include_seconds: true</tt> and the difference < 1 minute 29 seconds:
+      #   0-4   secs      # => less than 5 seconds
+      #   5-9   secs      # => less than 10 seconds
+      #   10-19 secs      # => less than 20 seconds
+      #   20-39 secs      # => half a minute
+      #   40-59 secs      # => less than a minute
+      #   60-89 secs      # => 1 minute
+      #
+      #   from_time = Time.now
+      #   distance_of_time_in_words(from_time, from_time + 50.minutes)                                # => about 1 hour
+      #   distance_of_time_in_words(from_time, 50.minutes.from_now)                                   # => about 1 hour
+      #   distance_of_time_in_words(from_time, from_time + 15.seconds)                                # => less than a minute
+      #   distance_of_time_in_words(from_time, from_time + 15.seconds, include_seconds: true)         # => less than 20 seconds
+      #   distance_of_time_in_words(from_time, 3.years.from_now)                                      # => about 3 years
+      #   distance_of_time_in_words(from_time, from_time + 60.hours)                                  # => 3 days
+      #   distance_of_time_in_words(from_time, from_time + 45.seconds, include_seconds: true)         # => less than a minute
+      #   distance_of_time_in_words(from_time, from_time - 45.seconds, include_seconds: true)         # => less than a minute
+      #   distance_of_time_in_words(from_time, 76.seconds.from_now)                                   # => 1 minute
+      #   distance_of_time_in_words(from_time, from_time + 1.year + 3.days)                           # => about 1 year
+      #   distance_of_time_in_words(from_time, from_time + 3.years + 6.months)                        # => over 3 years
+      #   distance_of_time_in_words(from_time, from_time + 4.years + 9.days + 30.minutes + 5.seconds) # => about 4 years
+      #
+      #   to_time = Time.now + 6.years + 19.days
+      #   distance_of_time_in_words(from_time, to_time, include_seconds: true)                        # => about 6 years
+      #   distance_of_time_in_words(to_time, from_time, include_seconds: true)                        # => about 6 years
+      #   distance_of_time_in_words(Time.now, Time.now)                                               # => less than a minute
+      #
+      # With the <tt>scope</tt> option, you can define a custom scope for Rails
+      # to look up the translation.
+      #
+      # For example you can define the following in your locale (e.g. en.yml).
+      #
+      #   datetime:
+      #     distance_in_words:
+      #       short:
+      #         about_x_hours:
+      #           one: 'an hour'
+      #           other: '%{count} hours'
+      #
+      # See https://github.com/svenfuchs/rails-i18n/blob/master/rails/locale/en.yml
+      # for more examples.
+      #
+      # Which will then result in the following:
+      #
+      #   from_time = Time.now
+      #   distance_of_time_in_words(from_time, from_time + 50.minutes, scope: 'datetime.distance_in_words.short') # => "an hour"
+      #   distance_of_time_in_words(from_time, from_time + 3.hours, scope: 'datetime.distance_in_words.short')    # => "3 hours"
+      def distance_of_time_in_words: (untyped from_time, ?::Integer to_time, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Like <tt>distance_of_time_in_words</tt>, but where <tt>to_time</tt> is fixed to <tt>Time.now</tt>.
+      #
+      #   time_ago_in_words(3.minutes.from_now)                 # => 3 minutes
+      #   time_ago_in_words(3.minutes.ago)                      # => 3 minutes
+      #   time_ago_in_words(Time.now - 15.hours)                # => about 15 hours
+      #   time_ago_in_words(Time.now)                           # => less than a minute
+      #   time_ago_in_words(Time.now, include_seconds: true) # => less than 5 seconds
+      #
+      #   from_time = Time.now - 3.days - 14.minutes - 25.seconds
+      #   time_ago_in_words(from_time)      # => 3 days
+      #
+      #   from_time = (3.days + 14.minutes + 25.seconds).ago
+      #   time_ago_in_words(from_time)      # => 3 days
+      #
+      # Note that you cannot pass a <tt>Numeric</tt> value to <tt>time_ago_in_words</tt>.
+      #
+      def time_ago_in_words: (untyped from_time, ?::Hash[untyped, untyped] options) -> untyped
+
+      alias distance_of_time_in_words_to_now time_ago_in_words
+
+      # Returns a set of select tags (one for year, month, and day) pre-selected for accessing a specified date-based
+      # attribute (identified by +method+) on an object assigned to the template (identified by +object+).
+      #
+      # ==== Options
+      # * <tt>:use_month_numbers</tt> - Set to true if you want to use month numbers rather than month names (e.g.
+      #   "2" instead of "February").
+      # * <tt>:use_two_digit_numbers</tt> - Set to true if you want to display two digit month and day numbers (e.g.
+      #   "02" instead of "February" and "08" instead of "8").
+      # * <tt>:use_short_month</tt>   - Set to true if you want to use abbreviated month names instead of full
+      #   month names (e.g. "Feb" instead of "February").
+      # * <tt>:add_month_numbers</tt>  - Set to true if you want to use both month numbers and month names (e.g.
+      #   "2 - February" instead of "February").
+      # * <tt>:use_month_names</tt>   - Set to an array with 12 month names if you want to customize month names.
+      #   Note: You can also use Rails' i18n functionality for this.
+      # * <tt>:month_format_string</tt> - Set to a format string. The string gets passed keys +:number+ (integer)
+      #   and +:name+ (string). A format string would be something like "%{name} (%<number>02d)" for example.
+      #   See <tt>Kernel.sprintf</tt> for documentation on format sequences.
+      # * <tt>:date_separator</tt>    - Specifies a string to separate the date fields. Default is "" (i.e. nothing).
+      # * <tt>:time_separator</tt>    - Specifies a string to separate the time fields. Default is "" (i.e. nothing).
+      # * <tt>:datetime_separator</tt>- Specifies a string to separate the date and time fields. Default is "" (i.e. nothing).
+      # * <tt>:start_year</tt>        - Set the start year for the year select. Default is <tt>Date.today.year - 5</tt> if
+      #   you are creating new record. While editing existing record, <tt>:start_year</tt> defaults to
+      #   the current selected year minus 5.
+      # * <tt>:end_year</tt>          - Set the end year for the year select. Default is <tt>Date.today.year + 5</tt> if
+      #   you are creating new record. While editing existing record, <tt>:end_year</tt> defaults to
+      #   the current selected year plus 5.
+      # * <tt>:year_format</tt>       - Set format of years for year select. Lambda should be passed.
+      # * <tt>:discard_day</tt>       - Set to true if you don't want to show a day select. This includes the day
+      #   as a hidden field instead of showing a select field. Also note that this implicitly sets the day to be the
+      #   first of the given month in order to not create invalid dates like 31 February.
+      # * <tt>:discard_month</tt>     - Set to true if you don't want to show a month select. This includes the month
+      #   as a hidden field instead of showing a select field. Also note that this implicitly sets :discard_day to true.
+      # * <tt>:discard_year</tt>      - Set to true if you don't want to show a year select. This includes the year
+      #   as a hidden field instead of showing a select field.
+      # * <tt>:order</tt>             - Set to an array containing <tt>:day</tt>, <tt>:month</tt> and <tt>:year</tt> to
+      #   customize the order in which the select fields are shown. If you leave out any of the symbols, the respective
+      #   select will not be shown (like when you set <tt>discard_xxx: true</tt>. Defaults to the order defined in
+      #   the respective locale (e.g. [:year, :month, :day] in the en locale that ships with Rails).
+      # * <tt>:include_blank</tt>     - Include a blank option in every select field so it's possible to set empty
+      #   dates.
+      # * <tt>:default</tt>           - Set a default date if the affected date isn't set or is +nil+.
+      # * <tt>:selected</tt>          - Set a date that overrides the actual value.
+      # * <tt>:disabled</tt>          - Set to true if you want show the select fields as disabled.
+      # * <tt>:prompt</tt>            - Set to true (for a generic prompt), a prompt string or a hash of prompt strings
+      #   for <tt>:year</tt>, <tt>:month</tt>, <tt>:day</tt>, <tt>:hour</tt>, <tt>:minute</tt> and <tt>:second</tt>.
+      #   Setting this option prepends a select option with a generic prompt  (Day, Month, Year, Hour, Minute, Seconds)
+      #   or the given prompt string.
+      # * <tt>:with_css_classes</tt>  - Set to true or a hash of strings. Use true if you want to assign generic styles for
+      #   select tags. This automatically set classes 'year', 'month', 'day', 'hour', 'minute' and 'second'. A hash of
+      #   strings for <tt>:year</tt>, <tt>:month</tt>, <tt>:day</tt>, <tt>:hour</tt>, <tt>:minute</tt>, <tt>:second</tt>
+      #   will extend the select type with the given value. Use +html_options+ to modify every select tag in the set.
+      # * <tt>:use_hidden</tt>         - Set to true if you only want to generate hidden input tags.
+      #
+      # If anything is passed in the +html_options+ hash it will be applied to every select tag in the set.
+      #
+      # NOTE: Discarded selects will default to 1. So if no month select is available, January will be assumed.
+      #
+      #   # Generates a date select that when POSTed is stored in the article variable, in the written_on attribute.
+      #   date_select("article", "written_on")
+      #
+      #   # Generates a date select that when POSTed is stored in the article variable, in the written_on attribute,
+      #   # with the year in the year drop down box starting at 1995.
+      #   date_select("article", "written_on", start_year: 1995)
+      #
+      #   # Generates a date select that when POSTed is stored in the article variable, in the written_on attribute,
+      #   # with the year in the year drop down box starting at 1995, numbers used for months instead of words,
+      #   # and without a day select box.
+      #   date_select("article", "written_on", start_year: 1995, use_month_numbers: true,
+      #                                     discard_day: true, include_blank: true)
+      #
+      #   # Generates a date select that when POSTed is stored in the article variable, in the written_on attribute,
+      #   # with two digit numbers used for months and days.
+      #   date_select("article", "written_on", use_two_digit_numbers: true)
+      #
+      #   # Generates a date select that when POSTed is stored in the article variable, in the written_on attribute
+      #   # with the fields ordered as day, month, year rather than month, day, year.
+      #   date_select("article", "written_on", order: [:day, :month, :year])
+      #
+      #   # Generates a date select that when POSTed is stored in the user variable, in the birthday attribute
+      #   # lacking a year field.
+      #   date_select("user", "birthday", order: [:month, :day])
+      #
+      #   # Generates a date select that when POSTed is stored in the article variable, in the written_on attribute
+      #   # which is initially set to the date 3 days from the current date
+      #   date_select("article", "written_on", default: 3.days.from_now)
+      #
+      #   # Generates a date select that when POSTed is stored in the article variable, in the written_on attribute
+      #   # which is set in the form with today's date, regardless of the value in the Active Record object.
+      #   date_select("article", "written_on", selected: Date.today)
+      #
+      #   # Generates a date select that when POSTed is stored in the credit_card variable, in the bill_due attribute
+      #   # that will have a default day of 20.
+      #   date_select("credit_card", "bill_due", default: { day: 20 })
+      #
+      #   # Generates a date select with custom prompts.
+      #   date_select("article", "written_on", prompt: { day: 'Select day', month: 'Select month', year: 'Select year' })
+      #
+      #   # Generates a date select with custom year format.
+      #   date_select("article", "written_on", year_format: ->(year) { "Heisei #{year - 1988}" })
+      #
+      # The selects are prepared for multi-parameter assignment to an Active Record object.
+      #
+      # Note: If the day is not included as an option but the month is, the day will be set to the 1st to ensure that
+      # all month choices are valid.
+      def date_select: (untyped object_name, untyped method, ?::Hash[untyped, untyped] options, ?::Hash[untyped, untyped] html_options) -> untyped
+
+      # Returns a set of select tags (one for hour, minute and optionally second) pre-selected for accessing a
+      # specified time-based attribute (identified by +method+) on an object assigned to the template (identified by
+      # +object+). You can include the seconds with <tt>:include_seconds</tt>. You can get hours in the AM/PM format
+      # with <tt>:ampm</tt> option.
+      #
+      # This method will also generate 3 input hidden tags, for the actual year, month and day unless the option
+      # <tt>:ignore_date</tt> is set to +true+. If you set the <tt>:ignore_date</tt> to +true+, you must have a
+      # +date_select+ on the same method within the form otherwise an exception will be raised.
+      #
+      # If anything is passed in the html_options hash it will be applied to every select tag in the set.
+      #
+      #   # Creates a time select tag that, when POSTed, will be stored in the article variable in the sunrise attribute.
+      #   time_select("article", "sunrise")
+      #
+      #   # Creates a time select tag with a seconds field that, when POSTed, will be stored in the article variables in
+      #   # the sunrise attribute.
+      #   time_select("article", "start_time", include_seconds: true)
+      #
+      #   # You can set the <tt>:minute_step</tt> to 15 which will give you: 00, 15, 30, and 45.
+      #   time_select 'game', 'game_time', { minute_step: 15 }
+      #
+      #   # Creates a time select tag with a custom prompt. Use <tt>prompt: true</tt> for generic prompts.
+      #   time_select("article", "written_on", prompt: { hour: 'Choose hour', minute: 'Choose minute', second: 'Choose seconds' })
+      #   time_select("article", "written_on", prompt: { hour: true }) # generic prompt for hours
+      #   time_select("article", "written_on", prompt: true) # generic prompts for all
+      #
+      #   # You can set :ampm option to true which will show the hours as: 12 PM, 01 AM .. 11 PM.
+      #   time_select 'game', 'game_time', { ampm: true }
+      #
+      # The selects are prepared for multi-parameter assignment to an Active Record object.
+      #
+      # Note: If the day is not included as an option but the month is, the day will be set to the 1st to ensure that
+      # all month choices are valid.
+      def time_select: (untyped object_name, untyped method, ?::Hash[untyped, untyped] options, ?::Hash[untyped, untyped] html_options) -> untyped
+
+      # Returns a set of select tags (one for year, month, day, hour, and minute) pre-selected for accessing a
+      # specified datetime-based attribute (identified by +method+) on an object assigned to the template (identified
+      # by +object+).
+      #
+      # If anything is passed in the html_options hash it will be applied to every select tag in the set.
+      #
+      #   # Generates a datetime select that, when POSTed, will be stored in the article variable in the written_on
+      #   # attribute.
+      #   datetime_select("article", "written_on")
+      #
+      #   # Generates a datetime select with a year select that starts at 1995 that, when POSTed, will be stored in the
+      #   # article variable in the written_on attribute.
+      #   datetime_select("article", "written_on", start_year: 1995)
+      #
+      #   # Generates a datetime select with a default value of 3 days from the current time that, when POSTed, will
+      #   # be stored in the trip variable in the departing attribute.
+      #   datetime_select("trip", "departing", default: 3.days.from_now)
+      #
+      #   # Generate a datetime select with hours in the AM/PM format
+      #   datetime_select("article", "written_on", ampm: true)
+      #
+      #   # Generates a datetime select that discards the type that, when POSTed, will be stored in the article variable
+      #   # as the written_on attribute.
+      #   datetime_select("article", "written_on", discard_type: true)
+      #
+      #   # Generates a datetime select with a custom prompt. Use <tt>prompt: true</tt> for generic prompts.
+      #   datetime_select("article", "written_on", prompt: { day: 'Choose day', month: 'Choose month', year: 'Choose year' })
+      #   datetime_select("article", "written_on", prompt: { hour: true }) # generic prompt for hours
+      #   datetime_select("article", "written_on", prompt: true) # generic prompts for all
+      #
+      # The selects are prepared for multi-parameter assignment to an Active Record object.
+      def datetime_select: (untyped object_name, untyped method, ?::Hash[untyped, untyped] options, ?::Hash[untyped, untyped] html_options) -> untyped
+
+      # Returns a set of HTML select-tags (one for year, month, day, hour, minute, and second) pre-selected with the
+      # +datetime+. It's also possible to explicitly set the order of the tags using the <tt>:order</tt> option with
+      # an array of symbols <tt>:year</tt>, <tt>:month</tt> and <tt>:day</tt> in the desired order. If you do not
+      # supply a Symbol, it will be appended onto the <tt>:order</tt> passed in. You can also add
+      # <tt>:date_separator</tt>, <tt>:datetime_separator</tt> and <tt>:time_separator</tt> keys to the +options+ to
+      # control visual display of the elements.
+      #
+      # If anything is passed in the html_options hash it will be applied to every select tag in the set.
+      #
+      #   my_date_time = Time.now + 4.days
+      #
+      #   # Generates a datetime select that defaults to the datetime in my_date_time (four days after today).
+      #   select_datetime(my_date_time)
+      #
+      #   # Generates a datetime select that defaults to today (no specified datetime)
+      #   select_datetime()
+      #
+      #   # Generates a datetime select that defaults to the datetime in my_date_time (four days after today)
+      #   # with the fields ordered year, month, day rather than month, day, year.
+      #   select_datetime(my_date_time, order: [:year, :month, :day])
+      #
+      #   # Generates a datetime select that defaults to the datetime in my_date_time (four days after today)
+      #   # with a '/' between each date field.
+      #   select_datetime(my_date_time, date_separator: '/')
+      #
+      #   # Generates a datetime select that defaults to the datetime in my_date_time (four days after today)
+      #   # with a date fields separated by '/', time fields separated by '' and the date and time fields
+      #   # separated by a comma (',').
+      #   select_datetime(my_date_time, date_separator: '/', time_separator: '', datetime_separator: ',')
+      #
+      #   # Generates a datetime select that discards the type of the field and defaults to the datetime in
+      #   # my_date_time (four days after today)
+      #   select_datetime(my_date_time, discard_type: true)
+      #
+      #   # Generate a datetime field with hours in the AM/PM format
+      #   select_datetime(my_date_time, ampm: true)
+      #
+      #   # Generates a datetime select that defaults to the datetime in my_date_time (four days after today)
+      #   # prefixed with 'payday' rather than 'date'
+      #   select_datetime(my_date_time, prefix: 'payday')
+      #
+      #   # Generates a datetime select with a custom prompt. Use <tt>prompt: true</tt> for generic prompts.
+      #   select_datetime(my_date_time, prompt: { day: 'Choose day', month: 'Choose month', year: 'Choose year' })
+      #   select_datetime(my_date_time, prompt: { hour: true }) # generic prompt for hours
+      #   select_datetime(my_date_time, prompt: true) # generic prompts for all
+      def select_datetime: (?untyped datetime, ?::Hash[untyped, untyped] options, ?::Hash[untyped, untyped] html_options) -> untyped
+
+      # Returns a set of HTML select-tags (one for year, month, and day) pre-selected with the +date+.
+      # It's possible to explicitly set the order of the tags using the <tt>:order</tt> option with an array of
+      # symbols <tt>:year</tt>, <tt>:month</tt> and <tt>:day</tt> in the desired order.
+      # If the array passed to the <tt>:order</tt> option does not contain all the three symbols, all tags will be hidden.
+      #
+      # If anything is passed in the html_options hash it will be applied to every select tag in the set.
+      #
+      #   my_date = Time.now + 6.days
+      #
+      #   # Generates a date select that defaults to the date in my_date (six days after today).
+      #   select_date(my_date)
+      #
+      #   # Generates a date select that defaults to today (no specified date).
+      #   select_date()
+      #
+      #   # Generates a date select that defaults to the date in my_date (six days after today)
+      #   # with the fields ordered year, month, day rather than month, day, year.
+      #   select_date(my_date, order: [:year, :month, :day])
+      #
+      #   # Generates a date select that discards the type of the field and defaults to the date in
+      #   # my_date (six days after today).
+      #   select_date(my_date, discard_type: true)
+      #
+      #   # Generates a date select that defaults to the date in my_date,
+      #   # which has fields separated by '/'.
+      #   select_date(my_date, date_separator: '/')
+      #
+      #   # Generates a date select that defaults to the datetime in my_date (six days after today)
+      #   # prefixed with 'payday' rather than 'date'.
+      #   select_date(my_date, prefix: 'payday')
+      #
+      #   # Generates a date select with a custom prompt. Use <tt>prompt: true</tt> for generic prompts.
+      #   select_date(my_date, prompt: { day: 'Choose day', month: 'Choose month', year: 'Choose year' })
+      #   select_date(my_date, prompt: { hour: true }) # generic prompt for hours
+      #   select_date(my_date, prompt: true) # generic prompts for all
+      def select_date: (?untyped date, ?::Hash[untyped, untyped] options, ?::Hash[untyped, untyped] html_options) -> untyped
+
+      # Returns a set of HTML select-tags (one for hour and minute).
+      # You can set <tt>:time_separator</tt> key to format the output, and
+      # the <tt>:include_seconds</tt> option to include an input for seconds.
+      #
+      # If anything is passed in the html_options hash it will be applied to every select tag in the set.
+      #
+      #   my_time = Time.now + 5.days + 7.hours + 3.minutes + 14.seconds
+      #
+      #   # Generates a time select that defaults to the time in my_time.
+      #   select_time(my_time)
+      #
+      #   # Generates a time select that defaults to the current time (no specified time).
+      #   select_time()
+      #
+      #   # Generates a time select that defaults to the time in my_time,
+      #   # which has fields separated by ':'.
+      #   select_time(my_time, time_separator: ':')
+      #
+      #   # Generates a time select that defaults to the time in my_time,
+      #   # that also includes an input for seconds.
+      #   select_time(my_time, include_seconds: true)
+      #
+      #   # Generates a time select that defaults to the time in my_time, that has fields
+      #   # separated by ':' and includes an input for seconds.
+      #   select_time(my_time, time_separator: ':', include_seconds: true)
+      #
+      #   # Generate a time select field with hours in the AM/PM format
+      #   select_time(my_time, ampm: true)
+      #
+      #   # Generates a time select field with hours that range from 2 to 14
+      #   select_time(my_time, start_hour: 2, end_hour: 14)
+      #
+      #   # Generates a time select with a custom prompt. Use <tt>:prompt</tt> to true for generic prompts.
+      #   select_time(my_time, prompt: { day: 'Choose day', month: 'Choose month', year: 'Choose year' })
+      #   select_time(my_time, prompt: { hour: true }) # generic prompt for hours
+      #   select_time(my_time, prompt: true) # generic prompts for all
+      def select_time: (?untyped datetime, ?::Hash[untyped, untyped] options, ?::Hash[untyped, untyped] html_options) -> untyped
+
+      # Returns a select tag with options for each of the seconds 0 through 59 with the current second selected.
+      # The <tt>datetime</tt> can be either a +Time+ or +DateTime+ object or an integer.
+      # Override the field name using the <tt>:field_name</tt> option, 'second' by default.
+      #
+      #   my_time = Time.now + 16.seconds
+      #
+      #   # Generates a select field for seconds that defaults to the seconds for the time in my_time.
+      #   select_second(my_time)
+      #
+      #   # Generates a select field for seconds that defaults to the number given.
+      #   select_second(33)
+      #
+      #   # Generates a select field for seconds that defaults to the seconds for the time in my_time
+      #   # that is named 'interval' rather than 'second'.
+      #   select_second(my_time, field_name: 'interval')
+      #
+      #   # Generates a select field for seconds with a custom prompt. Use <tt>prompt: true</tt> for a
+      #   # generic prompt.
+      #   select_second(14, prompt: 'Choose seconds')
+      def select_second: (untyped datetime, ?::Hash[untyped, untyped] options, ?::Hash[untyped, untyped] html_options) -> untyped
+
+      # Returns a select tag with options for each of the minutes 0 through 59 with the current minute selected.
+      # Also can return a select tag with options by <tt>minute_step</tt> from 0 through 59 with the 00 minute
+      # selected. The <tt>datetime</tt> can be either a +Time+ or +DateTime+ object or an integer.
+      # Override the field name using the <tt>:field_name</tt> option, 'minute' by default.
+      #
+      #   my_time = Time.now + 10.minutes
+      #
+      #   # Generates a select field for minutes that defaults to the minutes for the time in my_time.
+      #   select_minute(my_time)
+      #
+      #   # Generates a select field for minutes that defaults to the number given.
+      #   select_minute(14)
+      #
+      #   # Generates a select field for minutes that defaults to the minutes for the time in my_time
+      #   # that is named 'moment' rather than 'minute'.
+      #   select_minute(my_time, field_name: 'moment')
+      #
+      #   # Generates a select field for minutes with a custom prompt. Use <tt>prompt: true</tt> for a
+      #   # generic prompt.
+      #   select_minute(14, prompt: 'Choose minutes')
+      def select_minute: (untyped datetime, ?::Hash[untyped, untyped] options, ?::Hash[untyped, untyped] html_options) -> untyped
+
+      # Returns a select tag with options for each of the hours 0 through 23 with the current hour selected.
+      # The <tt>datetime</tt> can be either a +Time+ or +DateTime+ object or an integer.
+      # Override the field name using the <tt>:field_name</tt> option, 'hour' by default.
+      #
+      #   my_time = Time.now + 6.hours
+      #
+      #   # Generates a select field for hours that defaults to the hour for the time in my_time.
+      #   select_hour(my_time)
+      #
+      #   # Generates a select field for hours that defaults to the number given.
+      #   select_hour(13)
+      #
+      #   # Generates a select field for hours that defaults to the hour for the time in my_time
+      #   # that is named 'stride' rather than 'hour'.
+      #   select_hour(my_time, field_name: 'stride')
+      #
+      #   # Generates a select field for hours with a custom prompt. Use <tt>prompt: true</tt> for a
+      #   # generic prompt.
+      #   select_hour(13, prompt: 'Choose hour')
+      #
+      #   # Generate a select field for hours in the AM/PM format
+      #   select_hour(my_time, ampm: true)
+      #
+      #   # Generates a select field that includes options for hours from 2 to 14.
+      #   select_hour(my_time, start_hour: 2, end_hour: 14)
+      def select_hour: (untyped datetime, ?::Hash[untyped, untyped] options, ?::Hash[untyped, untyped] html_options) -> untyped
+
+      # Returns a select tag with options for each of the days 1 through 31 with the current day selected.
+      # The <tt>date</tt> can also be substituted for a day number.
+      # If you want to display days with a leading zero set the <tt>:use_two_digit_numbers</tt> key in +options+ to true.
+      # Override the field name using the <tt>:field_name</tt> option, 'day' by default.
+      #
+      #   my_date = Time.now + 2.days
+      #
+      #   # Generates a select field for days that defaults to the day for the date in my_date.
+      #   select_day(my_date)
+      #
+      #   # Generates a select field for days that defaults to the number given.
+      #   select_day(5)
+      #
+      #   # Generates a select field for days that defaults to the number given, but displays it with two digits.
+      #   select_day(5, use_two_digit_numbers: true)
+      #
+      #   # Generates a select field for days that defaults to the day for the date in my_date
+      #   # that is named 'due' rather than 'day'.
+      #   select_day(my_date, field_name: 'due')
+      #
+      #   # Generates a select field for days with a custom prompt. Use <tt>prompt: true</tt> for a
+      #   # generic prompt.
+      #   select_day(5, prompt: 'Choose day')
+      def select_day: (untyped date, ?::Hash[untyped, untyped] options, ?::Hash[untyped, untyped] html_options) -> untyped
+
+      # Returns a select tag with options for each of the months January through December with the current month
+      # selected. The month names are presented as keys (what's shown to the user) and the month numbers (1-12) are
+      # used as values (what's submitted to the server). It's also possible to use month numbers for the presentation
+      # instead of names -- set the <tt>:use_month_numbers</tt> key in +options+ to true for this to happen. If you
+      # want both numbers and names, set the <tt>:add_month_numbers</tt> key in +options+ to true. If you would prefer
+      # to show month names as abbreviations, set the <tt>:use_short_month</tt> key in +options+ to true. If you want
+      # to use your own month names, set the <tt>:use_month_names</tt> key in +options+ to an array of 12 month names.
+      # If you want to display months with a leading zero set the <tt>:use_two_digit_numbers</tt> key in +options+ to true.
+      # Override the field name using the <tt>:field_name</tt> option, 'month' by default.
+      #
+      #   # Generates a select field for months that defaults to the current month that
+      #   # will use keys like "January", "March".
+      #   select_month(Date.today)
+      #
+      #   # Generates a select field for months that defaults to the current month that
+      #   # is named "start" rather than "month".
+      #   select_month(Date.today, field_name: 'start')
+      #
+      #   # Generates a select field for months that defaults to the current month that
+      #   # will use keys like "1", "3".
+      #   select_month(Date.today, use_month_numbers: true)
+      #
+      #   # Generates a select field for months that defaults to the current month that
+      #   # will use keys like "1 - January", "3 - March".
+      #   select_month(Date.today, add_month_numbers: true)
+      #
+      #   # Generates a select field for months that defaults to the current month that
+      #   # will use keys like "Jan", "Mar".
+      #   select_month(Date.today, use_short_month: true)
+      #
+      #   # Generates a select field for months that defaults to the current month that
+      #   # will use keys like "Januar", "Marts."
+      #   select_month(Date.today, use_month_names: %w(Januar Februar Marts ...))
+      #
+      #   # Generates a select field for months that defaults to the current month that
+      #   # will use keys with two digit numbers like "01", "03".
+      #   select_month(Date.today, use_two_digit_numbers: true)
+      #
+      #   # Generates a select field for months with a custom prompt. Use <tt>prompt: true</tt> for a
+      #   # generic prompt.
+      #   select_month(14, prompt: 'Choose month')
+      def select_month: (untyped date, ?::Hash[untyped, untyped] options, ?::Hash[untyped, untyped] html_options) -> untyped
+
+      # Returns a select tag with options for each of the five years on each side of the current, which is selected.
+      # The five year radius can be changed using the <tt>:start_year</tt> and <tt>:end_year</tt> keys in the
+      # +options+. Both ascending and descending year lists are supported by making <tt>:start_year</tt> less than or
+      # greater than <tt>:end_year</tt>. The <tt>date</tt> can also be substituted for a year given as a number.
+      # Override the field name using the <tt>:field_name</tt> option, 'year' by default.
+      #
+      #   # Generates a select field for years that defaults to the current year that
+      #   # has ascending year values.
+      #   select_year(Date.today, start_year: 1992, end_year: 2007)
+      #
+      #   # Generates a select field for years that defaults to the current year that
+      #   # is named 'birth' rather than 'year'.
+      #   select_year(Date.today, field_name: 'birth')
+      #
+      #   # Generates a select field for years that defaults to the current year that
+      #   # has descending year values.
+      #   select_year(Date.today, start_year: 2005, end_year: 1900)
+      #
+      #   # Generates a select field for years that defaults to the year 2006 that
+      #   # has ascending year values.
+      #   select_year(2006, start_year: 2000, end_year: 2010)
+      #
+      #   # Generates a select field for years with a custom prompt. Use <tt>prompt: true</tt> for a
+      #   # generic prompt.
+      #   select_year(14, prompt: 'Choose year')
+      def select_year: (untyped date, ?::Hash[untyped, untyped] options, ?::Hash[untyped, untyped] html_options) -> untyped
+
+      # Returns an HTML time tag for the given date or time.
+      #
+      #   time_tag Date.today  # =>
+      #     <time datetime="2010-11-04">November 04, 2010</time>
+      #   time_tag Time.now  # =>
+      #     <time datetime="2010-11-04T17:55:45+01:00">November 04, 2010 17:55</time>
+      #   time_tag Date.yesterday, 'Yesterday'  # =>
+      #     <time datetime="2010-11-03">Yesterday</time>
+      #   time_tag Date.today, datetime: Date.today.strftime('%G-W%V') # =>
+      #     <time datetime="2010-W44">November 04, 2010</time>
+      #
+      #   <%= time_tag Time.now do %>
+      #     <span>Right now</span>
+      #   <% end %>
+      #   # => <time datetime="2010-11-04T17:55:45+01:00"><span>Right now</span></time>
+      def time_tag: (untyped date_or_time, *untyped args) { () -> untyped } -> untyped
+
+      def normalize_distance_of_time_argument_to_time: (untyped value) -> untyped
+    end
+
+    class DateTimeSelector
+      # nodoc:
+      include ActionView::Helpers::TagHelper
+
+      DEFAULT_PREFIX: ::String
+
+      POSITION: untyped
+
+      AMPM_TRANSLATION: untyped
+
+      def initialize: (untyped datetime, ?::Hash[untyped, untyped] options, ?::Hash[untyped, untyped] html_options) -> untyped
+
+      def select_datetime: () -> untyped
+
+      def select_date: () -> untyped
+
+      def select_time: () -> untyped
+
+      def select_second: () -> untyped
+
+      def select_minute: () -> untyped
+
+      def select_hour: () -> untyped
+
+      def select_day: () -> untyped
+
+      def select_month: () -> untyped
+
+      def select_year: () -> untyped
+
+      # If the day is hidden, the day should be set to the 1st so all month and year choices are
+      # valid. Otherwise, February 31st or February 29th, 2011 can be selected, which are invalid.
+      def set_day_if_discarded: () -> untyped
+
+      # Returns translated month names, but also ensures that a custom month
+      # name array has a leading +nil+ element.
+      def month_names: () -> untyped
+
+      # Returns translated month names.
+      #  => [nil, "January", "February", "March",
+      #           "April", "May", "June", "July",
+      #           "August", "September", "October",
+      #           "November", "December"]
+      #
+      # If <tt>:use_short_month</tt> option is set
+      #  => [nil, "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+      #           "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
+      def translated_month_names: () -> untyped
+
+      # Looks up month names by number (1-based):
+      #
+      #   month_name(1) # => "January"
+      #
+      # If the <tt>:use_month_numbers</tt> option is passed:
+      #
+      #   month_name(1) # => 1
+      #
+      # If the <tt>:use_two_month_numbers</tt> option is passed:
+      #
+      #   month_name(1) # => '01'
+      #
+      # If the <tt>:add_month_numbers</tt> option is passed:
+      #
+      #   month_name(1) # => "1 - January"
+      #
+      # If the <tt>:month_format_string</tt> option is passed:
+      #
+      #   month_name(1) # => "January (01)"
+      #
+      # depending on the format string.
+      def month_name: (untyped number) -> untyped
+
+      # Looks up year names by number.
+      #
+      #   year_name(1998) # => 1998
+      #
+      # If the <tt>:year_format</tt> option is passed:
+      #
+      #   year_name(1998) # => "Heisei 10"
+      def year_name: (untyped number) -> untyped
+
+      def date_order: () -> untyped
+
+      def translated_date_order: () -> untyped
+
+      # Build full select tag from date type and options.
+      def build_options_and_select: (untyped `type`, untyped selected, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Build select option HTML from date value and options.
+      #  build_options(15, start: 1, end: 31)
+      #  => "<option value="1">1</option>
+      #      <option value="2">2</option>
+      #      <option value="3">3</option>..."
+      #
+      # If <tt>use_two_digit_numbers: true</tt> option is passed
+      #  build_options(15, start: 1, end: 31, use_two_digit_numbers: true)
+      #  => "<option value="1">01</option>
+      #      <option value="2">02</option>
+      #      <option value="3">03</option>..."
+      #
+      # If <tt>:step</tt> options is passed
+      #  build_options(15, start: 1, end: 31, step: 2)
+      #  => "<option value="1">1</option>
+      #      <option value="3">3</option>
+      #      <option value="5">5</option>..."
+      def build_options: (untyped selected, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Build select option HTML for year.
+      # If <tt>year_format</tt> option is not passed
+      #  build_year_options(1998, start: 1998, end: 2000)
+      #  => "<option value="1998" selected="selected">1998</option>
+      #      <option value="1999">1999</option>
+      #      <option value="2000">2000</option>"
+      #
+      # If <tt>year_format</tt> option is passed
+      #  build_year_options(1998, start: 1998, end: 2000, year_format: ->year { "Heisei #{ year - 1988 }" })
+      #  => "<option value="1998" selected="selected">Heisei 10</option>
+      #      <option value="1999">Heisei 11</option>
+      #      <option value="2000">Heisei 12</option>"
+      def build_year_options: (untyped selected, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Builds select tag from date type and HTML select options.
+      #  build_select(:month, "<option value="1">January</option>...")
+      #  => "<select id="post_written_on_2i" name="post[written_on(2i)]">
+      #        <option value="1">January</option>...
+      #      </select>"
+      def build_select: (untyped `type`, untyped select_options_as_html) -> untyped
+
+      def css_class_attribute: (untyped `type`, untyped html_options_class, untyped options) -> untyped
+
+      # Builds a prompt option tag with supplied options or from default options.
+      #  prompt_option_tag(:month, prompt: 'Select month')
+      #  => "<option value="">Select month</option>"
+      def prompt_option_tag: (untyped `type`, untyped options) -> untyped
+
+      # Builds hidden input tag for date part and value.
+      #  build_hidden(:year, 2008)
+      #  => "<input id="post_written_on_1i" name="post[written_on(1i)]" type="hidden" value="2008" />"
+      def build_hidden: (untyped `type`, untyped value) -> untyped
+
+      # Returns the name attribute for the input tag.
+      #  => post[written_on(1i)]
+      def input_name_from_type: (untyped `type`) -> untyped
+
+      # Returns the id attribute for the input tag.
+      #  => "post_written_on_1i"
+      def input_id_from_type: (untyped `type`) -> untyped
+
+      # Given an ordering of datetime components, create the selection HTML
+      # and join them with their appropriate separators.
+      def build_selects_from_types: (untyped order) -> untyped
+
+      # Returns the separator for a given datetime component.
+      def separator: (untyped `type`) -> (::String | untyped)
+    end
+
+    class FormBuilder
+      # Wraps ActionView::Helpers::DateHelper#date_select for form builders:
+      #
+      #   <%= form_for @person do |f| %>
+      #     <%= f.date_select :birth_date %>
+      #     <%= f.submit %>
+      #   <% end %>
+      #
+      # Please refer to the documentation of the base helper for details.
+      def date_select: (untyped method, ?::Hash[untyped, untyped] options, ?::Hash[untyped, untyped] html_options) -> untyped
+
+      # Wraps ActionView::Helpers::DateHelper#time_select for form builders:
+      #
+      #   <%= form_for @race do |f| %>
+      #     <%= f.time_select :average_lap %>
+      #     <%= f.submit %>
+      #   <% end %>
+      #
+      # Please refer to the documentation of the base helper for details.
+      def time_select: (untyped method, ?::Hash[untyped, untyped] options, ?::Hash[untyped, untyped] html_options) -> untyped
+
+      # Wraps ActionView::Helpers::DateHelper#datetime_select for form builders:
+      #
+      #   <%= form_for @person do |f| %>
+      #     <%= f.datetime_select :last_request_at %>
+      #     <%= f.submit %>
+      #   <% end %>
+      #
+      # Please refer to the documentation of the base helper for details.
+      def datetime_select: (untyped method, ?::Hash[untyped, untyped] options, ?::Hash[untyped, untyped] html_options) -> untyped
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    # = Action View Debug Helper
+    #
+    # Provides a set of methods for making it easier to debug Rails objects.
+    # nodoc:
+    module DebugHelper
+      include TagHelper
+
+      # Returns a YAML representation of +object+ wrapped with <pre> and </pre>.
+      # If the object cannot be converted to YAML using +to_yaml+, +inspect+ will be called instead.
+      # Useful for inspecting an object at the time of rendering.
+      #
+      #   @user = User.new({ username: 'testing', password: 'xyz', age: 42})
+      #   debug(@user)
+      #   # =>
+      #   <pre class='debug_dump'>--- !ruby/object:User
+      #   attributes:
+      #     updated_at:
+      #     username: testing
+      #     age: 42
+      #     password: xyz
+      #     created_at:
+      #   </pre>
+      def debug: (untyped object) -> untyped
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    # = Action View Form Helpers
+    # nodoc:
+    # Form helpers are designed to make working with resources much easier
+    # compared to using vanilla HTML.
+    #
+    # Typically, a form designed to create or update a resource reflects the
+    # identity of the resource in several ways: (i) the URL that the form is
+    # sent to (the form element's +action+ attribute) should result in a request
+    # being routed to the appropriate controller action (with the appropriate <tt>:id</tt>
+    # parameter in the case of an existing resource), (ii) input fields should
+    # be named in such a way that in the controller their values appear in the
+    # appropriate places within the +params+ hash, and (iii) for an existing record,
+    # when the form is initially displayed, input fields corresponding to attributes
+    # of the resource should show the current values of those attributes.
+    #
+    # In Rails, this is usually achieved by creating the form using +form_for+ and
+    # a number of related helper methods. +form_for+ generates an appropriate <tt>form</tt>
+    # tag and yields a form builder object that knows the model the form is about.
+    # Input fields are created by calling methods defined on the form builder, which
+    # means they are able to generate the appropriate names and default values
+    # corresponding to the model attributes, as well as convenient IDs, etc.
+    # Conventions in the generated field names allow controllers to receive form data
+    # nicely structured in +params+ with no effort on your side.
+    #
+    # For example, to create a new person you typically set up a new instance of
+    # +Person+ in the <tt>PeopleController#new</tt> action, <tt>@person</tt>, and
+    # in the view template pass that object to +form_for+:
+    #
+    #   <%= form_for @person do |f| %>
+    #     <%= f.label :first_name %>:
+    #     <%= f.text_field :first_name %><br />
+    #
+    #     <%= f.label :last_name %>:
+    #     <%= f.text_field :last_name %><br />
+    #
+    #     <%= f.submit %>
+    #   <% end %>
+    #
+    # The HTML generated for this would be (modulus formatting):
+    #
+    #   <form action="/people" class="new_person" id="new_person" method="post">
+    #     <input name="authenticity_token" type="hidden" value="NrOp5bsjoLRuK8IW5+dQEYjKGUJDe7TQoZVvq95Wteg=" />
+    #     <label for="person_first_name">First name</label>:
+    #     <input id="person_first_name" name="person[first_name]" type="text" /><br />
+    #
+    #     <label for="person_last_name">Last name</label>:
+    #     <input id="person_last_name" name="person[last_name]" type="text" /><br />
+    #
+    #     <input name="commit" type="submit" value="Create Person" />
+    #   </form>
+    #
+    # As you see, the HTML reflects knowledge about the resource in several spots,
+    # like the path the form should be submitted to, or the names of the input fields.
+    #
+    # In particular, thanks to the conventions followed in the generated field names, the
+    # controller gets a nested hash <tt>params[:person]</tt> with the person attributes
+    # set in the form. That hash is ready to be passed to <tt>Person.new</tt>:
+    #
+    #   @person = Person.new(params[:person])
+    #   if @person.save
+    #     # success
+    #   else
+    #     # error handling
+    #   end
+    #
+    # Interestingly, the exact same view code in the previous example can be used to edit
+    # a person. If <tt>@person</tt> is an existing record with name "John Smith" and ID 256,
+    # the code above as is would yield instead:
+    #
+    #   <form action="/people/256" class="edit_person" id="edit_person_256" method="post">
+    #     <input name="_method" type="hidden" value="patch" />
+    #     <input name="authenticity_token" type="hidden" value="NrOp5bsjoLRuK8IW5+dQEYjKGUJDe7TQoZVvq95Wteg=" />
+    #     <label for="person_first_name">First name</label>:
+    #     <input id="person_first_name" name="person[first_name]" type="text" value="John" /><br />
+    #
+    #     <label for="person_last_name">Last name</label>:
+    #     <input id="person_last_name" name="person[last_name]" type="text" value="Smith" /><br />
+    #
+    #     <input name="commit" type="submit" value="Update Person" />
+    #   </form>
+    #
+    # Note that the endpoint, default values, and submit button label are tailored for <tt>@person</tt>.
+    # That works that way because the involved helpers know whether the resource is a new record or not,
+    # and generate HTML accordingly.
+    #
+    # The controller would receive the form data again in <tt>params[:person]</tt>, ready to be
+    # passed to <tt>Person#update</tt>:
+    #
+    #   if @person.update(params[:person])
+    #     # success
+    #   else
+    #     # error handling
+    #   end
+    #
+    # That's how you typically work with resources.
+    module FormHelper
+      extend ActiveSupport::Concern
+
+      include FormTagHelper
+
+      include UrlHelper
+
+      include ModelNaming
+
+      include RecordIdentifier
+
+      # Creates a form that allows the user to create or update the attributes
+      # of a specific model object.
+      #
+      # The method can be used in several slightly different ways, depending on
+      # how much you wish to rely on Rails to infer automatically from the model
+      # how the form should be constructed. For a generic model object, a form
+      # can be created by passing +form_for+ a string or symbol representing
+      # the object we are concerned with:
+      #
+      #   <%= form_for :person do |f| %>
+      #     First name: <%= f.text_field :first_name %><br />
+      #     Last name : <%= f.text_field :last_name %><br />
+      #     Biography : <%= f.text_area :biography %><br />
+      #     Admin?    : <%= f.check_box :admin %><br />
+      #     <%= f.submit %>
+      #   <% end %>
+      #
+      # The variable +f+ yielded to the block is a FormBuilder object that
+      # incorporates the knowledge about the model object represented by
+      # <tt>:person</tt> passed to +form_for+. Methods defined on the FormBuilder
+      # are used to generate fields bound to this model. Thus, for example,
+      #
+      #   <%= f.text_field :first_name %>
+      #
+      # will get expanded to
+      #
+      #   <%= text_field :person, :first_name %>
+      #
+      # which results in an HTML <tt><input></tt> tag whose +name+ attribute is
+      # <tt>person[first_name]</tt>. This means that when the form is submitted,
+      # the value entered by the user will be available in the controller as
+      # <tt>params[:person][:first_name]</tt>.
+      #
+      # For fields generated in this way using the FormBuilder,
+      # if <tt>:person</tt> also happens to be the name of an instance variable
+      # <tt>@person</tt>, the default value of the field shown when the form is
+      # initially displayed (e.g. in the situation where you are editing an
+      # existing record) will be the value of the corresponding attribute of
+      # <tt>@person</tt>.
+      #
+      # The rightmost argument to +form_for+ is an
+      # optional hash of options -
+      #
+      # * <tt>:url</tt> - The URL the form is to be submitted to. This may be
+      #   represented in the same way as values passed to +url_for+ or +link_to+.
+      #   So for example you may use a named route directly. When the model is
+      #   represented by a string or symbol, as in the example above, if the
+      #   <tt>:url</tt> option is not specified, by default the form will be
+      #   sent back to the current URL (We will describe below an alternative
+      #   resource-oriented usage of +form_for+ in which the URL does not need
+      #   to be specified explicitly).
+      # * <tt>:namespace</tt> - A namespace for your form to ensure uniqueness of
+      #   id attributes on form elements. The namespace attribute will be prefixed
+      #   with underscore on the generated HTML id.
+      # * <tt>:method</tt> - The method to use when submitting the form, usually
+      #   either "get" or "post". If "patch", "put", "delete", or another verb
+      #   is used, a hidden input with name <tt>_method</tt> is added to
+      #   simulate the verb over post.
+      # * <tt>:authenticity_token</tt> - Authenticity token to use in the form.
+      #   Use only if you need to pass custom authenticity token string, or to
+      #   not add authenticity_token field at all (by passing <tt>false</tt>).
+      #   Remote forms may omit the embedded authenticity token by setting
+      #   <tt>config.action_view.embed_authenticity_token_in_remote_forms = false</tt>.
+      #   This is helpful when you're fragment-caching the form. Remote forms
+      #   get the authenticity token from the <tt>meta</tt> tag, so embedding is
+      #   unnecessary unless you support browsers without JavaScript.
+      # * <tt>:remote</tt> - If set to true, will allow the Unobtrusive
+      #   JavaScript drivers to control the submit behavior. By default this
+      #   behavior is an ajax submit.
+      # * <tt>:enforce_utf8</tt> - If set to false, a hidden input with name
+      #   utf8 is not output.
+      # * <tt>:html</tt> - Optional HTML attributes for the form tag.
+      #
+      # Also note that +form_for+ doesn't create an exclusive scope. It's still
+      # possible to use both the stand-alone FormHelper methods and methods
+      # from FormTagHelper. For example:
+      #
+      #   <%= form_for :person do |f| %>
+      #     First name: <%= f.text_field :first_name %>
+      #     Last name : <%= f.text_field :last_name %>
+      #     Biography : <%= text_area :person, :biography %>
+      #     Admin?    : <%= check_box_tag "person[admin]", "1", @person.company.admin? %>
+      #     <%= f.submit %>
+      #   <% end %>
+      #
+      # This also works for the methods in FormOptionsHelper and DateHelper that
+      # are designed to work with an object as base, like
+      # FormOptionsHelper#collection_select and DateHelper#datetime_select.
+      #
+      # === #form_for with a model object
+      #
+      # In the examples above, the object to be created or edited was
+      # represented by a symbol passed to +form_for+, and we noted that
+      # a string can also be used equivalently. It is also possible, however,
+      # to pass a model object itself to +form_for+. For example, if <tt>@post</tt>
+      # is an existing record you wish to edit, you can create the form using
+      #
+      #   <%= form_for @post do |f| %>
+      #     ...
+      #   <% end %>
+      #
+      # This behaves in almost the same way as outlined previously, with a
+      # couple of small exceptions. First, the prefix used to name the input
+      # elements within the form (hence the key that denotes them in the +params+
+      # hash) is actually derived from the object's _class_, e.g. <tt>params[:post]</tt>
+      # if the object's class is +Post+. However, this can be overwritten using
+      # the <tt>:as</tt> option, e.g. -
+      #
+      #   <%= form_for(@person, as: :client) do |f| %>
+      #     ...
+      #   <% end %>
+      #
+      # would result in <tt>params[:client]</tt>.
+      #
+      # Secondly, the field values shown when the form is initially displayed
+      # are taken from the attributes of the object passed to +form_for+,
+      # regardless of whether the object is an instance
+      # variable. So, for example, if we had a _local_ variable +post+
+      # representing an existing record,
+      #
+      #   <%= form_for post do |f| %>
+      #     ...
+      #   <% end %>
+      #
+      # would produce a form with fields whose initial state reflect the current
+      # values of the attributes of +post+.
+      #
+      # === Resource-oriented style
+      #
+      # In the examples just shown, although not indicated explicitly, we still
+      # need to use the <tt>:url</tt> option in order to specify where the
+      # form is going to be sent. However, further simplification is possible
+      # if the record passed to +form_for+ is a _resource_, i.e. it corresponds
+      # to a set of RESTful routes, e.g. defined using the +resources+ method
+      # in <tt>config/routes.rb</tt>. In this case Rails will simply infer the
+      # appropriate URL from the record itself. For example,
+      #
+      #   <%= form_for @post do |f| %>
+      #     ...
+      #   <% end %>
+      #
+      # is then equivalent to something like:
+      #
+      #   <%= form_for @post, as: :post, url: post_path(@post), method: :patch, html: { class: "edit_post", id: "edit_post_45" } do |f| %>
+      #     ...
+      #   <% end %>
+      #
+      # And for a new record
+      #
+      #   <%= form_for(Post.new) do |f| %>
+      #     ...
+      #   <% end %>
+      #
+      # is equivalent to something like:
+      #
+      #   <%= form_for @post, as: :post, url: posts_path, html: { class: "new_post", id: "new_post" } do |f| %>
+      #     ...
+      #   <% end %>
+      #
+      # However you can still overwrite individual conventions, such as:
+      #
+      #   <%= form_for(@post, url: super_posts_path) do |f| %>
+      #     ...
+      #   <% end %>
+      #
+      # You can also set the answer format, like this:
+      #
+      #   <%= form_for(@post, format: :json) do |f| %>
+      #     ...
+      #   <% end %>
+      #
+      # For namespaced routes, like +admin_post_url+:
+      #
+      #   <%= form_for([:admin, @post]) do |f| %>
+      #    ...
+      #   <% end %>
+      #
+      # If your resource has associations defined, for example, you want to add comments
+      # to the document given that the routes are set correctly:
+      #
+      #   <%= form_for([@document, @comment]) do |f| %>
+      #    ...
+      #   <% end %>
+      #
+      # Where <tt>@document = Document.find(params[:id])</tt> and
+      # <tt>@comment = Comment.new</tt>.
+      #
+      # === Setting the method
+      #
+      # You can force the form to use the full array of HTTP verbs by setting
+      #
+      #    method: (:get|:post|:patch|:put|:delete)
+      #
+      # in the options hash. If the verb is not GET or POST, which are natively
+      # supported by HTML forms, the form will be set to POST and a hidden input
+      # called _method will carry the intended verb for the server to interpret.
+      #
+      # === Unobtrusive JavaScript
+      #
+      # Specifying:
+      #
+      #    remote: true
+      #
+      # in the options hash creates a form that will allow the unobtrusive JavaScript drivers to modify its
+      # behavior. The expected default behavior is an XMLHttpRequest in the background instead of the regular
+      # POST arrangement, but ultimately the behavior is the choice of the JavaScript driver implementor.
+      # Even though it's using JavaScript to serialize the form elements, the form submission will work just like
+      # a regular submission as viewed by the receiving side (all elements available in <tt>params</tt>).
+      #
+      # Example:
+      #
+      #   <%= form_for(@post, remote: true) do |f| %>
+      #     ...
+      #   <% end %>
+      #
+      # The HTML generated for this would be:
+      #
+      #   <form action='http://www.example.com' method='post' data-remote='true'>
+      #     <input name='_method' type='hidden' value='patch' />
+      #     ...
+      #   </form>
+      #
+      # === Setting HTML options
+      #
+      # You can set data attributes directly by passing in a data hash, but all other HTML options must be wrapped in
+      # the HTML key. Example:
+      #
+      #   <%= form_for(@post, data: { behavior: "autosave" }, html: { name: "go" }) do |f| %>
+      #     ...
+      #   <% end %>
+      #
+      # The HTML generated for this would be:
+      #
+      #   <form action='http://www.example.com' method='post' data-behavior='autosave' name='go'>
+      #     <input name='_method' type='hidden' value='patch' />
+      #     ...
+      #   </form>
+      #
+      # === Removing hidden model id's
+      #
+      # The form_for method automatically includes the model id as a hidden field in the form.
+      # This is used to maintain the correlation between the form data and its associated model.
+      # Some ORM systems do not use IDs on nested models so in this case you want to be able
+      # to disable the hidden id.
+      #
+      # In the following example the Post model has many Comments stored within it in a NoSQL database,
+      # thus there is no primary key for comments.
+      #
+      # Example:
+      #
+      #   <%= form_for(@post) do |f| %>
+      #     <%= f.fields_for(:comments, include_id: false) do |cf| %>
+      #       ...
+      #     <% end %>
+      #   <% end %>
+      #
+      # === Customized form builders
+      #
+      # You can also build forms using a customized FormBuilder class. Subclass
+      # FormBuilder and override or define some more helpers, then use your
+      # custom builder. For example, let's say you made a helper to
+      # automatically add labels to form inputs.
+      #
+      #   <%= form_for @person, url: { action: "create" }, builder: LabellingFormBuilder do |f| %>
+      #     <%= f.text_field :first_name %>
+      #     <%= f.text_field :last_name %>
+      #     <%= f.text_area :biography %>
+      #     <%= f.check_box :admin %>
+      #     <%= f.submit %>
+      #   <% end %>
+      #
+      # In this case, if you use this:
+      #
+      #   <%= render f %>
+      #
+      # The rendered template is <tt>people/_labelling_form</tt> and the local
+      # variable referencing the form builder is called
+      # <tt>labelling_form</tt>.
+      #
+      # The custom FormBuilder class is automatically merged with the options
+      # of a nested fields_for call, unless it's explicitly set.
+      #
+      # In many cases you will want to wrap the above in another helper, so you
+      # could do something like the following:
+      #
+      #   def labelled_form_for(record_or_name_or_array, *args, &block)
+      #     options = args.extract_options!
+      #     form_for(record_or_name_or_array, *(args << options.merge(builder: LabellingFormBuilder)), &block)
+      #   end
+      #
+      # If you don't need to attach a form to a model instance, then check out
+      # FormTagHelper#form_tag.
+      #
+      # === Form to external resources
+      #
+      # When you build forms to external resources sometimes you need to set an authenticity token or just render a form
+      # without it, for example when you submit data to a payment gateway number and types of fields could be limited.
+      #
+      # To set an authenticity token you need to pass an <tt>:authenticity_token</tt> parameter
+      #
+      #   <%= form_for @invoice, url: external_url, authenticity_token: 'external_token' do |f| %>
+      #     ...
+      #   <% end %>
+      #
+      # If you don't want to an authenticity token field be rendered at all just pass <tt>false</tt>:
+      #
+      #   <%= form_for @invoice, url: external_url, authenticity_token: false do |f| %>
+      #     ...
+      #   <% end %>
+      def form_for: (untyped record, ?::Hash[untyped, untyped] options) { () -> untyped } -> untyped
+
+      def apply_form_for_options!: (untyped record, untyped object, untyped options) -> untyped
+
+      # Creates a form tag based on mixing URLs, scopes, or models.
+      #
+      #   # Using just a URL:
+      #   <%= form_with url: posts_path do |form| %>
+      #     <%= form.text_field :title %>
+      #   <% end %>
+      #   # =>
+      #   <form action="/posts" method="post" data-remote="true">
+      #     <input type="text" name="title">
+      #   </form>
+      #
+      #   # Adding a scope prefixes the input field names:
+      #   <%= form_with scope: :post, url: posts_path do |form| %>
+      #     <%= form.text_field :title %>
+      #   <% end %>
+      #   # =>
+      #   <form action="/posts" method="post" data-remote="true">
+      #     <input type="text" name="post[title]">
+      #   </form>
+      #
+      #   # Using a model infers both the URL and scope:
+      #   <%= form_with model: Post.new do |form| %>
+      #     <%= form.text_field :title %>
+      #   <% end %>
+      #   # =>
+      #   <form action="/posts" method="post" data-remote="true">
+      #     <input type="text" name="post[title]">
+      #   </form>
+      #
+      #   # An existing model makes an update form and fills out field values:
+      #   <%= form_with model: Post.first do |form| %>
+      #     <%= form.text_field :title %>
+      #   <% end %>
+      #   # =>
+      #   <form action="/posts/1" method="post" data-remote="true">
+      #     <input type="hidden" name="_method" value="patch">
+      #     <input type="text" name="post[title]" value="<the title of the post>">
+      #   </form>
+      #
+      #   # Though the fields don't have to correspond to model attributes:
+      #   <%= form_with model: Cat.new do |form| %>
+      #     <%= form.text_field :cats_dont_have_gills %>
+      #     <%= form.text_field :but_in_forms_they_can %>
+      #   <% end %>
+      #   # =>
+      #   <form action="/cats" method="post" data-remote="true">
+      #     <input type="text" name="cat[cats_dont_have_gills]">
+      #     <input type="text" name="cat[but_in_forms_they_can]">
+      #   </form>
+      #
+      # The parameters in the forms are accessible in controllers according to
+      # their name nesting. So inputs named +title+ and <tt>post[title]</tt> are
+      # accessible as <tt>params[:title]</tt> and <tt>params[:post][:title]</tt>
+      # respectively.
+      #
+      # By default +form_with+ attaches the <tt>data-remote</tt> attribute
+      # submitting the form via an XMLHTTPRequest in the background if an
+      # Unobtrusive JavaScript driver, like rails-ujs, is used. See the
+      # <tt>:local</tt> option for more.
+      #
+      # For ease of comparison the examples above left out the submit button,
+      # as well as the auto generated hidden fields that enable UTF-8 support
+      # and adds an authenticity token needed for cross site request forgery
+      # protection.
+      #
+      # === Resource-oriented style
+      #
+      # In many of the examples just shown, the +:model+ passed to +form_with+
+      # is a _resource_. It corresponds to a set of RESTful routes, most likely
+      # defined via +resources+ in <tt>config/routes.rb</tt>.
+      #
+      # So when passing such a model record, Rails infers the URL and method.
+      #
+      #   <%= form_with model: @post do |form| %>
+      #     ...
+      #   <% end %>
+      #
+      # is then equivalent to something like:
+      #
+      #   <%= form_with scope: :post, url: post_path(@post), method: :patch do |form| %>
+      #     ...
+      #   <% end %>
+      #
+      # And for a new record
+      #
+      #   <%= form_with model: Post.new do |form| %>
+      #     ...
+      #   <% end %>
+      #
+      # is equivalent to something like:
+      #
+      #   <%= form_with scope: :post, url: posts_path do |form| %>
+      #     ...
+      #   <% end %>
+      #
+      # ==== +form_with+ options
+      #
+      # * <tt>:url</tt> - The URL the form submits to. Akin to values passed to
+      #   +url_for+ or +link_to+. For example, you may use a named route
+      #   directly. When a <tt>:scope</tt> is passed without a <tt>:url</tt> the
+      #   form just submits to the current URL.
+      # * <tt>:method</tt> - The method to use when submitting the form, usually
+      #   either "get" or "post". If "patch", "put", "delete", or another verb
+      #   is used, a hidden input named <tt>_method</tt> is added to
+      #   simulate the verb over post.
+      # * <tt>:format</tt> - The format of the route the form submits to.
+      #   Useful when submitting to another resource type, like <tt>:json</tt>.
+      #   Skipped if a <tt>:url</tt> is passed.
+      # * <tt>:scope</tt> - The scope to prefix input field names with and
+      #   thereby how the submitted parameters are grouped in controllers.
+      # * <tt>:namespace</tt> - A namespace for your form to ensure uniqueness of
+      #   id attributes on form elements. The namespace attribute will be prefixed
+      #   with underscore on the generated HTML id.
+      # * <tt>:model</tt> - A model object to infer the <tt>:url</tt> and
+      #   <tt>:scope</tt> by, plus fill out input field values.
+      #   So if a +title+ attribute is set to "Ahoy!" then a +title+ input
+      #   field's value would be "Ahoy!".
+      #   If the model is a new record a create form is generated, if an
+      #   existing record, however, an update form is generated.
+      #   Pass <tt>:scope</tt> or <tt>:url</tt> to override the defaults.
+      #   E.g. turn <tt>params[:post]</tt> into <tt>params[:article]</tt>.
+      # * <tt>:authenticity_token</tt> - Authenticity token to use in the form.
+      #   Override with a custom authenticity token or pass <tt>false</tt> to
+      #   skip the authenticity token field altogether.
+      #   Useful when submitting to an external resource like a payment gateway
+      #   that might limit the valid fields.
+      #   Remote forms may omit the embedded authenticity token by setting
+      #   <tt>config.action_view.embed_authenticity_token_in_remote_forms = false</tt>.
+      #   This is helpful when fragment-caching the form. Remote forms
+      #   get the authenticity token from the <tt>meta</tt> tag, so embedding is
+      #   unnecessary unless you support browsers without JavaScript.
+      # * <tt>:local</tt> - By default form submits are remote and unobtrusive XHRs.
+      #   Disable remote submits with <tt>local: true</tt>.
+      # * <tt>:skip_enforcing_utf8</tt> - If set to true, a hidden input with name
+      #   utf8 is not output.
+      # * <tt>:builder</tt> - Override the object used to build the form.
+      # * <tt>:id</tt> - Optional HTML id attribute.
+      # * <tt>:class</tt> - Optional HTML class attribute.
+      # * <tt>:data</tt> - Optional HTML data attributes.
+      # * <tt>:html</tt> - Other optional HTML attributes for the form tag.
+      #
+      # === Examples
+      #
+      # When not passing a block, +form_with+ just generates an opening form tag.
+      #
+      #   <%= form_with(model: @post, url: super_posts_path) %>
+      #   <%= form_with(model: @post, scope: :article) %>
+      #   <%= form_with(model: @post, format: :json) %>
+      #   <%= form_with(model: @post, authenticity_token: false) %> # Disables the token.
+      #
+      # For namespaced routes, like +admin_post_url+:
+      #
+      #   <%= form_with(model: [ :admin, @post ]) do |form| %>
+      #     ...
+      #   <% end %>
+      #
+      # If your resource has associations defined, for example, you want to add comments
+      # to the document given that the routes are set correctly:
+      #
+      #   <%= form_with(model: [ @document, Comment.new ]) do |form| %>
+      #     ...
+      #   <% end %>
+      #
+      # Where <tt>@document = Document.find(params[:id])</tt>.
+      #
+      # === Mixing with other form helpers
+      #
+      # While +form_with+ uses a FormBuilder object it's possible to mix and
+      # match the stand-alone FormHelper methods and methods
+      # from FormTagHelper:
+      #
+      #   <%= form_with scope: :person do |form| %>
+      #     <%= form.text_field :first_name %>
+      #     <%= form.text_field :last_name %>
+      #
+      #     <%= text_area :person, :biography %>
+      #     <%= check_box_tag "person[admin]", "1", @person.company.admin? %>
+      #
+      #     <%= form.submit %>
+      #   <% end %>
+      #
+      # Same goes for the methods in FormOptionsHelper and DateHelper designed
+      # to work with an object as a base, like
+      # FormOptionsHelper#collection_select and DateHelper#datetime_select.
+      #
+      # === Setting the method
+      #
+      # You can force the form to use the full array of HTTP verbs by setting
+      #
+      #    method: (:get|:post|:patch|:put|:delete)
+      #
+      # in the options hash. If the verb is not GET or POST, which are natively
+      # supported by HTML forms, the form will be set to POST and a hidden input
+      # called _method will carry the intended verb for the server to interpret.
+      #
+      # === Setting HTML options
+      #
+      # You can set data attributes directly in a data hash, but HTML options
+      # besides id and class must be wrapped in an HTML key:
+      #
+      #   <%= form_with(model: @post, data: { behavior: "autosave" }, html: { name: "go" }) do |form| %>
+      #     ...
+      #   <% end %>
+      #
+      # generates
+      #
+      #   <form action="/posts/123" method="post" data-behavior="autosave" name="go">
+      #     <input name="_method" type="hidden" value="patch" />
+      #     ...
+      #   </form>
+      #
+      # === Removing hidden model id's
+      #
+      # The +form_with+ method automatically includes the model id as a hidden field in the form.
+      # This is used to maintain the correlation between the form data and its associated model.
+      # Some ORM systems do not use IDs on nested models so in this case you want to be able
+      # to disable the hidden id.
+      #
+      # In the following example the Post model has many Comments stored within it in a NoSQL database,
+      # thus there is no primary key for comments.
+      #
+      #   <%= form_with(model: @post) do |form| %>
+      #     <%= form.fields(:comments, skip_id: true) do |fields| %>
+      #       ...
+      #     <% end %>
+      #   <% end %>
+      #
+      # === Customized form builders
+      #
+      # You can also build forms using a customized FormBuilder class. Subclass
+      # FormBuilder and override or define some more helpers, then use your
+      # custom builder. For example, let's say you made a helper to
+      # automatically add labels to form inputs.
+      #
+      #   <%= form_with model: @person, url: { action: "create" }, builder: LabellingFormBuilder do |form| %>
+      #     <%= form.text_field :first_name %>
+      #     <%= form.text_field :last_name %>
+      #     <%= form.text_area :biography %>
+      #     <%= form.check_box :admin %>
+      #     <%= form.submit %>
+      #   <% end %>
+      #
+      # In this case, if you use:
+      #
+      #   <%= render form %>
+      #
+      # The rendered template is <tt>people/_labelling_form</tt> and the local
+      # variable referencing the form builder is called
+      # <tt>labelling_form</tt>.
+      #
+      # The custom FormBuilder class is automatically merged with the options
+      # of a nested +fields+ call, unless it's explicitly set.
+      #
+      # In many cases you will want to wrap the above in another helper, so you
+      # could do something like the following:
+      #
+      #   def labelled_form_with(**options, &block)
+      #     form_with(**options.merge(builder: LabellingFormBuilder), &block)
+      #   end
+      def form_with: (?format: untyped? format, ?url: untyped? url, ?scope: untyped? scope, ?model: untyped? model, **untyped options) { () -> untyped } -> untyped
+
+      # Creates a scope around a specific model object like form_for, but
+      # doesn't create the form tags themselves. This makes fields_for suitable
+      # for specifying additional model objects in the same form.
+      #
+      # Although the usage and purpose of +fields_for+ is similar to +form_for+'s,
+      # its method signature is slightly different. Like +form_for+, it yields
+      # a FormBuilder object associated with a particular model object to a block,
+      # and within the block allows methods to be called on the builder to
+      # generate fields associated with the model object. Fields may reflect
+      # a model object in two ways - how they are named (hence how submitted
+      # values appear within the +params+ hash in the controller) and what
+      # default values are shown when the form the fields appear in is first
+      # displayed. In order for both of these features to be specified independently,
+      # both an object name (represented by either a symbol or string) and the
+      # object itself can be passed to the method separately -
+      #
+      #   <%= form_for @person do |person_form| %>
+      #     First name: <%= person_form.text_field :first_name %>
+      #     Last name : <%= person_form.text_field :last_name %>
+      #
+      #     <%= fields_for :permission, @person.permission do |permission_fields| %>
+      #       Admin?  : <%= permission_fields.check_box :admin %>
+      #     <% end %>
+      #
+      #     <%= person_form.submit %>
+      #   <% end %>
+      #
+      # In this case, the checkbox field will be represented by an HTML +input+
+      # tag with the +name+ attribute <tt>permission[admin]</tt>, and the submitted
+      # value will appear in the controller as <tt>params[:permission][:admin]</tt>.
+      # If <tt>@person.permission</tt> is an existing record with an attribute
+      # +admin+, the initial state of the checkbox when first displayed will
+      # reflect the value of <tt>@person.permission.admin</tt>.
+      #
+      # Often this can be simplified by passing just the name of the model
+      # object to +fields_for+ -
+      #
+      #   <%= fields_for :permission do |permission_fields| %>
+      #     Admin?: <%= permission_fields.check_box :admin %>
+      #   <% end %>
+      #
+      # ...in which case, if <tt>:permission</tt> also happens to be the name of an
+      # instance variable <tt>@permission</tt>, the initial state of the input
+      # field will reflect the value of that variable's attribute <tt>@permission.admin</tt>.
+      #
+      # Alternatively, you can pass just the model object itself (if the first
+      # argument isn't a string or symbol +fields_for+ will realize that the
+      # name has been omitted) -
+      #
+      #   <%= fields_for @person.permission do |permission_fields| %>
+      #     Admin?: <%= permission_fields.check_box :admin %>
+      #   <% end %>
+      #
+      # and +fields_for+ will derive the required name of the field from the
+      # _class_ of the model object, e.g. if <tt>@person.permission</tt>, is
+      # of class +Permission+, the field will still be named <tt>permission[admin]</tt>.
+      #
+      # Note: This also works for the methods in FormOptionsHelper and
+      # DateHelper that are designed to work with an object as base, like
+      # FormOptionsHelper#collection_select and DateHelper#datetime_select.
+      #
+      # === Nested Attributes Examples
+      #
+      # When the object belonging to the current scope has a nested attribute
+      # writer for a certain attribute, fields_for will yield a new scope
+      # for that attribute. This allows you to create forms that set or change
+      # the attributes of a parent object and its associations in one go.
+      #
+      # Nested attribute writers are normal setter methods named after an
+      # association. The most common way of defining these writers is either
+      # with +accepts_nested_attributes_for+ in a model definition or by
+      # defining a method with the proper name. For example: the attribute
+      # writer for the association <tt>:address</tt> is called
+      # <tt>address_attributes=</tt>.
+      #
+      # Whether a one-to-one or one-to-many style form builder will be yielded
+      # depends on whether the normal reader method returns a _single_ object
+      # or an _array_ of objects.
+      #
+      # ==== One-to-one
+      #
+      # Consider a Person class which returns a _single_ Address from the
+      # <tt>address</tt> reader method and responds to the
+      # <tt>address_attributes=</tt> writer method:
+      #
+      #   class Person
+      #     def address
+      #       @address
+      #     end
+      #
+      #     def address_attributes=(attributes)
+      #       # Process the attributes hash
+      #     end
+      #   end
+      #
+      # This model can now be used with a nested fields_for, like so:
+      #
+      #   <%= form_for @person do |person_form| %>
+      #     ...
+      #     <%= person_form.fields_for :address do |address_fields| %>
+      #       Street  : <%= address_fields.text_field :street %>
+      #       Zip code: <%= address_fields.text_field :zip_code %>
+      #     <% end %>
+      #     ...
+      #   <% end %>
+      #
+      # When address is already an association on a Person you can use
+      # +accepts_nested_attributes_for+ to define the writer method for you:
+      #
+      #   class Person < ActiveRecord::Base
+      #     has_one :address
+      #     accepts_nested_attributes_for :address
+      #   end
+      #
+      # If you want to destroy the associated model through the form, you have
+      # to enable it first using the <tt>:allow_destroy</tt> option for
+      # +accepts_nested_attributes_for+:
+      #
+      #   class Person < ActiveRecord::Base
+      #     has_one :address
+      #     accepts_nested_attributes_for :address, allow_destroy: true
+      #   end
+      #
+      # Now, when you use a form element with the <tt>_destroy</tt> parameter,
+      # with a value that evaluates to +true+, you will destroy the associated
+      # model (eg. 1, '1', true, or 'true'):
+      #
+      #   <%= form_for @person do |person_form| %>
+      #     ...
+      #     <%= person_form.fields_for :address do |address_fields| %>
+      #       ...
+      #       Delete: <%= address_fields.check_box :_destroy %>
+      #     <% end %>
+      #     ...
+      #   <% end %>
+      #
+      # ==== One-to-many
+      #
+      # Consider a Person class which returns an _array_ of Project instances
+      # from the <tt>projects</tt> reader method and responds to the
+      # <tt>projects_attributes=</tt> writer method:
+      #
+      #   class Person
+      #     def projects
+      #       [@project1, @project2]
+      #     end
+      #
+      #     def projects_attributes=(attributes)
+      #       # Process the attributes hash
+      #     end
+      #   end
+      #
+      # Note that the <tt>projects_attributes=</tt> writer method is in fact
+      # required for fields_for to correctly identify <tt>:projects</tt> as a
+      # collection, and the correct indices to be set in the form markup.
+      #
+      # When projects is already an association on Person you can use
+      # +accepts_nested_attributes_for+ to define the writer method for you:
+      #
+      #   class Person < ActiveRecord::Base
+      #     has_many :projects
+      #     accepts_nested_attributes_for :projects
+      #   end
+      #
+      # This model can now be used with a nested fields_for. The block given to
+      # the nested fields_for call will be repeated for each instance in the
+      # collection:
+      #
+      #   <%= form_for @person do |person_form| %>
+      #     ...
+      #     <%= person_form.fields_for :projects do |project_fields| %>
+      #       <% if project_fields.object.active? %>
+      #         Name: <%= project_fields.text_field :name %>
+      #       <% end %>
+      #     <% end %>
+      #     ...
+      #   <% end %>
+      #
+      # It's also possible to specify the instance to be used:
+      #
+      #   <%= form_for @person do |person_form| %>
+      #     ...
+      #     <% @person.projects.each do |project| %>
+      #       <% if project.active? %>
+      #         <%= person_form.fields_for :projects, project do |project_fields| %>
+      #           Name: <%= project_fields.text_field :name %>
+      #         <% end %>
+      #       <% end %>
+      #     <% end %>
+      #     ...
+      #   <% end %>
+      #
+      # Or a collection to be used:
+      #
+      #   <%= form_for @person do |person_form| %>
+      #     ...
+      #     <%= person_form.fields_for :projects, @active_projects do |project_fields| %>
+      #       Name: <%= project_fields.text_field :name %>
+      #     <% end %>
+      #     ...
+      #   <% end %>
+      #
+      # If you want to destroy any of the associated models through the
+      # form, you have to enable it first using the <tt>:allow_destroy</tt>
+      # option for +accepts_nested_attributes_for+:
+      #
+      #   class Person < ActiveRecord::Base
+      #     has_many :projects
+      #     accepts_nested_attributes_for :projects, allow_destroy: true
+      #   end
+      #
+      # This will allow you to specify which models to destroy in the
+      # attributes hash by adding a form element for the <tt>_destroy</tt>
+      # parameter with a value that evaluates to +true+
+      # (eg. 1, '1', true, or 'true'):
+      #
+      #   <%= form_for @person do |person_form| %>
+      #     ...
+      #     <%= person_form.fields_for :projects do |project_fields| %>
+      #       Delete: <%= project_fields.check_box :_destroy %>
+      #     <% end %>
+      #     ...
+      #   <% end %>
+      #
+      # When a collection is used you might want to know the index of each
+      # object into the array. For this purpose, the <tt>index</tt> method
+      # is available in the FormBuilder object.
+      #
+      #   <%= form_for @person do |person_form| %>
+      #     ...
+      #     <%= person_form.fields_for :projects do |project_fields| %>
+      #       Project #<%= project_fields.index %>
+      #       ...
+      #     <% end %>
+      #     ...
+      #   <% end %>
+      #
+      # Note that fields_for will automatically generate a hidden field
+      # to store the ID of the record. There are circumstances where this
+      # hidden field is not needed and you can pass <tt>include_id: false</tt>
+      # to prevent fields_for from rendering it automatically.
+      def fields_for: (untyped record_name, ?untyped? record_object, ?::Hash[untyped, untyped] options) { () -> untyped } -> untyped
+
+      # Scopes input fields with either an explicit scope or model.
+      # Like +form_with+ does with <tt>:scope</tt> or <tt>:model</tt>,
+      # except it doesn't output the form tags.
+      #
+      #   # Using a scope prefixes the input field names:
+      #   <%= fields :comment do |fields| %>
+      #     <%= fields.text_field :body %>
+      #   <% end %>
+      #   # => <input type="text" name="comment[body]">
+      #
+      #   # Using a model infers the scope and assigns field values:
+      #   <%= fields model: Comment.new(body: "full bodied") do |fields| %>
+      #     <%= fields.text_field :body %>
+      #   <% end %>
+      #   # => <input type="text" name="comment[body]" value="full bodied">
+      #
+      #   # Using +fields+ with +form_with+:
+      #   <%= form_with model: @post do |form| %>
+      #     <%= form.text_field :title %>
+      #
+      #     <%= form.fields :comment do |fields| %>
+      #       <%= fields.text_field :body %>
+      #     <% end %>
+      #   <% end %>
+      #
+      # Much like +form_with+ a FormBuilder instance associated with the scope
+      # or model is yielded, so any generated field names are prefixed with
+      # either the passed scope or the scope inferred from the <tt>:model</tt>.
+      #
+      # === Mixing with other form helpers
+      #
+      # While +form_with+ uses a FormBuilder object it's possible to mix and
+      # match the stand-alone FormHelper methods and methods
+      # from FormTagHelper:
+      #
+      #   <%= fields model: @comment do |fields| %>
+      #     <%= fields.text_field :body %>
+      #
+      #     <%= text_area :commenter, :biography %>
+      #     <%= check_box_tag "comment[all_caps]", "1", @comment.commenter.hulk_mode? %>
+      #   <% end %>
+      #
+      # Same goes for the methods in FormOptionsHelper and DateHelper designed
+      # to work with an object as a base, like
+      # FormOptionsHelper#collection_select and DateHelper#datetime_select.
+      def fields: (?untyped? scope, ?model: untyped? model, **untyped options) { () -> untyped } -> untyped
+
+      # Returns a label tag tailored for labelling an input field for a specified attribute (identified by +method+) on an object
+      # assigned to the template (identified by +object+). The text of label will default to the attribute name unless a translation
+      # is found in the current I18n locale (through helpers.label.<modelname>.<attribute>) or you specify it explicitly.
+      # Additional options on the label tag can be passed as a hash with +options+. These options will be tagged
+      # onto the HTML as an HTML element attribute as in the example shown, except for the <tt>:value</tt> option, which is designed to
+      # target labels for radio_button tags (where the value is used in the ID of the input tag).
+      #
+      # ==== Examples
+      #   label(:post, :title)
+      #   # => <label for="post_title">Title</label>
+      #
+      # You can localize your labels based on model and attribute names.
+      # For example you can define the following in your locale (e.g. en.yml)
+      #
+      #   helpers:
+      #     label:
+      #       post:
+      #         body: "Write your entire text here"
+      #
+      # Which then will result in
+      #
+      #   label(:post, :body)
+      #   # => <label for="post_body">Write your entire text here</label>
+      #
+      # Localization can also be based purely on the translation of the attribute-name
+      # (if you are using ActiveRecord):
+      #
+      #   activerecord:
+      #     attributes:
+      #       post:
+      #         cost: "Total cost"
+      #
+      #   label(:post, :cost)
+      #   # => <label for="post_cost">Total cost</label>
+      #
+      #   label(:post, :title, "A short title")
+      #   # => <label for="post_title">A short title</label>
+      #
+      #   label(:post, :title, "A short title", class: "title_label")
+      #   # => <label for="post_title" class="title_label">A short title</label>
+      #
+      #   label(:post, :privacy, "Public Post", value: "public")
+      #   # => <label for="post_privacy_public">Public Post</label>
+      #
+      #   label(:post, :terms) do
+      #     raw('Accept <a href="/terms">Terms</a>.')
+      #   end
+      #   # => <label for="post_terms">Accept <a href="/terms">Terms</a>.</label>
+      def label: (untyped object_name, untyped method, ?untyped? content_or_options, ?untyped? options) { () -> untyped } -> untyped
+
+      # Returns an input tag of the "text" type tailored for accessing a specified attribute (identified by +method+) on an object
+      # assigned to the template (identified by +object+). Additional options on the input tag can be passed as a
+      # hash with +options+. These options will be tagged onto the HTML as an HTML element attribute as in the example
+      # shown.
+      #
+      # ==== Examples
+      #   text_field(:post, :title, size: 20)
+      #   # => <input type="text" id="post_title" name="post[title]" size="20" value="#{@post.title}" />
+      #
+      #   text_field(:post, :title, class: "create_input")
+      #   # => <input type="text" id="post_title" name="post[title]" value="#{@post.title}" class="create_input" />
+      #
+      #   text_field(:post, :title,  maxlength: 30, class: "title_input")
+      #   # => <input type="text" id="post_title" name="post[title]" maxlength="30" size="30" value="#{@post.title}" class="title_input" />
+      #
+      #   text_field(:session, :user, onchange: "if ($('#session_user').val() === 'admin') { alert('Your login cannot be admin!'); }")
+      #   # => <input type="text" id="session_user" name="session[user]" value="#{@session.user}" onchange="if ($('#session_user').val() === 'admin') { alert('Your login cannot be admin!'); }"/>
+      #
+      #   text_field(:snippet, :code, size: 20, class: 'code_input')
+      #   # => <input type="text" id="snippet_code" name="snippet[code]" size="20" value="#{@snippet.code}" class="code_input" />
+      def text_field: (untyped object_name, untyped method, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Returns an input tag of the "password" type tailored for accessing a specified attribute (identified by +method+) on an object
+      # assigned to the template (identified by +object+). Additional options on the input tag can be passed as a
+      # hash with +options+. These options will be tagged onto the HTML as an HTML element attribute as in the example
+      # shown. For security reasons this field is blank by default; pass in a value via +options+ if this is not desired.
+      #
+      # ==== Examples
+      #   password_field(:login, :pass, size: 20)
+      #   # => <input type="password" id="login_pass" name="login[pass]" size="20" />
+      #
+      #   password_field(:account, :secret, class: "form_input", value: @account.secret)
+      #   # => <input type="password" id="account_secret" name="account[secret]" value="#{@account.secret}" class="form_input" />
+      #
+      #   password_field(:user, :password, onchange: "if ($('#user_password').val().length > 30) { alert('Your password needs to be shorter!'); }")
+      #   # => <input type="password" id="user_password" name="user[password]" onchange="if ($('#user_password').val().length > 30) { alert('Your password needs to be shorter!'); }"/>
+      #
+      #   password_field(:account, :pin, size: 20, class: 'form_input')
+      #   # => <input type="password" id="account_pin" name="account[pin]" size="20" class="form_input" />
+      def password_field: (untyped object_name, untyped method, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Returns a hidden input tag tailored for accessing a specified attribute (identified by +method+) on an object
+      # assigned to the template (identified by +object+). Additional options on the input tag can be passed as a
+      # hash with +options+. These options will be tagged onto the HTML as an HTML element attribute as in the example
+      # shown.
+      #
+      # ==== Examples
+      #   hidden_field(:signup, :pass_confirm)
+      #   # => <input type="hidden" id="signup_pass_confirm" name="signup[pass_confirm]" value="#{@signup.pass_confirm}" />
+      #
+      #   hidden_field(:post, :tag_list)
+      #   # => <input type="hidden" id="post_tag_list" name="post[tag_list]" value="#{@post.tag_list}" />
+      #
+      #   hidden_field(:user, :token)
+      #   # => <input type="hidden" id="user_token" name="user[token]" value="#{@user.token}" />
+      def hidden_field: (untyped object_name, untyped method, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Returns a file upload input tag tailored for accessing a specified attribute (identified by +method+) on an object
+      # assigned to the template (identified by +object+). Additional options on the input tag can be passed as a
+      # hash with +options+. These options will be tagged onto the HTML as an HTML element attribute as in the example
+      # shown.
+      #
+      # Using this method inside a +form_for+ block will set the enclosing form's encoding to <tt>multipart/form-data</tt>.
+      #
+      # ==== Options
+      # * Creates standard HTML attributes for the tag.
+      # * <tt>:disabled</tt> - If set to true, the user will not be able to use this input.
+      # * <tt>:multiple</tt> - If set to true, *in most updated browsers* the user will be allowed to select multiple files.
+      # * <tt>:accept</tt> - If set to one or multiple mime-types, the user will be suggested a filter when choosing a file. You still need to set up model validations.
+      #
+      # ==== Examples
+      #   file_field(:user, :avatar)
+      #   # => <input type="file" id="user_avatar" name="user[avatar]" />
+      #
+      #   file_field(:post, :image, multiple: true)
+      #   # => <input type="file" id="post_image" name="post[image][]" multiple="multiple" />
+      #
+      #   file_field(:post, :attached, accept: 'text/html')
+      #   # => <input accept="text/html" type="file" id="post_attached" name="post[attached]" />
+      #
+      #   file_field(:post, :image, accept: 'image/png,image/gif,image/jpeg')
+      #   # => <input type="file" id="post_image" name="post[image]" accept="image/png,image/gif,image/jpeg" />
+      #
+      #   file_field(:attachment, :file, class: 'file_input')
+      #   # => <input type="file" id="attachment_file" name="attachment[file]" class="file_input" />
+      def file_field: (untyped object_name, untyped method, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Returns a textarea opening and closing tag set tailored for accessing a specified attribute (identified by +method+)
+      # on an object assigned to the template (identified by +object+). Additional options on the input tag can be passed as a
+      # hash with +options+.
+      #
+      # ==== Examples
+      #   text_area(:post, :body, cols: 20, rows: 40)
+      #   # => <textarea cols="20" rows="40" id="post_body" name="post[body]">
+      #   #      #{@post.body}
+      #   #    </textarea>
+      #
+      #   text_area(:comment, :text, size: "20x30")
+      #   # => <textarea cols="20" rows="30" id="comment_text" name="comment[text]">
+      #   #      #{@comment.text}
+      #   #    </textarea>
+      #
+      #   text_area(:application, :notes, cols: 40, rows: 15, class: 'app_input')
+      #   # => <textarea cols="40" rows="15" id="application_notes" name="application[notes]" class="app_input">
+      #   #      #{@application.notes}
+      #   #    </textarea>
+      #
+      #   text_area(:entry, :body, size: "20x20", disabled: 'disabled')
+      #   # => <textarea cols="20" rows="20" id="entry_body" name="entry[body]" disabled="disabled">
+      #   #      #{@entry.body}
+      #   #    </textarea>
+      def text_area: (untyped object_name, untyped method, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Returns a checkbox tag tailored for accessing a specified attribute (identified by +method+) on an object
+      # assigned to the template (identified by +object+). This object must be an instance object (@object) and not a local object.
+      # It's intended that +method+ returns an integer and if that integer is above zero, then the checkbox is checked.
+      # Additional options on the input tag can be passed as a hash with +options+. The +checked_value+ defaults to 1
+      # while the default +unchecked_value+ is set to 0 which is convenient for boolean values.
+      #
+      # ==== Gotcha
+      #
+      # The HTML specification says unchecked check boxes are not successful, and
+      # thus web browsers do not send them. Unfortunately this introduces a gotcha:
+      # if an +Invoice+ model has a +paid+ flag, and in the form that edits a paid
+      # invoice the user unchecks its check box, no +paid+ parameter is sent. So,
+      # any mass-assignment idiom like
+      #
+      #   @invoice.update(params[:invoice])
+      #
+      # wouldn't update the flag.
+      #
+      # To prevent this the helper generates an auxiliary hidden field before
+      # the very check box. The hidden field has the same name and its
+      # attributes mimic an unchecked check box.
+      #
+      # This way, the client either sends only the hidden field (representing
+      # the check box is unchecked), or both fields. Since the HTML specification
+      # says key/value pairs have to be sent in the same order they appear in the
+      # form, and parameters extraction gets the last occurrence of any repeated
+      # key in the query string, that works for ordinary forms.
+      #
+      # Unfortunately that workaround does not work when the check box goes
+      # within an array-like parameter, as in
+      #
+      #   <%= fields_for "project[invoice_attributes][]", invoice, index: nil do |form| %>
+      #     <%= form.check_box :paid %>
+      #     ...
+      #   <% end %>
+      #
+      # because parameter name repetition is precisely what Rails seeks to distinguish
+      # the elements of the array. For each item with a checked check box you
+      # get an extra ghost item with only that attribute, assigned to "0".
+      #
+      # In that case it is preferable to either use +check_box_tag+ or to use
+      # hashes instead of arrays.
+      #
+      #   # Let's say that @post.validated? is 1:
+      #   check_box("post", "validated")
+      #   # => <input name="post[validated]" type="hidden" value="0" />
+      #   #    <input checked="checked" type="checkbox" id="post_validated" name="post[validated]" value="1" />
+      #
+      #   # Let's say that @puppy.gooddog is "no":
+      #   check_box("puppy", "gooddog", {}, "yes", "no")
+      #   # => <input name="puppy[gooddog]" type="hidden" value="no" />
+      #   #    <input type="checkbox" id="puppy_gooddog" name="puppy[gooddog]" value="yes" />
+      #
+      #   check_box("eula", "accepted", { class: 'eula_check' }, "yes", "no")
+      #   # => <input name="eula[accepted]" type="hidden" value="no" />
+      #   #    <input type="checkbox" class="eula_check" id="eula_accepted" name="eula[accepted]" value="yes" />
+      def check_box: (untyped object_name, untyped method, ?::Hash[untyped, untyped] options, ?::String checked_value, ?::String unchecked_value) -> untyped
+
+      # Returns a radio button tag for accessing a specified attribute (identified by +method+) on an object
+      # assigned to the template (identified by +object+). If the current value of +method+ is +tag_value+ the
+      # radio button will be checked.
+      #
+      # To force the radio button to be checked pass <tt>checked: true</tt> in the
+      # +options+ hash. You may pass HTML options there as well.
+      #
+      #   # Let's say that @post.category returns "rails":
+      #   radio_button("post", "category", "rails")
+      #   radio_button("post", "category", "java")
+      #   # => <input type="radio" id="post_category_rails" name="post[category]" value="rails" checked="checked" />
+      #   #    <input type="radio" id="post_category_java" name="post[category]" value="java" />
+      #
+      #   # Let's say that @user.receive_newsletter returns "no":
+      #   radio_button("user", "receive_newsletter", "yes")
+      #   radio_button("user", "receive_newsletter", "no")
+      #   # => <input type="radio" id="user_receive_newsletter_yes" name="user[receive_newsletter]" value="yes" />
+      #   #    <input type="radio" id="user_receive_newsletter_no" name="user[receive_newsletter]" value="no" checked="checked" />
+      def radio_button: (untyped object_name, untyped method, untyped tag_value, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Returns a text_field of type "color".
+      #
+      #   color_field("car", "color")
+      #   # => <input id="car_color" name="car[color]" type="color" value="#000000" />
+      def color_field: (untyped object_name, untyped method, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Returns an input of type "search" for accessing a specified attribute (identified by +method+) on an object
+      # assigned to the template (identified by +object_name+). Inputs of type "search" may be styled differently by
+      # some browsers.
+      #
+      #   search_field(:user, :name)
+      #   # => <input id="user_name" name="user[name]" type="search" />
+      #   search_field(:user, :name, autosave: false)
+      #   # => <input autosave="false" id="user_name" name="user[name]" type="search" />
+      #   search_field(:user, :name, results: 3)
+      #   # => <input id="user_name" name="user[name]" results="3" type="search" />
+      #   #  Assume request.host returns "www.example.com"
+      #   search_field(:user, :name, autosave: true)
+      #   # => <input autosave="com.example.www" id="user_name" name="user[name]" results="10" type="search" />
+      #   search_field(:user, :name, onsearch: true)
+      #   # => <input id="user_name" incremental="true" name="user[name]" onsearch="true" type="search" />
+      #   search_field(:user, :name, autosave: false, onsearch: true)
+      #   # => <input autosave="false" id="user_name" incremental="true" name="user[name]" onsearch="true" type="search" />
+      #   search_field(:user, :name, autosave: true, onsearch: true)
+      #   # => <input autosave="com.example.www" id="user_name" incremental="true" name="user[name]" onsearch="true" results="10" type="search" />
+      def search_field: (untyped object_name, untyped method, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Returns a text_field of type "tel".
+      #
+      #   telephone_field("user", "phone")
+      #   # => <input id="user_phone" name="user[phone]" type="tel" />
+      #
+      def telephone_field: (untyped object_name, untyped method, ?::Hash[untyped, untyped] options) -> untyped
+
+      # aliases telephone_field
+      alias phone_field telephone_field
+
+      # Returns a text_field of type "date".
+      #
+      #   date_field("user", "born_on")
+      #   # => <input id="user_born_on" name="user[born_on]" type="date" />
+      #
+      # The default value is generated by trying to call +strftime+ with "%Y-%m-%d"
+      # on the object's value, which makes it behave as expected for instances
+      # of DateTime and ActiveSupport::TimeWithZone. You can still override that
+      # by passing the "value" option explicitly, e.g.
+      #
+      #   @user.born_on = Date.new(1984, 1, 27)
+      #   date_field("user", "born_on", value: "1984-05-12")
+      #   # => <input id="user_born_on" name="user[born_on]" type="date" value="1984-05-12" />
+      #
+      # You can create values for the "min" and "max" attributes by passing
+      # instances of Date or Time to the options hash.
+      #
+      #   date_field("user", "born_on", min: Date.today)
+      #   # => <input id="user_born_on" name="user[born_on]" type="date" min="2014-05-20" />
+      #
+      # Alternatively, you can pass a String formatted as an ISO8601 date as the
+      # values for "min" and "max."
+      #
+      #   date_field("user", "born_on", min: "2014-05-20")
+      #   # => <input id="user_born_on" name="user[born_on]" type="date" min="2014-05-20" />
+      #
+      def date_field: (untyped object_name, untyped method, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Returns a text_field of type "time".
+      #
+      # The default value is generated by trying to call +strftime+ with "%T.%L"
+      # on the object's value. It is still possible to override that
+      # by passing the "value" option.
+      #
+      # === Options
+      # * Accepts same options as time_field_tag
+      #
+      # === Example
+      #   time_field("task", "started_at")
+      #   # => <input id="task_started_at" name="task[started_at]" type="time" />
+      #
+      # You can create values for the "min" and "max" attributes by passing
+      # instances of Date or Time to the options hash.
+      #
+      #   time_field("task", "started_at", min: Time.now)
+      #   # => <input id="task_started_at" name="task[started_at]" type="time" min="01:00:00.000" />
+      #
+      # Alternatively, you can pass a String formatted as an ISO8601 time as the
+      # values for "min" and "max."
+      #
+      #   time_field("task", "started_at", min: "01:00:00")
+      #   # => <input id="task_started_at" name="task[started_at]" type="time" min="01:00:00.000" />
+      #
+      def time_field: (untyped object_name, untyped method, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Returns a text_field of type "datetime-local".
+      #
+      #   datetime_field("user", "born_on")
+      #   # => <input id="user_born_on" name="user[born_on]" type="datetime-local" />
+      #
+      # The default value is generated by trying to call +strftime+ with "%Y-%m-%dT%T"
+      # on the object's value, which makes it behave as expected for instances
+      # of DateTime and ActiveSupport::TimeWithZone.
+      #
+      #   @user.born_on = Date.new(1984, 1, 12)
+      #   datetime_field("user", "born_on")
+      #   # => <input id="user_born_on" name="user[born_on]" type="datetime-local" value="1984-01-12T00:00:00" />
+      #
+      # You can create values for the "min" and "max" attributes by passing
+      # instances of Date or Time to the options hash.
+      #
+      #   datetime_field("user", "born_on", min: Date.today)
+      #   # => <input id="user_born_on" name="user[born_on]" type="datetime-local" min="2014-05-20T00:00:00.000" />
+      #
+      # Alternatively, you can pass a String formatted as an ISO8601 datetime as
+      # the values for "min" and "max."
+      #
+      #   datetime_field("user", "born_on", min: "2014-05-20T00:00:00")
+      #   # => <input id="user_born_on" name="user[born_on]" type="datetime-local" min="2014-05-20T00:00:00.000" />
+      #
+      def datetime_field: (untyped object_name, untyped method, ?::Hash[untyped, untyped] options) -> untyped
+
+      alias datetime_local_field datetime_field
+
+      # Returns a text_field of type "month".
+      #
+      #   month_field("user", "born_on")
+      #   # => <input id="user_born_on" name="user[born_on]" type="month" />
+      #
+      # The default value is generated by trying to call +strftime+ with "%Y-%m"
+      # on the object's value, which makes it behave as expected for instances
+      # of DateTime and ActiveSupport::TimeWithZone.
+      #
+      #   @user.born_on = Date.new(1984, 1, 27)
+      #   month_field("user", "born_on")
+      #   # => <input id="user_born_on" name="user[born_on]" type="date" value="1984-01" />
+      #
+      def month_field: (untyped object_name, untyped method, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Returns a text_field of type "week".
+      #
+      #   week_field("user", "born_on")
+      #   # => <input id="user_born_on" name="user[born_on]" type="week" />
+      #
+      # The default value is generated by trying to call +strftime+ with "%Y-W%W"
+      # on the object's value, which makes it behave as expected for instances
+      # of DateTime and ActiveSupport::TimeWithZone.
+      #
+      #   @user.born_on = Date.new(1984, 5, 12)
+      #   week_field("user", "born_on")
+      #   # => <input id="user_born_on" name="user[born_on]" type="date" value="1984-W19" />
+      #
+      def week_field: (untyped object_name, untyped method, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Returns a text_field of type "url".
+      #
+      #   url_field("user", "homepage")
+      #   # => <input id="user_homepage" name="user[homepage]" type="url" />
+      #
+      def url_field: (untyped object_name, untyped method, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Returns a text_field of type "email".
+      #
+      #   email_field("user", "address")
+      #   # => <input id="user_address" name="user[address]" type="email" />
+      #
+      def email_field: (untyped object_name, untyped method, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Returns an input tag of type "number".
+      #
+      # ==== Options
+      # * Accepts same options as number_field_tag
+      def number_field: (untyped object_name, untyped method, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Returns an input tag of type "range".
+      #
+      # ==== Options
+      # * Accepts same options as range_field_tag
+      def range_field: (untyped object_name, untyped method, ?::Hash[untyped, untyped] options) -> untyped
+
+      def html_options_for_form_with: (?untyped? url_for_options, ?untyped? model, ?skip_enforcing_utf8: untyped? skip_enforcing_utf8, ?local: untyped local, ?html: ::Hash[untyped, untyped] html, **untyped options) -> untyped
+
+      def instantiate_builder: (untyped record_name, untyped record_object, untyped options) -> untyped
+
+      def default_form_builder_class: () -> untyped
+    end
+
+    # A +FormBuilder+ object is associated with a particular model object and
+    # allows you to generate fields associated with the model object. The
+    # +FormBuilder+ object is yielded when using +form_for+ or +fields_for+.
+    # For example:
+    #
+    #   <%= form_for @person do |person_form| %>
+    #     Name: <%= person_form.text_field :name %>
+    #     Admin: <%= person_form.check_box :admin %>
+    #   <% end %>
+    #
+    # In the above block, a +FormBuilder+ object is yielded as the
+    # +person_form+ variable. This allows you to generate the +text_field+
+    # and +check_box+ fields by specifying their eponymous methods, which
+    # modify the underlying template and associates the <tt>@person</tt> model object
+    # with the form.
+    #
+    # The +FormBuilder+ object can be thought of as serving as a proxy for the
+    # methods in the +FormHelper+ module. This class, however, allows you to
+    # call methods with the model object you are building the form for.
+    #
+    # You can create your own custom FormBuilder templates by subclassing this
+    # class. For example:
+    #
+    #   class MyFormBuilder < ActionView::Helpers::FormBuilder
+    #     def div_radio_button(method, tag_value, options = {})
+    #       @template.content_tag(:div,
+    #         @template.radio_button(
+    #           @object_name, method, tag_value, objectify_options(options)
+    #         )
+    #       )
+    #     end
+    #   end
+    #
+    # The above code creates a new method +div_radio_button+ which wraps a div
+    # around the new radio button. Note that when options are passed in, you
+    # must call +objectify_options+ in order for the model object to get
+    # correctly passed to the method. If +objectify_options+ is not called,
+    # then the newly created helper will not be linked back to the model.
+    #
+    # The +div_radio_button+ code from above can now be used as follows:
+    #
+    #   <%= form_for @person, :builder => MyFormBuilder do |f| %>
+    #     I am a child: <%= f.div_radio_button(:admin, "child") %>
+    #     I am an adult: <%= f.div_radio_button(:admin, "adult") %>
+    #   <% end -%>
+    #
+    # The standard set of helper methods for form building are located in the
+    # +field_helpers+ class attribute.
+    class FormBuilder
+      include ModelNaming
+
+      attr_accessor object_name: untyped
+
+      attr_accessor object: untyped
+
+      attr_accessor options: untyped
+
+      attr_reader multipart: untyped
+
+      attr_reader index: untyped
+
+      alias multipart? multipart
+
+      def multipart=: (untyped multipart) -> untyped
+
+      def self._to_partial_path: () -> untyped
+
+      def to_partial_path: () -> untyped
+
+      def to_model: () -> untyped
+
+      def initialize: (untyped object_name, untyped object, untyped template, untyped options) -> untyped
+
+      # Creates a scope around a specific model object like form_for, but
+      # doesn't create the form tags themselves. This makes fields_for suitable
+      # for specifying additional model objects in the same form.
+      #
+      # Although the usage and purpose of +fields_for+ is similar to +form_for+'s,
+      # its method signature is slightly different. Like +form_for+, it yields
+      # a FormBuilder object associated with a particular model object to a block,
+      # and within the block allows methods to be called on the builder to
+      # generate fields associated with the model object. Fields may reflect
+      # a model object in two ways - how they are named (hence how submitted
+      # values appear within the +params+ hash in the controller) and what
+      # default values are shown when the form the fields appear in is first
+      # displayed. In order for both of these features to be specified independently,
+      # both an object name (represented by either a symbol or string) and the
+      # object itself can be passed to the method separately -
+      #
+      #   <%= form_for @person do |person_form| %>
+      #     First name: <%= person_form.text_field :first_name %>
+      #     Last name : <%= person_form.text_field :last_name %>
+      #
+      #     <%= fields_for :permission, @person.permission do |permission_fields| %>
+      #       Admin?  : <%= permission_fields.check_box :admin %>
+      #     <% end %>
+      #
+      #     <%= person_form.submit %>
+      #   <% end %>
+      #
+      # In this case, the checkbox field will be represented by an HTML +input+
+      # tag with the +name+ attribute <tt>permission[admin]</tt>, and the submitted
+      # value will appear in the controller as <tt>params[:permission][:admin]</tt>.
+      # If <tt>@person.permission</tt> is an existing record with an attribute
+      # +admin+, the initial state of the checkbox when first displayed will
+      # reflect the value of <tt>@person.permission.admin</tt>.
+      #
+      # Often this can be simplified by passing just the name of the model
+      # object to +fields_for+ -
+      #
+      #   <%= fields_for :permission do |permission_fields| %>
+      #     Admin?: <%= permission_fields.check_box :admin %>
+      #   <% end %>
+      #
+      # ...in which case, if <tt>:permission</tt> also happens to be the name of an
+      # instance variable <tt>@permission</tt>, the initial state of the input
+      # field will reflect the value of that variable's attribute <tt>@permission.admin</tt>.
+      #
+      # Alternatively, you can pass just the model object itself (if the first
+      # argument isn't a string or symbol +fields_for+ will realize that the
+      # name has been omitted) -
+      #
+      #   <%= fields_for @person.permission do |permission_fields| %>
+      #     Admin?: <%= permission_fields.check_box :admin %>
+      #   <% end %>
+      #
+      # and +fields_for+ will derive the required name of the field from the
+      # _class_ of the model object, e.g. if <tt>@person.permission</tt>, is
+      # of class +Permission+, the field will still be named <tt>permission[admin]</tt>.
+      #
+      # Note: This also works for the methods in FormOptionsHelper and
+      # DateHelper that are designed to work with an object as base, like
+      # FormOptionsHelper#collection_select and DateHelper#datetime_select.
+      #
+      # === Nested Attributes Examples
+      #
+      # When the object belonging to the current scope has a nested attribute
+      # writer for a certain attribute, fields_for will yield a new scope
+      # for that attribute. This allows you to create forms that set or change
+      # the attributes of a parent object and its associations in one go.
+      #
+      # Nested attribute writers are normal setter methods named after an
+      # association. The most common way of defining these writers is either
+      # with +accepts_nested_attributes_for+ in a model definition or by
+      # defining a method with the proper name. For example: the attribute
+      # writer for the association <tt>:address</tt> is called
+      # <tt>address_attributes=</tt>.
+      #
+      # Whether a one-to-one or one-to-many style form builder will be yielded
+      # depends on whether the normal reader method returns a _single_ object
+      # or an _array_ of objects.
+      #
+      # ==== One-to-one
+      #
+      # Consider a Person class which returns a _single_ Address from the
+      # <tt>address</tt> reader method and responds to the
+      # <tt>address_attributes=</tt> writer method:
+      #
+      #   class Person
+      #     def address
+      #       @address
+      #     end
+      #
+      #     def address_attributes=(attributes)
+      #       # Process the attributes hash
+      #     end
+      #   end
+      #
+      # This model can now be used with a nested fields_for, like so:
+      #
+      #   <%= form_for @person do |person_form| %>
+      #     ...
+      #     <%= person_form.fields_for :address do |address_fields| %>
+      #       Street  : <%= address_fields.text_field :street %>
+      #       Zip code: <%= address_fields.text_field :zip_code %>
+      #     <% end %>
+      #     ...
+      #   <% end %>
+      #
+      # When address is already an association on a Person you can use
+      # +accepts_nested_attributes_for+ to define the writer method for you:
+      #
+      #   class Person < ActiveRecord::Base
+      #     has_one :address
+      #     accepts_nested_attributes_for :address
+      #   end
+      #
+      # If you want to destroy the associated model through the form, you have
+      # to enable it first using the <tt>:allow_destroy</tt> option for
+      # +accepts_nested_attributes_for+:
+      #
+      #   class Person < ActiveRecord::Base
+      #     has_one :address
+      #     accepts_nested_attributes_for :address, allow_destroy: true
+      #   end
+      #
+      # Now, when you use a form element with the <tt>_destroy</tt> parameter,
+      # with a value that evaluates to +true+, you will destroy the associated
+      # model (eg. 1, '1', true, or 'true'):
+      #
+      #   <%= form_for @person do |person_form| %>
+      #     ...
+      #     <%= person_form.fields_for :address do |address_fields| %>
+      #       ...
+      #       Delete: <%= address_fields.check_box :_destroy %>
+      #     <% end %>
+      #     ...
+      #   <% end %>
+      #
+      # ==== One-to-many
+      #
+      # Consider a Person class which returns an _array_ of Project instances
+      # from the <tt>projects</tt> reader method and responds to the
+      # <tt>projects_attributes=</tt> writer method:
+      #
+      #   class Person
+      #     def projects
+      #       [@project1, @project2]
+      #     end
+      #
+      #     def projects_attributes=(attributes)
+      #       # Process the attributes hash
+      #     end
+      #   end
+      #
+      # Note that the <tt>projects_attributes=</tt> writer method is in fact
+      # required for fields_for to correctly identify <tt>:projects</tt> as a
+      # collection, and the correct indices to be set in the form markup.
+      #
+      # When projects is already an association on Person you can use
+      # +accepts_nested_attributes_for+ to define the writer method for you:
+      #
+      #   class Person < ActiveRecord::Base
+      #     has_many :projects
+      #     accepts_nested_attributes_for :projects
+      #   end
+      #
+      # This model can now be used with a nested fields_for. The block given to
+      # the nested fields_for call will be repeated for each instance in the
+      # collection:
+      #
+      #   <%= form_for @person do |person_form| %>
+      #     ...
+      #     <%= person_form.fields_for :projects do |project_fields| %>
+      #       <% if project_fields.object.active? %>
+      #         Name: <%= project_fields.text_field :name %>
+      #       <% end %>
+      #     <% end %>
+      #     ...
+      #   <% end %>
+      #
+      # It's also possible to specify the instance to be used:
+      #
+      #   <%= form_for @person do |person_form| %>
+      #     ...
+      #     <% @person.projects.each do |project| %>
+      #       <% if project.active? %>
+      #         <%= person_form.fields_for :projects, project do |project_fields| %>
+      #           Name: <%= project_fields.text_field :name %>
+      #         <% end %>
+      #       <% end %>
+      #     <% end %>
+      #     ...
+      #   <% end %>
+      #
+      # Or a collection to be used:
+      #
+      #   <%= form_for @person do |person_form| %>
+      #     ...
+      #     <%= person_form.fields_for :projects, @active_projects do |project_fields| %>
+      #       Name: <%= project_fields.text_field :name %>
+      #     <% end %>
+      #     ...
+      #   <% end %>
+      #
+      # If you want to destroy any of the associated models through the
+      # form, you have to enable it first using the <tt>:allow_destroy</tt>
+      # option for +accepts_nested_attributes_for+:
+      #
+      #   class Person < ActiveRecord::Base
+      #     has_many :projects
+      #     accepts_nested_attributes_for :projects, allow_destroy: true
+      #   end
+      #
+      # This will allow you to specify which models to destroy in the
+      # attributes hash by adding a form element for the <tt>_destroy</tt>
+      # parameter with a value that evaluates to +true+
+      # (eg. 1, '1', true, or 'true'):
+      #
+      #   <%= form_for @person do |person_form| %>
+      #     ...
+      #     <%= person_form.fields_for :projects do |project_fields| %>
+      #       Delete: <%= project_fields.check_box :_destroy %>
+      #     <% end %>
+      #     ...
+      #   <% end %>
+      #
+      # When a collection is used you might want to know the index of each
+      # object into the array. For this purpose, the <tt>index</tt> method
+      # is available in the FormBuilder object.
+      #
+      #   <%= form_for @person do |person_form| %>
+      #     ...
+      #     <%= person_form.fields_for :projects do |project_fields| %>
+      #       Project #<%= project_fields.index %>
+      #       ...
+      #     <% end %>
+      #     ...
+      #   <% end %>
+      #
+      # Note that fields_for will automatically generate a hidden field
+      # to store the ID of the record. There are circumstances where this
+      # hidden field is not needed and you can pass <tt>include_id: false</tt>
+      # to prevent fields_for from rendering it automatically.
+      def fields_for: (untyped record_name, ?untyped? record_object, ?::Hash[untyped, untyped] fields_options) { () -> untyped } -> untyped
+
+      # See the docs for the <tt>ActionView::FormHelper.fields</tt> helper method.
+      def fields: (?untyped? scope, ?model: untyped? model, **untyped options) { () -> untyped } -> untyped
+
+      # Returns a label tag tailored for labelling an input field for a specified attribute (identified by +method+) on an object
+      # assigned to the template (identified by +object+). The text of label will default to the attribute name unless a translation
+      # is found in the current I18n locale (through helpers.label.<modelname>.<attribute>) or you specify it explicitly.
+      # Additional options on the label tag can be passed as a hash with +options+. These options will be tagged
+      # onto the HTML as an HTML element attribute as in the example shown, except for the <tt>:value</tt> option, which is designed to
+      # target labels for radio_button tags (where the value is used in the ID of the input tag).
+      #
+      # ==== Examples
+      #   label(:title)
+      #   # => <label for="post_title">Title</label>
+      #
+      # You can localize your labels based on model and attribute names.
+      # For example you can define the following in your locale (e.g. en.yml)
+      #
+      #   helpers:
+      #     label:
+      #       post:
+      #         body: "Write your entire text here"
+      #
+      # Which then will result in
+      #
+      #   label(:body)
+      #   # => <label for="post_body">Write your entire text here</label>
+      #
+      # Localization can also be based purely on the translation of the attribute-name
+      # (if you are using ActiveRecord):
+      #
+      #   activerecord:
+      #     attributes:
+      #       post:
+      #         cost: "Total cost"
+      #
+      #   label(:cost)
+      #   # => <label for="post_cost">Total cost</label>
+      #
+      #   label(:title, "A short title")
+      #   # => <label for="post_title">A short title</label>
+      #
+      #   label(:title, "A short title", class: "title_label")
+      #   # => <label for="post_title" class="title_label">A short title</label>
+      #
+      #   label(:privacy, "Public Post", value: "public")
+      #   # => <label for="post_privacy_public">Public Post</label>
+      #
+      #   label(:terms) do
+      #     raw('Accept <a href="/terms">Terms</a>.')
+      #   end
+      #   # => <label for="post_terms">Accept <a href="/terms">Terms</a>.</label>
+      def label: (untyped method, ?untyped? text, ?::Hash[untyped, untyped] options) { () -> untyped } -> untyped
+
+      # Returns a checkbox tag tailored for accessing a specified attribute (identified by +method+) on an object
+      # assigned to the template (identified by +object+). This object must be an instance object (@object) and not a local object.
+      # It's intended that +method+ returns an integer and if that integer is above zero, then the checkbox is checked.
+      # Additional options on the input tag can be passed as a hash with +options+. The +checked_value+ defaults to 1
+      # while the default +unchecked_value+ is set to 0 which is convenient for boolean values.
+      #
+      # ==== Gotcha
+      #
+      # The HTML specification says unchecked check boxes are not successful, and
+      # thus web browsers do not send them. Unfortunately this introduces a gotcha:
+      # if an +Invoice+ model has a +paid+ flag, and in the form that edits a paid
+      # invoice the user unchecks its check box, no +paid+ parameter is sent. So,
+      # any mass-assignment idiom like
+      #
+      #   @invoice.update(params[:invoice])
+      #
+      # wouldn't update the flag.
+      #
+      # To prevent this the helper generates an auxiliary hidden field before
+      # the very check box. The hidden field has the same name and its
+      # attributes mimic an unchecked check box.
+      #
+      # This way, the client either sends only the hidden field (representing
+      # the check box is unchecked), or both fields. Since the HTML specification
+      # says key/value pairs have to be sent in the same order they appear in the
+      # form, and parameters extraction gets the last occurrence of any repeated
+      # key in the query string, that works for ordinary forms.
+      #
+      # Unfortunately that workaround does not work when the check box goes
+      # within an array-like parameter, as in
+      #
+      #   <%= fields_for "project[invoice_attributes][]", invoice, index: nil do |form| %>
+      #     <%= form.check_box :paid %>
+      #     ...
+      #   <% end %>
+      #
+      # because parameter name repetition is precisely what Rails seeks to distinguish
+      # the elements of the array. For each item with a checked check box you
+      # get an extra ghost item with only that attribute, assigned to "0".
+      #
+      # In that case it is preferable to either use +check_box_tag+ or to use
+      # hashes instead of arrays.
+      #
+      #   # Let's say that @post.validated? is 1:
+      #   check_box("validated")
+      #   # => <input name="post[validated]" type="hidden" value="0" />
+      #   #    <input checked="checked" type="checkbox" id="post_validated" name="post[validated]" value="1" />
+      #
+      #   # Let's say that @puppy.gooddog is "no":
+      #   check_box("gooddog", {}, "yes", "no")
+      #   # => <input name="puppy[gooddog]" type="hidden" value="no" />
+      #   #    <input type="checkbox" id="puppy_gooddog" name="puppy[gooddog]" value="yes" />
+      #
+      #   # Let's say that @eula.accepted is "no":
+      #   check_box("accepted", { class: 'eula_check' }, "yes", "no")
+      #   # => <input name="eula[accepted]" type="hidden" value="no" />
+      #   #    <input type="checkbox" class="eula_check" id="eula_accepted" name="eula[accepted]" value="yes" />
+      def check_box: (untyped method, ?::Hash[untyped, untyped] options, ?::String checked_value, ?::String unchecked_value) -> untyped
+
+      # Returns a radio button tag for accessing a specified attribute (identified by +method+) on an object
+      # assigned to the template (identified by +object+). If the current value of +method+ is +tag_value+ the
+      # radio button will be checked.
+      #
+      # To force the radio button to be checked pass <tt>checked: true</tt> in the
+      # +options+ hash. You may pass HTML options there as well.
+      #
+      #   # Let's say that @post.category returns "rails":
+      #   radio_button("category", "rails")
+      #   radio_button("category", "java")
+      #   # => <input type="radio" id="post_category_rails" name="post[category]" value="rails" checked="checked" />
+      #   #    <input type="radio" id="post_category_java" name="post[category]" value="java" />
+      #
+      #   # Let's say that @user.receive_newsletter returns "no":
+      #   radio_button("receive_newsletter", "yes")
+      #   radio_button("receive_newsletter", "no")
+      #   # => <input type="radio" id="user_receive_newsletter_yes" name="user[receive_newsletter]" value="yes" />
+      #   #    <input type="radio" id="user_receive_newsletter_no" name="user[receive_newsletter]" value="no" checked="checked" />
+      def radio_button: (untyped method, untyped tag_value, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Returns a hidden input tag tailored for accessing a specified attribute (identified by +method+) on an object
+      # assigned to the template (identified by +object+). Additional options on the input tag can be passed as a
+      # hash with +options+. These options will be tagged onto the HTML as an HTML element attribute as in the example
+      # shown.
+      #
+      # ==== Examples
+      #   # Let's say that @signup.pass_confirm returns true:
+      #   hidden_field(:pass_confirm)
+      #   # => <input type="hidden" id="signup_pass_confirm" name="signup[pass_confirm]" value="true" />
+      #
+      #   # Let's say that @post.tag_list returns "blog, ruby":
+      #   hidden_field(:tag_list)
+      #   # => <input type="hidden" id="post_tag_list" name="post[tag_list]" value="blog, ruby" />
+      #
+      #   # Let's say that @user.token returns "abcde":
+      #   hidden_field(:token)
+      #   # => <input type="hidden" id="user_token" name="user[token]" value="abcde" />
+      #
+      def hidden_field: (untyped method, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Returns a file upload input tag tailored for accessing a specified attribute (identified by +method+) on an object
+      # assigned to the template (identified by +object+). Additional options on the input tag can be passed as a
+      # hash with +options+. These options will be tagged onto the HTML as an HTML element attribute as in the example
+      # shown.
+      #
+      # Using this method inside a +form_for+ block will set the enclosing form's encoding to <tt>multipart/form-data</tt>.
+      #
+      # ==== Options
+      # * Creates standard HTML attributes for the tag.
+      # * <tt>:disabled</tt> - If set to true, the user will not be able to use this input.
+      # * <tt>:multiple</tt> - If set to true, *in most updated browsers* the user will be allowed to select multiple files.
+      # * <tt>:accept</tt> - If set to one or multiple mime-types, the user will be suggested a filter when choosing a file. You still need to set up model validations.
+      #
+      # ==== Examples
+      #   # Let's say that @user has avatar:
+      #   file_field(:avatar)
+      #   # => <input type="file" id="user_avatar" name="user[avatar]" />
+      #
+      #   # Let's say that @post has image:
+      #   file_field(:image, :multiple => true)
+      #   # => <input type="file" id="post_image" name="post[image][]" multiple="multiple" />
+      #
+      #   # Let's say that @post has attached:
+      #   file_field(:attached, accept: 'text/html')
+      #   # => <input accept="text/html" type="file" id="post_attached" name="post[attached]" />
+      #
+      #   # Let's say that @post has image:
+      #   file_field(:image, accept: 'image/png,image/gif,image/jpeg')
+      #   # => <input type="file" id="post_image" name="post[image]" accept="image/png,image/gif,image/jpeg" />
+      #
+      #   # Let's say that @attachment has file:
+      #   file_field(:file, class: 'file_input')
+      #   # => <input type="file" id="attachment_file" name="attachment[file]" class="file_input" />
+      def file_field: (untyped method, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Add the submit button for the given form. When no value is given, it checks
+      # if the object is a new resource or not to create the proper label:
+      #
+      #   <%= form_for @post do |f| %>
+      #     <%= f.submit %>
+      #   <% end %>
+      #
+      # In the example above, if <tt>@post</tt> is a new record, it will use "Create Post" as
+      # submit button label; otherwise, it uses "Update Post".
+      #
+      # Those labels can be customized using I18n under the +helpers.submit+ key and using
+      # <tt>%{model}</tt> for translation interpolation:
+      #
+      #   en:
+      #     helpers:
+      #       submit:
+      #         create: "Create a %{model}"
+      #         update: "Confirm changes to %{model}"
+      #
+      # It also searches for a key specific to the given object:
+      #
+      #   en:
+      #     helpers:
+      #       submit:
+      #         post:
+      #           create: "Add %{model}"
+      #
+      def submit: (?untyped? value, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Add the submit button for the given form. When no value is given, it checks
+      # if the object is a new resource or not to create the proper label:
+      #
+      #   <%= form_for @post do |f| %>
+      #     <%= f.button %>
+      #   <% end %>
+      #
+      # In the example above, if <tt>@post</tt> is a new record, it will use "Create Post" as
+      # button label; otherwise, it uses "Update Post".
+      #
+      # Those labels can be customized using I18n under the +helpers.submit+ key
+      # (the same as submit helper) and using <tt>%{model}</tt> for translation interpolation:
+      #
+      #   en:
+      #     helpers:
+      #       submit:
+      #         create: "Create a %{model}"
+      #         update: "Confirm changes to %{model}"
+      #
+      # It also searches for a key specific to the given object:
+      #
+      #   en:
+      #     helpers:
+      #       submit:
+      #         post:
+      #           create: "Add %{model}"
+      #
+      # ==== Examples
+      #   button("Create post")
+      #   # => <button name='button' type='submit'>Create post</button>
+      #
+      #   button do
+      #     content_tag(:strong, 'Ask me!')
+      #   end
+      #   # => <button name='button' type='submit'>
+      #   #      <strong>Ask me!</strong>
+      #   #    </button>
+      #
+      def button: (?untyped? value, ?::Hash[untyped, untyped] options) { () -> untyped } -> untyped
+
+      def emitted_hidden_id?: () -> untyped
+
+      def objectify_options: (untyped options) -> untyped
+
+      def submit_default_value: () -> untyped
+
+      def nested_attributes_association?: (untyped association_name) -> untyped
+
+      def fields_for_with_nested_attributes: (untyped association_name, untyped association, untyped options, untyped block) -> untyped
+
+      def fields_for_nested_model: (untyped name, untyped object, untyped fields_options, untyped block) -> untyped
+
+      def nested_child_index: (untyped name) -> untyped
+
+      def convert_to_legacy_options: (untyped options) -> untyped
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    # = Action View Form Option Helpers
+    # nodoc:
+    # Provides a number of methods for turning different kinds of containers into a set of option tags.
+    #
+    # The <tt>collection_select</tt>, <tt>select</tt> and <tt>time_zone_select</tt> methods take an <tt>options</tt> parameter, a hash:
+    #
+    # * <tt>:include_blank</tt> - set to true or a prompt string if the first option element of the select element is a blank. Useful if there is not a default value required for the select element.
+    #
+    #     select("post", "category", Post::CATEGORIES, { include_blank: true })
+    #
+    #   could become:
+    #
+    #     <select name="post[category]" id="post_category">
+    #       <option value=""></option>
+    #       <option value="joke">joke</option>
+    #       <option value="poem">poem</option>
+    #     </select>
+    #
+    #   Another common case is a select tag for a <tt>belongs_to</tt>-associated object.
+    #
+    #   Example with <tt>@post.person_id => 2</tt>:
+    #
+    #     select("post", "person_id", Person.all.collect { |p| [ p.name, p.id ] }, { include_blank: 'None' })
+    #
+    #   could become:
+    #
+    #     <select name="post[person_id]" id="post_person_id">
+    #       <option value="">None</option>
+    #       <option value="1">David</option>
+    #       <option value="2" selected="selected">Eileen</option>
+    #       <option value="3">Rafael</option>
+    #     </select>
+    #
+    # * <tt>:prompt</tt> - set to true or a prompt string. When the select element doesn't have a value yet, this prepends an option with a generic prompt -- "Please select" -- or the given prompt string.
+    #
+    #     select("post", "person_id", Person.all.collect { |p| [ p.name, p.id ] }, { prompt: 'Select Person' })
+    #
+    #   could become:
+    #
+    #     <select name="post[person_id]" id="post_person_id">
+    #       <option value="">Select Person</option>
+    #       <option value="1">David</option>
+    #       <option value="2">Eileen</option>
+    #       <option value="3">Rafael</option>
+    #     </select>
+    #
+    # * <tt>:index</tt> - like the other form helpers, +select+ can accept an <tt>:index</tt> option to manually set the ID used in the resulting output. Unlike other helpers, +select+ expects this
+    #   option to be in the +html_options+ parameter.
+    #
+    #     select("album[]", "genre", %w[rap rock country], {}, { index: nil })
+    #
+    #   becomes:
+    #
+    #     <select name="album[][genre]" id="album__genre">
+    #       <option value="rap">rap</option>
+    #       <option value="rock">rock</option>
+    #       <option value="country">country</option>
+    #     </select>
+    #
+    # * <tt>:disabled</tt> - can be a single value or an array of values that will be disabled options in the final output.
+    #
+    #     select("post", "category", Post::CATEGORIES, { disabled: 'restricted' })
+    #
+    #   could become:
+    #
+    #     <select name="post[category]" id="post_category">
+    #       <option value=""></option>
+    #       <option value="joke">joke</option>
+    #       <option value="poem">poem</option>
+    #       <option disabled="disabled" value="restricted">restricted</option>
+    #     </select>
+    #
+    #   When used with the <tt>collection_select</tt> helper, <tt>:disabled</tt> can also be a Proc that identifies those options that should be disabled.
+    #
+    #     collection_select(:post, :category_id, Category.all, :id, :name, { disabled: -> (category) { category.archived? } })
+    #
+    #   If the categories "2008 stuff" and "Christmas" return true when the method <tt>archived?</tt> is called, this would return:
+    #     <select name="post[category_id]" id="post_category_id">
+    #       <option value="1" disabled="disabled">2008 stuff</option>
+    #       <option value="2" disabled="disabled">Christmas</option>
+    #       <option value="3">Jokes</option>
+    #       <option value="4">Poems</option>
+    #     </select>
+    #
+    module FormOptionsHelper
+      # ERB::Util can mask some helpers like textilize. Make sure to include them.
+      include TextHelper
+
+      # Create a select tag and a series of contained option tags for the provided object and method.
+      # The option currently held by the object will be selected, provided that the object is available.
+      #
+      # There are two possible formats for the +choices+ parameter, corresponding to other helpers' output:
+      #
+      # * A flat collection (see +options_for_select+).
+      #
+      # * A nested collection (see +grouped_options_for_select+).
+      #
+      # For example:
+      #
+      #   select("post", "person_id", Person.all.collect { |p| [ p.name, p.id ] }, { include_blank: true })
+      #
+      # would become:
+      #
+      #   <select name="post[person_id]" id="post_person_id">
+      #     <option value=""></option>
+      #     <option value="1" selected="selected">David</option>
+      #     <option value="2">Eileen</option>
+      #     <option value="3">Rafael</option>
+      #   </select>
+      #
+      # assuming the associated person has ID 1.
+      #
+      # This can be used to provide a default set of options in the standard way: before rendering the create form, a
+      # new model instance is assigned the default options and bound to @model_name. Usually this model is not saved
+      # to the database. Instead, a second model object is created when the create request is received.
+      # This allows the user to submit a form page more than once with the expected results of creating multiple records.
+      # In addition, this allows a single partial to be used to generate form inputs for both edit and create forms.
+      #
+      # By default, <tt>post.person_id</tt> is the selected option. Specify <tt>selected: value</tt> to use a different selection
+      # or <tt>selected: nil</tt> to leave all options unselected. Similarly, you can specify values to be disabled in the option
+      # tags by specifying the <tt>:disabled</tt> option. This can either be a single value or an array of values to be disabled.
+      #
+      # A block can be passed to +select+ to customize how the options tags will be rendered. This
+      # is useful when the options tag has complex attributes.
+      #
+      #   select(report, "campaign_ids") do
+      #     available_campaigns.each do |c|
+      #       content_tag(:option, c.name, value: c.id, data: { tags: c.tags.to_json })
+      #     end
+      #   end
+      #
+      # ==== Gotcha
+      #
+      # The HTML specification says when +multiple+ parameter passed to select and all options got deselected
+      # web browsers do not send any value to server. Unfortunately this introduces a gotcha:
+      # if an +User+ model has many +roles+ and have +role_ids+ accessor, and in the form that edits roles of the user
+      # the user deselects all roles from +role_ids+ multiple select box, no +role_ids+ parameter is sent. So,
+      # any mass-assignment idiom like
+      #
+      #   @user.update(params[:user])
+      #
+      # wouldn't update roles.
+      #
+      # To prevent this the helper generates an auxiliary hidden field before
+      # every multiple select. The hidden field has the same name as multiple select and blank value.
+      #
+      # <b>Note:</b> The client either sends only the hidden field (representing
+      # the deselected multiple select box), or both fields. This means that the resulting array
+      # always contains a blank string.
+      #
+      # In case if you don't want the helper to generate this hidden field you can specify
+      # <tt>include_hidden: false</tt> option.
+      #
+      def select: (untyped object, untyped method, ?untyped? choices, ?::Hash[untyped, untyped] options, ?::Hash[untyped, untyped] html_options) { () -> untyped } -> untyped
+
+      # Returns <tt><select></tt> and <tt><option></tt> tags for the collection of existing return values of
+      # +method+ for +object+'s class. The value returned from calling +method+ on the instance +object+ will
+      # be selected. If calling +method+ returns +nil+, no selection is made without including <tt>:prompt</tt>
+      # or <tt>:include_blank</tt> in the +options+ hash.
+      #
+      # The <tt>:value_method</tt> and <tt>:text_method</tt> parameters are methods to be called on each member
+      # of +collection+. The return values are used as the +value+ attribute and contents of each
+      # <tt><option></tt> tag, respectively. They can also be any object that responds to +call+, such
+      # as a +proc+, that will be called for each member of the +collection+ to
+      # retrieve the value/text.
+      #
+      # Example object structure for use with this method:
+      #
+      #   class Post < ActiveRecord::Base
+      #     belongs_to :author
+      #   end
+      #
+      #   class Author < ActiveRecord::Base
+      #     has_many :posts
+      #     def name_with_initial
+      #       "#{first_name.first}. #{last_name}"
+      #     end
+      #   end
+      #
+      # Sample usage (selecting the associated Author for an instance of Post, <tt>@post</tt>):
+      #
+      #   collection_select(:post, :author_id, Author.all, :id, :name_with_initial, prompt: true)
+      #
+      # If <tt>@post.author_id</tt> is already <tt>1</tt>, this would return:
+      #   <select name="post[author_id]" id="post_author_id">
+      #     <option value="">Please select</option>
+      #     <option value="1" selected="selected">D. Heinemeier Hansson</option>
+      #     <option value="2">D. Thomas</option>
+      #     <option value="3">M. Clark</option>
+      #   </select>
+      def collection_select: (untyped object, untyped method, untyped collection, untyped value_method, untyped text_method, ?::Hash[untyped, untyped] options, ?::Hash[untyped, untyped] html_options) -> untyped
+
+      # Returns <tt><select></tt>, <tt><optgroup></tt> and <tt><option></tt> tags for the collection of existing return values of
+      # +method+ for +object+'s class. The value returned from calling +method+ on the instance +object+ will
+      # be selected. If calling +method+ returns +nil+, no selection is made without including <tt>:prompt</tt>
+      # or <tt>:include_blank</tt> in the +options+ hash.
+      #
+      # Parameters:
+      # * +object+ - The instance of the class to be used for the select tag
+      # * +method+ - The attribute of +object+ corresponding to the select tag
+      # * +collection+ - An array of objects representing the <tt><optgroup></tt> tags.
+      # * +group_method+ - The name of a method which, when called on a member of +collection+, returns an
+      #   array of child objects representing the <tt><option></tt> tags. It can also be any object that responds
+      #   to +call+, such as a +proc+, that will be called for each member of the +collection+ to retrieve the
+      #   value.
+      # * +group_label_method+ - The name of a method which, when called on a member of +collection+, returns a
+      #   string to be used as the +label+ attribute for its <tt><optgroup></tt> tag. It can also be any object
+      #   that responds to +call+, such as a +proc+, that will be called for each member of the +collection+ to
+      #   retrieve the label.
+      # * +option_key_method+ - The name of a method which, when called on a child object of a member of
+      #   +collection+, returns a value to be used as the +value+ attribute for its <tt><option></tt> tag.
+      # * +option_value_method+ - The name of a method which, when called on a child object of a member of
+      #   +collection+, returns a value to be used as the contents of its <tt><option></tt> tag.
+      #
+      # Example object structure for use with this method:
+      #
+      #   class Continent < ActiveRecord::Base
+      #     has_many :countries
+      #     # attribs: id, name
+      #   end
+      #
+      #   class Country < ActiveRecord::Base
+      #     belongs_to :continent
+      #     # attribs: id, name, continent_id
+      #   end
+      #
+      #   class City < ActiveRecord::Base
+      #     belongs_to :country
+      #     # attribs: id, name, country_id
+      #   end
+      #
+      # Sample usage:
+      #
+      #   grouped_collection_select(:city, :country_id, @continents, :countries, :name, :id, :name)
+      #
+      # Possible output:
+      #
+      #   <select name="city[country_id]" id="city_country_id">
+      #     <optgroup label="Africa">
+      #       <option value="1">South Africa</option>
+      #       <option value="3">Somalia</option>
+      #     </optgroup>
+      #     <optgroup label="Europe">
+      #       <option value="7" selected="selected">Denmark</option>
+      #       <option value="2">Ireland</option>
+      #     </optgroup>
+      #   </select>
+      #
+      def grouped_collection_select: (untyped object, untyped method, untyped collection, untyped group_method, untyped group_label_method, untyped option_key_method, untyped option_value_method, ?::Hash[untyped, untyped] options, ?::Hash[untyped, untyped] html_options) -> untyped
+
+      # Returns select and option tags for the given object and method, using
+      # #time_zone_options_for_select to generate the list of option tags.
+      #
+      # In addition to the <tt>:include_blank</tt> option documented above,
+      # this method also supports a <tt>:model</tt> option, which defaults
+      # to ActiveSupport::TimeZone. This may be used by users to specify a
+      # different time zone model object. (See +time_zone_options_for_select+
+      # for more information.)
+      #
+      # You can also supply an array of ActiveSupport::TimeZone objects
+      # as +priority_zones+ so that they will be listed above the rest of the
+      # (long) list. You can use ActiveSupport::TimeZone.us_zones for a list
+      # of US time zones, ActiveSupport::TimeZone.country_zones(country_code)
+      # for another country's time zones, or a Regexp to select the zones of
+      # your choice.
+      #
+      # Finally, this method supports a <tt>:default</tt> option, which selects
+      # a default ActiveSupport::TimeZone if the object's time zone is +nil+.
+      #
+      #   time_zone_select("user", "time_zone", nil, include_blank: true)
+      #
+      #   time_zone_select("user", "time_zone", nil, default: "Pacific Time (US & Canada)")
+      #
+      #   time_zone_select("user", 'time_zone', ActiveSupport::TimeZone.us_zones, default: "Pacific Time (US & Canada)")
+      #
+      #   time_zone_select("user", 'time_zone', [ ActiveSupport::TimeZone['Alaska'], ActiveSupport::TimeZone['Hawaii'] ])
+      #
+      #   time_zone_select("user", 'time_zone', /Australia/)
+      #
+      #   time_zone_select("user", "time_zone", ActiveSupport::TimeZone.all.sort, model: ActiveSupport::TimeZone)
+      def time_zone_select: (untyped object, untyped method, ?untyped? priority_zones, ?::Hash[untyped, untyped] options, ?::Hash[untyped, untyped] html_options) -> untyped
+
+      # Accepts a container (hash, array, enumerable, your type) and returns a string of option tags. Given a container
+      # where the elements respond to first and last (such as a two-element array), the "lasts" serve as option values and
+      # the "firsts" as option text. Hashes are turned into this form automatically, so the keys become "firsts" and values
+      # become lasts. If +selected+ is specified, the matching "last" or element will get the selected option-tag. +selected+
+      # may also be an array of values to be selected when using a multiple select.
+      #
+      #   options_for_select([["Dollar", "$"], ["Kroner", "DKK"]])
+      #   # => <option value="$">Dollar</option>
+      #   # => <option value="DKK">Kroner</option>
+      #
+      #   options_for_select([ "VISA", "MasterCard" ], "MasterCard")
+      #   # => <option value="VISA">VISA</option>
+      #   # => <option selected="selected" value="MasterCard">MasterCard</option>
+      #
+      #   options_for_select({ "Basic" => "$20", "Plus" => "$40" }, "$40")
+      #   # => <option value="$20">Basic</option>
+      #   # => <option value="$40" selected="selected">Plus</option>
+      #
+      #   options_for_select([ "VISA", "MasterCard", "Discover" ], ["VISA", "Discover"])
+      #   # => <option selected="selected" value="VISA">VISA</option>
+      #   # => <option value="MasterCard">MasterCard</option>
+      #   # => <option selected="selected" value="Discover">Discover</option>
+      #
+      # You can optionally provide HTML attributes as the last element of the array.
+      #
+      #   options_for_select([ "Denmark", ["USA", { class: 'bold' }], "Sweden" ], ["USA", "Sweden"])
+      #   # => <option value="Denmark">Denmark</option>
+      #   # => <option value="USA" class="bold" selected="selected">USA</option>
+      #   # => <option value="Sweden" selected="selected">Sweden</option>
+      #
+      #   options_for_select([["Dollar", "$", { class: "bold" }], ["Kroner", "DKK", { onclick: "alert('HI');" }]])
+      #   # => <option value="$" class="bold">Dollar</option>
+      #   # => <option value="DKK" onclick="alert('HI');">Kroner</option>
+      #
+      # If you wish to specify disabled option tags, set +selected+ to be a hash, with <tt>:disabled</tt> being either a value
+      # or array of values to be disabled. In this case, you can use <tt>:selected</tt> to specify selected option tags.
+      #
+      #   options_for_select(["Free", "Basic", "Advanced", "Super Platinum"], disabled: "Super Platinum")
+      #   # => <option value="Free">Free</option>
+      #   # => <option value="Basic">Basic</option>
+      #   # => <option value="Advanced">Advanced</option>
+      #   # => <option value="Super Platinum" disabled="disabled">Super Platinum</option>
+      #
+      #   options_for_select(["Free", "Basic", "Advanced", "Super Platinum"], disabled: ["Advanced", "Super Platinum"])
+      #   # => <option value="Free">Free</option>
+      #   # => <option value="Basic">Basic</option>
+      #   # => <option value="Advanced" disabled="disabled">Advanced</option>
+      #   # => <option value="Super Platinum" disabled="disabled">Super Platinum</option>
+      #
+      #   options_for_select(["Free", "Basic", "Advanced", "Super Platinum"], selected: "Free", disabled: "Super Platinum")
+      #   # => <option value="Free" selected="selected">Free</option>
+      #   # => <option value="Basic">Basic</option>
+      #   # => <option value="Advanced">Advanced</option>
+      #   # => <option value="Super Platinum" disabled="disabled">Super Platinum</option>
+      #
+      # NOTE: Only the option tags are returned, you have to wrap this call in a regular HTML select tag.
+      def options_for_select: (untyped container, ?untyped? selected) -> untyped
+
+      # Returns a string of option tags that have been compiled by iterating over the +collection+ and assigning
+      # the result of a call to the +value_method+ as the option value and the +text_method+ as the option text.
+      #
+      #   options_from_collection_for_select(@people, 'id', 'name')
+      #   # => <option value="#{person.id}">#{person.name}</option>
+      #
+      # This is more often than not used inside a #select_tag like this example:
+      #
+      #   select_tag 'person', options_from_collection_for_select(@people, 'id', 'name')
+      #
+      # If +selected+ is specified as a value or array of values, the element(s) returning a match on +value_method+
+      # will be selected option tag(s).
+      #
+      # If +selected+ is specified as a Proc, those members of the collection that return true for the anonymous
+      # function are the selected values.
+      #
+      # +selected+ can also be a hash, specifying both <tt>:selected</tt> and/or <tt>:disabled</tt> values as required.
+      #
+      # Be sure to specify the same class as the +value_method+ when specifying selected or disabled options.
+      # Failure to do this will produce undesired results. Example:
+      #   options_from_collection_for_select(@people, 'id', 'name', '1')
+      # Will not select a person with the id of 1 because 1 (an Integer) is not the same as '1' (a string)
+      #   options_from_collection_for_select(@people, 'id', 'name', 1)
+      # should produce the desired results.
+      def options_from_collection_for_select: (untyped collection, untyped value_method, untyped text_method, ?untyped? selected) -> untyped
+
+      # Returns a string of <tt><option></tt> tags, like <tt>options_from_collection_for_select</tt>, but
+      # groups them by <tt><optgroup></tt> tags based on the object relationships of the arguments.
+      #
+      # Parameters:
+      # * +collection+ - An array of objects representing the <tt><optgroup></tt> tags.
+      # * +group_method+ - The name of a method which, when called on a member of +collection+, returns an
+      #   array of child objects representing the <tt><option></tt> tags.
+      # * +group_label_method+ - The name of a method which, when called on a member of +collection+, returns a
+      #   string to be used as the +label+ attribute for its <tt><optgroup></tt> tag.
+      # * +option_key_method+ - The name of a method which, when called on a child object of a member of
+      #   +collection+, returns a value to be used as the +value+ attribute for its <tt><option></tt> tag.
+      # * +option_value_method+ - The name of a method which, when called on a child object of a member of
+      #   +collection+, returns a value to be used as the contents of its <tt><option></tt> tag.
+      # * +selected_key+ - A value equal to the +value+ attribute for one of the <tt><option></tt> tags,
+      #   which will have the +selected+ attribute set. Corresponds to the return value of one of the calls
+      #   to +option_key_method+. If +nil+, no selection is made. Can also be a hash if disabled values are
+      #   to be specified.
+      #
+      # Example object structure for use with this method:
+      #
+      #   class Continent < ActiveRecord::Base
+      #     has_many :countries
+      #     # attribs: id, name
+      #   end
+      #
+      #   class Country < ActiveRecord::Base
+      #     belongs_to :continent
+      #     # attribs: id, name, continent_id
+      #   end
+      #
+      # Sample usage:
+      #   option_groups_from_collection_for_select(@continents, :countries, :name, :id, :name, 3)
+      #
+      # Possible output:
+      #   <optgroup label="Africa">
+      #     <option value="1">Egypt</option>
+      #     <option value="4">Rwanda</option>
+      #     ...
+      #   </optgroup>
+      #   <optgroup label="Asia">
+      #     <option value="3" selected="selected">China</option>
+      #     <option value="12">India</option>
+      #     <option value="5">Japan</option>
+      #     ...
+      #   </optgroup>
+      #
+      # <b>Note:</b> Only the <tt><optgroup></tt> and <tt><option></tt> tags are returned, so you still have to
+      # wrap the output in an appropriate <tt><select></tt> tag.
+      def option_groups_from_collection_for_select: (untyped collection, untyped group_method, untyped group_label_method, untyped option_key_method, untyped option_value_method, ?untyped? selected_key) -> untyped
+
+      # Returns a string of <tt><option></tt> tags, like <tt>options_for_select</tt>, but
+      # wraps them with <tt><optgroup></tt> tags:
+      #
+      #   grouped_options = [
+      #    ['North America',
+      #      [['United States','US'],'Canada']],
+      #    ['Europe',
+      #      ['Denmark','Germany','France']]
+      #   ]
+      #   grouped_options_for_select(grouped_options)
+      #
+      #   grouped_options = {
+      #     'North America' => [['United States','US'], 'Canada'],
+      #     'Europe' => ['Denmark','Germany','France']
+      #   }
+      #   grouped_options_for_select(grouped_options)
+      #
+      # Possible output:
+      #   <optgroup label="North America">
+      #     <option value="US">United States</option>
+      #     <option value="Canada">Canada</option>
+      #   </optgroup>
+      #   <optgroup label="Europe">
+      #     <option value="Denmark">Denmark</option>
+      #     <option value="Germany">Germany</option>
+      #     <option value="France">France</option>
+      #   </optgroup>
+      #
+      # Parameters:
+      # * +grouped_options+ - Accepts a nested array or hash of strings. The first value serves as the
+      #   <tt><optgroup></tt> label while the second value must be an array of options. The second value can be a
+      #   nested array of text-value pairs. See <tt>options_for_select</tt> for more info.
+      #    Ex. ["North America",[["United States","US"],["Canada","CA"]]]
+      # * +selected_key+ - A value equal to the +value+ attribute for one of the <tt><option></tt> tags,
+      #   which will have the +selected+ attribute set. Note: It is possible for this value to match multiple options
+      #   as you might have the same option in multiple groups. Each will then get <tt>selected="selected"</tt>.
+      #
+      # Options:
+      # * <tt>:prompt</tt> - set to true or a prompt string. When the select element doesn't have a value yet, this
+      #   prepends an option with a generic prompt - "Please select" - or the given prompt string.
+      # * <tt>:divider</tt> - the divider for the options groups.
+      #
+      #     grouped_options = [
+      #       [['United States','US'], 'Canada'],
+      #       ['Denmark','Germany','France']
+      #     ]
+      #     grouped_options_for_select(grouped_options, nil, divider: '---------')
+      #
+      #   Possible output:
+      #     <optgroup label="---------">
+      #       <option value="US">United States</option>
+      #       <option value="Canada">Canada</option>
+      #     </optgroup>
+      #     <optgroup label="---------">
+      #       <option value="Denmark">Denmark</option>
+      #       <option value="Germany">Germany</option>
+      #       <option value="France">France</option>
+      #     </optgroup>
+      #
+      # <b>Note:</b> Only the <tt><optgroup></tt> and <tt><option></tt> tags are returned, so you still have to
+      # wrap the output in an appropriate <tt><select></tt> tag.
+      def grouped_options_for_select: (untyped grouped_options, ?untyped? selected_key, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Returns a string of option tags for pretty much any time zone in the
+      # world. Supply an ActiveSupport::TimeZone name as +selected+ to have it
+      # marked as the selected option tag. You can also supply an array of
+      # ActiveSupport::TimeZone objects as +priority_zones+, so that they will
+      # be listed above the rest of the (long) list. (You can use
+      # ActiveSupport::TimeZone.us_zones as a convenience for obtaining a list
+      # of the US time zones, or a Regexp to select the zones of your choice)
+      #
+      # The +selected+ parameter must be either +nil+, or a string that names
+      # an ActiveSupport::TimeZone.
+      #
+      # By default, +model+ is the ActiveSupport::TimeZone constant (which can
+      # be obtained in Active Record as a value object). The +model+ parameter
+      # must respond to +all+ and return an array of objects that represent time
+      # zones; each object must respond to +name+. If a Regexp is given it will
+      # attempt to match the zones using the <code>=~<code> operator.
+      #
+      # NOTE: Only the option tags are returned, you have to wrap this call in
+      # a regular HTML select tag.
+      def time_zone_options_for_select: (?untyped? selected, ?untyped? priority_zones, ?untyped model) -> untyped
+
+      # Returns radio button tags for the collection of existing return values
+      # of +method+ for +object+'s class. The value returned from calling
+      # +method+ on the instance +object+ will be selected. If calling +method+
+      # returns +nil+, no selection is made.
+      #
+      # The <tt>:value_method</tt> and <tt>:text_method</tt> parameters are
+      # methods to be called on each member of +collection+. The return values
+      # are used as the +value+ attribute and contents of each radio button tag,
+      # respectively. They can also be any object that responds to +call+, such
+      # as a +proc+, that will be called for each member of the +collection+ to
+      # retrieve the value/text.
+      #
+      # Example object structure for use with this method:
+      #   class Post < ActiveRecord::Base
+      #     belongs_to :author
+      #   end
+      #   class Author < ActiveRecord::Base
+      #     has_many :posts
+      #     def name_with_initial
+      #       "#{first_name.first}. #{last_name}"
+      #     end
+      #   end
+      #
+      # Sample usage (selecting the associated Author for an instance of Post, <tt>@post</tt>):
+      #   collection_radio_buttons(:post, :author_id, Author.all, :id, :name_with_initial)
+      #
+      # If <tt>@post.author_id</tt> is already <tt>1</tt>, this would return:
+      #   <input id="post_author_id_1" name="post[author_id]" type="radio" value="1" checked="checked" />
+      #   <label for="post_author_id_1">D. Heinemeier Hansson</label>
+      #   <input id="post_author_id_2" name="post[author_id]" type="radio" value="2" />
+      #   <label for="post_author_id_2">D. Thomas</label>
+      #   <input id="post_author_id_3" name="post[author_id]" type="radio" value="3" />
+      #   <label for="post_author_id_3">M. Clark</label>
+      #
+      # It is also possible to customize the way the elements will be shown by
+      # giving a block to the method:
+      #   collection_radio_buttons(:post, :author_id, Author.all, :id, :name_with_initial) do |b|
+      #     b.label { b.radio_button }
+      #   end
+      #
+      # The argument passed to the block is a special kind of builder for this
+      # collection, which has the ability to generate the label and radio button
+      # for the current item in the collection, with proper text and value.
+      # Using it, you can change the label and radio button display order or
+      # even use the label as wrapper, as in the example above.
+      #
+      # The builder methods <tt>label</tt> and <tt>radio_button</tt> also accept
+      # extra HTML options:
+      #   collection_radio_buttons(:post, :author_id, Author.all, :id, :name_with_initial) do |b|
+      #     b.label(class: "radio_button") { b.radio_button(class: "radio_button") }
+      #   end
+      #
+      # There are also three special methods available: <tt>object</tt>, <tt>text</tt> and
+      # <tt>value</tt>, which are the current item being rendered, its text and value methods,
+      # respectively. You can use them like this:
+      #   collection_radio_buttons(:post, :author_id, Author.all, :id, :name_with_initial) do |b|
+      #      b.label(:"data-value" => b.value) { b.radio_button + b.text }
+      #   end
+      #
+      # ==== Gotcha
+      #
+      # The HTML specification says when nothing is selected on a collection of radio buttons
+      # web browsers do not send any value to server.
+      # Unfortunately this introduces a gotcha:
+      # if a +User+ model has a +category_id+ field and in the form no category is selected, no +category_id+ parameter is sent. So,
+      # any strong parameters idiom like:
+      #
+      #   params.require(:user).permit(...)
+      #
+      # will raise an error since no <tt>{user: ...}</tt> will be present.
+      #
+      # To prevent this the helper generates an auxiliary hidden field before
+      # every collection of radio buttons. The hidden field has the same name as collection radio button and blank value.
+      #
+      # In case if you don't want the helper to generate this hidden field you can specify
+      # <tt>include_hidden: false</tt> option.
+      def collection_radio_buttons: (untyped object, untyped method, untyped collection, untyped value_method, untyped text_method, ?::Hash[untyped, untyped] options, ?::Hash[untyped, untyped] html_options) { () -> untyped } -> untyped
+
+      # Returns check box tags for the collection of existing return values of
+      # +method+ for +object+'s class. The value returned from calling +method+
+      # on the instance +object+ will be selected. If calling +method+ returns
+      # +nil+, no selection is made.
+      #
+      # The <tt>:value_method</tt> and <tt>:text_method</tt> parameters are
+      # methods to be called on each member of +collection+. The return values
+      # are used as the +value+ attribute and contents of each check box tag,
+      # respectively. They can also be any object that responds to +call+, such
+      # as a +proc+, that will be called for each member of the +collection+ to
+      # retrieve the value/text.
+      #
+      # Example object structure for use with this method:
+      #   class Post < ActiveRecord::Base
+      #     has_and_belongs_to_many :authors
+      #   end
+      #   class Author < ActiveRecord::Base
+      #     has_and_belongs_to_many :posts
+      #     def name_with_initial
+      #       "#{first_name.first}. #{last_name}"
+      #     end
+      #   end
+      #
+      # Sample usage (selecting the associated Author for an instance of Post, <tt>@post</tt>):
+      #   collection_check_boxes(:post, :author_ids, Author.all, :id, :name_with_initial)
+      #
+      # If <tt>@post.author_ids</tt> is already <tt>[1]</tt>, this would return:
+      #   <input id="post_author_ids_1" name="post[author_ids][]" type="checkbox" value="1" checked="checked" />
+      #   <label for="post_author_ids_1">D. Heinemeier Hansson</label>
+      #   <input id="post_author_ids_2" name="post[author_ids][]" type="checkbox" value="2" />
+      #   <label for="post_author_ids_2">D. Thomas</label>
+      #   <input id="post_author_ids_3" name="post[author_ids][]" type="checkbox" value="3" />
+      #   <label for="post_author_ids_3">M. Clark</label>
+      #   <input name="post[author_ids][]" type="hidden" value="" />
+      #
+      # It is also possible to customize the way the elements will be shown by
+      # giving a block to the method:
+      #   collection_check_boxes(:post, :author_ids, Author.all, :id, :name_with_initial) do |b|
+      #     b.label { b.check_box }
+      #   end
+      #
+      # The argument passed to the block is a special kind of builder for this
+      # collection, which has the ability to generate the label and check box
+      # for the current item in the collection, with proper text and value.
+      # Using it, you can change the label and check box display order or even
+      # use the label as wrapper, as in the example above.
+      #
+      # The builder methods <tt>label</tt> and <tt>check_box</tt> also accept
+      # extra HTML options:
+      #   collection_check_boxes(:post, :author_ids, Author.all, :id, :name_with_initial) do |b|
+      #     b.label(class: "check_box") { b.check_box(class: "check_box") }
+      #   end
+      #
+      # There are also three special methods available: <tt>object</tt>, <tt>text</tt> and
+      # <tt>value</tt>, which are the current item being rendered, its text and value methods,
+      # respectively. You can use them like this:
+      #   collection_check_boxes(:post, :author_ids, Author.all, :id, :name_with_initial) do |b|
+      #      b.label(:"data-value" => b.value) { b.check_box + b.text }
+      #   end
+      #
+      # ==== Gotcha
+      #
+      # When no selection is made for a collection of checkboxes most
+      # web browsers will not send any value.
+      #
+      # For example, if we have a +User+ model with +category_ids+ field and we
+      # have the following code in our update action:
+      #
+      #   @user.update(params[:user])
+      #
+      # If no +category_ids+ are selected then we can safely assume this field
+      # will not be updated.
+      #
+      # This is possible thanks to a hidden field generated by the helper method
+      # for every collection of checkboxes.
+      # This hidden field is given the same field name as the checkboxes with a
+      # blank value.
+      #
+      # In the rare case you don't want this hidden field, you can pass the
+      # <tt>include_hidden: false</tt> option to the helper method.
+      def collection_check_boxes: (untyped object, untyped method, untyped collection, untyped value_method, untyped text_method, ?::Hash[untyped, untyped] options, ?::Hash[untyped, untyped] html_options) { () -> untyped } -> untyped
+
+      def option_html_attributes: (untyped element) -> untyped
+
+      def option_text_and_value: (untyped option) -> untyped
+
+      def option_value_selected?: (untyped value, untyped selected) -> untyped
+
+      def extract_selected_and_disabled: (untyped selected) -> untyped
+
+      def extract_values_from_collection: (untyped collection, untyped value_method, untyped selected) -> untyped
+
+      def value_for_collection: (untyped item, untyped value) -> untyped
+
+      def public_or_deprecated_send: (untyped item, untyped value) -> untyped
+
+      def prompt_text: (untyped prompt) -> untyped
+    end
+
+    class FormBuilder
+      # Wraps ActionView::Helpers::FormOptionsHelper#select for form builders:
+      #
+      #   <%= form_for @post do |f| %>
+      #     <%= f.select :person_id, Person.all.collect { |p| [ p.name, p.id ] }, include_blank: true %>
+      #     <%= f.submit %>
+      #   <% end %>
+      #
+      # Please refer to the documentation of the base helper for details.
+      def select: (untyped method, ?untyped? choices, ?::Hash[untyped, untyped] options, ?::Hash[untyped, untyped] html_options) { () -> untyped } -> untyped
+
+      # Wraps ActionView::Helpers::FormOptionsHelper#collection_select for form builders:
+      #
+      #   <%= form_for @post do |f| %>
+      #     <%= f.collection_select :person_id, Author.all, :id, :name_with_initial, prompt: true %>
+      #     <%= f.submit %>
+      #   <% end %>
+      #
+      # Please refer to the documentation of the base helper for details.
+      def collection_select: (untyped method, untyped collection, untyped value_method, untyped text_method, ?::Hash[untyped, untyped] options, ?::Hash[untyped, untyped] html_options) -> untyped
+
+      # Wraps ActionView::Helpers::FormOptionsHelper#grouped_collection_select for form builders:
+      #
+      #   <%= form_for @city do |f| %>
+      #     <%= f.grouped_collection_select :country_id, @continents, :countries, :name, :id, :name %>
+      #     <%= f.submit %>
+      #   <% end %>
+      #
+      # Please refer to the documentation of the base helper for details.
+      def grouped_collection_select: (untyped method, untyped collection, untyped group_method, untyped group_label_method, untyped option_key_method, untyped option_value_method, ?::Hash[untyped, untyped] options, ?::Hash[untyped, untyped] html_options) -> untyped
+
+      # Wraps ActionView::Helpers::FormOptionsHelper#time_zone_select for form builders:
+      #
+      #   <%= form_for @user do |f| %>
+      #     <%= f.time_zone_select :time_zone, nil, include_blank: true %>
+      #     <%= f.submit %>
+      #   <% end %>
+      #
+      # Please refer to the documentation of the base helper for details.
+      def time_zone_select: (untyped method, ?untyped? priority_zones, ?::Hash[untyped, untyped] options, ?::Hash[untyped, untyped] html_options) -> untyped
+
+      # Wraps ActionView::Helpers::FormOptionsHelper#collection_check_boxes for form builders:
+      #
+      #   <%= form_for @post do |f| %>
+      #     <%= f.collection_check_boxes :author_ids, Author.all, :id, :name_with_initial %>
+      #     <%= f.submit %>
+      #   <% end %>
+      #
+      # Please refer to the documentation of the base helper for details.
+      def collection_check_boxes: (untyped method, untyped collection, untyped value_method, untyped text_method, ?::Hash[untyped, untyped] options, ?::Hash[untyped, untyped] html_options) { () -> untyped } -> untyped
+
+      # Wraps ActionView::Helpers::FormOptionsHelper#collection_radio_buttons for form builders:
+      #
+      #   <%= form_for @post do |f| %>
+      #     <%= f.collection_radio_buttons :author_id, Author.all, :id, :name_with_initial %>
+      #     <%= f.submit %>
+      #   <% end %>
+      #
+      # Please refer to the documentation of the base helper for details.
+      def collection_radio_buttons: (untyped method, untyped collection, untyped value_method, untyped text_method, ?::Hash[untyped, untyped] options, ?::Hash[untyped, untyped] html_options) { () -> untyped } -> untyped
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    # = Action View Form Tag Helpers
+    # nodoc:
+    # Provides a number of methods for creating form tags that don't rely on an Active Record object assigned to the template like
+    # FormHelper does. Instead, you provide the names and values manually.
+    #
+    # NOTE: The HTML options <tt>disabled</tt>, <tt>readonly</tt>, and <tt>multiple</tt> can all be treated as booleans. So specifying
+    # <tt>disabled: true</tt> will give <tt>disabled="disabled"</tt>.
+    module FormTagHelper
+      extend ActiveSupport::Concern
+
+      include UrlHelper
+
+      include TextHelper
+
+      # Starts a form tag that points the action to a URL configured with <tt>url_for_options</tt> just like
+      # ActionController::Base#url_for. The method for the form defaults to POST.
+      #
+      # ==== Options
+      # * <tt>:multipart</tt> - If set to true, the enctype is set to "multipart/form-data".
+      # * <tt>:method</tt> - The method to use when submitting the form, usually either "get" or "post".
+      #   If "patch", "put", "delete", or another verb is used, a hidden input with name <tt>_method</tt>
+      #   is added to simulate the verb over post.
+      # * <tt>:authenticity_token</tt> - Authenticity token to use in the form. Use only if you need to
+      #   pass custom authenticity token string, or to not add authenticity_token field at all
+      #   (by passing <tt>false</tt>).  Remote forms may omit the embedded authenticity token
+      #   by setting <tt>config.action_view.embed_authenticity_token_in_remote_forms = false</tt>.
+      #   This is helpful when you're fragment-caching the form. Remote forms get the
+      #   authenticity token from the <tt>meta</tt> tag, so embedding is unnecessary unless you
+      #   support browsers without JavaScript.
+      # * <tt>:remote</tt> - If set to true, will allow the Unobtrusive JavaScript drivers to control the
+      #   submit behavior. By default this behavior is an ajax submit.
+      # * <tt>:enforce_utf8</tt> - If set to false, a hidden input with name utf8 is not output.
+      # * Any other key creates standard HTML attributes for the tag.
+      #
+      # ==== Examples
+      #   form_tag('/posts')
+      #   # => <form action="/posts" method="post">
+      #
+      #   form_tag('/posts/1', method: :put)
+      #   # => <form action="/posts/1" method="post"> ... <input name="_method" type="hidden" value="put" /> ...
+      #
+      #   form_tag('/upload', multipart: true)
+      #   # => <form action="/upload" method="post" enctype="multipart/form-data">
+      #
+      #   <%= form_tag('/posts') do -%>
+      #     <div><%= submit_tag 'Save' %></div>
+      #   <% end -%>
+      #   # => <form action="/posts" method="post"><div><input type="submit" name="commit" value="Save" /></div></form>
+      #
+      #   <%= form_tag('/posts', remote: true) %>
+      #   # => <form action="/posts" method="post" data-remote="true">
+      #
+      #   form_tag('http://far.away.com/form', authenticity_token: false)
+      #   # form without authenticity token
+      #
+      #   form_tag('http://far.away.com/form', authenticity_token: "cf50faa3fe97702ca1ae")
+      #   # form with custom authenticity token
+      #
+      def form_tag: (?::Hash[untyped, untyped] url_for_options, ?::Hash[untyped, untyped] options) { () -> untyped } -> untyped
+
+      # Creates a dropdown selection box, or if the <tt>:multiple</tt> option is set to true, a multiple
+      # choice selection box.
+      #
+      # Helpers::FormOptions can be used to create common select boxes such as countries, time zones, or
+      # associated records. <tt>option_tags</tt> is a string containing the option tags for the select box.
+      #
+      # ==== Options
+      # * <tt>:multiple</tt> - If set to true, the selection will allow multiple choices.
+      # * <tt>:disabled</tt> - If set to true, the user will not be able to use this input.
+      # * <tt>:include_blank</tt> - If set to true, an empty option will be created. If set to a string, the string will be used as the option's content and the value will be empty.
+      # * <tt>:prompt</tt> - Create a prompt option with blank value and the text asking user to select something.
+      # * Any other key creates standard HTML attributes for the tag.
+      #
+      # ==== Examples
+      #   select_tag "people", options_from_collection_for_select(@people, "id", "name")
+      #   # <select id="people" name="people"><option value="1">David</option></select>
+      #
+      #   select_tag "people", options_from_collection_for_select(@people, "id", "name", "1")
+      #   # <select id="people" name="people"><option value="1" selected="selected">David</option></select>
+      #
+      #   select_tag "people", raw("<option>David</option>")
+      #   # => <select id="people" name="people"><option>David</option></select>
+      #
+      #   select_tag "count", raw("<option>1</option><option>2</option><option>3</option><option>4</option>")
+      #   # => <select id="count" name="count"><option>1</option><option>2</option>
+      #   #    <option>3</option><option>4</option></select>
+      #
+      #   select_tag "colors", raw("<option>Red</option><option>Green</option><option>Blue</option>"), multiple: true
+      #   # => <select id="colors" multiple="multiple" name="colors[]"><option>Red</option>
+      #   #    <option>Green</option><option>Blue</option></select>
+      #
+      #   select_tag "locations", raw("<option>Home</option><option selected='selected'>Work</option><option>Out</option>")
+      #   # => <select id="locations" name="locations"><option>Home</option><option selected='selected'>Work</option>
+      #   #    <option>Out</option></select>
+      #
+      #   select_tag "access", raw("<option>Read</option><option>Write</option>"), multiple: true, class: 'form_input', id: 'unique_id'
+      #   # => <select class="form_input" id="unique_id" multiple="multiple" name="access[]"><option>Read</option>
+      #   #    <option>Write</option></select>
+      #
+      #   select_tag "people", options_from_collection_for_select(@people, "id", "name"), include_blank: true
+      #   # => <select id="people" name="people"><option value="" label=" "></option><option value="1">David</option></select>
+      #
+      #   select_tag "people", options_from_collection_for_select(@people, "id", "name"), include_blank: "All"
+      #   # => <select id="people" name="people"><option value="">All</option><option value="1">David</option></select>
+      #
+      #   select_tag "people", options_from_collection_for_select(@people, "id", "name"), prompt: "Select something"
+      #   # => <select id="people" name="people"><option value="">Select something</option><option value="1">David</option></select>
+      #
+      #   select_tag "destination", raw("<option>NYC</option><option>Paris</option><option>Rome</option>"), disabled: true
+      #   # => <select disabled="disabled" id="destination" name="destination"><option>NYC</option>
+      #   #    <option>Paris</option><option>Rome</option></select>
+      #
+      #   select_tag "credit_card", options_for_select([ "VISA", "MasterCard" ], "MasterCard")
+      #   # => <select id="credit_card" name="credit_card"><option>VISA</option>
+      #   #    <option selected="selected">MasterCard</option></select>
+      def select_tag: (untyped name, ?untyped? option_tags, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Creates a standard text field; use these text fields to input smaller chunks of text like a username
+      # or a search query.
+      #
+      # ==== Options
+      # * <tt>:disabled</tt> - If set to true, the user will not be able to use this input.
+      # * <tt>:size</tt> - The number of visible characters that will fit in the input.
+      # * <tt>:maxlength</tt> - The maximum number of characters that the browser will allow the user to enter.
+      # * <tt>:placeholder</tt> - The text contained in the field by default which is removed when the field receives focus.
+      #   If set to true, use a translation is found in the current I18n locale
+      #   (through helpers.placeholders.<modelname>.<attribute>).
+      # * Any other key creates standard HTML attributes for the tag.
+      #
+      # ==== Examples
+      #   text_field_tag 'name'
+      #   # => <input id="name" name="name" type="text" />
+      #
+      #   text_field_tag 'query', 'Enter your search query here'
+      #   # => <input id="query" name="query" type="text" value="Enter your search query here" />
+      #
+      #   text_field_tag 'search', nil, placeholder: 'Enter search term...'
+      #   # => <input id="search" name="search" placeholder="Enter search term..." type="text" />
+      #
+      #   text_field_tag 'request', nil, class: 'special_input'
+      #   # => <input class="special_input" id="request" name="request" type="text" />
+      #
+      #   text_field_tag 'address', '', size: 75
+      #   # => <input id="address" name="address" size="75" type="text" value="" />
+      #
+      #   text_field_tag 'zip', nil, maxlength: 5
+      #   # => <input id="zip" maxlength="5" name="zip" type="text" />
+      #
+      #   text_field_tag 'payment_amount', '$0.00', disabled: true
+      #   # => <input disabled="disabled" id="payment_amount" name="payment_amount" type="text" value="$0.00" />
+      #
+      #   text_field_tag 'ip', '0.0.0.0', maxlength: 15, size: 20, class: "ip-input"
+      #   # => <input class="ip-input" id="ip" maxlength="15" name="ip" size="20" type="text" value="0.0.0.0" />
+      def text_field_tag: (untyped name, ?untyped? value, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Creates a label element. Accepts a block.
+      #
+      # ==== Options
+      # * Creates standard HTML attributes for the tag.
+      #
+      # ==== Examples
+      #   label_tag 'name'
+      #   # => <label for="name">Name</label>
+      #
+      #   label_tag 'name', 'Your name'
+      #   # => <label for="name">Your name</label>
+      #
+      #   label_tag 'name', nil, class: 'small_label'
+      #   # => <label for="name" class="small_label">Name</label>
+      def label_tag: (?untyped? name, ?untyped? content_or_options, ?untyped? options) { () -> untyped } -> untyped
+
+      # Creates a hidden form input field used to transmit data that would be lost due to HTTP's statelessness or
+      # data that should be hidden from the user.
+      #
+      # ==== Options
+      # * Creates standard HTML attributes for the tag.
+      #
+      # ==== Examples
+      #   hidden_field_tag 'tags_list'
+      #   # => <input id="tags_list" name="tags_list" type="hidden" />
+      #
+      #   hidden_field_tag 'token', 'VUBJKB23UIVI1UU1VOBVI@'
+      #   # => <input id="token" name="token" type="hidden" value="VUBJKB23UIVI1UU1VOBVI@" />
+      #
+      #   hidden_field_tag 'collected_input', '', onchange: "alert('Input collected!')"
+      #   # => <input id="collected_input" name="collected_input" onchange="alert('Input collected!')"
+      #   #    type="hidden" value="" />
+      def hidden_field_tag: (untyped name, ?untyped? value, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Creates a file upload field. If you are using file uploads then you will also need
+      # to set the multipart option for the form tag:
+      #
+      #   <%= form_tag '/upload', multipart: true do %>
+      #     <label for="file">File to Upload</label> <%= file_field_tag "file" %>
+      #     <%= submit_tag %>
+      #   <% end %>
+      #
+      # The specified URL will then be passed a File object containing the selected file, or if the field
+      # was left blank, a StringIO object.
+      #
+      # ==== Options
+      # * Creates standard HTML attributes for the tag.
+      # * <tt>:disabled</tt> - If set to true, the user will not be able to use this input.
+      # * <tt>:multiple</tt> - If set to true, *in most updated browsers* the user will be allowed to select multiple files.
+      # * <tt>:accept</tt> - If set to one or multiple mime-types, the user will be suggested a filter when choosing a file. You still need to set up model validations.
+      #
+      # ==== Examples
+      #   file_field_tag 'attachment'
+      #   # => <input id="attachment" name="attachment" type="file" />
+      #
+      #   file_field_tag 'avatar', class: 'profile_input'
+      #   # => <input class="profile_input" id="avatar" name="avatar" type="file" />
+      #
+      #   file_field_tag 'picture', disabled: true
+      #   # => <input disabled="disabled" id="picture" name="picture" type="file" />
+      #
+      #   file_field_tag 'resume', value: '~/resume.doc'
+      #   # => <input id="resume" name="resume" type="file" value="~/resume.doc" />
+      #
+      #   file_field_tag 'user_pic', accept: 'image/png,image/gif,image/jpeg'
+      #   # => <input accept="image/png,image/gif,image/jpeg" id="user_pic" name="user_pic" type="file" />
+      #
+      #   file_field_tag 'file', accept: 'text/html', class: 'upload', value: 'index.html'
+      #   # => <input accept="text/html" class="upload" id="file" name="file" type="file" value="index.html" />
+      def file_field_tag: (untyped name, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Creates a password field, a masked text field that will hide the users input behind a mask character.
+      #
+      # ==== Options
+      # * <tt>:disabled</tt> - If set to true, the user will not be able to use this input.
+      # * <tt>:size</tt> - The number of visible characters that will fit in the input.
+      # * <tt>:maxlength</tt> - The maximum number of characters that the browser will allow the user to enter.
+      # * Any other key creates standard HTML attributes for the tag.
+      #
+      # ==== Examples
+      #   password_field_tag 'pass'
+      #   # => <input id="pass" name="pass" type="password" />
+      #
+      #   password_field_tag 'secret', 'Your secret here'
+      #   # => <input id="secret" name="secret" type="password" value="Your secret here" />
+      #
+      #   password_field_tag 'masked', nil, class: 'masked_input_field'
+      #   # => <input class="masked_input_field" id="masked" name="masked" type="password" />
+      #
+      #   password_field_tag 'token', '', size: 15
+      #   # => <input id="token" name="token" size="15" type="password" value="" />
+      #
+      #   password_field_tag 'key', nil, maxlength: 16
+      #   # => <input id="key" maxlength="16" name="key" type="password" />
+      #
+      #   password_field_tag 'confirm_pass', nil, disabled: true
+      #   # => <input disabled="disabled" id="confirm_pass" name="confirm_pass" type="password" />
+      #
+      #   password_field_tag 'pin', '1234', maxlength: 4, size: 6, class: "pin_input"
+      #   # => <input class="pin_input" id="pin" maxlength="4" name="pin" size="6" type="password" value="1234" />
+      def password_field_tag: (?::String name, ?untyped? value, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Creates a text input area; use a textarea for longer text inputs such as blog posts or descriptions.
+      #
+      # ==== Options
+      # * <tt>:size</tt> - A string specifying the dimensions (columns by rows) of the textarea (e.g., "25x10").
+      # * <tt>:rows</tt> - Specify the number of rows in the textarea
+      # * <tt>:cols</tt> - Specify the number of columns in the textarea
+      # * <tt>:disabled</tt> - If set to true, the user will not be able to use this input.
+      # * <tt>:escape</tt> - By default, the contents of the text input are HTML escaped.
+      #   If you need unescaped contents, set this to false.
+      # * Any other key creates standard HTML attributes for the tag.
+      #
+      # ==== Examples
+      #   text_area_tag 'post'
+      #   # => <textarea id="post" name="post"></textarea>
+      #
+      #   text_area_tag 'bio', @user.bio
+      #   # => <textarea id="bio" name="bio">This is my biography.</textarea>
+      #
+      #   text_area_tag 'body', nil, rows: 10, cols: 25
+      #   # => <textarea cols="25" id="body" name="body" rows="10"></textarea>
+      #
+      #   text_area_tag 'body', nil, size: "25x10"
+      #   # => <textarea name="body" id="body" cols="25" rows="10"></textarea>
+      #
+      #   text_area_tag 'description', "Description goes here.", disabled: true
+      #   # => <textarea disabled="disabled" id="description" name="description">Description goes here.</textarea>
+      #
+      #   text_area_tag 'comment', nil, class: 'comment_input'
+      #   # => <textarea class="comment_input" id="comment" name="comment"></textarea>
+      def text_area_tag: (untyped name, ?untyped? content, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Creates a check box form input tag.
+      #
+      # ==== Options
+      # * <tt>:disabled</tt> - If set to true, the user will not be able to use this input.
+      # * Any other key creates standard HTML options for the tag.
+      #
+      # ==== Examples
+      #   check_box_tag 'accept'
+      #   # => <input id="accept" name="accept" type="checkbox" value="1" />
+      #
+      #   check_box_tag 'rock', 'rock music'
+      #   # => <input id="rock" name="rock" type="checkbox" value="rock music" />
+      #
+      #   check_box_tag 'receive_email', 'yes', true
+      #   # => <input checked="checked" id="receive_email" name="receive_email" type="checkbox" value="yes" />
+      #
+      #   check_box_tag 'tos', 'yes', false, class: 'accept_tos'
+      #   # => <input class="accept_tos" id="tos" name="tos" type="checkbox" value="yes" />
+      #
+      #   check_box_tag 'eula', 'accepted', false, disabled: true
+      #   # => <input disabled="disabled" id="eula" name="eula" type="checkbox" value="accepted" />
+      def check_box_tag: (untyped name, ?::String value, ?bool checked, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Creates a radio button; use groups of radio buttons named the same to allow users to
+      # select from a group of options.
+      #
+      # ==== Options
+      # * <tt>:disabled</tt> - If set to true, the user will not be able to use this input.
+      # * Any other key creates standard HTML options for the tag.
+      #
+      # ==== Examples
+      #   radio_button_tag 'favorite_color', 'maroon'
+      #   # => <input id="favorite_color_maroon" name="favorite_color" type="radio" value="maroon" />
+      #
+      #   radio_button_tag 'receive_updates', 'no', true
+      #   # => <input checked="checked" id="receive_updates_no" name="receive_updates" type="radio" value="no" />
+      #
+      #   radio_button_tag 'time_slot', "3:00 p.m.", false, disabled: true
+      #   # => <input disabled="disabled" id="time_slot_3:00_p.m." name="time_slot" type="radio" value="3:00 p.m." />
+      #
+      #   radio_button_tag 'color', "green", true, class: "color_input"
+      #   # => <input checked="checked" class="color_input" id="color_green" name="color" type="radio" value="green" />
+      def radio_button_tag: (untyped name, untyped value, ?bool checked, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Creates a submit button with the text <tt>value</tt> as the caption.
+      #
+      # ==== Options
+      # * <tt>:data</tt> - This option can be used to add custom data attributes.
+      # * <tt>:disabled</tt> - If true, the user will not be able to use this input.
+      # * Any other key creates standard HTML options for the tag.
+      #
+      # ==== Data attributes
+      #
+      # * <tt>confirm: 'question?'</tt> - If present the unobtrusive JavaScript
+      #   drivers will provide a prompt with the question specified. If the user accepts,
+      #   the form is processed normally, otherwise no action is taken.
+      # * <tt>:disable_with</tt> - Value of this parameter will be used as the value for a
+      #   disabled version of the submit button when the form is submitted. This feature is
+      #   provided by the unobtrusive JavaScript driver. To disable this feature for a single submit tag
+      #   pass <tt>:data => { disable_with: false }</tt> Defaults to value attribute.
+      #
+      # ==== Examples
+      #   submit_tag
+      #   # => <input name="commit" data-disable-with="Save changes" type="submit" value="Save changes" />
+      #
+      #   submit_tag "Edit this article"
+      #   # => <input name="commit" data-disable-with="Edit this article" type="submit" value="Edit this article" />
+      #
+      #   submit_tag "Save edits", disabled: true
+      #   # => <input disabled="disabled" name="commit" data-disable-with="Save edits" type="submit" value="Save edits" />
+      #
+      #   submit_tag "Complete sale", data: { disable_with: "Submitting..." }
+      #   # => <input name="commit" data-disable-with="Submitting..." type="submit" value="Complete sale" />
+      #
+      #   submit_tag nil, class: "form_submit"
+      #   # => <input class="form_submit" name="commit" type="submit" />
+      #
+      #   submit_tag "Edit", class: "edit_button"
+      #   # => <input class="edit_button" data-disable-with="Edit" name="commit" type="submit" value="Edit" />
+      #
+      #   submit_tag "Save", data: { confirm: "Are you sure?" }
+      #   # => <input name='commit' type='submit' value='Save' data-disable-with="Save" data-confirm="Are you sure?" />
+      #
+      def submit_tag: (?::String value, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Creates a button element that defines a <tt>submit</tt> button,
+      # <tt>reset</tt> button or a generic button which can be used in
+      # JavaScript, for example. You can use the button tag as a regular
+      # submit tag but it isn't supported in legacy browsers. However,
+      # the button tag does allow for richer labels such as images and emphasis,
+      # so this helper will also accept a block. By default, it will create
+      # a button tag with type <tt>submit</tt>, if type is not given.
+      #
+      # ==== Options
+      # * <tt>:data</tt> - This option can be used to add custom data attributes.
+      # * <tt>:disabled</tt> - If true, the user will not be able to
+      #   use this input.
+      # * Any other key creates standard HTML options for the tag.
+      #
+      # ==== Data attributes
+      #
+      # * <tt>confirm: 'question?'</tt> - If present, the
+      #   unobtrusive JavaScript drivers will provide a prompt with
+      #   the question specified. If the user accepts, the form is
+      #   processed normally, otherwise no action is taken.
+      # * <tt>:disable_with</tt> - Value of this parameter will be
+      #   used as the value for a disabled version of the submit
+      #   button when the form is submitted. This feature is provided
+      #   by the unobtrusive JavaScript driver.
+      #
+      # ==== Examples
+      #   button_tag
+      #   # => <button name="button" type="submit">Button</button>
+      #
+      #   button_tag 'Reset', type: 'reset'
+      #   # => <button name="button" type="reset">Reset</button>
+      #
+      #   button_tag 'Button', type: 'button'
+      #   # => <button name="button" type="button">Button</button>
+      #
+      #   button_tag 'Reset', type: 'reset', disabled: true
+      #   # => <button name="button" type="reset" disabled="disabled">Reset</button>
+      #
+      #   button_tag(type: 'button') do
+      #     content_tag(:strong, 'Ask me!')
+      #   end
+      #   # => <button name="button" type="button">
+      #   #     <strong>Ask me!</strong>
+      #   #    </button>
+      #
+      #   button_tag "Save", data: { confirm: "Are you sure?" }
+      #   # => <button name="button" type="submit" data-confirm="Are you sure?">Save</button>
+      #
+      #   button_tag "Checkout", data: { disable_with: "Please wait..." }
+      #   # => <button data-disable-with="Please wait..." name="button" type="submit">Checkout</button>
+      #
+      def button_tag: (?untyped? content_or_options, ?untyped? options) { () -> untyped } -> untyped
+
+      # Displays an image which when clicked will submit the form.
+      #
+      # <tt>source</tt> is passed to AssetTagHelper#path_to_image
+      #
+      # ==== Options
+      # * <tt>:data</tt> - This option can be used to add custom data attributes.
+      # * <tt>:disabled</tt> - If set to true, the user will not be able to use this input.
+      # * Any other key creates standard HTML options for the tag.
+      #
+      # ==== Data attributes
+      #
+      # * <tt>confirm: 'question?'</tt> - This will add a JavaScript confirm
+      #   prompt with the question specified. If the user accepts, the form is
+      #   processed normally, otherwise no action is taken.
+      #
+      # ==== Examples
+      #   image_submit_tag("login.png")
+      #   # => <input src="/assets/login.png" type="image" />
+      #
+      #   image_submit_tag("purchase.png", disabled: true)
+      #   # => <input disabled="disabled" src="/assets/purchase.png" type="image" />
+      #
+      #   image_submit_tag("search.png", class: 'search_button', alt: 'Find')
+      #   # => <input class="search_button" src="/assets/search.png" type="image" />
+      #
+      #   image_submit_tag("agree.png", disabled: true, class: "agree_disagree_button")
+      #   # => <input class="agree_disagree_button" disabled="disabled" src="/assets/agree.png" type="image" />
+      #
+      #   image_submit_tag("save.png", data: { confirm: "Are you sure?" })
+      #   # => <input src="/assets/save.png" data-confirm="Are you sure?" type="image" />
+      def image_submit_tag: (untyped source, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Creates a field set for grouping HTML form elements.
+      #
+      # <tt>legend</tt> will become the fieldset's title (optional as per W3C).
+      # <tt>options</tt> accept the same values as tag.
+      #
+      # ==== Examples
+      #   <%= field_set_tag do %>
+      #     <p><%= text_field_tag 'name' %></p>
+      #   <% end %>
+      #   # => <fieldset><p><input id="name" name="name" type="text" /></p></fieldset>
+      #
+      #   <%= field_set_tag 'Your details' do %>
+      #     <p><%= text_field_tag 'name' %></p>
+      #   <% end %>
+      #   # => <fieldset><legend>Your details</legend><p><input id="name" name="name" type="text" /></p></fieldset>
+      #
+      #   <%= field_set_tag nil, class: 'format' do %>
+      #     <p><%= text_field_tag 'name' %></p>
+      #   <% end %>
+      #   # => <fieldset class="format"><p><input id="name" name="name" type="text" /></p></fieldset>
+      def field_set_tag: (?untyped? legend, ?untyped? options) { () -> untyped } -> untyped
+
+      # Creates a text field of type "color".
+      #
+      # ==== Options
+      # * Accepts the same options as text_field_tag.
+      #
+      # ==== Examples
+      #   color_field_tag 'name'
+      #   # => <input id="name" name="name" type="color" />
+      #
+      #   color_field_tag 'color', '#DEF726'
+      #   # => <input id="color" name="color" type="color" value="#DEF726" />
+      #
+      #   color_field_tag 'color', nil, class: 'special_input'
+      #   # => <input class="special_input" id="color" name="color" type="color" />
+      #
+      #   color_field_tag 'color', '#DEF726', class: 'special_input', disabled: true
+      #   # => <input disabled="disabled" class="special_input" id="color" name="color" type="color" value="#DEF726" />
+      def color_field_tag: (untyped name, ?untyped? value, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Creates a text field of type "search".
+      #
+      # ==== Options
+      # * Accepts the same options as text_field_tag.
+      #
+      # ==== Examples
+      #   search_field_tag 'name'
+      #   # => <input id="name" name="name" type="search" />
+      #
+      #   search_field_tag 'search', 'Enter your search query here'
+      #   # => <input id="search" name="search" type="search" value="Enter your search query here" />
+      #
+      #   search_field_tag 'search', nil, class: 'special_input'
+      #   # => <input class="special_input" id="search" name="search" type="search" />
+      #
+      #   search_field_tag 'search', 'Enter your search query here', class: 'special_input', disabled: true
+      #   # => <input disabled="disabled" class="special_input" id="search" name="search" type="search" value="Enter your search query here" />
+      def search_field_tag: (untyped name, ?untyped? value, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Creates a text field of type "tel".
+      #
+      # ==== Options
+      # * Accepts the same options as text_field_tag.
+      #
+      # ==== Examples
+      #   telephone_field_tag 'name'
+      #   # => <input id="name" name="name" type="tel" />
+      #
+      #   telephone_field_tag 'tel', '0123456789'
+      #   # => <input id="tel" name="tel" type="tel" value="0123456789" />
+      #
+      #   telephone_field_tag 'tel', nil, class: 'special_input'
+      #   # => <input class="special_input" id="tel" name="tel" type="tel" />
+      #
+      #   telephone_field_tag 'tel', '0123456789', class: 'special_input', disabled: true
+      #   # => <input disabled="disabled" class="special_input" id="tel" name="tel" type="tel" value="0123456789" />
+      def telephone_field_tag: (untyped name, ?untyped? value, ?::Hash[untyped, untyped] options) -> untyped
+
+      alias phone_field_tag telephone_field_tag
+
+      # Creates a text field of type "date".
+      #
+      # ==== Options
+      # * Accepts the same options as text_field_tag.
+      #
+      # ==== Examples
+      #   date_field_tag 'name'
+      #   # => <input id="name" name="name" type="date" />
+      #
+      #   date_field_tag 'date', '01/01/2014'
+      #   # => <input id="date" name="date" type="date" value="01/01/2014" />
+      #
+      #   date_field_tag 'date', nil, class: 'special_input'
+      #   # => <input class="special_input" id="date" name="date" type="date" />
+      #
+      #   date_field_tag 'date', '01/01/2014', class: 'special_input', disabled: true
+      #   # => <input disabled="disabled" class="special_input" id="date" name="date" type="date" value="01/01/2014" />
+      def date_field_tag: (untyped name, ?untyped? value, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Creates a text field of type "time".
+      #
+      # === Options
+      # * <tt>:min</tt> - The minimum acceptable value.
+      # * <tt>:max</tt> - The maximum acceptable value.
+      # * <tt>:step</tt> - The acceptable value granularity.
+      # * Otherwise accepts the same options as text_field_tag.
+      def time_field_tag: (untyped name, ?untyped? value, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Creates a text field of type "datetime-local".
+      #
+      # === Options
+      # * <tt>:min</tt> - The minimum acceptable value.
+      # * <tt>:max</tt> - The maximum acceptable value.
+      # * <tt>:step</tt> - The acceptable value granularity.
+      # * Otherwise accepts the same options as text_field_tag.
+      def datetime_field_tag: (untyped name, ?untyped? value, ?::Hash[untyped, untyped] options) -> untyped
+
+      alias datetime_local_field_tag datetime_field_tag
+
+      # Creates a text field of type "month".
+      #
+      # === Options
+      # * <tt>:min</tt> - The minimum acceptable value.
+      # * <tt>:max</tt> - The maximum acceptable value.
+      # * <tt>:step</tt> - The acceptable value granularity.
+      # * Otherwise accepts the same options as text_field_tag.
+      def month_field_tag: (untyped name, ?untyped? value, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Creates a text field of type "week".
+      #
+      # === Options
+      # * <tt>:min</tt> - The minimum acceptable value.
+      # * <tt>:max</tt> - The maximum acceptable value.
+      # * <tt>:step</tt> - The acceptable value granularity.
+      # * Otherwise accepts the same options as text_field_tag.
+      def week_field_tag: (untyped name, ?untyped? value, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Creates a text field of type "url".
+      #
+      # ==== Options
+      # * Accepts the same options as text_field_tag.
+      #
+      # ==== Examples
+      #   url_field_tag 'name'
+      #   # => <input id="name" name="name" type="url" />
+      #
+      #   url_field_tag 'url', 'http://rubyonrails.org'
+      #   # => <input id="url" name="url" type="url" value="http://rubyonrails.org" />
+      #
+      #   url_field_tag 'url', nil, class: 'special_input'
+      #   # => <input class="special_input" id="url" name="url" type="url" />
+      #
+      #   url_field_tag 'url', 'http://rubyonrails.org', class: 'special_input', disabled: true
+      #   # => <input disabled="disabled" class="special_input" id="url" name="url" type="url" value="http://rubyonrails.org" />
+      def url_field_tag: (untyped name, ?untyped? value, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Creates a text field of type "email".
+      #
+      # ==== Options
+      # * Accepts the same options as text_field_tag.
+      #
+      # ==== Examples
+      #   email_field_tag 'name'
+      #   # => <input id="name" name="name" type="email" />
+      #
+      #   email_field_tag 'email', 'email@example.com'
+      #   # => <input id="email" name="email" type="email" value="email@example.com" />
+      #
+      #   email_field_tag 'email', nil, class: 'special_input'
+      #   # => <input class="special_input" id="email" name="email" type="email" />
+      #
+      #   email_field_tag 'email', 'email@example.com', class: 'special_input', disabled: true
+      #   # => <input disabled="disabled" class="special_input" id="email" name="email" type="email" value="email@example.com" />
+      def email_field_tag: (untyped name, ?untyped? value, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Creates a number field.
+      #
+      # ==== Options
+      # * <tt>:min</tt> - The minimum acceptable value.
+      # * <tt>:max</tt> - The maximum acceptable value.
+      # * <tt>:in</tt> - A range specifying the <tt>:min</tt> and
+      #   <tt>:max</tt> values.
+      # * <tt>:within</tt> - Same as <tt>:in</tt>.
+      # * <tt>:step</tt> - The acceptable value granularity.
+      # * Otherwise accepts the same options as text_field_tag.
+      #
+      # ==== Examples
+      #   number_field_tag 'quantity'
+      #   # => <input id="quantity" name="quantity" type="number" />
+      #
+      #   number_field_tag 'quantity', '1'
+      #   # => <input id="quantity" name="quantity" type="number" value="1" />
+      #
+      #   number_field_tag 'quantity', nil, class: 'special_input'
+      #   # => <input class="special_input" id="quantity" name="quantity" type="number" />
+      #
+      #   number_field_tag 'quantity', nil, min: 1
+      #   # => <input id="quantity" name="quantity" min="1" type="number" />
+      #
+      #   number_field_tag 'quantity', nil, max: 9
+      #   # => <input id="quantity" name="quantity" max="9" type="number" />
+      #
+      #   number_field_tag 'quantity', nil, in: 1...10
+      #   # => <input id="quantity" name="quantity" min="1" max="9" type="number" />
+      #
+      #   number_field_tag 'quantity', nil, within: 1...10
+      #   # => <input id="quantity" name="quantity" min="1" max="9" type="number" />
+      #
+      #   number_field_tag 'quantity', nil, min: 1, max: 10
+      #   # => <input id="quantity" name="quantity" min="1" max="10" type="number" />
+      #
+      #   number_field_tag 'quantity', nil, min: 1, max: 10, step: 2
+      #   # => <input id="quantity" name="quantity" min="1" max="10" step="2" type="number" />
+      #
+      #   number_field_tag 'quantity', '1', class: 'special_input', disabled: true
+      #   # => <input disabled="disabled" class="special_input" id="quantity" name="quantity" type="number" value="1" />
+      def number_field_tag: (untyped name, ?untyped? value, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Creates a range form element.
+      #
+      # ==== Options
+      # * Accepts the same options as number_field_tag.
+      def range_field_tag: (untyped name, ?untyped? value, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Creates the hidden UTF8 enforcer tag. Override this method in a helper
+      # to customize the tag.
+      def utf8_enforcer_tag: () -> untyped
+
+      def html_options_for_form: (untyped url_for_options, untyped options) -> untyped
+
+      def extra_tags_for_form: (untyped html_options) -> untyped
+
+      def form_tag_html: (untyped html_options) -> untyped
+
+      def form_tag_with_body: (untyped html_options, untyped content) -> untyped
+
+      # see http://www.w3.org/TR/html4/types.html#type-name
+      def sanitize_to_id: (untyped name) -> untyped
+
+      def set_default_disable_with: (untyped value, untyped tag_options) -> (nil | untyped)
+
+      def convert_direct_upload_option_to_url: (untyped options) -> untyped
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    # nodoc:
+    module JavaScriptHelper
+      JS_ESCAPE_MAP: ::Hash[untyped, untyped]
+
+      # Escapes carriage returns and single and double quotes for JavaScript segments.
+      #
+      # Also available through the alias j(). This is particularly helpful in JavaScript
+      # responses, like:
+      #
+      #   $('some_element').replaceWith('<%= j render 'some/element_template' %>');
+      def escape_javascript: (untyped javascript) -> untyped
+
+      alias j escape_javascript
+
+      # Returns a JavaScript tag with the +content+ inside. Example:
+      #   javascript_tag "alert('All is good')"
+      #
+      # Returns:
+      #   <script>
+      #   //<![CDATA[
+      #   alert('All is good')
+      #   //]]>
+      #   </script>
+      #
+      # +html_options+ may be a hash of attributes for the <tt>\<script></tt>
+      # tag.
+      #
+      #   javascript_tag "alert('All is good')", defer: 'defer'
+      #
+      # Returns:
+      #   <script defer="defer">
+      #   //<![CDATA[
+      #   alert('All is good')
+      #   //]]>
+      #   </script>
+      #
+      # Instead of passing the content as an argument, you can also use a block
+      # in which case, you pass your +html_options+ as the first parameter.
+      #
+      #   <%= javascript_tag defer: 'defer' do -%>
+      #     alert('All is good')
+      #   <% end -%>
+      #
+      # If you have a content security policy enabled then you can add an automatic
+      # nonce value by passing <tt>nonce: true</tt> as part of +html_options+. Example:
+      #
+      #   <%= javascript_tag nonce: true do -%>
+      #     alert('All is good')
+      #   <% end -%>
+      def javascript_tag: (?untyped? content_or_options_with_block, ?::Hash[untyped, untyped] html_options) { () -> untyped } -> untyped
+
+      def javascript_cdata_section: (untyped content) -> untyped
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    # = Action View Number Helpers
+    # nodoc:
+    # Provides methods for converting numbers into formatted strings.
+    # Methods are provided for phone numbers, currency, percentage,
+    # precision, positional notation, file size and pretty printing.
+    #
+    # Most methods expect a +number+ argument, and will return it
+    # unchanged if can't be converted into a valid number.
+    module NumberHelper
+      # Raised when argument +number+ param given to the helpers is invalid and
+      # the option :raise is set to  +true+.
+      class InvalidNumberError < StandardError
+        attr_accessor number: untyped
+
+        def initialize: (untyped number) -> untyped
+      end
+
+      # Formats a +number+ into a phone number (US by default e.g., (555)
+      # 123-9876). You can customize the format in the +options+ hash.
+      #
+      # ==== Options
+      #
+      # * <tt>:area_code</tt> - Adds parentheses around the area code.
+      # * <tt>:delimiter</tt> - Specifies the delimiter to use
+      #   (defaults to "-").
+      # * <tt>:extension</tt> - Specifies an extension to add to the
+      #   end of the generated number.
+      # * <tt>:country_code</tt> - Sets the country code for the phone
+      #   number.
+      # * <tt>:pattern</tt> - Specifies how the number is divided into three
+      #   groups with the custom regexp to override the default format.
+      # * <tt>:raise</tt> - If true, raises +InvalidNumberError+ when
+      #   the argument is invalid.
+      #
+      # ==== Examples
+      #
+      #   number_to_phone(5551234)                                           # => 555-1234
+      #   number_to_phone("5551234")                                         # => 555-1234
+      #   number_to_phone(1235551234)                                        # => 123-555-1234
+      #   number_to_phone(1235551234, area_code: true)                       # => (123) 555-1234
+      #   number_to_phone(1235551234, delimiter: " ")                        # => 123 555 1234
+      #   number_to_phone(1235551234, area_code: true, extension: 555)       # => (123) 555-1234 x 555
+      #   number_to_phone(1235551234, country_code: 1)                       # => +1-123-555-1234
+      #   number_to_phone("123a456")                                         # => 123a456
+      #   number_to_phone("1234a567", raise: true)                           # => InvalidNumberError
+      #
+      #   number_to_phone(1235551234, country_code: 1, extension: 1343, delimiter: ".")
+      #   # => +1.123.555.1234 x 1343
+      #
+      #   number_to_phone(75561234567, pattern: /(\d{1,4})(\d{4})(\d{4})$/, area_code: true)
+      #   # => "(755) 6123-4567"
+      #   number_to_phone(13312345678, pattern: /(\d{3})(\d{4})(\d{4})$/)
+      #   # => "133-1234-5678"
+      def number_to_phone: (untyped number, ?::Hash[untyped, untyped] options) -> (nil | untyped)
+
+      # Formats a +number+ into a currency string (e.g., $13.65). You
+      # can customize the format in the +options+ hash.
+      #
+      # The currency unit and number formatting of the current locale will be used
+      # unless otherwise specified in the provided options. No currency conversion
+      # is performed. If the user is given a way to change their locale, they will
+      # also be able to change the relative value of the currency displayed with
+      # this helper. If your application will ever support multiple locales, you
+      # may want to specify a constant <tt>:locale</tt> option or consider
+      # using a library capable of currency conversion.
+      #
+      # ==== Options
+      #
+      # * <tt>:locale</tt> - Sets the locale to be used for formatting
+      #   (defaults to current locale).
+      # * <tt>:precision</tt> - Sets the level of precision (defaults
+      #   to 2).
+      # * <tt>:unit</tt> - Sets the denomination of the currency
+      #   (defaults to "$").
+      # * <tt>:separator</tt> - Sets the separator between the units
+      #   (defaults to ".").
+      # * <tt>:delimiter</tt> - Sets the thousands delimiter (defaults
+      #   to ",").
+      # * <tt>:format</tt> - Sets the format for non-negative numbers
+      #   (defaults to "%u%n").  Fields are <tt>%u</tt> for the
+      #   currency, and <tt>%n</tt> for the number.
+      # * <tt>:negative_format</tt> - Sets the format for negative
+      #   numbers (defaults to prepending a hyphen to the formatted
+      #   number given by <tt>:format</tt>).  Accepts the same fields
+      #   than <tt>:format</tt>, except <tt>%n</tt> is here the
+      #   absolute value of the number.
+      # * <tt>:raise</tt> - If true, raises +InvalidNumberError+ when
+      #   the argument is invalid.
+      # * <tt>:strip_insignificant_zeros</tt> - If +true+ removes
+      #   insignificant zeros after the decimal separator (defaults to
+      #   +false+).
+      #
+      # ==== Examples
+      #
+      #   number_to_currency(1234567890.50)                    # => $1,234,567,890.50
+      #   number_to_currency(1234567890.506)                   # => $1,234,567,890.51
+      #   number_to_currency(1234567890.506, precision: 3)     # => $1,234,567,890.506
+      #   number_to_currency(1234567890.506, locale: :fr)      # => 1 234 567 890,51 (trim non-ascii characters)
+      #   number_to_currency("123a456")                        # => $123a456
+      #
+      #   number_to_currency("123a456", raise: true)           # => InvalidNumberError
+      #
+      #   number_to_currency(-0.456789, precision: 0)
+      #   # => "$0"
+      #   number_to_currency(-1234567890.50, negative_format: "(%u%n)")
+      #   # => ($1,234,567,890.50)
+      #   number_to_currency(1234567890.50, unit: "R$", separator: ",", delimiter: "")
+      #   # => R$1234567890,50
+      #   number_to_currency(1234567890.50, unit: "R$", separator: ",", delimiter: "", format: "%n %u")
+      #   # => 1234567890,50 R$
+      #   number_to_currency(1234567890.50, strip_insignificant_zeros: true)
+      #   # => "$1,234,567,890.5"
+      def number_to_currency: (untyped number, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Formats a +number+ as a percentage string (e.g., 65%). You can
+      # customize the format in the +options+ hash.
+      #
+      # ==== Options
+      #
+      # * <tt>:locale</tt> - Sets the locale to be used for formatting
+      #   (defaults to current locale).
+      # * <tt>:precision</tt> - Sets the precision of the number
+      #   (defaults to 3).
+      # * <tt>:significant</tt> - If +true+, precision will be the number
+      #   of significant_digits. If +false+, the number of fractional
+      #   digits (defaults to +false+).
+      # * <tt>:separator</tt> - Sets the separator between the
+      #   fractional and integer digits (defaults to ".").
+      # * <tt>:delimiter</tt> - Sets the thousands delimiter (defaults
+      #   to "").
+      # * <tt>:strip_insignificant_zeros</tt> - If +true+ removes
+      #   insignificant zeros after the decimal separator (defaults to
+      #   +false+).
+      # * <tt>:format</tt> - Specifies the format of the percentage
+      #   string The number field is <tt>%n</tt> (defaults to "%n%").
+      # * <tt>:raise</tt> - If true, raises +InvalidNumberError+ when
+      #   the argument is invalid.
+      #
+      # ==== Examples
+      #
+      #   number_to_percentage(100)                                        # => 100.000%
+      #   number_to_percentage("98")                                       # => 98.000%
+      #   number_to_percentage(100, precision: 0)                          # => 100%
+      #   number_to_percentage(1000, delimiter: '.', separator: ',')       # => 1.000,000%
+      #   number_to_percentage(302.24398923423, precision: 5)              # => 302.24399%
+      #   number_to_percentage(1000, locale: :fr)                          # => 1 000,000%
+      #   number_to_percentage("98a")                                      # => 98a%
+      #   number_to_percentage(100, format: "%n  %")                       # => 100.000  %
+      #
+      #   number_to_percentage("98a", raise: true)                         # => InvalidNumberError
+      def number_to_percentage: (untyped number, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Formats a +number+ with grouped thousands using +delimiter+
+      # (e.g., 12,324). You can customize the format in the +options+
+      # hash.
+      #
+      # ==== Options
+      #
+      # * <tt>:locale</tt> - Sets the locale to be used for formatting
+      #   (defaults to current locale).
+      # * <tt>:delimiter</tt> - Sets the thousands delimiter (defaults
+      #   to ",").
+      # * <tt>:separator</tt> - Sets the separator between the
+      #   fractional and integer digits (defaults to ".").
+      # * <tt>:delimiter_pattern</tt> - Sets a custom regular expression used for
+      #   deriving the placement of delimiter. Helpful when using currency formats
+      #   like INR.
+      # * <tt>:raise</tt> - If true, raises +InvalidNumberError+ when
+      #   the argument is invalid.
+      #
+      # ==== Examples
+      #
+      #   number_with_delimiter(12345678)                        # => 12,345,678
+      #   number_with_delimiter("123456")                        # => 123,456
+      #   number_with_delimiter(12345678.05)                     # => 12,345,678.05
+      #   number_with_delimiter(12345678, delimiter: ".")        # => 12.345.678
+      #   number_with_delimiter(12345678, delimiter: ",")        # => 12,345,678
+      #   number_with_delimiter(12345678.05, separator: " ")     # => 12,345,678 05
+      #   number_with_delimiter(12345678.05, locale: :fr)        # => 12 345 678,05
+      #   number_with_delimiter("112a")                          # => 112a
+      #   number_with_delimiter(98765432.98, delimiter: " ", separator: ",")
+      #   # => 98 765 432,98
+      #
+      #   number_with_delimiter("123456.78",
+      #     delimiter_pattern: /(\d+?)(?=(\d\d)+(\d)(?!\d))/)    # => "1,23,456.78"
+      #
+      #  number_with_delimiter("112a", raise: true)              # => raise InvalidNumberError
+      def number_with_delimiter: (untyped number, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Formats a +number+ with the specified level of
+      # <tt>:precision</tt> (e.g., 112.32 has a precision of 2 if
+      # +:significant+ is +false+, and 5 if +:significant+ is +true+).
+      # You can customize the format in the +options+ hash.
+      #
+      # ==== Options
+      #
+      # * <tt>:locale</tt> - Sets the locale to be used for formatting
+      #   (defaults to current locale).
+      # * <tt>:precision</tt> - Sets the precision of the number
+      #   (defaults to 3).
+      # * <tt>:significant</tt> - If +true+, precision will be the number
+      #   of significant_digits. If +false+, the number of fractional
+      #   digits (defaults to +false+).
+      # * <tt>:separator</tt> - Sets the separator between the
+      #   fractional and integer digits (defaults to ".").
+      # * <tt>:delimiter</tt> - Sets the thousands delimiter (defaults
+      #   to "").
+      # * <tt>:strip_insignificant_zeros</tt> - If +true+ removes
+      #   insignificant zeros after the decimal separator (defaults to
+      #   +false+).
+      # * <tt>:raise</tt> - If true, raises +InvalidNumberError+ when
+      #   the argument is invalid.
+      #
+      # ==== Examples
+      #
+      #   number_with_precision(111.2345)                                         # => 111.235
+      #   number_with_precision(111.2345, precision: 2)                           # => 111.23
+      #   number_with_precision(13, precision: 5)                                 # => 13.00000
+      #   number_with_precision(389.32314, precision: 0)                          # => 389
+      #   number_with_precision(111.2345, significant: true)                      # => 111
+      #   number_with_precision(111.2345, precision: 1, significant: true)        # => 100
+      #   number_with_precision(13, precision: 5, significant: true)              # => 13.000
+      #   number_with_precision(111.234, locale: :fr)                             # => 111,234
+      #
+      #   number_with_precision(13, precision: 5, significant: true, strip_insignificant_zeros: true)
+      #   # => 13
+      #
+      #   number_with_precision(389.32314, precision: 4, significant: true)       # => 389.3
+      #   number_with_precision(1111.2345, precision: 2, separator: ',', delimiter: '.')
+      #   # => 1.111,23
+      def number_with_precision: (untyped number, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Formats the bytes in +number+ into a more understandable
+      # representation (e.g., giving it 1500 yields 1.5 KB). This
+      # method is useful for reporting file sizes to users. You can
+      # customize the format in the +options+ hash.
+      #
+      # See <tt>number_to_human</tt> if you want to pretty-print a
+      # generic number.
+      #
+      # ==== Options
+      #
+      # * <tt>:locale</tt> - Sets the locale to be used for formatting
+      #   (defaults to current locale).
+      # * <tt>:precision</tt> - Sets the precision of the number
+      #   (defaults to 3).
+      # * <tt>:significant</tt> - If +true+, precision will be the number
+      #   of significant_digits. If +false+, the number of fractional
+      #   digits (defaults to +true+)
+      # * <tt>:separator</tt> - Sets the separator between the
+      #   fractional and integer digits (defaults to ".").
+      # * <tt>:delimiter</tt> - Sets the thousands delimiter (defaults
+      #   to "").
+      # * <tt>:strip_insignificant_zeros</tt> - If +true+ removes
+      #   insignificant zeros after the decimal separator (defaults to
+      #   +true+)
+      # * <tt>:raise</tt> - If true, raises +InvalidNumberError+ when
+      #   the argument is invalid.
+      #
+      # ==== Examples
+      #
+      #   number_to_human_size(123)                                          # => 123 Bytes
+      #   number_to_human_size(1234)                                         # => 1.21 KB
+      #   number_to_human_size(12345)                                        # => 12.1 KB
+      #   number_to_human_size(1234567)                                      # => 1.18 MB
+      #   number_to_human_size(1234567890)                                   # => 1.15 GB
+      #   number_to_human_size(1234567890123)                                # => 1.12 TB
+      #   number_to_human_size(1234567890123456)                             # => 1.1 PB
+      #   number_to_human_size(1234567890123456789)                          # => 1.07 EB
+      #   number_to_human_size(1234567, precision: 2)                        # => 1.2 MB
+      #   number_to_human_size(483989, precision: 2)                         # => 470 KB
+      #   number_to_human_size(1234567, precision: 2, separator: ',')        # => 1,2 MB
+      #   number_to_human_size(1234567890123, precision: 5)                  # => "1.1228 TB"
+      #   number_to_human_size(524288000, precision: 5)                      # => "500 MB"
+      def number_to_human_size: (untyped number, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Pretty prints (formats and approximates) a number in a way it
+      # is more readable by humans (eg.: 1200000000 becomes "1.2
+      # Billion"). This is useful for numbers that can get very large
+      # (and too hard to read).
+      #
+      # See <tt>number_to_human_size</tt> if you want to print a file
+      # size.
+      #
+      # You can also define your own unit-quantifier names if you want
+      # to use other decimal units (eg.: 1500 becomes "1.5
+      # kilometers", 0.150 becomes "150 milliliters", etc). You may
+      # define a wide range of unit quantifiers, even fractional ones
+      # (centi, deci, mili, etc).
+      #
+      # ==== Options
+      #
+      # * <tt>:locale</tt> - Sets the locale to be used for formatting
+      #   (defaults to current locale).
+      # * <tt>:precision</tt> - Sets the precision of the number
+      #   (defaults to 3).
+      # * <tt>:significant</tt> - If +true+, precision will be the number
+      #   of significant_digits. If +false+, the number of fractional
+      #   digits (defaults to +true+)
+      # * <tt>:separator</tt> - Sets the separator between the
+      #   fractional and integer digits (defaults to ".").
+      # * <tt>:delimiter</tt> - Sets the thousands delimiter (defaults
+      #   to "").
+      # * <tt>:strip_insignificant_zeros</tt> - If +true+ removes
+      #   insignificant zeros after the decimal separator (defaults to
+      #   +true+)
+      # * <tt>:units</tt> - A Hash of unit quantifier names. Or a
+      #   string containing an i18n scope where to find this hash. It
+      #   might have the following keys:
+      #   * *integers*: <tt>:unit</tt>, <tt>:ten</tt>,
+      #     <tt>:hundred</tt>, <tt>:thousand</tt>, <tt>:million</tt>,
+      #     <tt>:billion</tt>, <tt>:trillion</tt>,
+      #     <tt>:quadrillion</tt>
+      #   * *fractionals*: <tt>:deci</tt>, <tt>:centi</tt>,
+      #     <tt>:mili</tt>, <tt>:micro</tt>, <tt>:nano</tt>,
+      #     <tt>:pico</tt>, <tt>:femto</tt>
+      # * <tt>:format</tt> - Sets the format of the output string
+      #   (defaults to "%n %u"). The field types are:
+      #   * %u - The quantifier (ex.: 'thousand')
+      #   * %n - The number
+      # * <tt>:raise</tt> - If true, raises +InvalidNumberError+ when
+      #   the argument is invalid.
+      #
+      # ==== Examples
+      #
+      #   number_to_human(123)                                          # => "123"
+      #   number_to_human(1234)                                         # => "1.23 Thousand"
+      #   number_to_human(12345)                                        # => "12.3 Thousand"
+      #   number_to_human(1234567)                                      # => "1.23 Million"
+      #   number_to_human(1234567890)                                   # => "1.23 Billion"
+      #   number_to_human(1234567890123)                                # => "1.23 Trillion"
+      #   number_to_human(1234567890123456)                             # => "1.23 Quadrillion"
+      #   number_to_human(1234567890123456789)                          # => "1230 Quadrillion"
+      #   number_to_human(489939, precision: 2)                         # => "490 Thousand"
+      #   number_to_human(489939, precision: 4)                         # => "489.9 Thousand"
+      #   number_to_human(1234567, precision: 4,
+      #                           significant: false)                   # => "1.2346 Million"
+      #   number_to_human(1234567, precision: 1,
+      #                           separator: ',',
+      #                           significant: false)                   # => "1,2 Million"
+      #
+      #   number_to_human(500000000, precision: 5)                      # => "500 Million"
+      #   number_to_human(12345012345, significant: false)              # => "12.345 Billion"
+      #
+      # Non-significant zeros after the decimal separator are stripped
+      # out by default (set <tt>:strip_insignificant_zeros</tt> to
+      # +false+ to change that):
+      #
+      # number_to_human(12.00001)                                       # => "12"
+      # number_to_human(12.00001, strip_insignificant_zeros: false)     # => "12.0"
+      #
+      # ==== Custom Unit Quantifiers
+      #
+      # You can also use your own custom unit quantifiers:
+      #  number_to_human(500000, units: {unit: "ml", thousand: "lt"})  # => "500 lt"
+      #
+      # If in your I18n locale you have:
+      #   distance:
+      #     centi:
+      #       one: "centimeter"
+      #       other: "centimeters"
+      #     unit:
+      #       one: "meter"
+      #       other: "meters"
+      #     thousand:
+      #       one: "kilometer"
+      #       other: "kilometers"
+      #     billion: "gazillion-distance"
+      #
+      # Then you could do:
+      #
+      #  number_to_human(543934, units: :distance)              # => "544 kilometers"
+      #  number_to_human(54393498, units: :distance)            # => "54400 kilometers"
+      #  number_to_human(54393498000, units: :distance)         # => "54.4 gazillion-distance"
+      #  number_to_human(343, units: :distance, precision: 1)   # => "300 meters"
+      #  number_to_human(1, units: :distance)                   # => "1 meter"
+      #  number_to_human(0.34, units: :distance)                # => "34 centimeters"
+      #
+      def number_to_human: (untyped number, ?::Hash[untyped, untyped] options) -> untyped
+
+      def delegate_number_helper_method: (untyped method, untyped number, untyped options) -> (nil | untyped)
+
+      def escape_unsafe_options: (untyped options) -> untyped
+
+      def escape_units: (untyped units) -> untyped
+
+      def wrap_with_output_safety_handling: (untyped number, untyped raise_on_invalid) { () -> untyped } -> untyped
+
+      def valid_float?: (untyped number) -> untyped
+
+      def parse_float: (untyped number, untyped raise_error) -> untyped
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    # nodoc:
+    # = Action View Raw Output Helper
+    # nodoc:
+    module OutputSafetyHelper
+      # This method outputs without escaping a string. Since escaping tags is
+      # now default, this can be used when you don't want Rails to automatically
+      # escape tags. This is not recommended if the data is coming from the user's
+      # input.
+      #
+      # For example:
+      #
+      #  raw @user.name
+      #  # => 'Jimmy <alert>Tables</alert>'
+      def raw: (untyped stringish) -> untyped
+
+      # This method returns an HTML safe string similar to what <tt>Array#join</tt>
+      # would return. The array is flattened, and all items, including
+      # the supplied separator, are HTML escaped unless they are HTML
+      # safe, and the returned string is marked as HTML safe.
+      #
+      #   safe_join([raw("<p>foo</p>"), "<p>bar</p>"], "<br />")
+      #   # => "<p>foo</p>&lt;br /&gt;&lt;p&gt;bar&lt;/p&gt;"
+      #
+      #   safe_join([raw("<p>foo</p>"), raw("<p>bar</p>")], raw("<br />"))
+      #   # => "<p>foo</p><br /><p>bar</p>"
+      #
+      def safe_join: (untyped array, ?untyped sep) -> untyped
+
+      # Converts the array to a comma-separated sentence where the last element is
+      # joined by the connector word. This is the html_safe-aware version of
+      # ActiveSupport's {Array#to_sentence}[https://api.rubyonrails.org/classes/Array.html#method-i-to_sentence].
+      #
+      def to_sentence: (untyped array, ?::Hash[untyped, untyped] options) -> untyped
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    # nodoc:
+    # = Action View Rendering
+    #
+    # Implements methods that allow rendering from a view context.
+    # In order to use this module, all you need is to implement
+    # view_renderer that returns an ActionView::Renderer object.
+    module RenderingHelper
+      # Returns the result of a render that's dictated by the options hash. The primary options are:
+      #
+      # * <tt>:partial</tt> - See <tt>ActionView::PartialRenderer</tt>.
+      # * <tt>:file</tt> - Renders an explicit template file (this used to be the old default), add :locals to pass in those.
+      # * <tt>:inline</tt> - Renders an inline template similar to how it's done in the controller.
+      # * <tt>:plain</tt> - Renders the text passed in out. Setting the content
+      #   type as <tt>text/plain</tt>.
+      # * <tt>:html</tt> - Renders the HTML safe string passed in out, otherwise
+      #   performs HTML escape on the string first. Setting the content type as
+      #   <tt>text/html</tt>.
+      # * <tt>:body</tt> - Renders the text passed in, and inherits the content
+      #   type of <tt>text/plain</tt> from <tt>ActionDispatch::Response</tt>
+      #   object.
+      #
+      # If no options hash is passed or :update specified, the default is to render a partial and use the second parameter
+      # as the locals hash.
+      def render: (?::Hash[untyped, untyped] options, ?::Hash[untyped, untyped] locals) { () -> untyped } -> untyped
+
+      # Overwrites _layout_for in the context object so it supports the case a block is
+      # passed to a partial. Returns the contents that are yielded to a layout, given a
+      # name or a block.
+      #
+      # You can think of a layout as a method that is called with a block. If the user calls
+      # <tt>yield :some_name</tt>, the block, by default, returns <tt>content_for(:some_name)</tt>.
+      # If the user calls simply +yield+, the default block returns <tt>content_for(:layout)</tt>.
+      #
+      # The user can override this default by passing a block to the layout:
+      #
+      #   # The template
+      #   <%= render layout: "my_layout" do %>
+      #     Content
+      #   <% end %>
+      #
+      #   # The layout
+      #   <html>
+      #     <%= yield %>
+      #   </html>
+      #
+      # In this case, instead of the default block, which would return <tt>content_for(:layout)</tt>,
+      # this method returns the block that was passed in to <tt>render :layout</tt>, and the response
+      # would be
+      #
+      #   <html>
+      #     Content
+      #   </html>
+      #
+      # Finally, the block can take block arguments, which can be passed in by +yield+:
+      #
+      #   # The template
+      #   <%= render layout: "my_layout" do |customer| %>
+      #     Hello <%= customer.name %>
+      #   <% end %>
+      #
+      #   # The layout
+      #   <html>
+      #     <%= yield Struct.new(:name).new("David") %>
+      #   </html>
+      #
+      # In this case, the layout would receive the block passed into <tt>render :layout</tt>,
+      # and the struct specified would be passed into the block as an argument. The result
+      # would be
+      #
+      #   <html>
+      #     Hello David
+      #   </html>
+      #
+      def _layout_for: (*untyped args) { () -> untyped } -> untyped
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    # = Action View Sanitize Helpers
+    # nodoc:
+    # The SanitizeHelper module provides a set of methods for scrubbing text of undesired HTML elements.
+    # These helper methods extend Action View making them callable within your template files.
+    module SanitizeHelper
+      extend ActiveSupport::Concern
+
+      # Sanitizes HTML input, stripping all but known-safe tags and attributes.
+      #
+      # It also strips href/src attributes with unsafe protocols like
+      # <tt>javascript:</tt>, while also protecting against attempts to use Unicode,
+      # ASCII, and hex character references to work around these protocol filters.
+      # All special characters will be escaped.
+      #
+      # The default sanitizer is Rails::Html::SafeListSanitizer. See {Rails HTML
+      # Sanitizers}[https://github.com/rails/rails-html-sanitizer] for more information.
+      #
+      # Custom sanitization rules can also be provided.
+      #
+      # Please note that sanitizing user-provided text does not guarantee that the
+      # resulting markup is valid or even well-formed.
+      #
+      # ==== Options
+      #
+      # * <tt>:tags</tt> - An array of allowed tags.
+      # * <tt>:attributes</tt> - An array of allowed attributes.
+      # * <tt>:scrubber</tt> - A {Rails::Html scrubber}[https://github.com/rails/rails-html-sanitizer]
+      #   or {Loofah::Scrubber}[https://github.com/flavorjones/loofah] object that
+      #   defines custom sanitization rules. A custom scrubber takes precedence over
+      #   custom tags and attributes.
+      #
+      # ==== Examples
+      #
+      # Normal use:
+      #
+      #   <%= sanitize @comment.body %>
+      #
+      # Providing custom lists of permitted tags and attributes:
+      #
+      #   <%= sanitize @comment.body, tags: %w(strong em a), attributes: %w(href) %>
+      #
+      # Providing a custom Rails::Html scrubber:
+      #
+      #   class CommentScrubber < Rails::Html::PermitScrubber
+      #     def initialize
+      #       super
+      #       self.tags = %w( form script comment blockquote )
+      #       self.attributes = %w( style )
+      #     end
+      #
+      #     def skip_node?(node)
+      #       node.text?
+      #     end
+      #   end
+      #
+      #   <%= sanitize @comment.body, scrubber: CommentScrubber.new %>
+      #
+      # See {Rails HTML Sanitizer}[https://github.com/rails/rails-html-sanitizer] for
+      # documentation about Rails::Html scrubbers.
+      #
+      # Providing a custom Loofah::Scrubber:
+      #
+      #   scrubber = Loofah::Scrubber.new do |node|
+      #     node.remove if node.name == 'script'
+      #   end
+      #
+      #   <%= sanitize @comment.body, scrubber: scrubber %>
+      #
+      # See {Loofah's documentation}[https://github.com/flavorjones/loofah] for more
+      # information about defining custom Loofah::Scrubber objects.
+      #
+      # To set the default allowed tags or attributes across your application:
+      #
+      #   # In config/application.rb
+      #   config.action_view.sanitized_allowed_tags = ['strong', 'em', 'a']
+      #   config.action_view.sanitized_allowed_attributes = ['href', 'title']
+      def sanitize: (untyped html, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Sanitizes a block of CSS code. Used by +sanitize+ when it comes across a style attribute.
+      def sanitize_css: (untyped style) -> untyped
+
+      # Strips all HTML tags from +html+, including comments and special characters.
+      #
+      #   strip_tags("Strip <i>these</i> tags!")
+      #   # => Strip these tags!
+      #
+      #   strip_tags("<b>Bold</b> no more!  <a href='more.html'>See more here</a>...")
+      #   # => Bold no more!  See more here...
+      #
+      #   strip_tags("<div id='top-bar'>Welcome to my website!</div>")
+      #   # => Welcome to my website!
+      #
+      #   strip_tags("> A quote from Smith & Wesson")
+      #   # => &gt; A quote from Smith &amp; Wesson
+      def strip_tags: (untyped html) -> untyped
+
+      # Strips all link tags from +html+ leaving just the link text.
+      #
+      #   strip_links('<a href="http://www.rubyonrails.org">Ruby on Rails</a>')
+      #   # => Ruby on Rails
+      #
+      #   strip_links('Please e-mail me at <a href="mailto:me@email.com">me@email.com</a>.')
+      #   # => Please e-mail me at me@email.com.
+      #
+      #   strip_links('Blog: <a href="http://www.myblog.com/" class="nav" target=\"_blank\">Visit</a>.')
+      #   # => Blog: Visit.
+      #
+      #   strip_links('<<a href="https://example.org">malformed & link</a>')
+      #   # => &lt;malformed &amp; link
+      def strip_links: (untyped html) -> untyped
+
+      module ClassMethods
+        # nodoc:
+        attr_writer full_sanitizer: untyped
+
+        # nodoc:
+        attr_writer link_sanitizer: untyped
+
+        # nodoc:
+        attr_writer safe_list_sanitizer: untyped
+
+        def sanitizer_vendor: () -> untyped
+
+        def sanitized_allowed_tags: () -> untyped
+
+        def sanitized_allowed_attributes: () -> untyped
+
+        # Gets the Rails::Html::FullSanitizer instance used by +strip_tags+. Replace with
+        # any object that responds to +sanitize+.
+        #
+        #   class Application < Rails::Application
+        #     config.action_view.full_sanitizer = MySpecialSanitizer.new
+        #   end
+        def full_sanitizer: () -> untyped
+
+        # Gets the Rails::Html::LinkSanitizer instance used by +strip_links+.
+        # Replace with any object that responds to +sanitize+.
+        #
+        #   class Application < Rails::Application
+        #     config.action_view.link_sanitizer = MySpecialSanitizer.new
+        #   end
+        def link_sanitizer: () -> untyped
+
+        # Gets the Rails::Html::SafeListSanitizer instance used by sanitize and +sanitize_css+.
+        # Replace with any object that responds to +sanitize+.
+        #
+        #   class Application < Rails::Application
+        #     config.action_view.safe_list_sanitizer = MySpecialSanitizer.new
+        #   end
+        def safe_list_sanitizer: () -> untyped
+      end
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    # = Action View Tag Helpers
+    # nodoc:
+    # Provides methods to generate HTML tags programmatically both as a modern
+    # HTML5 compliant builder style and legacy XHTML compliant tags.
+    module TagHelper
+      extend ActiveSupport::Concern
+
+      include CaptureHelper
+
+      include OutputSafetyHelper
+
+      BOOLEAN_ATTRIBUTES: untyped
+
+      TAG_PREFIXES: untyped
+
+      PRE_CONTENT_STRINGS: untyped
+
+      class TagBuilder
+        # nodoc:
+        include CaptureHelper
+
+        include OutputSafetyHelper
+
+        VOID_ELEMENTS: untyped
+
+        def initialize: (untyped view_context) -> untyped
+
+        def tag_string: (untyped name, ?untyped? content, ?escape_attributes: bool escape_attributes, **untyped options) { () -> untyped } -> untyped
+
+        def content_tag_string: (untyped name, untyped content, untyped options, ?bool escape) -> untyped
+
+        def tag_options: (untyped options, ?bool escape) -> (nil | untyped)
+
+        def boolean_tag_option: (untyped key) -> ::String
+
+        def tag_option: (untyped key, untyped value, untyped escape) -> ::String
+
+        def prefix_tag_option: (untyped prefix, untyped key, untyped value, untyped escape) -> untyped
+
+        def respond_to_missing?: (*untyped args) -> ::TrueClass
+
+        def method_missing: (untyped called, *untyped args, **untyped options) { () -> untyped } -> untyped
+      end
+
+      # Returns an HTML tag.
+      #
+      # === Building HTML tags
+      #
+      # Builds HTML5 compliant tags with a tag proxy. Every tag can be built with:
+      #
+      #   tag.<tag name>(optional content, options)
+      #
+      # where tag name can be e.g. br, div, section, article, or any tag really.
+      #
+      # ==== Passing content
+      #
+      # Tags can pass content to embed within it:
+      #
+      #   tag.h1 'All titles fit to print' # => <h1>All titles fit to print</h1>
+      #
+      #   tag.div tag.p('Hello world!')  # => <div><p>Hello world!</p></div>
+      #
+      # Content can also be captured with a block, which is useful in templates:
+      #
+      #   <%= tag.p do %>
+      #     The next great American novel starts here.
+      #   <% end %>
+      #   # => <p>The next great American novel starts here.</p>
+      #
+      # ==== Options
+      #
+      # Use symbol keyed options to add attributes to the generated tag.
+      #
+      #   tag.section class: %w( kitties puppies )
+      #   # => <section class="kitties puppies"></section>
+      #
+      #   tag.section id: dom_id(@post)
+      #   # => <section id="<generated dom id>"></section>
+      #
+      # Pass +true+ for any attributes that can render with no values, like +disabled+ and +readonly+.
+      #
+      #   tag.input type: 'text', disabled: true
+      #   # => <input type="text" disabled="disabled">
+      #
+      # HTML5 <tt>data-*</tt> attributes can be set with a single +data+ key
+      # pointing to a hash of sub-attributes.
+      #
+      # To play nicely with JavaScript conventions, sub-attributes are dasherized.
+      #
+      #   tag.article data: { user_id: 123 }
+      #   # => <article data-user-id="123"></article>
+      #
+      # Thus <tt>data-user-id</tt> can be accessed as <tt>dataset.userId</tt>.
+      #
+      # Data attribute values are encoded to JSON, with the exception of strings, symbols and
+      # BigDecimals.
+      # This may come in handy when using jQuery's HTML5-aware <tt>.data()</tt>
+      # from 1.4.3.
+      #
+      #   tag.div data: { city_state: %w( Chicago IL ) }
+      #   # => <div data-city-state="[&quot;Chicago&quot;,&quot;IL&quot;]"></div>
+      #
+      # The generated attributes are escaped by default. This can be disabled using
+      # +escape_attributes+.
+      #
+      #   tag.img src: 'open & shut.png'
+      #   # => <img src="open &amp; shut.png">
+      #
+      #   tag.img src: 'open & shut.png', escape_attributes: false
+      #   # => <img src="open & shut.png">
+      #
+      # The tag builder respects
+      # {HTML5 void elements}[https://www.w3.org/TR/html5/syntax.html#void-elements]
+      # if no content is passed, and omits closing tags for those elements.
+      #
+      #   # A standard element:
+      #   tag.div # => <div></div>
+      #
+      #   # A void element:
+      #   tag.br  # => <br>
+      #
+      # === Legacy syntax
+      #
+      # The following format is for legacy syntax support. It will be deprecated in future versions of Rails.
+      #
+      #   tag(name, options = nil, open = false, escape = true)
+      #
+      # It returns an empty HTML tag of type +name+ which by default is XHTML
+      # compliant. Set +open+ to true to create an open tag compatible
+      # with HTML 4.0 and below. Add HTML attributes by passing an attributes
+      # hash to +options+. Set +escape+ to false to disable attribute value
+      # escaping.
+      #
+      # ==== Options
+      #
+      # You can use symbols or strings for the attribute names.
+      #
+      # Use +true+ with boolean attributes that can render with no value, like
+      # +disabled+ and +readonly+.
+      #
+      # HTML5 <tt>data-*</tt> attributes can be set with a single +data+ key
+      # pointing to a hash of sub-attributes.
+      #
+      # ==== Examples
+      #
+      #   tag("br")
+      #   # => <br />
+      #
+      #   tag("br", nil, true)
+      #   # => <br>
+      #
+      #   tag("input", type: 'text', disabled: true)
+      #   # => <input type="text" disabled="disabled" />
+      #
+      #   tag("input", type: 'text', class: ["strong", "highlight"])
+      #   # => <input class="strong highlight" type="text" />
+      #
+      #   tag("img", src: "open & shut.png")
+      #   # => <img src="open &amp; shut.png" />
+      #
+      #   tag("img", { src: "open &amp; shut.png" }, false, false)
+      #   # => <img src="open &amp; shut.png" />
+      #
+      #   tag("div", data: { name: 'Stephen', city_state: %w(Chicago IL) })
+      #   # => <div data-name="Stephen" data-city-state="[&quot;Chicago&quot;,&quot;IL&quot;]" />
+      def tag: (?untyped? name, ?untyped? options, ?bool open, ?bool escape) -> untyped
+
+      # Returns an HTML block tag of type +name+ surrounding the +content+. Add
+      # HTML attributes by passing an attributes hash to +options+.
+      # Instead of passing the content as an argument, you can also use a block
+      # in which case, you pass your +options+ as the second parameter.
+      # Set escape to false to disable attribute value escaping.
+      # Note: this is legacy syntax, see +tag+ method description for details.
+      #
+      # ==== Options
+      # The +options+ hash can be used with attributes with no value like (<tt>disabled</tt> and
+      # <tt>readonly</tt>), which you can give a value of true in the +options+ hash. You can use
+      # symbols or strings for the attribute names.
+      #
+      # ==== Examples
+      #   content_tag(:p, "Hello world!")
+      #    # => <p>Hello world!</p>
+      #   content_tag(:div, content_tag(:p, "Hello world!"), class: "strong")
+      #    # => <div class="strong"><p>Hello world!</p></div>
+      #   content_tag(:div, "Hello world!", class: ["strong", "highlight"])
+      #    # => <div class="strong highlight">Hello world!</div>
+      #   content_tag("select", options, multiple: true)
+      #    # => <select multiple="multiple">...options...</select>
+      #
+      #   <%= content_tag :div, class: "strong" do -%>
+      #     Hello world!
+      #   <% end -%>
+      #    # => <div class="strong">Hello world!</div>
+      def content_tag: (untyped name, ?untyped? content_or_options_with_block, ?untyped? options, ?bool escape) { () -> untyped } -> untyped
+
+      # Returns a CDATA section with the given +content+. CDATA sections
+      # are used to escape blocks of text containing characters which would
+      # otherwise be recognized as markup. CDATA sections begin with the string
+      # <tt><![CDATA[</tt> and end with (and may not contain) the string <tt>]]></tt>.
+      #
+      #   cdata_section("<hello world>")
+      #   # => <![CDATA[<hello world>]]>
+      #
+      #   cdata_section(File.read("hello_world.txt"))
+      #   # => <![CDATA[<hello from a text file]]>
+      #
+      #   cdata_section("hello]]>world")
+      #   # => <![CDATA[hello]]]]><![CDATA[>world]]>
+      def cdata_section: (untyped content) -> untyped
+
+      # Returns an escaped version of +html+ without affecting existing escaped entities.
+      #
+      #   escape_once("1 < 2 &amp; 3")
+      #   # => "1 &lt; 2 &amp; 3"
+      #
+      #   escape_once("&lt;&lt; Accept & Checkout")
+      #   # => "&lt;&lt; Accept &amp; Checkout"
+      def escape_once: (untyped html) -> untyped
+
+      def tag_builder: () -> untyped
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    module Tags
+      class Base
+        # :nodoc:
+        # :nodoc:
+        include Helpers::ActiveModelInstanceTag
+
+        # :nodoc:
+        # :nodoc:
+        include Helpers::TagHelper
+
+        # :nodoc:
+        # :nodoc:
+        include Helpers::FormTagHelper
+
+        include FormOptionsHelper
+
+        attr_reader object: untyped
+
+        def initialize: (untyped object_name, untyped method_name, untyped template_object, ?::Hash[untyped, untyped] options) -> untyped
+
+        # This is what child classes implement.
+        def render: () -> untyped
+
+        def value: () -> untyped
+
+        def value_before_type_cast: () -> untyped
+
+        def value_came_from_user?: () -> untyped
+
+        def retrieve_object: (untyped object) -> untyped
+
+        def retrieve_autoindex: (untyped pre_match) -> untyped
+
+        def add_default_name_and_id_for_value: (untyped tag_value, untyped options) -> untyped
+
+        def add_default_name_and_id: (untyped options) -> untyped
+
+        def tag_name: (?bool multiple, ?untyped? index) -> untyped
+
+        def tag_id: (?untyped? index) -> untyped
+
+        def sanitized_object_name: () -> untyped
+
+        def sanitized_method_name: () -> untyped
+
+        def sanitized_value: (untyped value) -> untyped
+
+        def select_content_tag: (untyped option_tags, untyped options, untyped html_options) -> untyped
+
+        def placeholder_required?: (untyped html_options) -> untyped
+
+        def add_options: (untyped option_tags, untyped options, ?untyped? value) -> untyped
+
+        def name_and_id_index: (untyped options) -> untyped
+
+        def generate_ids?: () -> untyped
+      end
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    module Tags
+      class CheckBox < Base
+        # :nodoc:
+        # nodoc:
+        include Checkable
+
+        def initialize: (untyped object_name, untyped method_name, untyped template_object, untyped checked_value, untyped unchecked_value, untyped options) -> untyped
+
+        def render: () -> untyped
+
+        def checked?: (untyped value) -> untyped
+
+        def hidden_field_for_checkbox: (untyped options) -> untyped
+      end
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    module Tags
+      module Checkable
+        # :nodoc:
+        # :nodoc:
+        def input_checked?: (untyped options) -> untyped
+      end
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    module Tags
+      class CollectionCheckBoxes < Base
+        # :nodoc:
+        # :nodoc:
+        include CollectionHelpers
+
+        class CheckBoxBuilder < CollectionHelpers::Builder
+          # :nodoc:
+          def check_box: (?::Hash[untyped, untyped] extra_html_options) -> untyped
+        end
+
+        def render: () { () -> untyped } -> untyped
+
+        def render_component: (untyped builder) -> untyped
+
+        def hidden_field_name: () -> ::String
+      end
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    module Tags
+      module CollectionHelpers
+        class Builder
+          # :nodoc:
+          # :nodoc:
+          # :nodoc:
+          attr_reader object: untyped
+
+          # :nodoc:
+          # :nodoc:
+          # :nodoc:
+          attr_reader text: untyped
+
+          # :nodoc:
+          # :nodoc:
+          # :nodoc:
+          attr_reader value: untyped
+
+          def initialize: (untyped template_object, untyped object_name, untyped method_name, untyped object, untyped sanitized_attribute_name, untyped text, untyped value, untyped input_html_options) -> untyped
+
+          def label: (?::Hash[untyped, untyped] label_html_options) { () -> untyped } -> untyped
+        end
+
+        def initialize: (untyped object_name, untyped method_name, untyped template_object, untyped collection, untyped value_method, untyped text_method, untyped options, untyped html_options) -> untyped
+
+        def instantiate_builder: (untyped builder_class, untyped item, untyped value, untyped text, untyped html_options) -> untyped
+
+        # Generate default options for collection helpers, such as :checked and
+        # :disabled.
+        def default_html_options_for_collection: (untyped item, untyped value) -> untyped
+
+        def sanitize_attribute_name: (untyped value) -> ::String
+
+        def render_collection: () { (untyped, untyped, untyped, untyped) -> untyped } -> untyped
+
+        def render_collection_for: (untyped builder_class) { () -> untyped } -> untyped
+
+        def hidden_field: () -> untyped
+
+        def hidden_field_name: () -> ::String
+      end
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    module Tags
+      class CollectionRadioButtons < Base
+        # :nodoc:
+        # :nodoc:
+        include CollectionHelpers
+
+        class RadioButtonBuilder < CollectionHelpers::Builder
+          # :nodoc:
+          def radio_button: (?::Hash[untyped, untyped] extra_html_options) -> untyped
+        end
+
+        def render: () { () -> untyped } -> untyped
+
+        def render_component: (untyped builder) -> untyped
+      end
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    module Tags
+      class CollectionSelect < Base
+        # :nodoc:
+        # nodoc:
+        def initialize: (untyped object_name, untyped method_name, untyped template_object, untyped collection, untyped value_method, untyped text_method, untyped options, untyped html_options) -> untyped
+
+        def render: () -> untyped
+      end
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    module Tags
+      class ColorField < TextField
+        # :nodoc:
+        # :nodoc:
+        def render: () -> untyped
+
+        def validate_color_string: (untyped string) -> untyped
+      end
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    module Tags
+      class DateField < DatetimeField
+        def format_date: (untyped value) -> untyped
+      end
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    module Tags
+      class DateSelect < Base
+        # :nodoc:
+        # :nodoc:
+        def initialize: (untyped object_name, untyped method_name, untyped template_object, untyped options, untyped html_options) -> untyped
+
+        def render: () -> untyped
+
+        def self.select_type: () -> untyped
+
+        def select_type: () -> untyped
+
+        def datetime_selector: (untyped options, untyped html_options) -> DateTimeSelector
+
+        def default_datetime: (untyped options) -> (nil | untyped)
+      end
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    module Tags
+      class DatetimeField < TextField
+        # :nodoc:
+        # :nodoc:
+        def render: () -> untyped
+
+        def format_date: (untyped value) -> untyped
+
+        def datetime_value: (untyped value) -> untyped
+      end
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    module Tags
+      class DatetimeLocalField < DatetimeField
+        def self.field_type: () -> untyped
+
+        def format_date: (untyped value) -> untyped
+      end
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    module Tags
+      class DatetimeSelect < DateSelect
+      end
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    module Tags
+      class EmailField < TextField
+      end
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    module Tags
+      class FileField < TextField
+      end
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    module Tags
+      class GroupedCollectionSelect < Base
+        # :nodoc:
+        # :nodoc:
+        def initialize: (untyped object_name, untyped method_name, untyped template_object, untyped collection, untyped group_method, untyped group_label_method, untyped option_key_method, untyped option_value_method, untyped options, untyped html_options) -> untyped
+
+        def render: () -> untyped
+      end
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    module Tags
+      class HiddenField < TextField
+      end
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    module Tags
+      class Label < Base
+        class LabelBuilder
+          # :nodoc:
+          # :nodoc:
+          # :nodoc:
+          attr_reader object: untyped
+
+          def initialize: (untyped template_object, untyped object_name, untyped method_name, untyped object, untyped tag_value) -> untyped
+
+          def translation: () -> untyped
+        end
+
+        def initialize: (untyped object_name, untyped method_name, untyped template_object, ?untyped? content_or_options, ?untyped? options) -> untyped
+
+        def render: () { () -> untyped } -> untyped
+
+        def render_component: (untyped builder) -> untyped
+      end
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    module Tags
+      class MonthField < DatetimeField
+        def format_date: (untyped value) -> untyped
+      end
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    module Tags
+      class NumberField < TextField
+        # :nodoc:
+        # :nodoc:
+        def render: () -> untyped
+      end
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    module Tags
+      class PasswordField < TextField
+        # :nodoc:
+        # :nodoc:
+        def render: () -> untyped
+      end
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    module Tags
+      module Placeholderable
+        # :nodoc:
+        # :nodoc:
+        def initialize: () -> untyped
+      end
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    module Tags
+      class RadioButton < Base
+        # :nodoc:
+        # :nodoc:
+        include Checkable
+
+        def initialize: (untyped object_name, untyped method_name, untyped template_object, untyped tag_value, untyped options) -> untyped
+
+        def render: () -> untyped
+
+        def checked?: (untyped value) -> untyped
+      end
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    module Tags
+      class RangeField < NumberField
+      end
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    module Tags
+      class SearchField < TextField
+        # :nodoc:
+        # :nodoc:
+        def render: () -> untyped
+      end
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    module Tags
+      class Select < Base
+        # :nodoc:
+        # :nodoc:
+        def initialize: (untyped object_name, untyped method_name, untyped template_object, untyped choices, untyped options, untyped html_options) { () -> untyped } -> untyped
+
+        def render: () -> untyped
+
+        # Grouped choices look like this:
+        #
+        #   [nil, []]
+        #   { nil => [] }
+        def grouped_choices?: () -> untyped
+      end
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    module Tags
+      class TelField < TextField
+      end
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    module Tags
+      class TextArea < Base
+        # :nodoc:
+        # :nodoc:
+        include Placeholderable
+
+        def render: () -> untyped
+      end
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    module Tags
+      class TextField < Base
+        # :nodoc:
+        # :nodoc:
+        include Placeholderable
+
+        def render: () -> untyped
+
+        def self.field_type: () -> untyped
+
+        def field_type: () -> untyped
+      end
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    module Tags
+      class TimeField < DatetimeField
+        def format_date: (untyped value) -> untyped
+      end
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    module Tags
+      class TimeSelect < DateSelect
+      end
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    module Tags
+      class TimeZoneSelect < Base
+        # :nodoc:
+        # :nodoc:
+        def initialize: (untyped object_name, untyped method_name, untyped template_object, untyped priority_zones, untyped options, untyped html_options) -> untyped
+
+        def render: () -> untyped
+      end
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    module Tags
+      class Translator
+        # :nodoc:
+        # :nodoc:
+        def initialize: (untyped object, untyped object_name, untyped method_and_value, scope: untyped scope) -> untyped
+
+        def translate: () -> untyped
+
+        attr_reader object_name: untyped
+
+        attr_reader method_and_value: untyped
+
+        attr_reader scope: untyped
+
+        attr_reader model: untyped
+
+        def i18n_default: () -> untyped
+
+        def human_attribute_name: () -> untyped
+      end
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    module Tags
+      class UrlField < TextField
+      end
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    module Tags
+      class WeekField < DatetimeField
+        def format_date: (untyped value) -> untyped
+      end
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    module Tags
+      # nodoc:
+      # nodoc:
+      extend ActiveSupport::Autoload
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    # = Action View Text Helpers
+    # nodoc:
+    # The TextHelper module provides a set of methods for filtering, formatting
+    # and transforming strings, which can reduce the amount of inline Ruby code in
+    # your views. These helper methods extend Action View making them callable
+    # within your template files.
+    #
+    # ==== Sanitization
+    #
+    # Most text helpers that generate HTML output sanitize the given input by default,
+    # but do not escape it. This means HTML tags will appear in the page but all malicious
+    # code will be removed. Let's look at some examples using the +simple_format+ method:
+    #
+    #   simple_format('<a href="http://example.com/">Example</a>')
+    #   # => "<p><a href=\"http://example.com/\">Example</a></p>"
+    #
+    #   simple_format('<a href="javascript:alert(\'no!\')">Example</a>')
+    #   # => "<p><a>Example</a></p>"
+    #
+    # If you want to escape all content, you should invoke the +h+ method before
+    # calling the text helper.
+    #
+    #   simple_format h('<a href="http://example.com/">Example</a>')
+    #   # => "<p>&lt;a href=\"http://example.com/\"&gt;Example&lt;/a&gt;</p>"
+    module TextHelper
+      extend ActiveSupport::Concern
+
+      include SanitizeHelper
+
+      include TagHelper
+
+      include OutputSafetyHelper
+
+      # The preferred method of outputting text in your views is to use the
+      # <%= "text" %> eRuby syntax. The regular _puts_ and _print_ methods
+      # do not operate as expected in an eRuby code block. If you absolutely must
+      # output text within a non-output code block (i.e., <% %>), you can use the concat method.
+      #
+      #   <%
+      #       concat "hello"
+      #       # is the equivalent of <%= "hello" %>
+      #
+      #       if logged_in
+      #         concat "Logged in!"
+      #       else
+      #         concat link_to('login', action: :login)
+      #       end
+      #       # will either display "Logged in!" or a login link
+      #   %>
+      def concat: (untyped string) -> untyped
+
+      def safe_concat: (untyped string) -> untyped
+
+      # Truncates a given +text+ after a given <tt>:length</tt> if +text+ is longer than <tt>:length</tt>
+      # (defaults to 30). The last characters will be replaced with the <tt>:omission</tt> (defaults to "...")
+      # for a total length not exceeding <tt>:length</tt>.
+      #
+      # Pass a <tt>:separator</tt> to truncate +text+ at a natural break.
+      #
+      # Pass a block if you want to show extra content when the text is truncated.
+      #
+      # The result is marked as HTML-safe, but it is escaped by default, unless <tt>:escape</tt> is
+      # +false+. Care should be taken if +text+ contains HTML tags or entities, because truncation
+      # may produce invalid HTML (such as unbalanced or incomplete tags).
+      #
+      #   truncate("Once upon a time in a world far far away")
+      #   # => "Once upon a time in a world..."
+      #
+      #   truncate("Once upon a time in a world far far away", length: 17)
+      #   # => "Once upon a ti..."
+      #
+      #   truncate("Once upon a time in a world far far away", length: 17, separator: ' ')
+      #   # => "Once upon a..."
+      #
+      #   truncate("And they found that many people were sleeping better.", length: 25, omission: '... (continued)')
+      #   # => "And they f... (continued)"
+      #
+      #   truncate("<p>Once upon a time in a world far far away</p>")
+      #   # => "&lt;p&gt;Once upon a time in a wo..."
+      #
+      #   truncate("<p>Once upon a time in a world far far away</p>", escape: false)
+      #   # => "<p>Once upon a time in a wo..."
+      #
+      #   truncate("Once upon a time in a world far far away") { link_to "Continue", "#" }
+      #   # => "Once upon a time in a wo...<a href="#">Continue</a>"
+      def truncate: (untyped text, ?::Hash[untyped, untyped] options) { () -> untyped } -> untyped
+
+      # Highlights one or more +phrases+ everywhere in +text+ by inserting it into
+      # a <tt>:highlighter</tt> string. The highlighter can be specialized by passing <tt>:highlighter</tt>
+      # as a single-quoted string with <tt>\1</tt> where the phrase is to be inserted (defaults to
+      # '<mark>\1</mark>') or passing a block that receives each matched term. By default +text+
+      # is sanitized to prevent possible XSS attacks. If the input is trustworthy, passing false
+      # for <tt>:sanitize</tt> will turn sanitizing off.
+      #
+      #   highlight('You searched for: rails', 'rails')
+      #   # => You searched for: <mark>rails</mark>
+      #
+      #   highlight('You searched for: rails', /for|rails/)
+      #   # => You searched <mark>for</mark>: <mark>rails</mark>
+      #
+      #   highlight('You searched for: ruby, rails, dhh', 'actionpack')
+      #   # => You searched for: ruby, rails, dhh
+      #
+      #   highlight('You searched for: rails', ['for', 'rails'], highlighter: '<em>\1</em>')
+      #   # => You searched <em>for</em>: <em>rails</em>
+      #
+      #   highlight('You searched for: rails', 'rails', highlighter: '<a href="search?q=\1">\1</a>')
+      #   # => You searched for: <a href="search?q=rails">rails</a>
+      #
+      #   highlight('You searched for: rails', 'rails') { |match| link_to(search_path(q: match, match)) }
+      #   # => You searched for: <a href="search?q=rails">rails</a>
+      #
+      #   highlight('<a href="javascript:alert(\'no!\')">ruby</a> on rails', 'rails', sanitize: false)
+      #   # => <a href="javascript:alert('no!')">ruby</a> on <mark>rails</mark>
+      def highlight: (untyped text, untyped phrases, ?::Hash[untyped, untyped] options) { (untyped) -> untyped } -> untyped
+
+      # Extracts an excerpt from +text+ that matches the first instance of +phrase+.
+      # The <tt>:radius</tt> option expands the excerpt on each side of the first occurrence of +phrase+ by the number of characters
+      # defined in <tt>:radius</tt> (which defaults to 100). If the excerpt radius overflows the beginning or end of the +text+,
+      # then the <tt>:omission</tt> option (which defaults to "...") will be prepended/appended accordingly. Use the
+      # <tt>:separator</tt> option to choose the delimitation. The resulting string will be stripped in any case. If the +phrase+
+      # isn't found, +nil+ is returned.
+      #
+      #   excerpt('This is an example', 'an', radius: 5)
+      #   # => ...s is an exam...
+      #
+      #   excerpt('This is an example', 'is', radius: 5)
+      #   # => This is a...
+      #
+      #   excerpt('This is an example', 'is')
+      #   # => This is an example
+      #
+      #   excerpt('This next thing is an example', 'ex', radius: 2)
+      #   # => ...next...
+      #
+      #   excerpt('This is also an example', 'an', radius: 8, omission: '<chop> ')
+      #   # => <chop> is also an example
+      #
+      #   excerpt('This is a very beautiful morning', 'very', separator: ' ', radius: 1)
+      #   # => ...a very beautiful...
+      def excerpt: (untyped text, untyped phrase, ?::Hash[untyped, untyped] options) -> (nil | untyped)
+
+      # Attempts to pluralize the +singular+ word unless +count+ is 1. If
+      # +plural+ is supplied, it will use that when count is > 1, otherwise
+      # it will use the Inflector to determine the plural form for the given locale,
+      # which defaults to I18n.locale
+      #
+      # The word will be pluralized using rules defined for the locale
+      # (you must define your own inflection rules for languages other than English).
+      # See ActiveSupport::Inflector.pluralize
+      #
+      #   pluralize(1, 'person')
+      #   # => 1 person
+      #
+      #   pluralize(2, 'person')
+      #   # => 2 people
+      #
+      #   pluralize(3, 'person', plural: 'users')
+      #   # => 3 users
+      #
+      #   pluralize(0, 'person')
+      #   # => 0 people
+      #
+      #   pluralize(2, 'Person', locale: :de)
+      #   # => 2 Personen
+      def pluralize: (untyped count, untyped singular, ?untyped? plural_arg, ?locale: untyped locale, ?plural: untyped plural) -> ::String
+
+      # Wraps the +text+ into lines no longer than +line_width+ width. This method
+      # breaks on the first whitespace character that does not exceed +line_width+
+      # (which is 80 by default).
+      #
+      #   word_wrap('Once upon a time')
+      #   # => Once upon a time
+      #
+      #   word_wrap('Once upon a time, in a kingdom called Far Far Away, a king fell ill, and finding a successor to the throne turned out to be more trouble than anyone could have imagined...')
+      #   # => Once upon a time, in a kingdom called Far Far Away, a king fell ill, and finding\na successor to the throne turned out to be more trouble than anyone could have\nimagined...
+      #
+      #   word_wrap('Once upon a time', line_width: 8)
+      #   # => Once\nupon a\ntime
+      #
+      #   word_wrap('Once upon a time', line_width: 1)
+      #   # => Once\nupon\na\ntime
+      #
+      #   You can also specify a custom +break_sequence+ ("\n" by default)
+      #
+      #   word_wrap('Once upon a time', line_width: 1, break_sequence: "\r\n")
+      #   # => Once\r\nupon\r\na\r\ntime
+      def word_wrap: (untyped text, ?break_sequence: ::String break_sequence, ?line_width: ::Integer line_width) -> untyped
+
+      # Returns +text+ transformed into HTML using simple formatting rules.
+      # Two or more consecutive newlines(<tt>\n\n</tt> or <tt>\r\n\r\n</tt>) are
+      # considered a paragraph and wrapped in <tt><p></tt> tags. One newline
+      # (<tt>\n</tt> or <tt>\r\n</tt>) is considered a linebreak and a
+      # <tt><br /></tt> tag is appended. This method does not remove the
+      # newlines from the +text+.
+      #
+      # You can pass any HTML attributes into <tt>html_options</tt>. These
+      # will be added to all created paragraphs.
+      #
+      # ==== Options
+      # * <tt>:sanitize</tt> - If +false+, does not sanitize +text+.
+      # * <tt>:wrapper_tag</tt> - String representing the wrapper tag, defaults to <tt>"p"</tt>
+      #
+      # ==== Examples
+      #   my_text = "Here is some basic text...\n...with a line break."
+      #
+      #   simple_format(my_text)
+      #   # => "<p>Here is some basic text...\n<br />...with a line break.</p>"
+      #
+      #   simple_format(my_text, {}, wrapper_tag: "div")
+      #   # => "<div>Here is some basic text...\n<br />...with a line break.</div>"
+      #
+      #   more_text = "We want to put a paragraph...\n\n...right there."
+      #
+      #   simple_format(more_text)
+      #   # => "<p>We want to put a paragraph...</p>\n\n<p>...right there.</p>"
+      #
+      #   simple_format("Look ma! A class!", class: 'description')
+      #   # => "<p class='description'>Look ma! A class!</p>"
+      #
+      #   simple_format("<blink>Unblinkable.</blink>")
+      #   # => "<p>Unblinkable.</p>"
+      #
+      #   simple_format("<blink>Blinkable!</blink> It's true.", {}, sanitize: false)
+      #   # => "<p><blink>Blinkable!</blink> It's true.</p>"
+      def simple_format: (untyped text, ?::Hash[untyped, untyped] html_options, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Creates a Cycle object whose _to_s_ method cycles through elements of an
+      # array every time it is called. This can be used for example, to alternate
+      # classes for table rows. You can use named cycles to allow nesting in loops.
+      # Passing a Hash as the last parameter with a <tt>:name</tt> key will create a
+      # named cycle. The default name for a cycle without a +:name+ key is
+      # <tt>"default"</tt>. You can manually reset a cycle by calling reset_cycle
+      # and passing the name of the cycle. The current cycle string can be obtained
+      # anytime using the current_cycle method.
+      #
+      #   # Alternate CSS classes for even and odd numbers...
+      #   @items = [1,2,3,4]
+      #   <table>
+      #   <% @items.each do |item| %>
+      #     <tr class="<%= cycle("odd", "even") -%>">
+      #       <td><%= item %></td>
+      #     </tr>
+      #   <% end %>
+      #   </table>
+      #
+      #
+      #   # Cycle CSS classes for rows, and text colors for values within each row
+      #   @items = x = [{first: 'Robert', middle: 'Daniel', last: 'James'},
+      #                {first: 'Emily', middle: 'Shannon', maiden: 'Pike', last: 'Hicks'},
+      #               {first: 'June', middle: 'Dae', last: 'Jones'}]
+      #   <% @items.each do |item| %>
+      #     <tr class="<%= cycle("odd", "even", name: "row_class") -%>">
+      #       <td>
+      #         <% item.values.each do |value| %>
+      #           <%# Create a named cycle "colors" %>
+      #           <span style="color:<%= cycle("red", "green", "blue", name: "colors") -%>">
+      #             <%= value %>
+      #           </span>
+      #         <% end %>
+      #         <% reset_cycle("colors") %>
+      #       </td>
+      #    </tr>
+      #  <% end %>
+      def cycle: (untyped first_value, *untyped values) -> untyped
+
+      # Returns the current cycle string after a cycle has been started. Useful
+      # for complex table highlighting or any other design need which requires
+      # the current cycle string in more than one place.
+      #
+      #   # Alternate background colors
+      #   @items = [1,2,3,4]
+      #   <% @items.each do |item| %>
+      #     <div style="background-color:<%= cycle("red","white","blue") %>">
+      #       <span style="background-color:<%= current_cycle %>"><%= item %></span>
+      #     </div>
+      #   <% end %>
+      def current_cycle: (?::String name) -> untyped
+
+      # Resets a cycle so that it starts from the first element the next time
+      # it is called. Pass in +name+ to reset a named cycle.
+      #
+      #   # Alternate CSS classes for even and odd numbers...
+      #   @items = [[1,2,3,4], [5,6,3], [3,4,5,6,7,4]]
+      #   <table>
+      #   <% @items.each do |item| %>
+      #     <tr class="<%= cycle("even", "odd") -%>">
+      #         <% item.each do |value| %>
+      #           <span style="color:<%= cycle("#333", "#666", "#999", name: "colors") -%>">
+      #             <%= value %>
+      #           </span>
+      #         <% end %>
+      #
+      #         <% reset_cycle("colors") %>
+      #     </tr>
+      #   <% end %>
+      #   </table>
+      def reset_cycle: (?::String name) -> untyped
+
+      class Cycle
+        # nodoc:
+        attr_reader values: untyped
+
+        def initialize: (untyped first_value, *untyped values) -> untyped
+
+        def reset: () -> untyped
+
+        def current_value: () -> untyped
+
+        def to_s: () -> untyped
+
+        def next_index: () -> untyped
+
+        def previous_index: () -> untyped
+
+        def step_index: (untyped n) -> untyped
+      end
+
+      # The cycle helpers need to store the cycles in a place that is
+      # guaranteed to be reset every time a page is rendered, so it
+      # uses an instance variable of ActionView::Base.
+      def get_cycle: (untyped name) -> untyped
+
+      def set_cycle: (untyped name, untyped cycle_object) -> untyped
+
+      def split_paragraphs: (untyped text) -> (::Array[untyped] | untyped)
+
+      def cut_excerpt_part: (untyped part_position, untyped part, untyped separator, untyped options) -> untyped
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    # = Action View Translation Helpers
+    # nodoc:
+    module TranslationHelper
+      extend ActiveSupport::Concern
+
+      include TagHelper
+
+      # Delegates to <tt>I18n#translate</tt> but also performs three additional
+      # functions.
+      #
+      # First, it will ensure that any thrown +MissingTranslation+ messages will
+      # be rendered as inline spans that:
+      #
+      # * Have a <tt>translation-missing</tt> class applied
+      # * Contain the missing key as the value of the +title+ attribute
+      # * Have a titleized version of the last key segment as text
+      #
+      # For example, the value returned for the missing translation key
+      # <tt>"blog.post.title"</tt> will be:
+      #
+      #    <span
+      #      class="translation_missing"
+      #      title="translation missing: en.blog.post.title">Title</span>
+      #
+      # This allows for views to display rather reasonable strings while still
+      # giving developers a way to find missing translations.
+      #
+      # If you would prefer missing translations to raise an error, you can
+      # opt out of span-wrapping behavior globally by setting
+      # <tt>ActionView::Base.raise_on_missing_translations = true</tt> or
+      # individually by passing <tt>raise: true</tt> as an option to
+      # <tt>translate</tt>.
+      #
+      # Second, if the key starts with a period <tt>translate</tt> will scope
+      # the key by the current partial. Calling <tt>translate(".foo")</tt> from
+      # the <tt>people/index.html.erb</tt> template is equivalent to calling
+      # <tt>translate("people.index.foo")</tt>. This makes it less
+      # repetitive to translate many keys within the same partial and provides
+      # a convention to scope keys consistently.
+      #
+      # Third, the translation will be marked as <tt>html_safe</tt> if the key
+      # has the suffix "_html" or the last element of the key is "html". Calling
+      # <tt>translate("footer_html")</tt> or <tt>translate("footer.html")</tt>
+      # will return an HTML safe string that won't be escaped by other HTML
+      # helper methods. This naming convention helps to identify translations
+      # that include HTML tags so that you know what kind of output to expect
+      # when you call translate in a template and translators know which keys
+      # they can provide HTML values for.
+      def translate: (untyped key, **untyped options) -> untyped
+
+      alias t translate
+
+      # Delegates to <tt>I18n.localize</tt> with no additional functionality.
+      #
+      # See https://www.rubydoc.info/github/svenfuchs/i18n/master/I18n/Backend/Base:localize
+      # for more information.
+      def localize: (untyped object, **untyped options) -> untyped
+
+      alias l localize
+
+      def scope_key_by_partial: (untyped key) -> untyped
+
+      def html_safe_translation_key?: (untyped key) -> untyped
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    # = Action View URL Helpers
+    # nodoc:
+    # Provides a set of methods for making links and getting URLs that
+    # depend on the routing subsystem (see ActionDispatch::Routing).
+    # This allows you to use the same format for links in views
+    # and controllers.
+    module UrlHelper
+      # This helper may be included in any class that includes the
+      # URL helpers of a routes (routes.url_helpers). Some methods
+      # provided here will only work in the context of a request
+      # (link_to_unless_current, for instance), which must be provided
+      # as a method called #request on the context.
+      BUTTON_TAG_METHOD_VERBS: ::Array[untyped]
+
+      extend ActiveSupport::Concern
+
+      include TagHelper
+
+      module ClassMethods
+        def _url_for_modules: () -> untyped
+      end
+
+      def url_for: (?untyped? options) -> untyped
+
+      def _back_url: () -> untyped
+
+      def _filtered_referrer: () -> untyped
+
+      # Creates an anchor element of the given +name+ using a URL created by the set of +options+.
+      # See the valid options in the documentation for +url_for+. It's also possible to
+      # pass a String instead of an options hash, which generates an anchor element that uses the
+      # value of the String as the href for the link. Using a <tt>:back</tt> Symbol instead
+      # of an options hash will generate a link to the referrer (a JavaScript back link
+      # will be used in place of a referrer if none exists). If +nil+ is passed as the name
+      # the value of the link itself will become the name.
+      #
+      # ==== Signatures
+      #
+      #   link_to(body, url, html_options = {})
+      #     # url is a String; you can use URL helpers like
+      #     # posts_path
+      #
+      #   link_to(body, url_options = {}, html_options = {})
+      #     # url_options, except :method, is passed to url_for
+      #
+      #   link_to(options = {}, html_options = {}) do
+      #     # name
+      #   end
+      #
+      #   link_to(url, html_options = {}) do
+      #     # name
+      #   end
+      #
+      # ==== Options
+      # * <tt>:data</tt> - This option can be used to add custom data attributes.
+      # * <tt>method: symbol of HTTP verb</tt> - This modifier will dynamically
+      #   create an HTML form and immediately submit the form for processing using
+      #   the HTTP verb specified. Useful for having links perform a POST operation
+      #   in dangerous actions like deleting a record (which search bots can follow
+      #   while spidering your site). Supported verbs are <tt>:post</tt>, <tt>:delete</tt>, <tt>:patch</tt>, and <tt>:put</tt>.
+      #   Note that if the user has JavaScript disabled, the request will fall back
+      #   to using GET. If <tt>href: '#'</tt> is used and the user has JavaScript
+      #   disabled clicking the link will have no effect. If you are relying on the
+      #   POST behavior, you should check for it in your controller's action by using
+      #   the request object's methods for <tt>post?</tt>, <tt>delete?</tt>, <tt>patch?</tt>, or <tt>put?</tt>.
+      # * <tt>remote: true</tt> - This will allow the unobtrusive JavaScript
+      #   driver to make an Ajax request to the URL in question instead of following
+      #   the link. The drivers each provide mechanisms for listening for the
+      #   completion of the Ajax request and performing JavaScript operations once
+      #   they're complete
+      #
+      # ==== Data attributes
+      #
+      # * <tt>confirm: 'question?'</tt> - This will allow the unobtrusive JavaScript
+      #   driver to prompt with the question specified (in this case, the
+      #   resulting text would be <tt>question?</tt>. If the user accepts, the
+      #   link is processed normally, otherwise no action is taken.
+      # * <tt>:disable_with</tt> - Value of this parameter will be used as the
+      #   name for a disabled version of the link. This feature is provided by
+      #   the unobtrusive JavaScript driver.
+      #
+      # ==== Examples
+      # Because it relies on +url_for+, +link_to+ supports both older-style controller/action/id arguments
+      # and newer RESTful routes. Current Rails style favors RESTful routes whenever possible, so base
+      # your application on resources and use
+      #
+      #   link_to "Profile", profile_path(@profile)
+      #   # => <a href="/profiles/1">Profile</a>
+      #
+      # or the even pithier
+      #
+      #   link_to "Profile", @profile
+      #   # => <a href="/profiles/1">Profile</a>
+      #
+      # in place of the older more verbose, non-resource-oriented
+      #
+      #   link_to "Profile", controller: "profiles", action: "show", id: @profile
+      #   # => <a href="/profiles/show/1">Profile</a>
+      #
+      # Similarly,
+      #
+      #   link_to "Profiles", profiles_path
+      #   # => <a href="/profiles">Profiles</a>
+      #
+      # is better than
+      #
+      #   link_to "Profiles", controller: "profiles"
+      #   # => <a href="/profiles">Profiles</a>
+      #
+      # When name is +nil+ the href is presented instead
+      #
+      #   link_to nil, "http://example.com"
+      #   # => <a href="http://www.example.com">http://www.example.com</a>
+      #
+      # You can use a block as well if your link target is hard to fit into the name parameter. ERB example:
+      #
+      #   <%= link_to(@profile) do %>
+      #     <strong><%= @profile.name %></strong> -- <span>Check it out!</span>
+      #   <% end %>
+      #   # => <a href="/profiles/1">
+      #          <strong>David</strong> -- <span>Check it out!</span>
+      #        </a>
+      #
+      # Classes and ids for CSS are easy to produce:
+      #
+      #   link_to "Articles", articles_path, id: "news", class: "article"
+      #   # => <a href="/articles" class="article" id="news">Articles</a>
+      #
+      # Be careful when using the older argument style, as an extra literal hash is needed:
+      #
+      #   link_to "Articles", { controller: "articles" }, id: "news", class: "article"
+      #   # => <a href="/articles" class="article" id="news">Articles</a>
+      #
+      # Leaving the hash off gives the wrong link:
+      #
+      #   link_to "WRONG!", controller: "articles", id: "news", class: "article"
+      #   # => <a href="/articles/index/news?class=article">WRONG!</a>
+      #
+      # +link_to+ can also produce links with anchors or query strings:
+      #
+      #   link_to "Comment wall", profile_path(@profile, anchor: "wall")
+      #   # => <a href="/profiles/1#wall">Comment wall</a>
+      #
+      #   link_to "Ruby on Rails search", controller: "searches", query: "ruby on rails"
+      #   # => <a href="/searches?query=ruby+on+rails">Ruby on Rails search</a>
+      #
+      #   link_to "Nonsense search", searches_path(foo: "bar", baz: "quux")
+      #   # => <a href="/searches?foo=bar&amp;baz=quux">Nonsense search</a>
+      #
+      # The only option specific to +link_to+ (<tt>:method</tt>) is used as follows:
+      #
+      #   link_to("Destroy", "http://www.example.com", method: :delete)
+      #   # => <a href='http://www.example.com' rel="nofollow" data-method="delete">Destroy</a>
+      #
+      # You can also use custom data attributes using the <tt>:data</tt> option:
+      #
+      #   link_to "Visit Other Site", "http://www.rubyonrails.org/", data: { confirm: "Are you sure?" }
+      #   # => <a href="http://www.rubyonrails.org/" data-confirm="Are you sure?">Visit Other Site</a>
+      #
+      # Also you can set any link attributes such as <tt>target</tt>, <tt>rel</tt>, <tt>type</tt>:
+      #
+      #   link_to "External link", "http://www.rubyonrails.org/", target: "_blank", rel: "nofollow"
+      #   # => <a href="http://www.rubyonrails.org/" target="_blank" rel="nofollow">External link</a>
+      def link_to: (?untyped? name, ?untyped? options, ?untyped? html_options) { () -> untyped } -> untyped
+
+      # Generates a form containing a single button that submits to the URL created
+      # by the set of +options+. This is the safest method to ensure links that
+      # cause changes to your data are not triggered by search bots or accelerators.
+      # If the HTML button does not work with your layout, you can also consider
+      # using the +link_to+ method with the <tt>:method</tt> modifier as described in
+      # the +link_to+ documentation.
+      #
+      # By default, the generated form element has a class name of <tt>button_to</tt>
+      # to allow styling of the form itself and its children. This can be changed
+      # using the <tt>:form_class</tt> modifier within +html_options+. You can control
+      # the form submission and input element behavior using +html_options+.
+      # This method accepts the <tt>:method</tt> modifier described in the +link_to+ documentation.
+      # If no <tt>:method</tt> modifier is given, it will default to performing a POST operation.
+      # You can also disable the button by passing <tt>disabled: true</tt> in +html_options+.
+      # If you are using RESTful routes, you can pass the <tt>:method</tt>
+      # to change the HTTP verb used to submit the form.
+      #
+      # ==== Options
+      # The +options+ hash accepts the same options as +url_for+.
+      #
+      # There are a few special +html_options+:
+      # * <tt>:method</tt> - Symbol of HTTP verb. Supported verbs are <tt>:post</tt>, <tt>:get</tt>,
+      #   <tt>:delete</tt>, <tt>:patch</tt>, and <tt>:put</tt>. By default it will be <tt>:post</tt>.
+      # * <tt>:disabled</tt> - If set to true, it will generate a disabled button.
+      # * <tt>:data</tt> - This option can be used to add custom data attributes.
+      # * <tt>:remote</tt> -  If set to true, will allow the Unobtrusive JavaScript drivers to control the
+      #   submit behavior. By default this behavior is an ajax submit.
+      # * <tt>:form</tt> - This hash will be form attributes
+      # * <tt>:form_class</tt> - This controls the class of the form within which the submit button will
+      #   be placed
+      # * <tt>:params</tt> - Hash of parameters to be rendered as hidden fields within the form.
+      #
+      # ==== Data attributes
+      #
+      # * <tt>:confirm</tt> - This will use the unobtrusive JavaScript driver to
+      #   prompt with the question specified. If the user accepts, the link is
+      #   processed normally, otherwise no action is taken.
+      # * <tt>:disable_with</tt> - Value of this parameter will be
+      #   used as the value for a disabled version of the submit
+      #   button when the form is submitted. This feature is provided
+      #   by the unobtrusive JavaScript driver.
+      #
+      # ==== Examples
+      #   <%= button_to "New", action: "new" %>
+      #   # => "<form method="post" action="/controller/new" class="button_to">
+      #   #      <input value="New" type="submit" />
+      #   #    </form>"
+      #
+      #   <%= button_to "New", new_article_path %>
+      #   # => "<form method="post" action="/articles/new" class="button_to">
+      #   #      <input value="New" type="submit" />
+      #   #    </form>"
+      #
+      #   <%= button_to [:make_happy, @user] do %>
+      #     Make happy <strong><%= @user.name %></strong>
+      #   <% end %>
+      #   # => "<form method="post" action="/users/1/make_happy" class="button_to">
+      #   #      <button type="submit">
+      #   #        Make happy <strong><%= @user.name %></strong>
+      #   #      </button>
+      #   #    </form>"
+      #
+      #   <%= button_to "New", { action: "new" }, form_class: "new-thing" %>
+      #   # => "<form method="post" action="/controller/new" class="new-thing">
+      #   #      <input value="New" type="submit" />
+      #   #    </form>"
+      #
+      #
+      #   <%= button_to "Create", { action: "create" }, remote: true, form: { "data-type" => "json" } %>
+      #   # => "<form method="post" action="/images/create" class="button_to" data-remote="true" data-type="json">
+      #   #      <input value="Create" type="submit" />
+      #   #      <input name="authenticity_token" type="hidden" value="10f2163b45388899ad4d5ae948988266befcb6c3d1b2451cf657a0c293d605a6"/>
+      #   #    </form>"
+      #
+      #
+      #   <%= button_to "Delete Image", { action: "delete", id: @image.id },
+      #                                   method: :delete, data: { confirm: "Are you sure?" } %>
+      #   # => "<form method="post" action="/images/delete/1" class="button_to">
+      #   #      <input type="hidden" name="_method" value="delete" />
+      #   #      <input data-confirm='Are you sure?' value="Delete Image" type="submit" />
+      #   #      <input name="authenticity_token" type="hidden" value="10f2163b45388899ad4d5ae948988266befcb6c3d1b2451cf657a0c293d605a6"/>
+      #   #    </form>"
+      #
+      #
+      #   <%= button_to('Destroy', 'http://www.example.com',
+      #             method: "delete", remote: true, data: { confirm: 'Are you sure?', disable_with: 'loading...' }) %>
+      #   # => "<form class='button_to' method='post' action='http://www.example.com' data-remote='true'>
+      #   #       <input name='_method' value='delete' type='hidden' />
+      #   #       <input value='Destroy' type='submit' data-disable-with='loading...' data-confirm='Are you sure?' />
+      #   #       <input name="authenticity_token" type="hidden" value="10f2163b45388899ad4d5ae948988266befcb6c3d1b2451cf657a0c293d605a6"/>
+      #   #     </form>"
+      #   #
+      def button_to: (?untyped? name, ?untyped? options, ?untyped? html_options) { () -> untyped } -> untyped
+
+      # Creates a link tag of the given +name+ using a URL created by the set of
+      # +options+ unless the current request URI is the same as the links, in
+      # which case only the name is returned (or the given block is yielded, if
+      # one exists). You can give +link_to_unless_current+ a block which will
+      # specialize the default behavior (e.g., show a "Start Here" link rather
+      # than the link's text).
+      #
+      # ==== Examples
+      # Let's say you have a navigation menu...
+      #
+      #   <ul id="navbar">
+      #     <li><%= link_to_unless_current("Home", { action: "index" }) %></li>
+      #     <li><%= link_to_unless_current("About Us", { action: "about" }) %></li>
+      #   </ul>
+      #
+      # If in the "about" action, it will render...
+      #
+      #   <ul id="navbar">
+      #     <li><a href="/controller/index">Home</a></li>
+      #     <li>About Us</li>
+      #   </ul>
+      #
+      # ...but if in the "index" action, it will render:
+      #
+      #   <ul id="navbar">
+      #     <li>Home</li>
+      #     <li><a href="/controller/about">About Us</a></li>
+      #   </ul>
+      #
+      # The implicit block given to +link_to_unless_current+ is evaluated if the current
+      # action is the action given. So, if we had a comments page and wanted to render a
+      # "Go Back" link instead of a link to the comments page, we could do something like this...
+      #
+      #    <%=
+      #        link_to_unless_current("Comment", { controller: "comments", action: "new" }) do
+      #           link_to("Go back", { controller: "posts", action: "index" })
+      #        end
+      #     %>
+      def link_to_unless_current: (untyped name, ?::Hash[untyped, untyped] options, ?::Hash[untyped, untyped] html_options) { () -> untyped } -> untyped
+
+      # Creates a link tag of the given +name+ using a URL created by the set of
+      # +options+ unless +condition+ is true, in which case only the name is
+      # returned. To specialize the default behavior (i.e., show a login link rather
+      # than just the plaintext link text), you can pass a block that
+      # accepts the name or the full argument list for +link_to_unless+.
+      #
+      # ==== Examples
+      #   <%= link_to_unless(@current_user.nil?, "Reply", { action: "reply" }) %>
+      #   # If the user is logged in...
+      #   # => <a href="/controller/reply/">Reply</a>
+      #
+      #   <%=
+      #      link_to_unless(@current_user.nil?, "Reply", { action: "reply" }) do |name|
+      #        link_to(name, { controller: "accounts", action: "signup" })
+      #      end
+      #   %>
+      #   # If the user is logged in...
+      #   # => <a href="/controller/reply/">Reply</a>
+      #   # If not...
+      #   # => <a href="/accounts/signup">Reply</a>
+      def link_to_unless: (untyped condition, untyped name, ?::Hash[untyped, untyped] options, ?::Hash[untyped, untyped] html_options) { () -> untyped } -> untyped
+
+      # Creates a link tag of the given +name+ using a URL created by the set of
+      # +options+ if +condition+ is true, otherwise only the name is
+      # returned. To specialize the default behavior, you can pass a block that
+      # accepts the name or the full argument list for +link_to_unless+ (see the examples
+      # in +link_to_unless+).
+      #
+      # ==== Examples
+      #   <%= link_to_if(@current_user.nil?, "Login", { controller: "sessions", action: "new" }) %>
+      #   # If the user isn't logged in...
+      #   # => <a href="/sessions/new/">Login</a>
+      #
+      #   <%=
+      #      link_to_if(@current_user.nil?, "Login", { controller: "sessions", action: "new" }) do
+      #        link_to(@current_user.login, { controller: "accounts", action: "show", id: @current_user })
+      #      end
+      #   %>
+      #   # If the user isn't logged in...
+      #   # => <a href="/sessions/new/">Login</a>
+      #   # If they are logged in...
+      #   # => <a href="/accounts/show/3">my_username</a>
+      def link_to_if: (untyped condition, untyped name, ?::Hash[untyped, untyped] options, ?::Hash[untyped, untyped] html_options) { () -> untyped } -> untyped
+
+      # Creates a mailto link tag to the specified +email_address+, which is
+      # also used as the name of the link unless +name+ is specified. Additional
+      # HTML attributes for the link can be passed in +html_options+.
+      #
+      # +mail_to+ has several methods for customizing the email itself by
+      # passing special keys to +html_options+.
+      #
+      # ==== Options
+      # * <tt>:subject</tt> - Preset the subject line of the email.
+      # * <tt>:body</tt> - Preset the body of the email.
+      # * <tt>:cc</tt> - Carbon Copy additional recipients on the email.
+      # * <tt>:bcc</tt> - Blind Carbon Copy additional recipients on the email.
+      # * <tt>:reply_to</tt> - Preset the Reply-To field of the email.
+      #
+      # ==== Obfuscation
+      # Prior to Rails 4.0, +mail_to+ provided options for encoding the address
+      # in order to hinder email harvesters.  To take advantage of these options,
+      # install the +actionview-encoded_mail_to+ gem.
+      #
+      # ==== Examples
+      #   mail_to "me@domain.com"
+      #   # => <a href="mailto:me@domain.com">me@domain.com</a>
+      #
+      #   mail_to "me@domain.com", "My email"
+      #   # => <a href="mailto:me@domain.com">My email</a>
+      #
+      #   mail_to "me@domain.com", "My email", cc: "ccaddress@domain.com",
+      #            subject: "This is an example email"
+      #   # => <a href="mailto:me@domain.com?cc=ccaddress@domain.com&subject=This%20is%20an%20example%20email">My email</a>
+      #
+      # You can use a block as well if your link target is hard to fit into the name parameter. ERB example:
+      #
+      #   <%= mail_to "me@domain.com" do %>
+      #     <strong>Email me:</strong> <span>me@domain.com</span>
+      #   <% end %>
+      #   # => <a href="mailto:me@domain.com">
+      #          <strong>Email me:</strong> <span>me@domain.com</span>
+      #        </a>
+      def mail_to: (untyped email_address, ?untyped? name, ?::Hash[untyped, untyped] html_options) { () -> untyped } -> untyped
+
+      # True if the current request URI was generated by the given +options+.
+      #
+      # ==== Examples
+      # Let's say we're in the <tt>http://www.example.com/shop/checkout?order=desc&page=1</tt> action.
+      #
+      #   current_page?(action: 'process')
+      #   # => false
+      #
+      #   current_page?(action: 'checkout')
+      #   # => true
+      #
+      #   current_page?(controller: 'library', action: 'checkout')
+      #   # => false
+      #
+      #   current_page?(controller: 'shop', action: 'checkout')
+      #   # => true
+      #
+      #   current_page?(controller: 'shop', action: 'checkout', order: 'asc')
+      #   # => false
+      #
+      #   current_page?(controller: 'shop', action: 'checkout', order: 'desc', page: '1')
+      #   # => true
+      #
+      #   current_page?(controller: 'shop', action: 'checkout', order: 'desc', page: '2')
+      #   # => false
+      #
+      #   current_page?('http://www.example.com/shop/checkout')
+      #   # => true
+      #
+      #   current_page?('http://www.example.com/shop/checkout', check_parameters: true)
+      #   # => false
+      #
+      #   current_page?('/shop/checkout')
+      #   # => true
+      #
+      #   current_page?('http://www.example.com/shop/checkout?order=desc&page=1')
+      #   # => true
+      #
+      # Let's say we're in the <tt>http://www.example.com/products</tt> action with method POST in case of invalid product.
+      #
+      #   current_page?(controller: 'product', action: 'index')
+      #   # => false
+      #
+      # We can also pass in the symbol arguments instead of strings.
+      #
+      def current_page?: (untyped options, ?check_parameters: bool check_parameters) -> (::FalseClass | untyped)
+
+      def convert_options_to_data_attributes: (untyped options, untyped html_options) -> untyped
+
+      def link_to_remote_options?: (untyped options) -> untyped
+
+      def add_method_to_attributes!: (untyped html_options, untyped method) -> untyped
+
+      STRINGIFIED_COMMON_METHODS: untyped
+
+      def method_not_get_method?: (untyped method) -> (::FalseClass | untyped)
+
+      def token_tag: (?untyped? token, ?form_options: ::Hash[untyped, untyped] form_options) -> untyped
+
+      def method_tag: (untyped method) -> untyped
+
+      # Returns an array of hashes each containing :name and :value keys
+      # suitable for use as the names and values of form input fields:
+      #
+      #   to_form_params(name: 'David', nationality: 'Danish')
+      #   # => [{name: 'name', value: 'David'}, {name: 'nationality', value: 'Danish'}]
+      #
+      #   to_form_params(country: { name: 'Denmark' })
+      #   # => [{name: 'country[name]', value: 'Denmark'}]
+      #
+      #   to_form_params(countries: ['Denmark', 'Sweden']})
+      #   # => [{name: 'countries[]', value: 'Denmark'}, {name: 'countries[]', value: 'Sweden'}]
+      #
+      # An optional namespace can be passed to enclose key names:
+      #
+      #   to_form_params({ name: 'Denmark' }, 'country')
+      #   # => [{name: 'country[name]', value: 'Denmark'}]
+      def to_form_params: (untyped attribute, ?untyped? namespace) -> untyped
+    end
+  end
+end
+
+module ActionView
+  module Helpers
+    # nodoc:
+    # nodoc:
+    extend ActiveSupport::Autoload
+
+    def self.eager_load!: () -> untyped
+
+    extend ActiveSupport::Concern
+
+    include ActiveSupport::Benchmarkable
+
+    include ActiveModelHelper
+
+    include AssetTagHelper
+
+    include AssetUrlHelper
+
+    include AtomFeedHelper
+
+    include CacheHelper
+
+    include CaptureHelper
+
+    include ControllerHelper
+
+    include CspHelper
+
+    include CsrfHelper
+
+    include DateHelper
+
+    include DebugHelper
+
+    include FormHelper
+
+    include FormOptionsHelper
+
+    include FormTagHelper
+
+    include JavaScriptHelper
+
+    include NumberHelper
+
+    include OutputSafetyHelper
+
+    include RenderingHelper
+
+    include SanitizeHelper
+
+    include TagHelper
+
+    include TextHelper
+
+    include TranslationHelper
+
+    include UrlHelper
+  end
+end
+
+module ActionView
+  # Layouts reverse the common pattern of including shared headers and footers in many templates to isolate changes in
+  # repeated setups. The inclusion pattern has pages that look like this:
+  #
+  #   <%= render "shared/header" %>
+  #   Hello World
+  #   <%= render "shared/footer" %>
+  #
+  # This approach is a decent way of keeping common structures isolated from the changing content, but it's verbose
+  # and if you ever want to change the structure of these two includes, you'll have to change all the templates.
+  #
+  # With layouts, you can flip it around and have the common structure know where to insert changing content. This means
+  # that the header and footer are only mentioned in one place, like this:
+  #
+  #   // The header part of this layout
+  #   <%= yield %>
+  #   // The footer part of this layout
+  #
+  # And then you have content pages that look like this:
+  #
+  #    hello world
+  #
+  # At rendering time, the content page is computed and then inserted in the layout, like this:
+  #
+  #   // The header part of this layout
+  #   hello world
+  #   // The footer part of this layout
+  #
+  # == Accessing shared variables
+  #
+  # Layouts have access to variables specified in the content pages and vice versa. This allows you to have layouts with
+  # references that won't materialize before rendering time:
+  #
+  #   <h1><%= @page_title %></h1>
+  #   <%= yield %>
+  #
+  # ...and content pages that fulfill these references _at_ rendering time:
+  #
+  #    <% @page_title = "Welcome" %>
+  #    Off-world colonies offers you a chance to start a new life
+  #
+  # The result after rendering is:
+  #
+  #   <h1>Welcome</h1>
+  #   Off-world colonies offers you a chance to start a new life
+  #
+  # == Layout assignment
+  #
+  # You can either specify a layout declaratively (using the #layout class method) or give
+  # it the same name as your controller, and place it in <tt>app/views/layouts</tt>.
+  # If a subclass does not have a layout specified, it inherits its layout using normal Ruby inheritance.
+  #
+  # For instance, if you have PostsController and a template named <tt>app/views/layouts/posts.html.erb</tt>,
+  # that template will be used for all actions in PostsController and controllers inheriting
+  # from PostsController.
+  #
+  # If you use a module, for instance Weblog::PostsController, you will need a template named
+  # <tt>app/views/layouts/weblog/posts.html.erb</tt>.
+  #
+  # Since all your controllers inherit from ApplicationController, they will use
+  # <tt>app/views/layouts/application.html.erb</tt> if no other layout is specified
+  # or provided.
+  #
+  # == Inheritance Examples
+  #
+  #   class BankController < ActionController::Base
+  #     # bank.html.erb exists
+  #
+  #   class ExchangeController < BankController
+  #     # exchange.html.erb exists
+  #
+  #   class CurrencyController < BankController
+  #
+  #   class InformationController < BankController
+  #     layout "information"
+  #
+  #   class TellerController < InformationController
+  #     # teller.html.erb exists
+  #
+  #   class EmployeeController < InformationController
+  #     # employee.html.erb exists
+  #     layout nil
+  #
+  #   class VaultController < BankController
+  #     layout :access_level_layout
+  #
+  #   class TillController < BankController
+  #     layout false
+  #
+  # In these examples, we have three implicit lookup scenarios:
+  # * The +BankController+ uses the "bank" layout.
+  # * The +ExchangeController+ uses the "exchange" layout.
+  # * The +CurrencyController+ inherits the layout from BankController.
+  #
+  # However, when a layout is explicitly set, the explicitly set layout wins:
+  # * The +InformationController+ uses the "information" layout, explicitly set.
+  # * The +TellerController+ also uses the "information" layout, because the parent explicitly set it.
+  # * The +EmployeeController+ uses the "employee" layout, because it set the layout to +nil+, resetting the parent configuration.
+  # * The +VaultController+ chooses a layout dynamically by calling the <tt>access_level_layout</tt> method.
+  # * The +TillController+ does not use a layout at all.
+  #
+  # == Types of layouts
+  #
+  # Layouts are basically just regular templates, but the name of this template needs not be specified statically. Sometimes
+  # you want to alternate layouts depending on runtime information, such as whether someone is logged in or not. This can
+  # be done either by specifying a method reference as a symbol or using an inline method (as a proc).
+  #
+  # The method reference is the preferred approach to variable layouts and is used like this:
+  #
+  #   class WeblogController < ActionController::Base
+  #     layout :writers_and_readers
+  #
+  #     def index
+  #       # fetching posts
+  #     end
+  #
+  #     private
+  #       def writers_and_readers
+  #         logged_in? ? "writer_layout" : "reader_layout"
+  #       end
+  #   end
+  #
+  # Now when a new request for the index action is processed, the layout will vary depending on whether the person accessing
+  # is logged in or not.
+  #
+  # If you want to use an inline method, such as a proc, do something like this:
+  #
+  #   class WeblogController < ActionController::Base
+  #     layout proc { |controller| controller.logged_in? ? "writer_layout" : "reader_layout" }
+  #   end
+  #
+  # If an argument isn't given to the proc, it's evaluated in the context of
+  # the current controller anyway.
+  #
+  #   class WeblogController < ActionController::Base
+  #     layout proc { logged_in? ? "writer_layout" : "reader_layout" }
+  #   end
+  #
+  # Of course, the most common way of specifying a layout is still just as a plain template name:
+  #
+  #   class WeblogController < ActionController::Base
+  #     layout "weblog_standard"
+  #   end
+  #
+  # The template will be looked always in <tt>app/views/layouts/</tt> folder. But you can point
+  # <tt>layouts</tt> folder direct also. <tt>layout "layouts/demo"</tt> is the same as <tt>layout "demo"</tt>.
+  #
+  # Setting the layout to +nil+ forces it to be looked up in the filesystem and fallbacks to the parent behavior if none exists.
+  # Setting it to +nil+ is useful to re-enable template lookup overriding a previous configuration set in the parent:
+  #
+  #     class ApplicationController < ActionController::Base
+  #       layout "application"
+  #     end
+  #
+  #     class PostsController < ApplicationController
+  #       # Will use "application" layout
+  #     end
+  #
+  #     class CommentsController < ApplicationController
+  #       # Will search for "comments" layout and fallback "application" layout
+  #       layout nil
+  #     end
+  #
+  # == Conditional layouts
+  #
+  # If you have a layout that by default is applied to all the actions of a controller, you still have the option of rendering
+  # a given action or set of actions without a layout, or restricting a layout to only a single action or a set of actions. The
+  # <tt>:only</tt> and <tt>:except</tt> options can be passed to the layout call. For example:
+  #
+  #   class WeblogController < ActionController::Base
+  #     layout "weblog_standard", except: :rss
+  #
+  #     # ...
+  #
+  #   end
+  #
+  # This will assign "weblog_standard" as the WeblogController's layout for all actions except for the +rss+ action, which will
+  # be rendered directly, without wrapping a layout around the rendered view.
+  #
+  # Both the <tt>:only</tt> and <tt>:except</tt> condition can accept an arbitrary number of method references, so
+  # #<tt>except: [ :rss, :text_only ]</tt> is valid, as is <tt>except: :rss</tt>.
+  #
+  # == Using a different layout in the action render call
+  #
+  # If most of your actions use the same layout, it makes perfect sense to define a controller-wide layout as described above.
+  # Sometimes you'll have exceptions where one action wants to use a different layout than the rest of the controller.
+  # You can do this by passing a <tt>:layout</tt> option to the <tt>render</tt> call. For example:
+  #
+  #   class WeblogController < ActionController::Base
+  #     layout "weblog_standard"
+  #
+  #     def help
+  #       render action: "help", layout: "help"
+  #     end
+  #   end
+  #
+  # This will override the controller-wide "weblog_standard" layout, and will render the help action with the "help" layout instead.
+  module Layouts
+    extend ActiveSupport::Concern
+
+    include ActionView::Rendering
+
+    module ClassMethods
+      def inherited: (untyped klass) -> untyped
+
+      module LayoutConditions
+        # Determines whether the current action has a layout definition by
+        # checking the action name against the :only and :except conditions
+        # set by the <tt>layout</tt> method.
+        #
+        # ==== Returns
+        # * <tt>Boolean</tt> - True if the action has a layout definition, false otherwise.
+        def _conditional_layout?: () -> (nil | untyped)
+      end
+
+      # Specify the layout to use for this class.
+      #
+      # If the specified layout is a:
+      # String:: the String is the template name
+      # Symbol:: call the method specified by the symbol
+      # Proc::   call the passed Proc
+      # false::  There is no layout
+      # true::   raise an ArgumentError
+      # nil::    Force default layout behavior with inheritance
+      #
+      # Return value of +Proc+ and +Symbol+ arguments should be +String+, +false+, +true+ or +nil+
+      # with the same meaning as described above.
+      # ==== Parameters
+      # * <tt>layout</tt> - The layout to use.
+      #
+      # ==== Options (conditions)
+      # * :only   - A list of actions to apply this layout to.
+      # * :except - Apply this layout to all actions but this one.
+      def layout: (untyped layout, ?::Hash[untyped, untyped] conditions) -> untyped
+
+      def _write_layout_method: () -> untyped
+
+      # If no layout is supplied, look for a template named the return
+      # value of this method.
+      #
+      # ==== Returns
+      # * <tt>String</tt> - A template name
+      def _implied_layout_name: () -> untyped
+    end
+
+    def _normalize_options: (untyped options) -> untyped
+
+    def initialize: () -> untyped
+
+    # Controls whether an action should be rendered using a layout.
+    # If you want to disable any <tt>layout</tt> settings for the
+    # current action so that it is rendered without a layout then
+    # either override this method in your controller to return false
+    # for that action or set the <tt>action_has_layout</tt> attribute
+    # to false before rendering.
+    def action_has_layout?: () -> untyped
+
+    def _conditional_layout?: () -> ::TrueClass
+
+    # This will be overwritten by _write_layout_method
+    def _layout: () -> nil
+
+    # Determine the layout for a given name, taking into account the name type.
+    #
+    # ==== Parameters
+    # * <tt>name</tt> - The name of the template
+    def _layout_for_option: (untyped name) -> untyped
+
+    def _normalize_layout: (untyped value) -> untyped
+
+    # Returns the default layout for this controller.
+    # Optionally raises an exception if the layout could not be found.
+    #
+    # ==== Parameters
+    # * <tt>formats</tt> - The formats accepted to this layout
+    # * <tt>require_layout</tt> - If set to +true+ and layout is not found,
+    #   an +ArgumentError+ exception is raised (defaults to +false+)
+    #
+    # ==== Returns
+    # * <tt>template</tt> - The template object for the default layout (or +nil+)
+    def _default_layout: (untyped lookup_context, untyped formats, ?bool require_layout) -> untyped
+
+    def _include_layout?: (untyped options) -> untyped
+  end
+end
+
+module ActionView
+  # = Action View Log Subscriber
+  #
+  # Provides functionality so that Rails can output logs from Action View.
+  class LogSubscriber < ActiveSupport::LogSubscriber
+    VIEWS_PATTERN: untyped
+
+    def initialize: () -> untyped
+
+    def render_template: (untyped event) -> untyped
+
+    def render_partial: (untyped event) -> untyped
+
+    def render_collection: (untyped event) -> untyped
+
+    def start: (untyped name, untyped id, untyped payload) -> untyped
+
+    def logger: () -> untyped
+
+    EMPTY: ::String
+
+    def from_rails_root: (untyped string) -> untyped
+
+    def rails_root: () -> untyped
+
+    def render_count: (untyped payload) -> untyped
+
+    def cache_message: (untyped payload) -> untyped
+
+    def log_rendering_start: (untyped payload) -> untyped
+  end
+end
+
+module ActionView
+  class LookupContext
+    # = Action View Lookup Context
+    #
+    # <tt>LookupContext</tt> is the object responsible for holding all information
+    # required for looking up templates, i.e. view paths and details.
+    # <tt>LookupContext</tt> is also responsible for generating a key, given to
+    # view paths, used in the resolver cache lookup. Since this key is generated
+    # only once during the request, it speeds up all cache accesses.
+    # nodoc:
+    attr_accessor prefixes: untyped
+
+    # = Action View Lookup Context
+    #
+    # <tt>LookupContext</tt> is the object responsible for holding all information
+    # required for looking up templates, i.e. view paths and details.
+    # <tt>LookupContext</tt> is also responsible for generating a key, given to
+    # view paths, used in the resolver cache lookup. Since this key is generated
+    # only once during the request, it speeds up all cache accesses.
+    # nodoc:
+    attr_accessor rendered_format: untyped
+
+    def self.register_detail: (untyped name) { () -> untyped } -> untyped
+
+    module Accessors
+      # Holds accessors for the registered details.
+      # nodoc:
+      DEFAULT_PROCS: ::Hash[untyped, untyped]
+    end
+
+    class DetailsKey
+      # nodoc:
+      alias eql? equal?
+
+      def self.digest_cache: (untyped details) -> untyped
+
+      def self.details_cache_key: (untyped details) -> untyped
+
+      def self.clear: () -> untyped
+
+      def self.digest_caches: () -> untyped
+
+      def self.view_context_class: (untyped klass) -> untyped
+    end
+
+    # Add caching behavior on top of Details.
+    module DetailsCache
+      attr_accessor cache: untyped
+
+      def details_key: () -> untyped
+
+      # Temporary skip passing the details_key forward.
+      def disable_cache: () { () -> untyped } -> untyped
+
+      def _set_detail: (untyped key, untyped value) -> untyped
+    end
+
+    # Helpers related to template lookup using the lookup context information.
+    module ViewPaths
+      attr_reader view_paths: untyped
+
+      attr_reader html_fallback_for_js: untyped
+
+      def find: (untyped name, ?untyped prefixes, ?bool partial, ?untyped keys, ?::Hash[untyped, untyped] options) -> untyped
+
+      alias find_template find
+
+      alias find_file find
+
+      def find_all: (untyped name, ?untyped prefixes, ?bool partial, ?untyped keys, ?::Hash[untyped, untyped] options) -> untyped
+
+      def exists?: (untyped name, ?untyped prefixes, ?bool partial, ?untyped keys, **untyped options) -> untyped
+
+      alias template_exists? exists?
+
+      def any?: (untyped name, ?untyped prefixes, ?bool partial) -> untyped
+
+      alias any_templates? any?
+
+      # Adds fallbacks to the view paths. Useful in cases when you are rendering
+      # a :file.
+      def with_fallbacks: () { () -> untyped } -> untyped
+
+      # Whenever setting view paths, makes a copy so that we can manipulate them in
+      # instance objects as we wish.
+      def build_view_paths: (untyped paths) -> ActionView::PathSet
+
+      def args_for_lookup: (untyped name, untyped prefixes, untyped partial, untyped keys, untyped details_options) -> ::Array[untyped]
+
+      def detail_args_for: (untyped options) -> (untyped | ::Array[untyped])
+
+      def args_for_any: (untyped name, untyped prefixes, untyped partial) -> ::Array[untyped]
+
+      def detail_args_for_any: () -> untyped
+
+      # Support legacy foo.erb names even though we now ignore .erb
+      # as well as incorrectly putting part of the path in the template
+      # name instead of the prefix.
+      def normalize_name: (untyped name, untyped prefixes) -> untyped
+    end
+
+    include Accessors
+
+    include DetailsCache
+
+    include ViewPaths
+
+    def initialize: (untyped view_paths, ?::Hash[untyped, untyped] details, ?untyped prefixes) -> untyped
+
+    def digest_cache: () -> untyped
+
+    def with_prepended_formats: (untyped formats) -> untyped
+
+    def initialize_details: (untyped target, untyped details) -> untyped
+
+    # Override formats= to expand ["*/*"] values and automatically
+    # add :html as fallback to :js.
+    def formats=: (untyped values) -> untyped
+
+    # Override locale to return a symbol instead of array.
+    def locale: () -> untyped
+
+    # Overload locale= to also set the I18n.locale. If the current I18n.config object responds
+    # to original_config, it means that it has a copy of the original I18n configuration and it's
+    # acting as proxy, which we need to skip.
+    def locale=: (untyped value) -> untyped
+  end
+end
+
+module ActionView
+  module ModelNaming
+    # nodoc:
+    # Converts the given object to an ActiveModel compliant one.
+    def convert_to_model: (untyped object) -> untyped
+
+    def model_name_from_record_or_class: (untyped record_or_class) -> untyped
+  end
+end
+
+module ActionView
+  class PathSet
+    # nodoc:
+    # = Action View PathSet
+    #
+    # This class is used to store and access paths in Action View. A number of
+    # operations are defined so that you can search among the paths in this
+    # set and also perform operations on other +PathSet+ objects.
+    #
+    # A +LookupContext+ will use a +PathSet+ to store the paths in its context.
+    # nodoc:
+    include Enumerable[untyped]
+
+    attr_reader paths: untyped
+
+    def initialize: (?untyped paths) -> untyped
+
+    def initialize_copy: (untyped other) -> untyped
+
+    def to_ary: () -> untyped
+
+    def compact: () -> PathSet
+
+    def +: (untyped array) -> PathSet
+
+    def find: (*untyped args) -> untyped
+
+    alias find_file find
+
+    def find_all: (untyped path, ?untyped prefixes, *untyped args) -> untyped
+
+    def exists?: (untyped path, untyped prefixes, *untyped args) -> untyped
+
+    def find_all_with_query: (untyped query) -> (untyped | ::Array[untyped])
+
+    def _find_all: (untyped path, untyped prefixes, untyped args) -> (untyped | ::Array[untyped])
+
+    def typecast: (untyped paths) -> untyped
+  end
+end
+
+module ActionView
+  class Railtie < Rails::Engine
+    # = Action View Railtie
+    # :nodoc:
+    NULL_OPTION: untyped
+  end
+end
+
+module ActionView
+  # RecordIdentifier encapsulates methods used by various ActionView helpers
+  # to associate records with DOM elements.
+  #
+  # Consider for example the following code that form of post:
+  #
+  #   <%= form_for(post) do |f| %>
+  #     <%= f.text_field :body %>
+  #   <% end %>
+  #
+  # When +post+ is a new, unsaved ActiveRecord::Base instance, the resulting HTML
+  # is:
+  #
+  #    <form class="new_post" id="new_post" action="/posts" accept-charset="UTF-8" method="post">
+  #      <input type="text" name="post[body]" id="post_body" />
+  #    </form>
+  #
+  # When +post+ is a persisted ActiveRecord::Base instance, the resulting HTML
+  # is:
+  #
+  #   <form class="edit_post" id="edit_post_42" action="/posts/42" accept-charset="UTF-8" method="post">
+  #     <input type="text" value="What a wonderful world!" name="post[body]" id="post_body" />
+  #   </form>
+  #
+  # In both cases, the +id+ and +class+ of the wrapping DOM element are
+  # automatically generated, following naming conventions encapsulated by the
+  # RecordIdentifier methods #dom_id and #dom_class:
+  #
+  #   dom_id(Post.new)         # => "new_post"
+  #   dom_class(Post.new)      # => "post"
+  #   dom_id(Post.find 42)     # => "post_42"
+  #   dom_class(Post.find 42)  # => "post"
+  #
+  # Note that these methods do not strictly require +Post+ to be a subclass of
+  # ActiveRecord::Base.
+  # Any +Post+ class will work as long as its instances respond to +to_key+
+  # and +model_name+, given that +model_name+ responds to +param_key+.
+  # For instance:
+  #
+  #   class Post
+  #     attr_accessor :to_key
+  #
+  #     def model_name
+  #       OpenStruct.new param_key: 'post'
+  #     end
+  #
+  #     def self.find(id)
+  #       new.tap { |post| post.to_key = [id] }
+  #     end
+  #   end
+  module RecordIdentifier
+    extend ModelNaming
+
+    include ModelNaming
+
+    JOIN: ::String
+
+    NEW: ::String
+
+    # The DOM class convention is to use the singular form of an object or class.
+    #
+    #   dom_class(post)   # => "post"
+    #   dom_class(Person) # => "person"
+    #
+    # If you need to address multiple instances of the same class in the same view, you can prefix the dom_class:
+    #
+    #   dom_class(post, :edit)   # => "edit_post"
+    #   dom_class(Person, :edit) # => "edit_person"
+    def dom_class: (untyped record_or_class, ?untyped? prefix) -> untyped
+
+    # The DOM id convention is to use the singular form of an object or class with the id following an underscore.
+    # If no id is found, prefix with "new_" instead.
+    #
+    #   dom_id(Post.find(45))       # => "post_45"
+    #   dom_id(Post.new)            # => "new_post"
+    #
+    # If you need to address multiple instances of the same class in the same view, you can prefix the dom_id:
+    #
+    #   dom_id(Post.find(45), :edit) # => "edit_post_45"
+    #   dom_id(Post.new, :custom)    # => "custom_post"
+    def dom_id: (untyped record, ?untyped? prefix) -> untyped
+
+    def record_key_for_dom_id: (untyped record) -> untyped
+  end
+end
+
+module ActionView
+  class AbstractRenderer
+    def initialize: (untyped lookup_context) -> untyped
+
+    def render: () -> untyped
+
+    class RenderedCollection
+      # :nodoc:
+      def self.empty: (untyped format) -> EmptyCollection
+
+      attr_reader rendered_templates: untyped
+
+      def initialize: (untyped rendered_templates, untyped spacer) -> untyped
+
+      def body: () -> untyped
+
+      def format: () -> untyped
+
+      class EmptyCollection
+        attr_reader format: untyped
+
+        def initialize: (untyped format) -> untyped
+
+        def body: () -> nil
+      end
+    end
+
+    class RenderedTemplate
+      # :nodoc:
+      attr_reader body: untyped
+
+      # :nodoc:
+      attr_reader layout: untyped
+
+      # :nodoc:
+      attr_reader template: untyped
+
+      def initialize: (untyped body, untyped layout, untyped template) -> untyped
+
+      def format: () -> untyped
+
+      EMPTY_SPACER: untyped
+    end
+
+    def extract_details: (untyped options) -> untyped
+
+    def instrument: (untyped name, **untyped options) { (untyped) -> untyped } -> untyped
+
+    def prepend_formats: (untyped formats) -> (nil | untyped)
+
+    def build_rendered_template: (untyped content, untyped template, ?untyped? layout) -> RenderedTemplate
+
+    def build_rendered_collection: (untyped templates, untyped spacer) -> RenderedCollection
+  end
+end
+
+module ActionView
+  module CollectionCaching
+    # :nodoc:
+    extend ActiveSupport::Concern
+
+    def cache_collection_render: (untyped instrumentation_payload, untyped view, untyped template) { () -> untyped } -> untyped
+
+    def callable_cache_key?: () -> untyped
+
+    def collection_by_cache_keys: (untyped view, untyped template) -> untyped
+
+    def expanded_cache_key: (untyped key, untyped view, untyped template, untyped digest_path) -> untyped
+
+    # `order_by` is an enumerable object containing keys of the cache,
+    # all keys are  passed in whether found already or not.
+    #
+    # `cached_partials` is a hash. If the value exists
+    # it represents the rendered partial from the cache
+    # otherwise `Hash#fetch` will take the value of its block.
+    #
+    # This method expects a block that will return the rendered
+    # partial. An example is to render all results
+    # for each element that was not found in the cache and store it as an array.
+    # Order it so that the first empty cache element in `cached_partials`
+    # corresponds to the first element in `rendered_partials`.
+    #
+    # If the partial is not already cached it will also be
+    # written back to the underlying cache store.
+    def fetch_or_cache_partial: (untyped cached_partials, untyped template, order_by: untyped order_by) { () -> untyped } -> untyped
+  end
+end
+
+module ActionView
+  class PartialIteration
+    # The number of iterations that will be done by the partial.
+    attr_reader size: untyped
+
+    # The current iteration of the partial.
+    attr_reader index: untyped
+
+    def initialize: (untyped size) -> untyped
+
+    # Check if this is the first iteration of the partial.
+    def first?: () -> untyped
+
+    # Check if this is the last iteration of the partial.
+    def last?: () -> untyped
+
+    def iterate!: () -> untyped
+  end
+
+  # = Action View Partials
+  #
+  # There's also a convenience method for rendering sub templates within the current controller that depends on a
+  # single object (we call this kind of sub templates for partials). It relies on the fact that partials should
+  # follow the naming convention of being prefixed with an underscore -- as to separate them from regular
+  # templates that could be rendered on their own.
+  #
+  # In a template for Advertiser#account:
+  #
+  #  <%= render partial: "account" %>
+  #
+  # This would render "advertiser/_account.html.erb".
+  #
+  # In another template for Advertiser#buy, we could have:
+  #
+  #   <%= render partial: "account", locals: { account: @buyer } %>
+  #
+  #   <% @advertisements.each do |ad| %>
+  #     <%= render partial: "ad", locals: { ad: ad } %>
+  #   <% end %>
+  #
+  # This would first render <tt>advertiser/_account.html.erb</tt> with <tt>@buyer</tt> passed in as the local variable +account+, then
+  # render <tt>advertiser/_ad.html.erb</tt> and pass the local variable +ad+ to the template for display.
+  #
+  # == The :as and :object options
+  #
+  # By default ActionView::PartialRenderer doesn't have any local variables.
+  # The <tt>:object</tt> option can be used to pass an object to the partial. For instance:
+  #
+  #   <%= render partial: "account", object: @buyer %>
+  #
+  # would provide the <tt>@buyer</tt> object to the partial, available under the local variable +account+ and is
+  # equivalent to:
+  #
+  #   <%= render partial: "account", locals: { account: @buyer } %>
+  #
+  # With the <tt>:as</tt> option we can specify a different name for said local variable. For example, if we
+  # wanted it to be +user+ instead of +account+ we'd do:
+  #
+  #   <%= render partial: "account", object: @buyer, as: 'user' %>
+  #
+  # This is equivalent to
+  #
+  #   <%= render partial: "account", locals: { user: @buyer } %>
+  #
+  # == \Rendering a collection of partials
+  #
+  # The example of partial use describes a familiar pattern where a template needs to iterate over an array and
+  # render a sub template for each of the elements. This pattern has been implemented as a single method that
+  # accepts an array and renders a partial by the same name as the elements contained within. So the three-lined
+  # example in "Using partials" can be rewritten with a single line:
+  #
+  #   <%= render partial: "ad", collection: @advertisements %>
+  #
+  # This will render <tt>advertiser/_ad.html.erb</tt> and pass the local variable +ad+ to the template for display. An
+  # iteration object will automatically be made available to the template with a name of the form
+  # +partial_name_iteration+. The iteration object has knowledge about which index the current object has in
+  # the collection and the total size of the collection. The iteration object also has two convenience methods,
+  # +first?+ and +last?+. In the case of the example above, the template would be fed +ad_iteration+.
+  # For backwards compatibility the +partial_name_counter+ is still present and is mapped to the iteration's
+  # +index+ method.
+  #
+  # The <tt>:as</tt> option may be used when rendering partials.
+  #
+  # You can specify a partial to be rendered between elements via the <tt>:spacer_template</tt> option.
+  # The following example will render <tt>advertiser/_ad_divider.html.erb</tt> between each ad partial:
+  #
+  #   <%= render partial: "ad", collection: @advertisements, spacer_template: "ad_divider" %>
+  #
+  # If the given <tt>:collection</tt> is +nil+ or empty, <tt>render</tt> will return +nil+. This will allow you
+  # to specify a text which will be displayed instead by using this form:
+  #
+  #   <%= render(partial: "ad", collection: @advertisements) || "There's no ad to be displayed" %>
+  #
+  # == \Rendering shared partials
+  #
+  # Two controllers can share a set of partials and render them like this:
+  #
+  #   <%= render partial: "advertisement/ad", locals: { ad: @advertisement } %>
+  #
+  # This will render the partial <tt>advertisement/_ad.html.erb</tt> regardless of which controller this is being called from.
+  #
+  # == \Rendering objects that respond to +to_partial_path+
+  #
+  # Instead of explicitly naming the location of a partial, you can also let PartialRenderer do the work
+  # and pick the proper path by checking +to_partial_path+ method.
+  #
+  #  # @account.to_partial_path returns 'accounts/account', so it can be used to replace:
+  #  # <%= render partial: "accounts/account", locals: { account: @account} %>
+  #  <%= render partial: @account %>
+  #
+  #  # @posts is an array of Post instances, so every post record returns 'posts/post' on +to_partial_path+,
+  #  # that's why we can replace:
+  #  # <%= render partial: "posts/post", collection: @posts %>
+  #  <%= render partial: @posts %>
+  #
+  # == \Rendering the default case
+  #
+  # If you're not going to be using any of the options like collections or layouts, you can also use the short-hand
+  # defaults of render to render partials. Examples:
+  #
+  #  # Instead of <%= render partial: "account" %>
+  #  <%= render "account" %>
+  #
+  #  # Instead of <%= render partial: "account", locals: { account: @buyer } %>
+  #  <%= render "account", account: @buyer %>
+  #
+  #  # @account.to_partial_path returns 'accounts/account', so it can be used to replace:
+  #  # <%= render partial: "accounts/account", locals: { account: @account} %>
+  #  <%= render @account %>
+  #
+  #  # @posts is an array of Post instances, so every post record returns 'posts/post' on +to_partial_path+,
+  #  # that's why we can replace:
+  #  # <%= render partial: "posts/post", collection: @posts %>
+  #  <%= render @posts %>
+  #
+  # == \Rendering partials with layouts
+  #
+  # Partials can have their own layouts applied to them. These layouts are different than the ones that are
+  # specified globally for the entire action, but they work in a similar fashion. Imagine a list with two types
+  # of users:
+  #
+  #   <%# app/views/users/index.html.erb %>
+  #   Here's the administrator:
+  #   <%= render partial: "user", layout: "administrator", locals: { user: administrator } %>
+  #
+  #   Here's the editor:
+  #   <%= render partial: "user", layout: "editor", locals: { user: editor } %>
+  #
+  #   <%# app/views/users/_user.html.erb %>
+  #   Name: <%= user.name %>
+  #
+  #   <%# app/views/users/_administrator.html.erb %>
+  #   <div id="administrator">
+  #     Budget: $<%= user.budget %>
+  #     <%= yield %>
+  #   </div>
+  #
+  #   <%# app/views/users/_editor.html.erb %>
+  #   <div id="editor">
+  #     Deadline: <%= user.deadline %>
+  #     <%= yield %>
+  #   </div>
+  #
+  # ...this will return:
+  #
+  #   Here's the administrator:
+  #   <div id="administrator">
+  #     Budget: $<%= user.budget %>
+  #     Name: <%= user.name %>
+  #   </div>
+  #
+  #   Here's the editor:
+  #   <div id="editor">
+  #     Deadline: <%= user.deadline %>
+  #     Name: <%= user.name %>
+  #   </div>
+  #
+  # If a collection is given, the layout will be rendered once for each item in
+  # the collection. For example, these two snippets have the same output:
+  #
+  #   <%# app/views/users/_user.html.erb %>
+  #   Name: <%= user.name %>
+  #
+  #   <%# app/views/users/index.html.erb %>
+  #   <%# This does not use layouts %>
+  #   <ul>
+  #     <% users.each do |user| -%>
+  #       <li>
+  #         <%= render partial: "user", locals: { user: user } %>
+  #       </li>
+  #     <% end -%>
+  #   </ul>
+  #
+  #   <%# app/views/users/_li_layout.html.erb %>
+  #   <li>
+  #     <%= yield %>
+  #   </li>
+  #
+  #   <%# app/views/users/index.html.erb %>
+  #   <ul>
+  #     <%= render partial: "user", layout: "li_layout", collection: users %>
+  #   </ul>
+  #
+  # Given two users whose names are Alice and Bob, these snippets return:
+  #
+  #   <ul>
+  #     <li>
+  #       Name: Alice
+  #     </li>
+  #     <li>
+  #       Name: Bob
+  #     </li>
+  #   </ul>
+  #
+  # The current object being rendered, as well as the object_counter, will be
+  # available as local variables inside the layout template under the same names
+  # as available in the partial.
+  #
+  # You can also apply a layout to a block within any template:
+  #
+  #   <%# app/views/users/_chief.html.erb %>
+  #   <%= render(layout: "administrator", locals: { user: chief }) do %>
+  #     Title: <%= chief.title %>
+  #   <% end %>
+  #
+  # ...this will return:
+  #
+  #   <div id="administrator">
+  #     Budget: $<%= user.budget %>
+  #     Title: <%= chief.name %>
+  #   </div>
+  #
+  # As you can see, the <tt>:locals</tt> hash is shared between both the partial and its layout.
+  #
+  # If you pass arguments to "yield" then this will be passed to the block. One way to use this is to pass
+  # an array to layout and treat it as an enumerable.
+  #
+  #   <%# app/views/users/_user.html.erb %>
+  #   <div class="user">
+  #     Budget: $<%= user.budget %>
+  #     <%= yield user %>
+  #   </div>
+  #
+  #   <%# app/views/users/index.html.erb %>
+  #   <%= render layout: @users do |user| %>
+  #     Title: <%= user.title %>
+  #   <% end %>
+  #
+  # This will render the layout for each user and yield to the block, passing the user, each time.
+  #
+  # You can also yield multiple times in one layout and use block arguments to differentiate the sections.
+  #
+  #   <%# app/views/users/_user.html.erb %>
+  #   <div class="user">
+  #     <%= yield user, :header %>
+  #     Budget: $<%= user.budget %>
+  #     <%= yield user, :footer %>
+  #   </div>
+  #
+  #   <%# app/views/users/index.html.erb %>
+  #   <%= render layout: @users do |user, section| %>
+  #     <%- case section when :header -%>
+  #       Title: <%= user.title %>
+  #     <%- when :footer -%>
+  #       Deadline: <%= user.deadline %>
+  #     <%- end -%>
+  #   <% end %>
+  class PartialRenderer < AbstractRenderer
+    include CollectionCaching
+
+    PREFIXED_PARTIAL_NAMES: untyped
+
+    def initialize: () -> untyped
+
+    def render: (untyped context, untyped options, untyped block) -> untyped
+
+    def render_collection: (untyped view, untyped template) -> untyped
+
+    def render_partial: (untyped view, untyped template) -> untyped
+
+    # Sets up instance variables needed for rendering a partial. This method
+    # finds the options and details and extracts them. The method also contains
+    # logic that handles the type of object passed in as the partial.
+    #
+    # If +options[:partial]+ is a string, then the <tt>@path</tt> instance variable is
+    # set to that string. Otherwise, the +options[:partial]+ object must
+    # respond to +to_partial_path+ in order to setup the path.
+    def setup: (untyped context, untyped options, untyped as, untyped block) -> untyped
+
+    def as_variable: (untyped options) -> untyped
+
+    def collection_from_options: () -> untyped
+
+    def collection_from_object: () -> untyped
+
+    def find_partial: (untyped path, untyped template_keys) -> untyped
+
+    def find_template: (untyped path, untyped locals) -> untyped
+
+    def collection_with_template: (untyped view, untyped template) -> untyped
+
+    def collection_without_template: (untyped view) -> untyped
+
+    # Obtains the path to where the object's partial is located. If the object
+    # responds to +to_partial_path+, then +to_partial_path+ will be called and
+    # will provide the path. If the object does not respond to +to_partial_path+,
+    # then an +ArgumentError+ is raised.
+    #
+    # If +prefix_partial_path_with_controller_namespace+ is true, then this
+    # method will prefix the partial paths with a namespace.
+    def partial_path: (untyped object, untyped view) -> untyped
+
+    def prefixed_partial_names: () -> untyped
+
+    def merge_prefix_into_object_path: (untyped prefix, untyped object_path) -> untyped
+
+    def retrieve_template_keys: (untyped variable) -> untyped
+
+    def retrieve_variable: (untyped path, untyped as) -> ::Array[untyped]
+
+    IDENTIFIER_ERROR_MESSAGE: ::String
+
+    OPTION_AS_ERROR_MESSAGE: ::String
+
+    def raise_invalid_identifier: (untyped path) -> untyped
+
+    def raise_invalid_option_as: (untyped as) -> untyped
+  end
+end
+
+module ActionView
+  # This is the main entry point for rendering. It basically delegates
+  # to other objects like TemplateRenderer and PartialRenderer which
+  # actually renders the template.
+  #
+  # The Renderer will parse the options from the +render+ or +render_body+
+  # method and render a partial or a template based on the options. The
+  # +TemplateRenderer+ and +PartialRenderer+ objects are wrappers which do all
+  # the setup and logic necessary to render a view and a new object is created
+  # each time +render+ is called.
+  class Renderer
+    attr_accessor lookup_context: untyped
+
+    def initialize: (untyped lookup_context) -> untyped
+
+    # Main render entry point shared by Action View and Action Controller.
+    def render: (untyped context, untyped options) -> untyped
+
+    def render_to_object: (untyped context, untyped options) -> untyped
+
+    # Render but returns a valid Rack body. If fibers are defined, we return
+    # a streaming body that renders the template piece by piece.
+    #
+    # Note that partials are not supported to be rendered with streaming,
+    # so in such cases, we just wrap them in an array.
+    def render_body: (untyped context, untyped options) -> untyped
+
+    def render_template: (untyped context, untyped options) -> untyped
+
+    def render_partial: (untyped context, untyped options) { () -> untyped } -> untyped
+
+    def cache_hits: () -> untyped
+
+    def render_template_to_object: (untyped context, untyped options) -> untyped
+
+    def render_partial_to_object: (untyped context, untyped options) { () -> untyped } -> untyped
+  end
+end
+
+module ActionView
+  class StreamingTemplateRenderer < TemplateRenderer
+    class Body
+      # == TODO
+      #
+      # * Support streaming from child templates, partials and so on.
+      # * Rack::Cache needs to support streaming bodies
+      # nodoc:
+      # A valid Rack::Body (i.e. it responds to each).
+      # It is initialized with a block that, when called, starts
+      # rendering the template.
+      # nodoc:
+      def initialize: () { () -> untyped } -> untyped
+
+      def each: () { () -> untyped } -> untyped
+
+      # This is the same logging logic as in ShowExceptions middleware.
+      def log_error: (untyped exception) -> (nil | untyped)
+    end
+
+    def render_template: (untyped view, untyped template, ?untyped? layout_name, ?::Hash[untyped, untyped] locals) -> (::Array[untyped] | untyped)
+
+    def delayed_render: (untyped buffer, untyped template, untyped layout, untyped view, untyped locals) -> untyped
+  end
+end
+
+module ActionView
+  class TemplateRenderer < AbstractRenderer
+    # nodoc:
+    def render: (untyped context, untyped options) -> untyped
+
+    # Determine the template to be rendered using the given options.
+    def determine_template: (untyped options) -> untyped
+
+    # Renders the given template. A string representing the layout can be
+    # supplied as well.
+    def render_template: (untyped view, untyped template, untyped layout_name, untyped locals) -> untyped
+
+    def render_with_layout: (untyped view, untyped template, untyped path, untyped locals) { (untyped) -> untyped } -> untyped
+
+    # This is the method which actually finds the layout using details in the lookup
+    # context object. If no layout is found, it checks if at least a layout with
+    # the given name exists across all details before raising the error.
+    def find_layout: (untyped layout, untyped keys, untyped formats) -> untyped
+
+    def resolve_layout: (untyped layout, untyped keys, untyped formats) -> untyped
+  end
+end
+
+module ActionView
+  class I18nProxy < ::I18n::Config
+    # This is a class to fix I18n global state. Whenever you provide I18n.locale during a request,
+    # it will trigger the lookup_context and consequently expire the cache.
+    # nodoc:
+    attr_reader original_config: untyped
+
+    # This is a class to fix I18n global state. Whenever you provide I18n.locale during a request,
+    # it will trigger the lookup_context and consequently expire the cache.
+    # nodoc:
+    attr_reader lookup_context: untyped
+
+    def initialize: (untyped original_config, untyped lookup_context) -> untyped
+
+    def locale: () -> untyped
+
+    def locale=: (untyped value) -> untyped
+  end
+
+  module Rendering
+    extend ActiveSupport::Concern
+
+    include ActionView::ViewPaths
+
+    attr_reader rendered_format: untyped
+
+    def initialize: () -> untyped
+
+    def process: () -> untyped
+
+    module ClassMethods
+      def _routes: () -> nil
+
+      def _helpers: () -> nil
+
+      def build_view_context_class: (untyped klass, untyped supports_path, untyped routes, untyped helpers) -> untyped
+
+      def view_context_class: () -> untyped
+    end
+
+    def view_context_class: () -> untyped
+
+    # An instance of a view class. The default view class is ActionView::Base.
+    #
+    # The view class must have the following methods:
+    #
+    # * <tt>View.new(lookup_context, assigns, controller)</tt> (trim non-ascii characters) Create a new
+    #   ActionView instance for a controller and we can also pass the arguments.
+    #
+    # * <tt>View#render(option)</tt> (trim non-ascii characters) Returns String with the rendered template.
+    #
+    # Override this method in a module to change the default behavior.
+    def view_context: () -> untyped
+
+    def view_renderer: () -> untyped
+
+    def render_to_body: (?::Hash[untyped, untyped] options) -> untyped
+
+    # Find and render a template based on the options given.
+    def _render_template: (untyped options) -> untyped
+
+    # Assign the rendered format to look up context.
+    def _process_format: (untyped format) -> untyped
+
+    # Normalize args by converting render "foo" to render :action => "foo" and
+    # render "foo/bar" to render :template => "foo/bar".
+    def _normalize_args: (?untyped? action, ?::Hash[untyped, untyped] options) -> untyped
+
+    # Normalize options.
+    def _normalize_options: (untyped options) -> untyped
+  end
+end
+
+module ActionView
+  module RoutingUrlFor
+    # Returns the URL for the set of +options+ provided. This takes the
+    # same options as +url_for+ in Action Controller (see the
+    # documentation for <tt>ActionController::Base#url_for</tt>). Note that by default
+    # <tt>:only_path</tt> is <tt>true</tt> so you'll get the relative "/controller/action"
+    # instead of the fully qualified URL like "http://example.com/controller/action".
+    #
+    # ==== Options
+    # * <tt>:anchor</tt> - Specifies the anchor name to be appended to the path.
+    # * <tt>:only_path</tt> - If true, returns the relative URL (omitting the protocol, host name, and port) (<tt>true</tt> by default unless <tt>:host</tt> is specified).
+    # * <tt>:trailing_slash</tt> - If true, adds a trailing slash, as in "/archive/2005/". Note that this
+    #   is currently not recommended since it breaks caching.
+    # * <tt>:host</tt> - Overrides the default (current) host if provided.
+    # * <tt>:protocol</tt> - Overrides the default (current) protocol if provided.
+    # * <tt>:user</tt> - Inline HTTP authentication (only plucked out if <tt>:password</tt> is also present).
+    # * <tt>:password</tt> - Inline HTTP authentication (only plucked out if <tt>:user</tt> is also present).
+    #
+    # ==== Relying on named routes
+    #
+    # Passing a record (like an Active Record) instead of a hash as the options parameter will
+    # trigger the named route for that record. The lookup will happen on the name of the class. So passing a
+    # Workshop object will attempt to use the +workshop_path+ route. If you have a nested route, such as
+    # +admin_workshop_path+ you'll have to call that explicitly (it's impossible for +url_for+ to guess that route).
+    #
+    # ==== Implicit Controller Namespacing
+    #
+    # Controllers passed in using the +:controller+ option will retain their namespace unless it is an absolute one.
+    #
+    # ==== Examples
+    #   <%= url_for(action: 'index') %>
+    #   # => /blogs/
+    #
+    #   <%= url_for(action: 'find', controller: 'books') %>
+    #   # => /books/find
+    #
+    #   <%= url_for(action: 'login', controller: 'members', only_path: false, protocol: 'https') %>
+    #   # => https://www.example.com/members/login/
+    #
+    #   <%= url_for(action: 'play', anchor: 'player') %>
+    #   # => /messages/play/#player
+    #
+    #   <%= url_for(action: 'jump', anchor: 'tax&ship') %>
+    #   # => /testing/jump/#tax&ship
+    #
+    #   <%= url_for(Workshop.new) %>
+    #   # relies on Workshop answering a persisted? call (and in this case returning false)
+    #   # => /workshops
+    #
+    #   <%= url_for(@workshop) %>
+    #   # calls @workshop.to_param which by default returns the id
+    #   # => /workshops/5
+    #
+    #   # to_param can be re-defined in a model to provide different URL names:
+    #   # => /workshops/1-workshop-name
+    #
+    #   <%= url_for("http://www.example.com") %>
+    #   # => http://www.example.com
+    #
+    #   <%= url_for(:back) %>
+    #   # if request.env["HTTP_REFERER"] is set to "http://www.example.com"
+    #   # => http://www.example.com
+    #
+    #   <%= url_for(:back) %>
+    #   # if request.env["HTTP_REFERER"] is not set or is blank
+    #   # => javascript:history.back()
+    #
+    #   <%= url_for(action: 'index', controller: 'users') %>
+    #   # Assuming an "admin" namespace
+    #   # => /admin/users
+    #
+    #   <%= url_for(action: 'index', controller: '/users') %>
+    #   # Specify absolute path with beginning slash
+    #   # => /users
+    def url_for: (?untyped? options) -> untyped
+
+    def url_options: () -> untyped
+
+    def _routes_context: () -> untyped
+
+    def optimize_routes_generation?: () -> untyped
+
+    def _generate_paths_by_default: () -> ::TrueClass
+
+    def ensure_only_path_option: (untyped options) -> untyped
+  end
+end
+
+module ActionView
+  class ActionViewError < StandardError
+  end
+
+  class EncodingError < StandardError
+  end
+
+  class WrongEncodingError < EncodingError
+    # nodoc:
+    def initialize: (untyped string, untyped encoding) -> untyped
+
+    def message: () -> ::String
+  end
+
+  class MissingTemplate < ActionViewError
+    # nodoc:
+    attr_reader path: untyped
+
+    def initialize: (untyped paths, untyped path, untyped prefixes, untyped partial, untyped details) -> untyped
+  end
+
+  class Template
+    class Error < ActionViewError
+      # The Template::Error exception is raised when the compilation or rendering of the template
+      # fails. This exception then gathers a bunch of intimate details and uses it to report a
+      # precise exception message.
+      # nodoc:
+      SOURCE_CODE_RADIUS: ::Integer
+
+      # Override to prevent #cause resetting during re-raise.
+      attr_reader cause: untyped
+
+      def initialize: (untyped template) -> untyped
+
+      def file_name: () -> untyped
+
+      def sub_template_message: () -> untyped
+
+      def source_extract: (?::Integer indentation) -> (::Array[untyped] | untyped)
+
+      def sub_template_of: (untyped template_path) -> untyped
+
+      def line_number: () -> untyped
+
+      def annotated_source_code: () -> untyped
+
+      def source_location: () -> untyped
+
+      def formatted_code_for: (untyped source_code, untyped line_counter, untyped indent) -> untyped
+    end
+  end
+
+  # It is actual TemplateError = Template::Error, but we can't write it in RBS
+  class TemplateError < Template::Error
+  end
+
+  class SyntaxErrorInTemplate < TemplateError
+    # nodoc
+    def initialize: (untyped template, untyped offending_code_string) -> untyped
+
+    def message: () -> ::String
+
+    def annotated_source_code: () -> untyped
+  end
+end
+
+module ActionView
+  module Template::Handlers
+    class Builder
+      def call: (untyped template, untyped source) -> untyped
+
+      def require_engine: () -> untyped
+    end
+  end
+end
+
+module ActionView
+  class Template
+    module Handlers
+      class ERB
+        class Erubi < ::Erubi::Engine
+          # :nodoc: all
+          def initialize: (untyped input, ?::Hash[untyped, untyped] properties) -> untyped
+
+          def evaluate: (untyped action_view_erb_handler_context) -> untyped
+
+          def add_text: (untyped text) -> (nil | untyped)
+
+          BLOCK_EXPR: untyped
+
+          def add_expression: (untyped indicator, untyped code) -> untyped
+
+          def add_code: (untyped code) -> untyped
+
+          def add_postamble: (untyped _) -> untyped
+
+          def flush_newline_if_pending: (untyped src) -> untyped
+        end
+      end
+    end
+  end
+end
+
+module ActionView
+  class Template
+    module Handlers
+      class ERB
+        ENCODING_TAG: untyped
+
+        def self.call: (untyped template, untyped source) -> untyped
+
+        def supports_streaming?: () -> ::TrueClass
+
+        def handles_encoding?: () -> ::TrueClass
+
+        def call: (untyped template, untyped source) -> untyped
+
+        def valid_encoding: (untyped string, untyped encoding) -> untyped
+      end
+    end
+  end
+end
+
+module ActionView
+  module Template::Handlers
+    class Html < Raw
+      def call: (untyped template, untyped source) -> ::String
+    end
+  end
+end
+
+module ActionView
+  module Template::Handlers
+    class Raw
+      def call: (untyped template, untyped source) -> ::String
+    end
+  end
+end
+
+module ActionView
+  class Template
+    module Handlers
+      def self.extended: (untyped base) -> untyped
+
+      def self.extensions: () -> untyped
+
+      class LegacyHandlerWrapper < SimpleDelegator
+        # :nodoc:
+        def call: (untyped view, untyped source) -> untyped
+      end
+
+      # Register an object that knows how to handle template files with the given
+      # extensions. This can be used to implement new template types.
+      # The handler must respond to +:call+, which will be passed the template
+      # and should return the rendered template as a String.
+      def register_template_handler: (*untyped extensions, untyped handler) -> untyped
+
+      # Opposite to register_template_handler.
+      def unregister_template_handler: (*untyped extensions) -> untyped
+
+      def template_handler_extensions: () -> untyped
+
+      def registered_template_handler: (untyped `extension`) -> untyped
+
+      def register_default_template_handler: (untyped `extension`, untyped klass) -> untyped
+
+      def handler_for_extension: (untyped `extension`) -> untyped
+    end
+  end
+end
+
+module ActionView
+  class Template
+    class HTML
+      # nodoc:
+      # = Action View HTML Template
+      # nodoc:
+      # nodoc:
+      attr_reader type: untyped
+
+      def initialize: (untyped string, ?untyped? `type`) -> untyped
+
+      def identifier: () -> "html template"
+
+      alias inspect identifier
+
+      def to_str: () -> untyped
+
+      def render: (*untyped args) -> untyped
+
+      def format: () -> untyped
+
+      def formats: () -> untyped
+    end
+  end
+end
+
+module ActionView
+  class Template
+    class Inline < Template
+      Finalizer: untyped
+
+      def compile: (untyped mod) -> untyped
+    end
+  end
+end
+
+module ActionView
+  class Template
+    class RawFile
+      # nodoc:
+      # = Action View RawFile Template
+      # nodoc:
+      # nodoc:
+      attr_accessor type: untyped
+
+      # nodoc:
+      # = Action View RawFile Template
+      # nodoc:
+      # nodoc:
+      attr_accessor format: untyped
+
+      def initialize: (untyped filename) -> untyped
+
+      def identifier: () -> untyped
+
+      def render: (*untyped args) -> untyped
+
+      def formats: () -> untyped
+    end
+  end
+end
+
+module ActionView
+  # = Action View Resolver
+  class Resolver
+    # Keeps all information about view path and builds virtual path.
+    class Path
+      attr_reader name: untyped
+
+      attr_reader prefix: untyped
+
+      attr_reader partial: untyped
+
+      attr_reader virtual: untyped
+
+      alias partial? partial
+
+      def self.build: (untyped name, untyped prefix, untyped partial) -> untyped
+
+      def initialize: (untyped name, untyped prefix, untyped partial, untyped virtual) -> untyped
+
+      def to_str: () -> untyped
+
+      alias to_s to_str
+    end
+
+    class Cache
+      # Threadsafe template cache
+      # nodoc:
+      class SmallCache < Concurrent::Map
+        def initialize: (?::Hash[untyped, untyped] options) -> untyped
+      end
+
+      # preallocate all the default blocks for performance/memory consumption reasons
+      PARTIAL_BLOCK: untyped
+
+      PREFIX_BLOCK: untyped
+
+      NAME_BLOCK: untyped
+
+      KEY_BLOCK: untyped
+
+      # usually a majority of template look ups return nothing, use this canonical preallocated array to save memory
+      NO_TEMPLATES: untyped
+
+      def initialize: () -> untyped
+
+      def inspect: () -> ::String
+
+      # Cache the templates returned by the block
+      def cache: (untyped key, untyped name, untyped prefix, untyped partial, untyped locals) { () -> untyped } -> untyped
+
+      def cache_query: (untyped query) { () -> untyped } -> untyped
+
+      def clear: () -> untyped
+
+      def size: () -> untyped
+
+      def canonical_no_templates: (untyped templates) -> untyped
+    end
+
+    alias self.caching? self.caching
+
+    def initialize: () -> untyped
+
+    def clear_cache: () -> untyped
+
+    # Normalizes the arguments and passes it on to find_templates.
+    def find_all: (untyped name, ?untyped? prefix, ?bool partial, ?::Hash[untyped, untyped] details, ?untyped? key, ?untyped locals) -> untyped
+
+    alias find_all_anywhere find_all
+
+    def find_all_with_query: (untyped query) -> untyped
+
+    def _find_all: (untyped name, untyped prefix, untyped partial, untyped details, untyped key, untyped locals) -> untyped
+
+    # This is what child classes implement. No defaults are needed
+    # because Resolver guarantees that the arguments are present and
+    # normalized.
+    def find_templates: (untyped name, untyped prefix, untyped partial, untyped details, ?untyped locals) -> untyped
+
+    # Handles templates caching. If a key is given and caching is on
+    # always check the cache before hitting the resolver. Otherwise,
+    # it always hits the resolver but if the key is present, check if the
+    # resolver is fresher before returning it.
+    def cached: (untyped key, untyped path_info, untyped details, untyped locals) { () -> untyped } -> untyped
+  end
+
+  class PathResolver < Resolver
+    # An abstract class that implements a Resolver with path semantics.
+    # nodoc:
+    EXTENSIONS: ::Hash[untyped, untyped]
+
+    DEFAULT_PATTERN: ::String
+
+    def initialize: (?untyped? pattern) -> untyped
+
+    def clear_cache: () -> untyped
+
+    def _find_all: (untyped name, untyped prefix, untyped partial, untyped details, untyped key, untyped locals) -> untyped
+
+    def query: (untyped path, untyped details, untyped formats, untyped locals, cache: untyped cache) -> untyped
+
+    def build_unbound_template: (untyped template, untyped virtual_path) -> UnboundTemplate
+
+    def reject_files_external_to_app: (untyped files) -> untyped
+
+    def find_template_paths_from_details: (untyped path, untyped details) -> untyped
+
+    def find_template_paths: (untyped query) -> untyped
+
+    def inside_path?: (untyped path, untyped filename) -> untyped
+
+    # Helper for building query glob string based on resolver's pattern.
+    def build_query: (untyped path, untyped details) -> untyped
+
+    def escape_entry: (untyped entry) -> untyped
+
+    # Extract handler, formats and variant from path. If a format cannot be found neither
+    # from the path, or the handler, we should return the array of formats given
+    # to the resolver.
+    def extract_handler_and_format_and_variant: (untyped path) -> ::Array[untyped]
+  end
+
+  # A resolver that loads files from the filesystem.
+  class FileSystemResolver < PathResolver
+    attr_reader path: untyped
+
+    def initialize: (untyped path, ?untyped? pattern) -> untyped
+
+    def to_s: () -> untyped
+
+    alias to_path to_s
+
+    def eql?: (untyped resolver) -> untyped
+
+    alias == eql?
+  end
+
+  class OptimizedFileSystemResolver < FileSystemResolver
+    # An Optimized resolver for Rails' most common case.
+    # nodoc:
+    def initialize: (untyped path) -> untyped
+
+    def find_template_paths_from_details: (untyped path, untyped details) -> untyped
+
+    def build_regex: (untyped path, untyped details) -> ::Regexp
+  end
+
+  class FallbackFileSystemResolver < FileSystemResolver
+    def self.instances: () -> ::Array[untyped]
+
+    def build_unbound_template: (untyped template, untyped _) -> untyped
+
+    def reject_files_external_to_app: (untyped files) -> untyped
+  end
+end
+
+module ActionView
+  class Template
+    module Sources
+      class File
+        def initialize: (untyped filename) -> untyped
+
+        def to_s: () -> untyped
+      end
+    end
+  end
+end
+
+module ActionView
+  class Template
+    module Sources
+      extend ActiveSupport::Autoload
+    end
+  end
+end
+
+module ActionView
+  class Template
+    class Text
+      # nodoc:
+      # = Action View Text Template
+      # nodoc:
+      # nodoc:
+      attr_accessor type: untyped
+
+      def initialize: (untyped string) -> untyped
+
+      def identifier: () -> "text template"
+
+      alias inspect identifier
+
+      def to_str: () -> untyped
+
+      def render: (*untyped args) -> untyped
+
+      def format: () -> :text
+
+      def formats: () -> untyped
+    end
+  end
+end
+
+module ActionView
+  class Template
+    # nodoc:
+    class Types
+      class Type
+        SET: untyped
+
+        def self.[]: (untyped `type`) -> untyped
+
+        attr_reader symbol: untyped
+
+        def initialize: (untyped symbol) -> untyped
+
+        def to_s: () -> untyped
+
+        alias to_str to_s
+
+        def ref: () -> untyped
+
+        alias to_sym ref
+
+        def ==: (untyped `type`) -> untyped
+      end
+
+      def self.delegate_to: (untyped klass) -> untyped
+
+      def self.[]: (untyped `type`) -> untyped
+
+      def self.symbols: () -> untyped
+    end
+  end
+end
+
+module ActionView
+  # = Action View Template
+  class Template
+    extend ActiveSupport::Autoload
+
+    def self.finalize_compiled_template_methods: () -> untyped
+
+    def self.finalize_compiled_template_methods=: (untyped _) -> untyped
+
+    extend Template::Handlers
+
+    attr_reader identifier: untyped
+
+    attr_reader handler: untyped
+
+    attr_reader original_encoding: untyped
+
+    attr_reader updated_at: untyped
+
+    attr_reader variable: untyped
+
+    attr_reader format: untyped
+
+    attr_reader variant: untyped
+
+    attr_reader locals: untyped
+
+    attr_reader virtual_path: untyped
+
+    def initialize: (untyped source, untyped identifier, untyped handler, ?updated_at: untyped? updated_at, ?virtual_path: untyped? virtual_path, ?locals: untyped? locals, ?variant: untyped? variant, ?format: untyped? format) -> untyped
+
+    def virtual_path=: (untyped _) -> nil
+
+    def locals=: (untyped _) -> nil
+
+    def formats=: (untyped _) -> nil
+
+    def formats: () -> untyped
+
+    def variants=: (untyped _) -> nil
+
+    def variants: () -> ::Array[untyped]
+
+    def refresh: (untyped _) -> untyped
+
+    # Returns whether the underlying handler supports streaming. If so,
+    # a streaming buffer *may* be passed when it starts rendering.
+    def supports_streaming?: () -> untyped
+
+    # Render a template. If the template was not compiled yet, it is done
+    # exactly before rendering.
+    #
+    # This method is instrumented as "!render_template.action_view". Notice that
+    # we use a bang in this instrumentation because you don't want to
+    # consume this in production. This is only slow if it's being listened to.
+    def render: (untyped view, untyped locals, ?untyped buffer) { () -> untyped } -> untyped
+
+    def `type`: () -> untyped
+
+    def short_identifier: () -> untyped
+
+    def inspect: () -> ::String
+
+    def source: () -> untyped
+
+    # This method is responsible for properly setting the encoding of the
+    # source. Until this point, we assume that the source is BINARY data.
+    # If no additional information is supplied, we assume the encoding is
+    # the same as <tt>Encoding.default_external</tt>.
+    #
+    # The user can also specify the encoding via a comment on the first
+    # line of the template (# encoding: NAME-OF-ENCODING). This will work
+    # with any template engine, as we process out the encoding comment
+    # before passing the source on to the template engine, leaving a
+    # blank line in its stead.
+    def encode!: () -> untyped
+
+    def marshal_dump: () -> ::Array[untyped]
+
+    def marshal_load: (untyped array) -> untyped
+
+    # Compile a template. This method ensures a template is compiled
+    # just once and removes the source after it is compiled.
+    def compile!: (untyped view) -> (nil | untyped)
+
+    class LegacyTemplate
+      # :nodoc:
+      attr_reader source: untyped
+
+      def initialize: (untyped template, untyped source) -> untyped
+    end
+
+    # Among other things, this method is responsible for properly setting
+    # the encoding of the compiled template.
+    #
+    # If the template engine handles encodings, we send the encoded
+    # String to the engine without further processing. This allows
+    # the template engine to support additional mechanisms for
+    # specifying the encoding. For instance, ERB supports <%# encoding: %>
+    #
+    # Otherwise, after we figure out the correct encoding, we then
+    # encode the source into <tt>Encoding.default_internal</tt>.
+    # In general, this means that templates will be UTF-8 inside of Rails,
+    # regardless of the original source encoding.
+    def compile: (untyped mod) -> untyped
+
+    def handle_render_error: (untyped view, untyped e) -> untyped
+
+    def locals_code: () -> untyped
+
+    def method_name: () -> untyped
+
+    def identifier_method_name: () -> untyped
+
+    def instrument: (untyped action) { () -> untyped } -> untyped
+
+    def instrument_render_template: () { () -> untyped } -> untyped
+
+    def instrument_payload: () -> { virtual_path: untyped, identifier: untyped }
+  end
+end
+
+module ActionView
+  # = Action View Test Case
+  class TestCase < ActiveSupport::TestCase
+    class TestController < ActionController::Base
+      include ActionDispatch::TestProcess
+
+      attr_accessor request: untyped
+
+      attr_accessor response: untyped
+
+      attr_accessor params: untyped
+
+      attr_writer controller_path: untyped
+
+      def controller_path=: (untyped path) -> untyped
+
+      def initialize: () -> untyped
+    end
+
+    module Behavior
+      extend ActiveSupport::Concern
+
+      include ActionDispatch::Assertions
+
+      include ActionDispatch::TestProcess
+
+      include Rails::Dom::Testing::Assertions
+
+      include ActionController::TemplateAssertions
+
+      include ActionView::Context
+
+      include ActionDispatch::Routing::PolymorphicRoutes
+
+      include AbstractController::Helpers
+
+      include ActionView::Helpers
+
+      include ActionView::RecordIdentifier
+
+      include ActionView::RoutingUrlFor
+
+      include ActiveSupport::Testing::ConstantLookup
+
+      attr_accessor controller: untyped
+
+      attr_accessor output_buffer: untyped
+
+      attr_accessor rendered: untyped
+
+      module ClassMethods
+        def tests: (untyped helper_class) -> untyped
+
+        def determine_default_helper_class: (untyped name) -> untyped
+
+        def helper_method: (*untyped methods) -> untyped
+
+        attr_writer helper_class: untyped
+
+        def helper_class: () -> untyped
+
+        def new: () -> untyped
+
+        def include_helper_modules!: () -> untyped
+      end
+
+      def setup_with_controller: () -> untyped
+
+      def config: () -> untyped
+
+      def render: (?::Hash[untyped, untyped] options, ?::Hash[untyped, untyped] local_assigns) { () -> untyped } -> untyped
+
+      def rendered_views: () -> untyped
+
+      def _routes: () -> untyped
+
+      # Need to experiment if this priority is the best one: rendered => output_buffer
+      class RenderedViewsCollection
+        def initialize: () -> untyped
+
+        def add: (untyped view, untyped locals) -> untyped
+
+        def locals_for: (untyped view) -> untyped
+
+        def rendered_views: () -> untyped
+
+        def view_rendered?: (untyped view, untyped expected_locals) -> untyped
+      end
+
+      # Need to experiment if this priority is the best one: rendered => output_buffer
+      def document_root_element: () -> untyped
+
+      def say_no_to_protect_against_forgery!: () -> untyped
+
+      def make_test_case_available_to_view!: () -> untyped
+
+      module Locals
+        attr_accessor rendered_views: untyped
+
+        def render: (?::Hash[untyped, untyped] options, ?::Hash[untyped, untyped] local_assigns) -> untyped
+      end
+
+      # The instance of ActionView::Base that is used by +render+.
+      def view: () -> untyped
+
+      alias _view view
+
+      INTERNAL_IVARS: ::Array[untyped]
+
+      def _user_defined_ivars: () -> untyped
+
+      # Returns a Hash of instance variables and their values, as defined by
+      # the user in the test case, which are then assigned to the view being
+      # rendered. This is generally intended for internal use and extension
+      # frameworks.
+      def view_assigns: () -> untyped
+
+      def method_missing: (untyped selector, *untyped args) -> untyped
+
+      def respond_to_missing?: (untyped name, ?bool include_private) -> untyped
+    end
+
+    include Behavior
+  end
+end
+
+module ActionView
+  # nodoc:
+  # Use FixtureResolver in your tests to simulate the presence of files on the
+  # file system. This is used internally by Rails' own test suite, and is
+  # useful for testing extensions that have no way of knowing what the file
+  # system will look like at runtime.
+  class FixtureResolver < OptimizedFileSystemResolver
+    def initialize: (?::Hash[untyped, untyped] hash, ?untyped? pattern) -> untyped
+
+    def data: () -> untyped
+
+    def to_s: () -> untyped
+
+    def query: (untyped path, untyped exts, untyped _, untyped locals, cache: untyped cache) -> untyped
+  end
+
+  class NullResolver < PathResolver
+    def query: (untyped path, untyped exts, untyped _, untyped locals, cache: untyped cache) -> ::Array[ActionView::Template]
+  end
+end
+
+module ActionView
+  class UnboundTemplate
+    def initialize: (untyped source, untyped identifer, untyped handler, untyped options) -> untyped
+
+    def bind_locals: (untyped locals) -> untyped
+
+    def build_template: (untyped locals) -> Template
+  end
+end
+
+module ActionView
+  # Returns the version of the currently loaded ActionView as a <tt>Gem::Version</tt>
+  def self.version: () -> untyped
+end
+
+module ActionView
+  module ViewPaths
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      def _view_paths: () -> untyped
+
+      def _view_paths=: (untyped paths) -> untyped
+
+      def _prefixes: () -> untyped
+
+      # Override this method in your controller if you want to change paths prefixes for finding views.
+      # Prefixes defined here will still be added to parents' <tt>._prefixes</tt>.
+      def local_prefixes: () -> ::Array[untyped]
+    end
+
+    def self.get_view_paths: (untyped klass) -> untyped
+
+    def self.set_view_paths: (untyped klass, untyped paths) -> untyped
+
+    def self.all_view_paths: () -> untyped
+
+    def _prefixes: () -> untyped
+
+    # <tt>LookupContext</tt> is the object responsible for holding all
+    # information required for looking up templates, i.e. view paths and
+    # details. Check <tt>ActionView::LookupContext</tt> for more information.
+    def lookup_context: () -> untyped
+
+    def details_for_lookup: () -> ::Hash[untyped, untyped]
+
+    # Append a path to the list of view paths for the current <tt>LookupContext</tt>.
+    #
+    # ==== Parameters
+    # * <tt>path</tt> - If a String is provided, it gets converted into
+    #   the default view path. You may also provide a custom view path
+    #   (see ActionView::PathSet for more information)
+    def append_view_path: (untyped path) -> untyped
+
+    # Prepend a path to the list of view paths for the current <tt>LookupContext</tt>.
+    #
+    # ==== Parameters
+    # * <tt>path</tt> - If a String is provided, it gets converted into
+    #   the default view path. You may also provide a custom view path
+    #   (see ActionView::PathSet for more information)
+    def prepend_view_path: (untyped path) -> untyped
+
+    module ClassMethods
+      # Append a path to the list of view paths for this controller.
+      #
+      # ==== Parameters
+      # * <tt>path</tt> - If a String is provided, it gets converted into
+      #   the default view path. You may also provide a custom view path
+      #   (see ActionView::PathSet for more information)
+      def append_view_path: (untyped path) -> untyped
+
+      # Prepend a path to the list of view paths for this controller.
+      #
+      # ==== Parameters
+      # * <tt>path</tt> - If a String is provided, it gets converted into
+      #   the default view path. You may also provide a custom view path
+      #   (see ActionView::PathSet for more information)
+      def prepend_view_path: (untyped path) -> untyped
+
+      # A list of all of the default view paths for this controller.
+      def view_paths: () -> untyped
+
+      # Set the view paths.
+      #
+      # ==== Parameters
+      # * <tt>paths</tt> - If a PathSet is provided, use that;
+      #   otherwise, process the parameter into a PathSet.
+      def view_paths=: (untyped paths) -> untyped
+    end
+  end
+end
+
+module ActionView
+  extend ActiveSupport::Autoload
+
+  ENCODING_FLAG: ::String
+
+  def self.eager_load!: () -> untyped
+end
+

--- a/gems/actionview/6.0.3.2/actionview-generated.rbs
+++ b/gems/actionview/6.0.3.2/actionview-generated.rbs
@@ -258,6 +258,8 @@ module ActionView
 
     def clear_cache: () -> untyped
 
+    private
+
     def dirs_to_watch: () -> untyped
 
     def all_view_paths: () -> untyped
@@ -341,6 +343,8 @@ module ActionView
 
       def dependencies: () -> untyped
 
+      private
+
       attr_reader name: untyped
 
       attr_reader template: untyped
@@ -378,6 +382,8 @@ module ActionView
 
     # Create a dependency tree for template named +name+.
     def self.tree: (untyped name, untyped finder, ?bool partial, ?::Hash[untyped, untyped] seen) -> untyped
+
+    private
 
     def self.find_template: (untyped finder, untyped name, untyped prefixes, untyped partial, untyped keys) -> untyped
 
@@ -453,6 +459,8 @@ module ActionView
     # if that's the key it's waiting for.
     def append!: (untyped key, untyped value) -> untyped
 
+    private
+
     def inside_fiber?: () -> untyped
   end
 end
@@ -491,6 +499,8 @@ module ActionView
       def error_wrapping: (untyped html_tag) -> untyped
 
       def error_message: () -> untyped
+
+      private
 
       def object_has_errors?: () -> untyped
 
@@ -816,6 +826,8 @@ module ActionView
       #   audio_tag("sound.wav", "sound.mid")
       #   # => <audio><source src="/audios/sound.wav" /><source src="/audios/sound.mid" /></audio>
       def audio_tag: (*untyped sources) -> untyped
+
+      private
 
       def multiple_sources_tag_builder: (untyped `type`, untyped sources) { (untyped) -> untyped } -> untyped
 
@@ -1305,6 +1317,8 @@ module ActionView
 
         def initialize: (untyped xml) -> untyped
 
+        private
+
         # Delegate to xml builder, first wrapping the element in an xhtml
         # namespaced div element if the method and arguments indicate
         # that an xhtml_block? is desired.
@@ -1531,6 +1545,8 @@ module ActionView
       def cache_fragment_name: (?::Hash[untyped, untyped] name, ?digest_path: untyped? digest_path, ?virtual_path: untyped? virtual_path, ?skip_digest: untyped? skip_digest) -> untyped
 
       def digest_path_from_template: (untyped template) -> untyped
+
+      private
 
       def fragment_name_with_digest: (untyped name, untyped virtual_path, untyped digest_path) -> untyped
 
@@ -2367,6 +2383,8 @@ module ActionView
       #   # => <time datetime="2010-11-04T17:55:45+01:00"><span>Right now</span></time>
       def time_tag: (untyped date_or_time, *untyped args) { () -> untyped } -> untyped
 
+      private
+
       def normalize_distance_of_time_argument_to_time: (untyped value) -> untyped
     end
 
@@ -2399,6 +2417,8 @@ module ActionView
       def select_month: () -> untyped
 
       def select_year: () -> untyped
+
+      private
 
       # If the day is hidden, the day should be set to the 1st so all month and year choices are
       # valid. Otherwise, February 31st or February 29th, 2011 can be selected, which are invalid.
@@ -3008,7 +3028,11 @@ module ActionView
       #   <% end %>
       def form_for: (untyped record, ?::Hash[untyped, untyped] options) { () -> untyped } -> untyped
 
+      private
+
       def apply_form_for_options!: (untyped record, untyped object, untyped options) -> untyped
+
+      public
 
       # Creates a form tag based on mixing URLs, scopes, or models.
       #
@@ -3979,6 +4003,8 @@ module ActionView
       # * Accepts same options as range_field_tag
       def range_field: (untyped object_name, untyped method, ?::Hash[untyped, untyped] options) -> untyped
 
+      private
+
       def html_options_for_form_with: (?untyped? url_for_options, ?untyped? model, ?skip_enforcing_utf8: untyped? skip_enforcing_utf8, ?local: untyped local, ?html: ::Hash[untyped, untyped] html, **untyped options) -> untyped
 
       def instantiate_builder: (untyped record_name, untyped record_object, untyped options) -> untyped
@@ -4559,6 +4585,8 @@ module ActionView
       def button: (?untyped? value, ?::Hash[untyped, untyped] options) { () -> untyped } -> untyped
 
       def emitted_hidden_id?: () -> untyped
+
+      private
 
       def objectify_options: (untyped options) -> untyped
 
@@ -5238,6 +5266,8 @@ module ActionView
       # In the rare case you don't want this hidden field, you can pass the
       # <tt>include_hidden: false</tt> option to the helper method.
       def collection_check_boxes: (untyped object, untyped method, untyped collection, untyped value_method, untyped text_method, ?::Hash[untyped, untyped] options, ?::Hash[untyped, untyped] html_options) { () -> untyped } -> untyped
+
+      private
 
       def option_html_attributes: (untyped element) -> untyped
 
@@ -6009,6 +6039,8 @@ module ActionView
       # to customize the tag.
       def utf8_enforcer_tag: () -> untyped
 
+      private
+
       def html_options_for_form: (untyped url_for_options, untyped options) -> untyped
 
       def extra_tags_for_form: (untyped html_options) -> untyped
@@ -6467,6 +6499,8 @@ module ActionView
       #
       def number_to_human: (untyped number, ?::Hash[untyped, untyped] options) -> untyped
 
+      private
+
       def delegate_number_helper_method: (untyped method, untyped number, untyped options) -> (nil | untyped)
 
       def escape_unsafe_options: (untyped options) -> untyped
@@ -6797,6 +6831,8 @@ module ActionView
 
         def tag_option: (untyped key, untyped value, untyped escape) -> ::String
 
+        private
+
         def prefix_tag_option: (untyped prefix, untyped key, untyped value, untyped escape) -> untyped
 
         def respond_to_missing?: (*untyped args) -> ::TrueClass
@@ -6979,6 +7015,8 @@ module ActionView
       #   # => "&lt;&lt; Accept &amp; Checkout"
       def escape_once: (untyped html) -> untyped
 
+      private
+
       def tag_builder: () -> untyped
     end
   end
@@ -7008,6 +7046,8 @@ module ActionView
 
         # This is what child classes implement.
         def render: () -> untyped
+
+        private
 
         def value: () -> untyped
 
@@ -7059,6 +7099,8 @@ module ActionView
 
         def render: () -> untyped
 
+        private
+
         def checked?: (untyped value) -> untyped
 
         def hidden_field_for_checkbox: (untyped options) -> untyped
@@ -7093,6 +7135,8 @@ module ActionView
         end
 
         def render: () { () -> untyped } -> untyped
+
+        private
 
         def render_component: (untyped builder) -> untyped
 
@@ -7129,6 +7173,8 @@ module ActionView
 
         def initialize: (untyped object_name, untyped method_name, untyped template_object, untyped collection, untyped value_method, untyped text_method, untyped options, untyped html_options) -> untyped
 
+        private
+
         def instantiate_builder: (untyped builder_class, untyped item, untyped value, untyped text, untyped html_options) -> untyped
 
         # Generate default options for collection helpers, such as :checked and
@@ -7164,6 +7210,8 @@ module ActionView
 
         def render: () { () -> untyped } -> untyped
 
+        private
+
         def render_component: (untyped builder) -> untyped
       end
     end
@@ -7192,6 +7240,8 @@ module ActionView
         # :nodoc:
         def render: () -> untyped
 
+        private
+
         def validate_color_string: (untyped string) -> untyped
       end
     end
@@ -7202,6 +7252,8 @@ module ActionView
   module Helpers
     module Tags
       class DateField < DatetimeField
+        private
+
         def format_date: (untyped value) -> untyped
       end
     end
@@ -7219,6 +7271,8 @@ module ActionView
         def render: () -> untyped
 
         def self.select_type: () -> untyped
+
+        private
 
         def select_type: () -> untyped
 
@@ -7238,6 +7292,8 @@ module ActionView
         # :nodoc:
         def render: () -> untyped
 
+        private
+
         def format_date: (untyped value) -> untyped
 
         def datetime_value: (untyped value) -> untyped
@@ -7251,6 +7307,8 @@ module ActionView
     module Tags
       class DatetimeLocalField < DatetimeField
         def self.field_type: () -> untyped
+
+        private
 
         def format_date: (untyped value) -> untyped
       end
@@ -7327,6 +7385,8 @@ module ActionView
 
         def render: () { () -> untyped } -> untyped
 
+        private
+
         def render_component: (untyped builder) -> untyped
       end
     end
@@ -7337,6 +7397,8 @@ module ActionView
   module Helpers
     module Tags
       class MonthField < DatetimeField
+        private
+
         def format_date: (untyped value) -> untyped
       end
     end
@@ -7391,6 +7453,8 @@ module ActionView
 
         def render: () -> untyped
 
+        private
+
         def checked?: (untyped value) -> untyped
       end
     end
@@ -7427,6 +7491,8 @@ module ActionView
         def initialize: (untyped object_name, untyped method_name, untyped template_object, untyped choices, untyped options, untyped html_options) { () -> untyped } -> untyped
 
         def render: () -> untyped
+
+        private
 
         # Grouped choices look like this:
         #
@@ -7473,6 +7539,8 @@ module ActionView
 
         def self.field_type: () -> untyped
 
+        private
+
         def field_type: () -> untyped
       end
     end
@@ -7483,6 +7551,8 @@ module ActionView
   module Helpers
     module Tags
       class TimeField < DatetimeField
+        private
+
         def format_date: (untyped value) -> untyped
       end
     end
@@ -7522,6 +7592,8 @@ module ActionView
 
         def translate: () -> untyped
 
+        private
+
         attr_reader object_name: untyped
 
         attr_reader method_and_value: untyped
@@ -7551,6 +7623,8 @@ module ActionView
   module Helpers
     module Tags
       class WeekField < DatetimeField
+        private
+
         def format_date: (untyped value) -> untyped
       end
     end
@@ -7880,12 +7954,16 @@ module ActionView
 
         def to_s: () -> untyped
 
+        private
+
         def next_index: () -> untyped
 
         def previous_index: () -> untyped
 
         def step_index: (untyped n) -> untyped
       end
+
+      private
 
       # The cycle helpers need to store the cycles in a place that is
       # guaranteed to be reset every time a page is rendered, so it
@@ -7962,6 +8040,8 @@ module ActionView
       def localize: (untyped object, **untyped options) -> untyped
 
       alias l localize
+
+      private
 
       def scope_key_by_partial: (untyped key) -> untyped
 
@@ -8402,6 +8482,8 @@ module ActionView
       #
       def current_page?: (untyped options, ?check_parameters: bool check_parameters) -> (::FalseClass | untyped)
 
+      private
+
       def convert_options_to_data_attributes: (untyped options, untyped html_options) -> untyped
 
       def link_to_remote_options?: (untyped options) -> untyped
@@ -8703,6 +8785,8 @@ module ActionView
       def inherited: (untyped klass) -> untyped
 
       module LayoutConditions
+        private
+
         # Determines whether the current action has a layout definition by
         # checking the action name against the :only and :except conditions
         # set by the <tt>layout</tt> method.
@@ -8734,6 +8818,8 @@ module ActionView
 
       def _write_layout_method: () -> untyped
 
+      private
+
       # If no layout is supplied, look for a template named the return
       # value of this method.
       #
@@ -8753,6 +8839,8 @@ module ActionView
     # for that action or set the <tt>action_has_layout</tt> attribute
     # to false before rendering.
     def action_has_layout?: () -> untyped
+
+    private
 
     def _conditional_layout?: () -> ::TrueClass
 
@@ -8801,6 +8889,8 @@ module ActionView
     def start: (untyped name, untyped id, untyped payload) -> untyped
 
     def logger: () -> untyped
+
+    private
 
     EMPTY: ::String
 
@@ -8870,6 +8960,8 @@ module ActionView
       # Temporary skip passing the details_key forward.
       def disable_cache: () { () -> untyped } -> untyped
 
+      private
+
       def _set_detail: (untyped key, untyped value) -> untyped
     end
 
@@ -8898,6 +8990,8 @@ module ActionView
       # Adds fallbacks to the view paths. Useful in cases when you are rendering
       # a :file.
       def with_fallbacks: () { () -> untyped } -> untyped
+
+      private
 
       # Whenever setting view paths, makes a copy so that we can manipulate them in
       # instance objects as we wish.
@@ -8929,7 +9023,11 @@ module ActionView
 
     def with_prepended_formats: (untyped formats) -> untyped
 
+    private
+
     def initialize_details: (untyped target, untyped details) -> untyped
+
+    public
 
     # Override formats= to expand ["*/*"] values and automatically
     # add :html as fallback to :js.
@@ -8989,6 +9087,8 @@ module ActionView
     def exists?: (untyped path, untyped prefixes, *untyped args) -> untyped
 
     def find_all_with_query: (untyped query) -> (untyped | ::Array[untyped])
+
+    private
 
     def _find_all: (untyped path, untyped prefixes, untyped args) -> (untyped | ::Array[untyped])
 
@@ -9055,6 +9155,8 @@ module ActionView
   #     end
   #   end
   module RecordIdentifier
+    extend ::ActionView::RecordIdentifier
+
     extend ModelNaming
 
     include ModelNaming
@@ -9085,6 +9187,8 @@ module ActionView
     #   dom_id(Post.find(45), :edit) # => "edit_post_45"
     #   dom_id(Post.new, :custom)    # => "custom_post"
     def dom_id: (untyped record, ?untyped? prefix) -> untyped
+
+    private
 
     def record_key_for_dom_id: (untyped record) -> untyped
   end
@@ -9134,6 +9238,8 @@ module ActionView
       EMPTY_SPACER: untyped
     end
 
+    private
+
     def extract_details: (untyped options) -> untyped
 
     def instrument: (untyped name, **untyped options) { (untyped) -> untyped } -> untyped
@@ -9150,6 +9256,8 @@ module ActionView
   module CollectionCaching
     # :nodoc:
     extend ActiveSupport::Concern
+
+    private
 
     def cache_collection_render: (untyped instrumentation_payload, untyped view, untyped template) { () -> untyped } -> untyped
 
@@ -9454,6 +9562,8 @@ module ActionView
 
     def render: (untyped context, untyped options, untyped block) -> untyped
 
+    private
+
     def render_collection: (untyped view, untyped template) -> untyped
 
     def render_partial: (untyped view, untyped template) -> untyped
@@ -9563,11 +9673,15 @@ module ActionView
 
       def each: () { () -> untyped } -> untyped
 
+      private
+
       # This is the same logging logic as in ShowExceptions middleware.
       def log_error: (untyped exception) -> (nil | untyped)
     end
 
     def render_template: (untyped view, untyped template, ?untyped? layout_name, ?::Hash[untyped, untyped] locals) -> (::Array[untyped] | untyped)
+
+    private
 
     def delayed_render: (untyped buffer, untyped template, untyped layout, untyped view, untyped locals) -> untyped
   end
@@ -9577,6 +9691,8 @@ module ActionView
   class TemplateRenderer < AbstractRenderer
     # nodoc:
     def render: (untyped context, untyped options) -> untyped
+
+    private
 
     # Determine the template to be rendered using the given options.
     def determine_template: (untyped options) -> untyped
@@ -9653,6 +9769,8 @@ module ActionView
     def view_renderer: () -> untyped
 
     def render_to_body: (?::Hash[untyped, untyped] options) -> untyped
+
+    private
 
     # Find and render a template based on the options given.
     def _render_template: (untyped options) -> untyped
@@ -9747,6 +9865,8 @@ module ActionView
 
     def url_options: () -> untyped
 
+    private
+
     def _routes_context: () -> untyped
 
     def optimize_routes_generation?: () -> untyped
@@ -9803,6 +9923,8 @@ module ActionView
 
       def annotated_source_code: () -> untyped
 
+      private
+
       def source_location: () -> untyped
 
       def formatted_code_for: (untyped source_code, untyped line_counter, untyped indent) -> untyped
@@ -9828,6 +9950,8 @@ module ActionView
     class Builder
       def call: (untyped template, untyped source) -> untyped
 
+      private
+
       def require_engine: () -> untyped
     end
   end
@@ -9842,6 +9966,8 @@ module ActionView
           def initialize: (untyped input, ?::Hash[untyped, untyped] properties) -> untyped
 
           def evaluate: (untyped action_view_erb_handler_context) -> untyped
+
+          private
 
           def add_text: (untyped text) -> (nil | untyped)
 
@@ -9873,6 +9999,8 @@ module ActionView
         def handles_encoding?: () -> ::TrueClass
 
         def call: (untyped template, untyped source) -> untyped
+
+        private
 
         def valid_encoding: (untyped string, untyped encoding) -> untyped
       end
@@ -10046,6 +10174,8 @@ module ActionView
 
       def size: () -> untyped
 
+      private
+
       def canonical_no_templates: (untyped templates) -> untyped
     end
 
@@ -10061,6 +10191,8 @@ module ActionView
     alias find_all_anywhere find_all
 
     def find_all_with_query: (untyped query) -> untyped
+
+    private
 
     def _find_all: (untyped name, untyped prefix, untyped partial, untyped details, untyped key, untyped locals) -> untyped
 
@@ -10086,6 +10218,8 @@ module ActionView
     def initialize: (?untyped? pattern) -> untyped
 
     def clear_cache: () -> untyped
+
+    private
 
     def _find_all: (untyped name, untyped prefix, untyped partial, untyped details, untyped key, untyped locals) -> untyped
 
@@ -10131,6 +10265,8 @@ module ActionView
     # An Optimized resolver for Rails' most common case.
     # nodoc:
     def initialize: (untyped path) -> untyped
+
+    private
 
     def find_template_paths_from_details: (untyped path, untyped details) -> untyped
 
@@ -10306,6 +10442,8 @@ module ActionView
 
     def marshal_load: (untyped array) -> untyped
 
+    private
+
     # Compile a template. This method ensures a template is compiled
     # just once and removes the source after it is compiled.
     def compile!: (untyped view) -> (nil | untyped)
@@ -10410,6 +10548,8 @@ module ActionView
 
         def new: () -> untyped
 
+        private
+
         def include_helper_modules!: () -> untyped
       end
 
@@ -10435,6 +10575,8 @@ module ActionView
 
         def view_rendered?: (untyped view, untyped expected_locals) -> untyped
       end
+
+      private
 
       # Need to experiment if this priority is the best one: rendered => output_buffer
       def document_root_element: () -> untyped
@@ -10486,6 +10628,8 @@ module ActionView
 
     def to_s: () -> untyped
 
+    private
+
     def query: (untyped path, untyped exts, untyped _, untyped locals, cache: untyped cache) -> untyped
   end
 
@@ -10499,6 +10643,8 @@ module ActionView
     def initialize: (untyped source, untyped identifer, untyped handler, untyped options) -> untyped
 
     def bind_locals: (untyped locals) -> untyped
+
+    private
 
     def build_template: (untyped locals) -> Template
   end
@@ -10519,6 +10665,8 @@ module ActionView
       def _view_paths=: (untyped paths) -> untyped
 
       def _prefixes: () -> untyped
+
+      private
 
       # Override this method in your controller if you want to change paths prefixes for finding views.
       # Prefixes defined here will still be added to parents' <tt>._prefixes</tt>.

--- a/gems/actionview/6.0.3.2/patch.rbs
+++ b/gems/actionview/6.0.3.2/patch.rbs
@@ -1,0 +1,18 @@
+module ActionView
+  class OutputBuffer < ActiveSupport::SafeBuffer
+    # alias bug: https://github.com/ruby/rbs/issues/458
+    def safe_concat: (untyped value) -> untyped
+  end
+
+  class LookupContext
+    class DetailsKey
+      # alias bug: https://github.com/ruby/rbs/issues/458
+      def equal?: (untyped other) -> bool
+    end
+  end
+
+  class Resolver
+    # Defined with meta-programming
+    def self.caching: () -> untyped
+  end
+end

--- a/gems/activejob/6.0.3.2/activejob-generated.rbs
+++ b/gems/activejob/6.0.3.2/activejob-generated.rbs
@@ -1,3 +1,27 @@
+# The generated code is based on Ruby on Rails source code
+# You can find the license of Ruby on Rails from following.
+
+#Copyright (c) 2005-2019 David Heinemeier Hansson
+#
+#Permission is hereby granted, free of charge, to any person obtaining
+#a copy of this software and associated documentation files (the
+#"Software"), to deal in the Software without restriction, including
+#without limitation the rights to use, copy, modify, merge, publish,
+#distribute, sublicense, and/or sell copies of the Software, and to
+#permit persons to whom the Software is furnished to do so, subject to
+#the following conditions:
+#
+#The above copyright notice and this permission notice shall be
+#included in all copies or substantial portions of the Software.
+#
+#THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+#EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+#MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+#LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+#OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+#WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 module ActiveJob
   # Raised when an exception is raised during job arguments deserialization.
   #

--- a/gems/activejob/6.0.3.2/activejob-generated.rbs
+++ b/gems/activejob/6.0.3.2/activejob-generated.rbs
@@ -43,6 +43,8 @@ module ActiveJob
   end
 
   module Arguments
+    extend ::ActiveJob::Arguments
+
     # Serializes a set of arguments. Intrinsic types that can safely be
     # serialized without mutation are returned as-is. Arrays/Hashes are
     # serialized element by element. All other types are serialized using
@@ -54,6 +56,8 @@ module ActiveJob
     # deserialized element by element. All other types are deserialized using
     # GlobalID.
     def deserialize: (untyped arguments) -> untyped
+
+    private
 
     # :nodoc:
     PERMITTED_TYPES: ::Array[untyped]
@@ -75,14 +79,6 @@ module ActiveJob
 
     # :nodoc:
     RESERVED_KEYS: ::Array[untyped]
-
-    def self.ruby2_keywords_hash?: (untyped hash) -> untyped
-
-    def self.ruby2_keywords_hash?: (untyped hash) -> ::FalseClass
-
-    def self.ruby2_keywords_hash: (untyped hash) -> untyped
-
-    def self._ruby2_keywords_hash: (*untyped args) -> untyped
 
     def serialize_argument: (untyped argument) -> untyped
 
@@ -431,6 +427,8 @@ module ActiveJob
     #    end
     def deserialize: (untyped job_data) -> untyped
 
+    private
+
     def serialize_arguments_if_needed: (untyped arguments) -> untyped
 
     def deserialize_arguments_if_needed: () -> untyped
@@ -460,6 +458,8 @@ module ActiveJob
       # Returns an instance of the job class queued with arguments available in
       # Job#arguments.
       def perform_later: (*untyped args) -> untyped
+
+      private
 
       def job_or_instantiate: (*untyped args) -> untyped
     end
@@ -574,6 +574,8 @@ module ActiveJob
     #  end
     def retry_job: (?::Hash[untyped, untyped] options) -> untyped
 
+    private
+
     def determine_delay: (executions: untyped executions, seconds_or_duration_or_algorithm: untyped seconds_or_duration_or_algorithm) -> untyped
 
     def instrument: (untyped name, ?wait: untyped? wait, ?error: untyped? error) { () -> untyped } -> untyped
@@ -631,6 +633,8 @@ module ActiveJob
     # nodoc:
     extend ActiveSupport::Concern
 
+    private
+
     def tag_logger: (*untyped tags) { () -> untyped } -> untyped
 
     def logger_tagged_by_active_job?: () -> untyped
@@ -650,6 +654,8 @@ module ActiveJob
       def retry_stopped: (untyped event) -> untyped
 
       def discard: (untyped event) -> untyped
+
+      private
 
       def queue_name: (untyped event) -> untyped
 
@@ -685,6 +691,8 @@ module ActiveJob
       # is the +:async+ queue. See QueueAdapters for more
       # information.
       def queue_adapter=: (untyped name_or_adapter) -> untyped
+
+      private
 
       def assign_adapter: (untyped adapter_name, untyped queue_adapter) -> untyped
 
@@ -1049,6 +1057,8 @@ module ActiveJob
 
       def enqueue_at: (untyped job, untyped timestamp) -> untyped
 
+      private
+
       def job_to_hash: (untyped job, ?::Hash[untyped, untyped] extras) -> untyped
 
       def perform_or_enqueue: (untyped perform, untyped job, untyped job_data) -> untyped
@@ -1267,6 +1277,8 @@ module ActiveJob
 
       def deserialize: (untyped hash) -> untyped
 
+      private
+
       def klass: () -> untyped
     end
   end
@@ -1280,6 +1292,8 @@ module ActiveJob
 
       def deserialize: (untyped hash) -> untyped
 
+      private
+
       def klass: () -> untyped
     end
   end
@@ -1292,6 +1306,8 @@ module ActiveJob
       def serialize: (untyped duration) -> untyped
 
       def deserialize: (untyped hash) -> untyped
+
+      private
 
       def klass: () -> untyped
     end
@@ -1331,6 +1347,8 @@ module ActiveJob
       # Deserializes an argument from a JSON primitive type.
       def deserialize: (untyped _argument) -> untyped
 
+      private
+
       def klass: () -> untyped
     end
   end
@@ -1343,6 +1361,8 @@ module ActiveJob
       def serialize: (untyped argument) -> untyped
 
       def deserialize: (untyped argument) -> untyped
+
+      private
 
       def klass: () -> untyped
     end
@@ -1357,6 +1377,8 @@ module ActiveJob
 
       def deserialize: (untyped hash) -> untyped
 
+      private
+
       def klass: () -> untyped
     end
   end
@@ -1369,6 +1391,8 @@ module ActiveJob
       def serialize: (untyped time) -> untyped
 
       def deserialize: (untyped hash) -> untyped
+
+      private
 
       def klass: () -> untyped
     end
@@ -1856,6 +1880,8 @@ module ActiveJob
     #   end
     def queue_adapter: () -> untyped
 
+    private
+
     def clear_enqueued_jobs: () -> untyped
 
     def clear_performed_jobs: () -> untyped
@@ -1913,6 +1939,8 @@ module Rails
       def self.default_generator_root: () -> untyped
 
       def create_job_file: () -> untyped
+
+      private
 
       def file_name: () -> untyped
 

--- a/gems/activejob/6.0.3.2/activejob-generated.rbs
+++ b/gems/activejob/6.0.3.2/activejob-generated.rbs
@@ -1,0 +1,1899 @@
+module ActiveJob
+  # Raised when an exception is raised during job arguments deserialization.
+  #
+  # Wraps the original exception raised as +cause+.
+  class DeserializationError < StandardError
+    def initialize: () -> untyped
+  end
+
+  # Raised when an unsupported argument type is set as a job argument. We
+  # currently support String, Integer, Float, NilClass, TrueClass, FalseClass,
+  # BigDecimal, Symbol, Date, Time, DateTime, ActiveSupport::TimeWithZone,
+  # ActiveSupport::Duration, Hash, ActiveSupport::HashWithIndifferentAccess,
+  # Array or GlobalID::Identification instances, although this can be extended
+  # by adding custom serializers.
+  # Raised if you set the key for a Hash something else than a string or
+  # a symbol. Also raised when trying to serialize an object which can't be
+  # identified with a GlobalID - such as an unpersisted Active Record model.
+  class SerializationError < ArgumentError
+  end
+
+  module Arguments
+    # Serializes a set of arguments. Intrinsic types that can safely be
+    # serialized without mutation are returned as-is. Arrays/Hashes are
+    # serialized element by element. All other types are serialized using
+    # GlobalID.
+    def serialize: (untyped arguments) -> untyped
+
+    # Deserializes a set of arguments. Intrinsic types that can safely be
+    # deserialized without mutation are returned as-is. Arrays/Hashes are
+    # deserialized element by element. All other types are deserialized using
+    # GlobalID.
+    def deserialize: (untyped arguments) -> untyped
+
+    # :nodoc:
+    PERMITTED_TYPES: ::Array[untyped]
+
+    # :nodoc:
+    GLOBALID_KEY: ::String
+
+    # :nodoc:
+    SYMBOL_KEYS_KEY: ::String
+
+    # :nodoc:
+    RUBY2_KEYWORDS_KEY: ::String
+
+    # :nodoc:
+    WITH_INDIFFERENT_ACCESS_KEY: ::String
+
+    # :nodoc:
+    OBJECT_SERIALIZER_KEY: ::String
+
+    # :nodoc:
+    RESERVED_KEYS: ::Array[untyped]
+
+    def self.ruby2_keywords_hash?: (untyped hash) -> untyped
+
+    def self.ruby2_keywords_hash?: (untyped hash) -> ::FalseClass
+
+    def self.ruby2_keywords_hash: (untyped hash) -> untyped
+
+    def self._ruby2_keywords_hash: (*untyped args) -> untyped
+
+    def serialize_argument: (untyped argument) -> untyped
+
+    def deserialize_argument: (untyped argument) -> untyped
+
+    def serialized_global_id?: (untyped hash) -> untyped
+
+    def deserialize_global_id: (untyped hash) -> untyped
+
+    def custom_serialized?: (untyped hash) -> untyped
+
+    def serialize_hash: (untyped argument) -> untyped
+
+    def deserialize_hash: (untyped serialized_hash) -> untyped
+
+    def serialize_hash_key: (untyped key) -> untyped
+
+    def serialize_indifferent_hash: (untyped indifferent_hash) -> untyped
+
+    def transform_symbol_keys: (untyped hash, untyped symbol_keys) -> untyped
+
+    def convert_to_global_id_hash: (untyped argument) -> untyped
+  end
+end
+
+module ActiveJob
+  # nodoc:
+  # = Active Job
+  #
+  # Active Job objects can be configured to work with different backend
+  # queuing frameworks. To specify a queue adapter to use:
+  #
+  #   ActiveJob::Base.queue_adapter = :inline
+  #
+  # A list of supported adapters can be found in QueueAdapters.
+  #
+  # Active Job objects can be defined by creating a class that inherits
+  # from the ActiveJob::Base class. The only necessary method to
+  # implement is the "perform" method.
+  #
+  # To define an Active Job object:
+  #
+  #   class ProcessPhotoJob < ActiveJob::Base
+  #     def perform(photo)
+  #       photo.watermark!('Rails')
+  #       photo.rotate!(90.degrees)
+  #       photo.resize_to_fit!(300, 300)
+  #       photo.upload!
+  #     end
+  #   end
+  #
+  # Records that are passed in are serialized/deserialized using Global
+  # ID. More information can be found in Arguments.
+  #
+  # To enqueue a job to be performed as soon as the queuing system is free:
+  #
+  #   ProcessPhotoJob.perform_later(photo)
+  #
+  # To enqueue a job to be processed at some point in the future:
+  #
+  #   ProcessPhotoJob.set(wait_until: Date.tomorrow.noon).perform_later(photo)
+  #
+  # More information can be found in ActiveJob::Core::ClassMethods#set
+  #
+  # A job can also be processed immediately without sending to the queue:
+  #
+  #  ProcessPhotoJob.perform_now(photo)
+  #
+  # == Exceptions
+  #
+  # * DeserializationError - Error class for deserialization errors.
+  # * SerializationError - Error class for serialization errors.
+  class Base
+    include Core
+
+    include QueueAdapter
+
+    include QueueName
+
+    include QueuePriority
+
+    include Enqueuing
+
+    include Execution
+
+    include Callbacks
+
+    include Exceptions
+
+    include Logging
+
+    include Timezones
+
+    include Translation
+  end
+end
+
+module ActiveJob
+  # = Active Job Callbacks
+  #
+  # Active Job provides hooks during the life cycle of a job. Callbacks allow you
+  # to trigger logic during this cycle. Available callbacks are:
+  #
+  # * <tt>before_enqueue</tt>
+  # * <tt>around_enqueue</tt>
+  # * <tt>after_enqueue</tt>
+  # * <tt>before_perform</tt>
+  # * <tt>around_perform</tt>
+  # * <tt>after_perform</tt>
+  #
+  # NOTE: Calling the same callback multiple times will overwrite previous callback definitions.
+  #
+  module Callbacks
+    extend ActiveSupport::Concern
+
+    include ActiveSupport::Callbacks
+
+    include ActiveSupport::Callbacks
+
+    # These methods will be included into any Active Job object, adding
+    # callbacks for +perform+ and +enqueue+ methods.
+    module ClassMethods
+      # Defines a callback that will get called right before the
+      # job's perform method is executed.
+      #
+      #   class VideoProcessJob < ActiveJob::Base
+      #     queue_as :default
+      #
+      #     before_perform do |job|
+      #       UserMailer.notify_video_started_processing(job.arguments.first)
+      #     end
+      #
+      #     def perform(video_id)
+      #       Video.find(video_id).process
+      #     end
+      #   end
+      #
+      def before_perform: (*untyped filters) { () -> untyped } -> untyped
+
+      # Defines a callback that will get called right after the
+      # job's perform method has finished.
+      #
+      #   class VideoProcessJob < ActiveJob::Base
+      #     queue_as :default
+      #
+      #     after_perform do |job|
+      #       UserMailer.notify_video_processed(job.arguments.first)
+      #     end
+      #
+      #     def perform(video_id)
+      #       Video.find(video_id).process
+      #     end
+      #   end
+      #
+      def after_perform: (*untyped filters) { () -> untyped } -> untyped
+
+      # Defines a callback that will get called around the job's perform method.
+      #
+      #   class VideoProcessJob < ActiveJob::Base
+      #     queue_as :default
+      #
+      #     around_perform do |job, block|
+      #       UserMailer.notify_video_started_processing(job.arguments.first)
+      #       block.call
+      #       UserMailer.notify_video_processed(job.arguments.first)
+      #     end
+      #
+      #     def perform(video_id)
+      #       Video.find(video_id).process
+      #     end
+      #   end
+      #
+      def around_perform: (*untyped filters) { () -> untyped } -> untyped
+
+      # Defines a callback that will get called right before the
+      # job is enqueued.
+      #
+      #   class VideoProcessJob < ActiveJob::Base
+      #     queue_as :default
+      #
+      #     before_enqueue do |job|
+      #       $statsd.increment "enqueue-video-job.try"
+      #     end
+      #
+      #     def perform(video_id)
+      #       Video.find(video_id).process
+      #     end
+      #   end
+      #
+      def before_enqueue: (*untyped filters) { () -> untyped } -> untyped
+
+      # Defines a callback that will get called right after the
+      # job is enqueued.
+      #
+      #   class VideoProcessJob < ActiveJob::Base
+      #     queue_as :default
+      #
+      #     after_enqueue do |job|
+      #       $statsd.increment "enqueue-video-job.success"
+      #     end
+      #
+      #     def perform(video_id)
+      #       Video.find(video_id).process
+      #     end
+      #   end
+      #
+      def after_enqueue: (*untyped filters) { () -> untyped } -> untyped
+
+      # Defines a callback that will get called around the enqueuing
+      # of the job.
+      #
+      #   class VideoProcessJob < ActiveJob::Base
+      #     queue_as :default
+      #
+      #     around_enqueue do |job, block|
+      #       $statsd.time "video-job.process" do
+      #         block.call
+      #       end
+      #     end
+      #
+      #     def perform(video_id)
+      #       Video.find(video_id).process
+      #     end
+      #   end
+      #
+      def around_enqueue: (*untyped filters) { () -> untyped } -> untyped
+    end
+  end
+end
+
+module ActiveJob
+  class ConfiguredJob
+    # nodoc:
+    def initialize: (untyped job_class, ?::Hash[untyped, untyped] options) -> untyped
+
+    def perform_now: (*untyped args) -> untyped
+
+    def perform_later: (*untyped args) -> untyped
+  end
+end
+
+module ActiveJob
+  # Provides general behavior that will be included into every Active Job
+  # object that inherits from ActiveJob::Base.
+  module Core
+    extend ActiveSupport::Concern
+
+    # Job arguments
+    attr_accessor arguments: untyped
+
+    attr_writer serialized_arguments: untyped
+
+    # Timestamp when the job should be performed
+    attr_accessor scheduled_at: untyped
+
+    # Job Identifier
+    attr_accessor job_id: untyped
+
+    # Queue in which the job will reside.
+    attr_writer queue_name: untyped
+
+    # Priority that the job will have (lower is more priority).
+    attr_writer priority: untyped
+
+    # ID optionally provided by adapter
+    attr_accessor provider_job_id: untyped
+
+    # Number of times this job has been executed (which increments on every retry, like after an exception).
+    attr_accessor executions: untyped
+
+    # Hash that contains the number of times this job handled errors for each specific retry_on declaration.
+    # Keys are the string representation of the exceptions listed in the retry_on declaration,
+    # while its associated value holds the number of executions where the corresponding retry_on
+    # declaration handled one of its listed exceptions.
+    attr_accessor exception_executions: untyped
+
+    # I18n.locale to be used during the job.
+    attr_accessor locale: untyped
+
+    # Timezone to be used during the job.
+    attr_accessor timezone: untyped
+
+    # Track when a job was enqueued
+    attr_accessor enqueued_at: untyped
+
+    # These methods will be included into any Active Job object, adding
+    # helpers for de/serialization and creation of job instances.
+    module ClassMethods
+      # Creates a new job instance from a hash created with +serialize+
+      def deserialize: (untyped job_data) -> untyped
+
+      # Creates a job preconfigured with the given options. You can call
+      # perform_later with the job arguments to enqueue the job with the
+      # preconfigured options
+      #
+      # ==== Options
+      # * <tt>:wait</tt> - Enqueues the job with the specified delay
+      # * <tt>:wait_until</tt> - Enqueues the job at the time specified
+      # * <tt>:queue</tt> - Enqueues the job on the specified queue
+      # * <tt>:priority</tt> - Enqueues the job with the specified priority
+      #
+      # ==== Examples
+      #
+      #    VideoJob.set(queue: :some_queue).perform_later(Video.last)
+      #    VideoJob.set(wait: 5.minutes).perform_later(Video.last)
+      #    VideoJob.set(wait_until: Time.now.tomorrow).perform_later(Video.last)
+      #    VideoJob.set(queue: :some_queue, wait: 5.minutes).perform_later(Video.last)
+      #    VideoJob.set(queue: :some_queue, wait_until: Time.now.tomorrow).perform_later(Video.last)
+      #    VideoJob.set(queue: :some_queue, wait: 5.minutes, priority: 10).perform_later(Video.last)
+      def set: (?::Hash[untyped, untyped] options) -> ConfiguredJob
+    end
+
+    # Creates a new job instance. Takes the arguments that will be
+    # passed to the perform method.
+    def initialize: (*untyped arguments) -> untyped
+
+    # Returns a hash with the job data that can safely be passed to the
+    # queuing adapter.
+    def serialize: () -> ::Hash[::String, untyped]
+
+    # Attaches the stored job data to the current instance. Receives a hash
+    # returned from +serialize+
+    #
+    # ==== Examples
+    #
+    #    class DeliverWebhookJob < ActiveJob::Base
+    #      attr_writer :attempt_number
+    #
+    #      def attempt_number
+    #        @attempt_number ||= 0
+    #      end
+    #
+    #      def serialize
+    #        super.merge('attempt_number' => attempt_number + 1)
+    #      end
+    #
+    #      def deserialize(job_data)
+    #        super
+    #        self.attempt_number = job_data['attempt_number']
+    #      end
+    #
+    #      rescue_from(Timeout::Error) do |exception|
+    #        raise exception if attempt_number > 5
+    #        retry_job(wait: 10)
+    #      end
+    #    end
+    def deserialize: (untyped job_data) -> untyped
+
+    def serialize_arguments_if_needed: (untyped arguments) -> untyped
+
+    def deserialize_arguments_if_needed: () -> untyped
+
+    def serialize_arguments: (untyped arguments) -> untyped
+
+    def deserialize_arguments: (untyped serialized_args) -> untyped
+
+    def arguments_serialized?: () -> untyped
+  end
+end
+
+module ActiveJob
+  # Provides behavior for enqueuing jobs.
+  module Enqueuing
+    extend ActiveSupport::Concern
+
+    # Includes the +perform_later+ method for job initialization.
+    module ClassMethods
+      # Push a job onto the queue. By default the arguments must be either String,
+      # Integer, Float, NilClass, TrueClass, FalseClass, BigDecimal, Symbol, Date,
+      # Time, DateTime, ActiveSupport::TimeWithZone, ActiveSupport::Duration,
+      # Hash, ActiveSupport::HashWithIndifferentAccess, Array or
+      # GlobalID::Identification instances, although this can be extended by adding
+      # custom serializers.
+      #
+      # Returns an instance of the job class queued with arguments available in
+      # Job#arguments.
+      def perform_later: (*untyped args) -> untyped
+
+      def job_or_instantiate: (*untyped args) -> untyped
+    end
+
+    # Enqueues the job to be performed by the queue adapter.
+    #
+    # ==== Options
+    # * <tt>:wait</tt> - Enqueues the job with the specified delay
+    # * <tt>:wait_until</tt> - Enqueues the job at the time specified
+    # * <tt>:queue</tt> - Enqueues the job on the specified queue
+    # * <tt>:priority</tt> - Enqueues the job with the specified priority
+    #
+    # ==== Examples
+    #
+    #    my_job_instance.enqueue
+    #    my_job_instance.enqueue wait: 5.minutes
+    #    my_job_instance.enqueue queue: :important
+    #    my_job_instance.enqueue wait_until: Date.tomorrow.midnight
+    #    my_job_instance.enqueue priority: 10
+    def enqueue: (?::Hash[untyped, untyped] options) -> untyped
+  end
+end
+
+module ActiveJob
+  # Provides behavior for retrying and discarding jobs on exceptions.
+  module Exceptions
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      # Catch the exception and reschedule job for re-execution after so many seconds, for a specific number of attempts.
+      # If the exception keeps getting raised beyond the specified number of attempts, the exception is allowed to
+      # bubble up to the underlying queuing system, which may have its own retry mechanism or place it in a
+      # holding queue for inspection.
+      #
+      # You can also pass a block that'll be invoked if the retry attempts fail for custom logic rather than letting
+      # the exception bubble up. This block is yielded with the job instance as the first and the error instance as the second parameter.
+      #
+      # ==== Options
+      # * <tt>:wait</tt> - Re-enqueues the job with a delay specified either in seconds (default: 3 seconds),
+      #   as a computing proc that the number of executions so far as an argument, or as a symbol reference of
+      #   <tt>:exponentially_longer</tt>, which applies the wait algorithm of <tt>(executions ** 4) + 2</tt>
+      #   (first wait 3s, then 18s, then 83s, etc)
+      # * <tt>:attempts</tt> - Re-enqueues the job the specified number of times (default: 5 attempts)
+      # * <tt>:queue</tt> - Re-enqueues the job on a different queue
+      # * <tt>:priority</tt> - Re-enqueues the job with a different priority
+      #
+      # ==== Examples
+      #
+      #  class RemoteServiceJob < ActiveJob::Base
+      #    retry_on CustomAppException # defaults to 3s wait, 5 attempts
+      #    retry_on AnotherCustomAppException, wait: ->(executions) { executions * 2 }
+      #
+      #    retry_on ActiveRecord::Deadlocked, wait: 5.seconds, attempts: 3
+      #    retry_on Net::OpenTimeout, Timeout::Error, wait: :exponentially_longer, attempts: 10 # retries at most 10 times for Net::OpenTimeout and Timeout::Error combined
+      #    # To retry at most 10 times for each individual exception:
+      #    # retry_on Net::OpenTimeout, wait: :exponentially_longer, attempts: 10
+      #    # retry_on Timeout::Error, wait: :exponentially_longer, attempts: 10
+      #
+      #    retry_on(YetAnotherCustomAppException) do |job, error|
+      #      ExceptionNotifier.caught(error)
+      #    end
+      #
+      #    def perform(*args)
+      #      # Might raise CustomAppException, AnotherCustomAppException, or YetAnotherCustomAppException for something domain specific
+      #      # Might raise ActiveRecord::Deadlocked when a local db deadlock is detected
+      #      # Might raise Net::OpenTimeout or Timeout::Error when the remote service is down
+      #    end
+      #  end
+      def retry_on: (*untyped exceptions, ?priority: untyped? priority, ?queue: untyped? queue, ?attempts: ::Integer attempts, ?wait: untyped wait) { (untyped, untyped) -> untyped } -> untyped
+
+      # Discard the job with no attempts to retry, if the exception is raised. This is useful when the subject of the job,
+      # like an Active Record, is no longer available, and the job is thus no longer relevant.
+      #
+      # You can also pass a block that'll be invoked. This block is yielded with the job instance as the first and the error instance as the second parameter.
+      #
+      # ==== Example
+      #
+      #  class SearchIndexingJob < ActiveJob::Base
+      #    discard_on ActiveJob::DeserializationError
+      #    discard_on(CustomAppException) do |job, error|
+      #      ExceptionNotifier.caught(error)
+      #    end
+      #
+      #    def perform(record)
+      #      # Will raise ActiveJob::DeserializationError if the record can't be deserialized
+      #      # Might raise CustomAppException for something domain specific
+      #    end
+      #  end
+      def discard_on: (*untyped exceptions) { (untyped, untyped) -> untyped } -> untyped
+    end
+
+    # Reschedules the job to be re-executed. This is useful in combination
+    # with the +rescue_from+ option. When you rescue an exception from your job
+    # you can ask Active Job to retry performing your job.
+    #
+    # ==== Options
+    # * <tt>:wait</tt> - Enqueues the job with the specified delay in seconds
+    # * <tt>:wait_until</tt> - Enqueues the job at the time specified
+    # * <tt>:queue</tt> - Enqueues the job on the specified queue
+    # * <tt>:priority</tt> - Enqueues the job with the specified priority
+    #
+    # ==== Examples
+    #
+    #  class SiteScraperJob < ActiveJob::Base
+    #    rescue_from(ErrorLoadingSite) do
+    #      retry_job queue: :low_priority
+    #    end
+    #
+    #    def perform(*args)
+    #      # raise ErrorLoadingSite if cannot scrape
+    #    end
+    #  end
+    def retry_job: (?::Hash[untyped, untyped] options) -> untyped
+
+    def determine_delay: (executions: untyped executions, seconds_or_duration_or_algorithm: untyped seconds_or_duration_or_algorithm) -> untyped
+
+    def instrument: (untyped name, ?wait: untyped? wait, ?error: untyped? error) { () -> untyped } -> untyped
+
+    def executions_for: (untyped exceptions) -> untyped
+  end
+end
+
+module ActiveJob
+  module Execution
+    extend ActiveSupport::Concern
+
+    include ActiveSupport::Rescuable
+
+    # Includes methods for executing and performing jobs instantly.
+    module ClassMethods
+      # Performs the job immediately.
+      #
+      #   MyJob.perform_now("mike")
+      #
+      def perform_now: (*untyped args) -> untyped
+
+      def execute: (untyped job_data) -> untyped
+    end
+
+    # Performs the job immediately. The job is not sent to the queuing adapter
+    # but directly executed by blocking the execution of others until it's finished.
+    #
+    #   MyJob.new(*args).perform_now
+    def perform_now: () -> untyped
+
+    def perform: () -> untyped
+  end
+end
+
+module ActiveJob
+  # Returns the version of the currently loaded Active Job as a <tt>Gem::Version</tt>
+  def self.gem_version: () -> Gem::Version
+
+  module VERSION
+    MAJOR: ::Integer
+
+    MINOR: ::Integer
+
+    TINY: ::Integer
+
+    PRE: ::String
+
+    STRING: untyped
+  end
+end
+
+module ActiveJob
+  module Logging
+    # nodoc:
+    extend ActiveSupport::Concern
+
+    def tag_logger: (*untyped tags) { () -> untyped } -> untyped
+
+    def logger_tagged_by_active_job?: () -> untyped
+
+    class LogSubscriber < ActiveSupport::LogSubscriber
+      # nodoc:
+      def enqueue: (untyped event) -> untyped
+
+      def enqueue_at: (untyped event) -> untyped
+
+      def perform_start: (untyped event) -> untyped
+
+      def perform: (untyped event) -> untyped
+
+      def enqueue_retry: (untyped event) -> untyped
+
+      def retry_stopped: (untyped event) -> untyped
+
+      def discard: (untyped event) -> untyped
+
+      def queue_name: (untyped event) -> untyped
+
+      def args_info: (untyped job) -> untyped
+
+      def format: (untyped arg) -> untyped
+
+      def scheduled_at: (untyped event) -> untyped
+
+      def logger: () -> untyped
+    end
+  end
+end
+
+module ActiveJob
+  module QueueAdapter
+    # The <tt>ActiveJob::QueueAdapter</tt> module is used to load the
+    # correct adapter. The default queue adapter is the +:async+ queue.
+    # nodoc:
+    extend ActiveSupport::Concern
+
+    # Includes the setter method for changing the active queue adapter.
+    module ClassMethods
+      # Returns the backend queue provider. The default queue adapter
+      # is the +:async+ queue. See QueueAdapters for more information.
+      def queue_adapter: () -> untyped
+
+      # Returns string denoting the name of the configured queue adapter.
+      # By default returns +"async"+.
+      def queue_adapter_name: () -> untyped
+
+      # Specify the backend queue provider. The default queue adapter
+      # is the +:async+ queue. See QueueAdapters for more
+      # information.
+      def queue_adapter=: (untyped name_or_adapter) -> untyped
+
+      def assign_adapter: (untyped adapter_name, untyped queue_adapter) -> untyped
+
+      QUEUE_ADAPTER_METHODS: untyped
+
+      def queue_adapter?: (untyped object) -> untyped
+    end
+  end
+end
+
+module ActiveJob
+  module QueueAdapters
+    # == Active Job Async adapter
+    #
+    # The Async adapter runs jobs with an in-process thread pool.
+    #
+    # This is the default queue adapter. It's well-suited for dev/test since
+    # it doesn't need an external infrastructure, but it's a poor fit for
+    # production since it drops pending jobs on restart.
+    #
+    # To use this adapter, set queue adapter to +:async+:
+    #
+    #   config.active_job.queue_adapter = :async
+    #
+    # To configure the adapter's thread pool, instantiate the adapter and
+    # pass your own config:
+    #
+    #   config.active_job.queue_adapter = ActiveJob::QueueAdapters::AsyncAdapter.new \
+    #     min_threads: 1,
+    #     max_threads: 2 * Concurrent.processor_count,
+    #     idletime: 600.seconds
+    #
+    # The adapter uses a {Concurrent Ruby}[https://github.com/ruby-concurrency/concurrent-ruby] thread pool to schedule and execute
+    # jobs. Since jobs share a single thread pool, long-running jobs will block
+    # short-lived jobs. Fine for dev/test; bad for production.
+    class AsyncAdapter
+      # See {Concurrent::ThreadPoolExecutor}[https://ruby-concurrency.github.io/concurrent-ruby/master/Concurrent/ThreadPoolExecutor.html] for executor options.
+      def initialize: (**untyped executor_options) -> untyped
+
+      def enqueue: (untyped job) -> untyped
+
+      def enqueue_at: (untyped job, untyped timestamp) -> untyped
+
+      def shutdown: (?wait: bool wait) -> untyped
+
+      def immediate=: (untyped immediate) -> untyped
+
+      class JobWrapper
+        # Note that we don't actually need to serialize the jobs since we're
+        # performing them in-process, but we do so anyway for parity with other
+        # adapters and deployment environments. Otherwise, serialization bugs
+        # may creep in undetected.
+        # nodoc:
+        def initialize: (untyped job) -> untyped
+
+        def perform: () -> untyped
+      end
+
+      class Scheduler
+        # nodoc:
+        DEFAULT_EXECUTOR_OPTIONS: untyped
+
+        attr_accessor immediate: untyped
+
+        def initialize: (**untyped options) -> untyped
+
+        def enqueue: (untyped job, queue_name: untyped queue_name) -> untyped
+
+        def enqueue_at: (untyped job, untyped timestamp, queue_name: untyped queue_name) -> untyped
+
+        def shutdown: (?wait: bool wait) -> untyped
+
+        def executor: () -> untyped
+      end
+    end
+  end
+end
+
+module ActiveJob
+  module QueueAdapters
+    # == Backburner adapter for Active Job
+    #
+    # Backburner is a beanstalkd-powered job queue that can handle a very
+    # high volume of jobs. You create background jobs and place them on
+    # multiple work queues to be processed later. Read more about
+    # Backburner {here}[https://github.com/nesquena/backburner].
+    #
+    # To use Backburner set the queue_adapter config to +:backburner+.
+    #
+    #   Rails.application.config.active_job.queue_adapter = :backburner
+    class BackburnerAdapter
+      def enqueue: (untyped job) -> untyped
+
+      def enqueue_at: (untyped job, untyped timestamp) -> untyped
+
+      class JobWrapper
+        def self.perform: (untyped job_data) -> untyped
+      end
+    end
+  end
+end
+
+module ActiveJob
+  module QueueAdapters
+    # == Delayed Job adapter for Active Job
+    #
+    # Delayed::Job (or DJ) encapsulates the common pattern of asynchronously
+    # executing longer tasks in the background. Although DJ can have many
+    # storage backends, one of the most used is based on Active Record.
+    # Read more about Delayed Job {here}[https://github.com/collectiveidea/delayed_job].
+    #
+    # To use Delayed Job, set the queue_adapter config to +:delayed_job+.
+    #
+    #   Rails.application.config.active_job.queue_adapter = :delayed_job
+    class DelayedJobAdapter
+      def enqueue: (untyped job) -> untyped
+
+      def enqueue_at: (untyped job, untyped timestamp) -> untyped
+
+      class JobWrapper
+        # nodoc:
+        attr_accessor job_data: untyped
+
+        def initialize: (untyped job_data) -> untyped
+
+        def display_name: () -> ::String
+
+        def perform: () -> untyped
+      end
+    end
+  end
+end
+
+module ActiveJob
+  module QueueAdapters
+    # == Active Job Inline adapter
+    #
+    # When enqueuing jobs with the Inline adapter the job will be executed
+    # immediately.
+    #
+    # To use the Inline set the queue_adapter config to +:inline+.
+    #
+    #   Rails.application.config.active_job.queue_adapter = :inline
+    class InlineAdapter
+      def enqueue: (untyped job) -> untyped
+
+      def enqueue_at: () -> untyped
+    end
+  end
+end
+
+module ActiveJob
+  module QueueAdapters
+    # == Que adapter for Active Job
+    #
+    # Que is a high-performance alternative to DelayedJob or QueueClassic that
+    # improves the reliability of your application by protecting your jobs with
+    # the same ACID guarantees as the rest of your data. Que is a queue for
+    # Ruby and PostgreSQL that manages jobs using advisory locks.
+    #
+    # Read more about Que {here}[https://github.com/chanks/que].
+    #
+    # To use Que set the queue_adapter config to +:que+.
+    #
+    #   Rails.application.config.active_job.queue_adapter = :que
+    class QueAdapter
+      def enqueue: (untyped job) -> untyped
+
+      def enqueue_at: (untyped job, untyped timestamp) -> untyped
+
+      class JobWrapper < Que::Job
+        # nodoc:
+        def run: (untyped job_data) -> untyped
+      end
+    end
+  end
+end
+
+module ActiveJob
+  module QueueAdapters
+    # == queue_classic adapter for Active Job
+    #
+    # queue_classic provides a simple interface to a PostgreSQL-backed message
+    # queue. queue_classic specializes in concurrent locking and minimizing
+    # database load while providing a simple, intuitive developer experience.
+    # queue_classic assumes that you are already using PostgreSQL in your
+    # production environment and that adding another dependency (e.g. redis,
+    # beanstalkd, 0mq) is undesirable.
+    #
+    # Read more about queue_classic {here}[https://github.com/QueueClassic/queue_classic].
+    #
+    # To use queue_classic set the queue_adapter config to +:queue_classic+.
+    #
+    #   Rails.application.config.active_job.queue_adapter = :queue_classic
+    class QueueClassicAdapter
+      def enqueue: (untyped job) -> untyped
+
+      def enqueue_at: (untyped job, untyped timestamp) -> untyped
+
+      # Builds a <tt>QC::Queue</tt> object to schedule jobs on.
+      #
+      # If you have a custom <tt>QC::Queue</tt> subclass you'll need to subclass
+      # <tt>ActiveJob::QueueAdapters::QueueClassicAdapter</tt> and override the
+      # <tt>build_queue</tt> method.
+      def build_queue: (untyped queue_name) -> QC::Queue
+
+      class JobWrapper
+        def self.perform: (untyped job_data) -> untyped
+      end
+    end
+  end
+end
+
+module ActiveJob
+  module QueueAdapters
+    # == Resque adapter for Active Job
+    #
+    # Resque (pronounced like "rescue") is a Redis-backed library for creating
+    # background jobs, placing those jobs on multiple queues, and processing
+    # them later.
+    #
+    # Read more about Resque {here}[https://github.com/resque/resque].
+    #
+    # To use Resque set the queue_adapter config to +:resque+.
+    #
+    #   Rails.application.config.active_job.queue_adapter = :resque
+    class ResqueAdapter
+      def enqueue: (untyped job) -> untyped
+
+      def enqueue_at: (untyped job, untyped timestamp) -> untyped
+
+      class JobWrapper
+        def self.perform: (untyped job_data) -> untyped
+      end
+    end
+  end
+end
+
+module ActiveJob
+  module QueueAdapters
+    # == Sidekiq adapter for Active Job
+    #
+    # Simple, efficient background processing for Ruby. Sidekiq uses threads to
+    # handle many jobs at the same time in the same process. It does not
+    # require Rails but will integrate tightly with it to make background
+    # processing dead simple.
+    #
+    # Read more about Sidekiq {here}[http://sidekiq.org].
+    #
+    # To use Sidekiq set the queue_adapter config to +:sidekiq+.
+    #
+    #   Rails.application.config.active_job.queue_adapter = :sidekiq
+    class SidekiqAdapter
+      def enqueue: (untyped job) -> untyped
+
+      def enqueue_at: (untyped job, untyped timestamp) -> untyped
+
+      class JobWrapper
+        # nodoc:
+        include Sidekiq::Worker
+
+        def perform: (untyped job_data) -> untyped
+      end
+    end
+  end
+end
+
+module ActiveJob
+  module QueueAdapters
+    # == Sneakers adapter for Active Job
+    #
+    # A high-performance RabbitMQ background processing framework for Ruby.
+    # Sneakers is being used in production for both I/O and CPU intensive
+    # workloads, and have achieved the goals of high-performance and
+    # 0-maintenance, as designed.
+    #
+    # Read more about Sneakers {here}[https://github.com/jondot/sneakers].
+    #
+    # To use Sneakers set the queue_adapter config to +:sneakers+.
+    #
+    #   Rails.application.config.active_job.queue_adapter = :sneakers
+    class SneakersAdapter
+      def initialize: () -> untyped
+
+      def enqueue: (untyped job) -> untyped
+
+      def enqueue_at: (untyped job, untyped timestamp) -> untyped
+
+      class JobWrapper
+        # nodoc:
+        include Sneakers::Worker
+
+        def work: (untyped msg) -> untyped
+      end
+    end
+  end
+end
+
+module ActiveJob
+  module QueueAdapters
+    # == Sucker Punch adapter for Active Job
+    #
+    # Sucker Punch is a single-process Ruby asynchronous processing library.
+    # This reduces the cost of hosting on a service like Heroku along
+    # with the memory footprint of having to maintain additional jobs if
+    # hosting on a dedicated server. All queues can run within a
+    # single application (eg. Rails, Sinatra, etc.) process.
+    #
+    # Read more about Sucker Punch {here}[https://github.com/brandonhilkert/sucker_punch].
+    #
+    # To use Sucker Punch set the queue_adapter config to +:sucker_punch+.
+    #
+    #   Rails.application.config.active_job.queue_adapter = :sucker_punch
+    class SuckerPunchAdapter
+      def enqueue: (untyped job) -> untyped
+
+      def enqueue_at: (untyped job, untyped timestamp) -> untyped
+
+      class JobWrapper
+        # nodoc:
+        include SuckerPunch::Job
+
+        def perform: (untyped job_data) -> untyped
+      end
+    end
+  end
+end
+
+module ActiveJob
+  module QueueAdapters
+    # == Test adapter for Active Job
+    #
+    # The test adapter should be used only in testing. Along with
+    # <tt>ActiveJob::TestCase</tt> and <tt>ActiveJob::TestHelper</tt>
+    # it makes a great tool to test your Rails application.
+    #
+    # To use the test adapter set queue_adapter config to +:test+.
+    #
+    #   Rails.application.config.active_job.queue_adapter = :test
+    class TestAdapter
+      attr_accessor perform_enqueued_jobs: untyped
+
+      attr_accessor perform_enqueued_at_jobs: untyped
+
+      attr_accessor filter: untyped
+
+      attr_accessor reject: untyped
+
+      attr_accessor queue: untyped
+
+      attr_writer enqueued_jobs: untyped
+
+      attr_writer performed_jobs: untyped
+
+      # Provides a store of all the enqueued jobs with the TestAdapter so you can check them.
+      def enqueued_jobs: () -> untyped
+
+      # Provides a store of all the performed jobs with the TestAdapter so you can check them.
+      def performed_jobs: () -> untyped
+
+      def enqueue: (untyped job) -> untyped
+
+      def enqueue_at: (untyped job, untyped timestamp) -> untyped
+
+      def job_to_hash: (untyped job, ?::Hash[untyped, untyped] extras) -> untyped
+
+      def perform_or_enqueue: (untyped perform, untyped job, untyped job_data) -> untyped
+
+      def filtered?: (untyped job) -> untyped
+
+      def filtered_queue?: (untyped job) -> untyped
+
+      def filtered_job_class?: (untyped job) -> untyped
+
+      def filter_as_proc: (untyped filter) -> untyped
+    end
+  end
+end
+
+module ActiveJob
+  # == Active Job adapters
+  #
+  # Active Job has adapters for the following queuing backends:
+  #
+  # * {Backburner}[https://github.com/nesquena/backburner]
+  # * {Delayed Job}[https://github.com/collectiveidea/delayed_job]
+  # * {Que}[https://github.com/chanks/que]
+  # * {queue_classic}[https://github.com/QueueClassic/queue_classic]
+  # * {Resque}[https://github.com/resque/resque]
+  # * {Sidekiq}[https://sidekiq.org]
+  # * {Sneakers}[https://github.com/jondot/sneakers]
+  # * {Sucker Punch}[https://github.com/brandonhilkert/sucker_punch]
+  # * {Active Job Async Job}[https://api.rubyonrails.org/classes/ActiveJob/QueueAdapters/AsyncAdapter.html]
+  # * {Active Job Inline}[https://api.rubyonrails.org/classes/ActiveJob/QueueAdapters/InlineAdapter.html]
+  # * Please Note: We are not accepting pull requests for new adapters. See the {README}[link:files/activejob/README_md.html] for more details.
+  #
+  # === Backends Features
+  #
+  #   |                   | Async | Queues | Delayed    | Priorities | Timeout | Retries |
+  #   |-------------------|-------|--------|------------|------------|---------|---------|
+  #   | Backburner        | Yes   | Yes    | Yes        | Yes        | Job     | Global  |
+  #   | Delayed Job       | Yes   | Yes    | Yes        | Job        | Global  | Global  |
+  #   | Que               | Yes   | Yes    | Yes        | Job        | No      | Job     |
+  #   | queue_classic     | Yes   | Yes    | Yes*       | No         | No      | No      |
+  #   | Resque            | Yes   | Yes    | Yes (Gem)  | Queue      | Global  | Yes     |
+  #   | Sidekiq           | Yes   | Yes    | Yes        | Queue      | No      | Job     |
+  #   | Sneakers          | Yes   | Yes    | No         | Queue      | Queue   | No      |
+  #   | Sucker Punch      | Yes   | Yes    | Yes        | No         | No      | No      |
+  #   | Active Job Async  | Yes   | Yes    | Yes        | No         | No      | No      |
+  #   | Active Job Inline | No    | Yes    | N/A        | N/A        | N/A     | N/A     |
+  #
+  # ==== Async
+  #
+  # Yes: The Queue Adapter has the ability to run the job in a non-blocking manner.
+  # It either runs on a separate or forked process, or on a different thread.
+  #
+  # No: The job is run in the same process.
+  #
+  # ==== Queues
+  #
+  # Yes: Jobs may set which queue they are run in with queue_as or by using the set
+  # method.
+  #
+  # ==== Delayed
+  #
+  # Yes: The adapter will run the job in the future through perform_later.
+  #
+  # (Gem): An additional gem is required to use perform_later with this adapter.
+  #
+  # No: The adapter will run jobs at the next opportunity and cannot use perform_later.
+  #
+  # N/A: The adapter does not support queuing.
+  #
+  # NOTE:
+  # queue_classic supports job scheduling since version 3.1.
+  # For older versions you can use the queue_classic-later gem.
+  #
+  # ==== Priorities
+  #
+  # The order in which jobs are processed can be configured differently depending
+  # on the adapter.
+  #
+  # Job: Any class inheriting from the adapter may set the priority on the job
+  # object relative to other jobs.
+  #
+  # Queue: The adapter can set the priority for job queues, when setting a queue
+  # with Active Job this will be respected.
+  #
+  # Yes: Allows the priority to be set on the job object, at the queue level or
+  # as default configuration option.
+  #
+  # No: Does not allow the priority of jobs to be configured.
+  #
+  # N/A: The adapter does not support queuing, and therefore sorting them.
+  #
+  # ==== Timeout
+  #
+  # When a job will stop after the allotted time.
+  #
+  # Job: The timeout can be set for each instance of the job class.
+  #
+  # Queue: The timeout is set for all jobs on the queue.
+  #
+  # Global: The adapter is configured that all jobs have a maximum run time.
+  #
+  # N/A: This adapter does not run in a separate process, and therefore timeout
+  # is unsupported.
+  #
+  # ==== Retries
+  #
+  # Job: The number of retries can be set per instance of the job class.
+  #
+  # Yes: The Number of retries can be configured globally, for each instance or
+  # on the queue. This adapter may also present failed instances of the job class
+  # that can be restarted.
+  #
+  # Global: The adapter has a global number of retries.
+  #
+  # N/A: The adapter does not run in a separate process, and therefore doesn't
+  # support retries.
+  #
+  # === Async and Inline Queue Adapters
+  #
+  # Active Job has two built-in queue adapters intended for development and
+  # testing: +:async+ and +:inline+.
+  module QueueAdapters
+    extend ActiveSupport::Autoload
+
+    ADAPTER: ::String
+
+    # Returns adapter for specified name.
+    #
+    #   ActiveJob::QueueAdapters.lookup(:sidekiq)
+    #   # => ActiveJob::QueueAdapters::SidekiqAdapter
+    def self.lookup: (untyped name) -> untyped
+  end
+end
+
+module ActiveJob
+  module QueueName
+    extend ActiveSupport::Concern
+
+    # Includes the ability to override the default queue name and prefix.
+    module ClassMethods
+      # Specifies the name of the queue to process the job on.
+      #
+      #   class PublishToFeedJob < ActiveJob::Base
+      #     queue_as :feeds
+      #
+      #     def perform(post)
+      #       post.to_feed!
+      #     end
+      #   end
+      #
+      # Can be given a block that will evaluate in the context of the job
+      # allowing +self.arguments+ to be accessed so that a dynamic queue name
+      # can be applied:
+      #
+      #   class PublishToFeedJob < ApplicationJob
+      #     queue_as do
+      #       post = self.arguments.first
+      #
+      #       if post.paid?
+      #         :paid_feeds
+      #       else
+      #         :feeds
+      #       end
+      #     end
+      #
+      #     def perform(post)
+      #       post.to_feed!
+      #     end
+      #   end
+      def queue_as: (?untyped? part_name) { () -> untyped } -> untyped
+
+      def queue_name_from_part: (untyped part_name) -> untyped
+    end
+
+    # Returns the name of the queue the job will be run on.
+    def queue_name: () -> untyped
+  end
+end
+
+module ActiveJob
+  module QueuePriority
+    extend ActiveSupport::Concern
+
+    # Includes the ability to override the default queue priority.
+    module ClassMethods
+      # Specifies the priority of the queue to create the job with.
+      #
+      #   class PublishToFeedJob < ActiveJob::Base
+      #     queue_with_priority 50
+      #
+      #     def perform(post)
+      #       post.to_feed!
+      #     end
+      #   end
+      #
+      # Specify either an argument or a block.
+      def queue_with_priority: (?untyped? priority) { () -> untyped } -> untyped
+    end
+
+    # Returns the priority that the job will be created with
+    def priority: () -> untyped
+  end
+end
+
+module ActiveJob
+  class Railtie < Rails::Railtie
+    include ActiveJob::TestHelper
+  end
+end
+
+module ActiveJob
+  module Serializers
+    class DateSerializer < ObjectSerializer
+      # :nodoc:
+      def serialize: (untyped date) -> untyped
+
+      def deserialize: (untyped hash) -> untyped
+
+      def klass: () -> untyped
+    end
+  end
+end
+
+module ActiveJob
+  module Serializers
+    class DateTimeSerializer < ObjectSerializer
+      # :nodoc:
+      def serialize: (untyped time) -> untyped
+
+      def deserialize: (untyped hash) -> untyped
+
+      def klass: () -> untyped
+    end
+  end
+end
+
+module ActiveJob
+  module Serializers
+    class DurationSerializer < ObjectSerializer
+      # :nodoc:
+      def serialize: (untyped duration) -> untyped
+
+      def deserialize: (untyped hash) -> untyped
+
+      def klass: () -> untyped
+    end
+  end
+end
+
+module ActiveJob
+  module Serializers
+    # Base class for serializing and deserializing custom objects.
+    #
+    # Example:
+    #
+    #   class MoneySerializer < ActiveJob::Serializers::ObjectSerializer
+    #     def serialize(money)
+    #       super("amount" => money.amount, "currency" => money.currency)
+    #     end
+    #
+    #     def deserialize(hash)
+    #       Money.new(hash["amount"], hash["currency"])
+    #     end
+    #
+    #     private
+    #
+    #       def klass
+    #         Money
+    #       end
+    #   end
+    class ObjectSerializer
+      include Singleton
+
+      # Determines if an argument should be serialized by a serializer.
+      def serialize?: (untyped argument) -> untyped
+
+      # Serializes an argument to a JSON primitive type.
+      def serialize: (untyped hash) -> untyped
+
+      # Deserializes an argument from a JSON primitive type.
+      def deserialize: (untyped _argument) -> untyped
+
+      def klass: () -> untyped
+    end
+  end
+end
+
+module ActiveJob
+  module Serializers
+    class SymbolSerializer < ObjectSerializer
+      # :nodoc:
+      def serialize: (untyped argument) -> untyped
+
+      def deserialize: (untyped argument) -> untyped
+
+      def klass: () -> untyped
+    end
+  end
+end
+
+module ActiveJob
+  module Serializers
+    class TimeSerializer < ObjectSerializer
+      # :nodoc:
+      def serialize: (untyped time) -> untyped
+
+      def deserialize: (untyped hash) -> untyped
+
+      def klass: () -> untyped
+    end
+  end
+end
+
+module ActiveJob
+  module Serializers
+    class TimeWithZoneSerializer < ObjectSerializer
+      # :nodoc:
+      def serialize: (untyped time) -> untyped
+
+      def deserialize: (untyped hash) -> untyped
+
+      def klass: () -> untyped
+    end
+  end
+end
+
+module ActiveJob
+  module Serializers
+    # The <tt>ActiveJob::Serializers</tt> module is used to store a list of known serializers
+    # and to add new ones. It also has helpers to serialize/deserialize objects.
+    # :nodoc:
+    extend ActiveSupport::Autoload
+
+    # Returns serialized representative of the passed object.
+    # Will look up through all known serializers.
+    # Raises <tt>ActiveJob::SerializationError</tt> if it can't find a proper serializer.
+    def self.serialize: (untyped argument) -> untyped
+
+    # Returns deserialized object.
+    # Will look up through all known serializers.
+    # If no serializer found will raise <tt>ArgumentError</tt>.
+    def self.deserialize: (untyped argument) -> untyped
+
+    # Returns list of known serializers.
+    def self.serializers: () -> untyped
+
+    # Adds new serializers to a list of known serializers.
+    def self.add_serializers: (*untyped new_serializers) -> untyped
+  end
+end
+
+module ActiveJob
+  class TestCase < ActiveSupport::TestCase
+    include ActiveJob::TestHelper
+  end
+end
+
+module ActiveJob
+  # Provides helper methods for testing Active Job
+  module TestHelper
+    module TestQueueAdapter
+      extend ActiveSupport::Concern
+
+      module ClassMethods
+        def queue_adapter: () -> untyped
+
+        def disable_test_adapter: () -> untyped
+
+        def enable_test_adapter: (untyped test_adapter) -> untyped
+      end
+    end
+
+    def before_setup: () -> untyped
+
+    def after_teardown: () -> untyped
+
+    # Specifies the queue adapter to use with all Active Job test helpers.
+    #
+    # Returns an instance of the queue adapter and defaults to
+    # <tt>ActiveJob::QueueAdapters::TestAdapter</tt>.
+    #
+    # Note: The adapter provided by this method must provide some additional
+    # methods from those expected of a standard <tt>ActiveJob::QueueAdapter</tt>
+    # in order to be used with the active job test helpers. Refer to
+    # <tt>ActiveJob::QueueAdapters::TestAdapter</tt>.
+    def queue_adapter_for_test: () -> ActiveJob::QueueAdapters::TestAdapter
+
+    # Asserts that the number of enqueued jobs matches the given number.
+    #
+    #   def test_jobs
+    #     assert_enqueued_jobs 0
+    #     HelloJob.perform_later('david')
+    #     assert_enqueued_jobs 1
+    #     HelloJob.perform_later('abdelkader')
+    #     assert_enqueued_jobs 2
+    #   end
+    #
+    # If a block is passed, asserts that the block will cause the specified number of
+    # jobs to be enqueued.
+    #
+    #   def test_jobs_again
+    #     assert_enqueued_jobs 1 do
+    #       HelloJob.perform_later('cristian')
+    #     end
+    #
+    #     assert_enqueued_jobs 2 do
+    #       HelloJob.perform_later('aaron')
+    #       HelloJob.perform_later('rafael')
+    #     end
+    #   end
+    #
+    # Asserts the number of times a specific job was enqueued by passing +:only+ option.
+    #
+    #   def test_logging_job
+    #     assert_enqueued_jobs 1, only: LoggingJob do
+    #       LoggingJob.perform_later
+    #       HelloJob.perform_later('jeremy')
+    #     end
+    #   end
+    #
+    # Asserts the number of times a job except specific class was enqueued by passing +:except+ option.
+    #
+    #   def test_logging_job
+    #     assert_enqueued_jobs 1, except: HelloJob do
+    #       LoggingJob.perform_later
+    #       HelloJob.perform_later('jeremy')
+    #     end
+    #   end
+    #
+    # +:only+ and +:except+ options accepts Class, Array of Class or Proc. When passed a Proc,
+    # a hash containing the job's class and it's argument are passed as argument.
+    #
+    # Asserts the number of times a job is enqueued to a specific queue by passing +:queue+ option.
+    #
+    #   def test_logging_job
+    #     assert_enqueued_jobs 2, queue: 'default' do
+    #       LoggingJob.perform_later
+    #       HelloJob.perform_later('elfassy')
+    #     end
+    #   end
+    def assert_enqueued_jobs: (untyped number, ?queue: untyped? queue, ?except: untyped? except, ?only: untyped? only) { () -> untyped } -> untyped
+
+    # Asserts that no jobs have been enqueued.
+    #
+    #   def test_jobs
+    #     assert_no_enqueued_jobs
+    #     HelloJob.perform_later('jeremy')
+    #     assert_enqueued_jobs 1
+    #   end
+    #
+    # If a block is passed, asserts that the block will not cause any job to be enqueued.
+    #
+    #   def test_jobs_again
+    #     assert_no_enqueued_jobs do
+    #       # No job should be enqueued from this block
+    #     end
+    #   end
+    #
+    # Asserts that no jobs of a specific kind are enqueued by passing +:only+ option.
+    #
+    #   def test_no_logging
+    #     assert_no_enqueued_jobs only: LoggingJob do
+    #       HelloJob.perform_later('jeremy')
+    #     end
+    #   end
+    #
+    # Asserts that no jobs except specific class are enqueued by passing +:except+ option.
+    #
+    #   def test_no_logging
+    #     assert_no_enqueued_jobs except: HelloJob do
+    #       HelloJob.perform_later('jeremy')
+    #     end
+    #   end
+    #
+    # +:only+ and +:except+ options accepts Class, Array of Class or Proc. When passed a Proc,
+    # a hash containing the job's class and it's argument are passed as argument.
+    #
+    # Asserts that no jobs are enqueued to a specific queue by passing +:queue+ option
+    #
+    #   def test_no_logging
+    #     assert_no_enqueued_jobs queue: 'default' do
+    #       LoggingJob.set(queue: :some_queue).perform_later
+    #     end
+    #   end
+    #
+    # Note: This assertion is simply a shortcut for:
+    #
+    #   assert_enqueued_jobs 0, &block
+    def assert_no_enqueued_jobs: (?queue: untyped? queue, ?except: untyped? except, ?only: untyped? only) { () -> untyped } -> untyped
+
+    # Asserts that the number of performed jobs matches the given number.
+    # If no block is passed, <tt>perform_enqueued_jobs</tt>
+    # must be called around or after the job call.
+    #
+    #   def test_jobs
+    #     assert_performed_jobs 0
+    #
+    #     perform_enqueued_jobs do
+    #       HelloJob.perform_later('xavier')
+    #     end
+    #     assert_performed_jobs 1
+    #
+    #     HelloJob.perform_later('yves')
+    #
+    #     perform_enqueued_jobs
+    #
+    #     assert_performed_jobs 2
+    #   end
+    #
+    # If a block is passed, asserts that the block will cause the specified number of
+    # jobs to be performed.
+    #
+    #   def test_jobs_again
+    #     assert_performed_jobs 1 do
+    #       HelloJob.perform_later('robin')
+    #     end
+    #
+    #     assert_performed_jobs 2 do
+    #       HelloJob.perform_later('carlos')
+    #       HelloJob.perform_later('sean')
+    #     end
+    #   end
+    #
+    # This method also supports filtering. If the +:only+ option is specified,
+    # then only the listed job(s) will be performed.
+    #
+    #     def test_hello_job
+    #       assert_performed_jobs 1, only: HelloJob do
+    #         HelloJob.perform_later('jeremy')
+    #         LoggingJob.perform_later
+    #       end
+    #     end
+    #
+    # Also if the +:except+ option is specified,
+    # then the job(s) except specific class will be performed.
+    #
+    #     def test_hello_job
+    #       assert_performed_jobs 1, except: LoggingJob do
+    #         HelloJob.perform_later('jeremy')
+    #         LoggingJob.perform_later
+    #       end
+    #     end
+    #
+    # An array may also be specified, to support testing multiple jobs.
+    #
+    #     def test_hello_and_logging_jobs
+    #       assert_nothing_raised do
+    #         assert_performed_jobs 2, only: [HelloJob, LoggingJob] do
+    #           HelloJob.perform_later('jeremy')
+    #           LoggingJob.perform_later('stewie')
+    #           RescueJob.perform_later('david')
+    #         end
+    #       end
+    #     end
+    #
+    # A proc may also be specified. When passed a Proc, the job's instance will be passed as argument.
+    #
+    #     def test_hello_and_logging_jobs
+    #       assert_nothing_raised do
+    #         assert_performed_jobs(1, only: ->(job) { job.is_a?(HelloJob) }) do
+    #           HelloJob.perform_later('jeremy')
+    #           LoggingJob.perform_later('stewie')
+    #           RescueJob.perform_later('david')
+    #         end
+    #       end
+    #     end
+    #
+    # If the +:queue+ option is specified,
+    # then only the job(s) enqueued to a specific queue will be performed.
+    #
+    #     def test_assert_performed_jobs_with_queue_option
+    #       assert_performed_jobs 1, queue: :some_queue do
+    #         HelloJob.set(queue: :some_queue).perform_later("jeremy")
+    #         HelloJob.set(queue: :other_queue).perform_later("bogdan")
+    #       end
+    #     end
+    def assert_performed_jobs: (untyped number, ?queue: untyped? queue, ?except: untyped? except, ?only: untyped? only) { () -> untyped } -> untyped
+
+    # Asserts that no jobs have been performed.
+    #
+    #   def test_jobs
+    #     assert_no_performed_jobs
+    #
+    #     perform_enqueued_jobs do
+    #       HelloJob.perform_later('matthew')
+    #       assert_performed_jobs 1
+    #     end
+    #   end
+    #
+    # If a block is passed, asserts that the block will not cause any job to be performed.
+    #
+    #   def test_jobs_again
+    #     assert_no_performed_jobs do
+    #       # No job should be performed from this block
+    #     end
+    #   end
+    #
+    # The block form supports filtering. If the +:only+ option is specified,
+    # then only the listed job(s) will not be performed.
+    #
+    #   def test_no_logging
+    #     assert_no_performed_jobs only: LoggingJob do
+    #       HelloJob.perform_later('jeremy')
+    #     end
+    #   end
+    #
+    # Also if the +:except+ option is specified,
+    # then the job(s) except specific class will not be performed.
+    #
+    #   def test_no_logging
+    #     assert_no_performed_jobs except: HelloJob do
+    #       HelloJob.perform_later('jeremy')
+    #     end
+    #   end
+    #
+    # +:only+ and +:except+ options accepts Class, Array of Class or Proc. When passed a Proc,
+    # an instance of the job will be passed as argument.
+    #
+    # If the +:queue+ option is specified,
+    # then only the job(s) enqueued to a specific queue will not be performed.
+    #
+    #   def test_assert_no_performed_jobs_with_queue_option
+    #     assert_no_performed_jobs queue: :some_queue do
+    #       HelloJob.set(queue: :other_queue).perform_later("jeremy")
+    #     end
+    #   end
+    #
+    # Note: This assertion is simply a shortcut for:
+    #
+    #   assert_performed_jobs 0, &block
+    def assert_no_performed_jobs: (?queue: untyped? queue, ?except: untyped? except, ?only: untyped? only) { () -> untyped } -> untyped
+
+    # Asserts that the job has been enqueued with the given arguments.
+    #
+    #   def test_assert_enqueued_with
+    #     MyJob.perform_later(1,2,3)
+    #     assert_enqueued_with(job: MyJob, args: [1,2,3], queue: 'low')
+    #
+    #     MyJob.set(wait_until: Date.tomorrow.noon).perform_later
+    #     assert_enqueued_with(job: MyJob, at: Date.tomorrow.noon)
+    #   end
+    #
+    # The +at+ and +args+ arguments also accept a proc.
+    #
+    # To the +at+ proc, it will get passed the actual job's at argument.
+    #
+    #   def test_assert_enqueued_with
+    #     expected_time = ->(at) do
+    #       (Date.yesterday..Date.tomorrow).cover?(at)
+    #     end
+    #
+    #     MyJob.set(at: Date.today.noon).perform_later
+    #     assert_enqueued_with(job: MyJob, at: expected_time)
+    #   end
+    #
+    # To the +args+ proc, it will get passed the actual job's arguments
+    # Your proc needs to return a boolean value determining if
+    # the job's arguments matches your expectation. This is useful to check only
+    # for a subset of arguments.
+    #
+    #   def test_assert_enqueued_with
+    #     expected_args = ->(job_args) do
+    #       assert job_args.first.key?(:foo)
+    #     end
+    #
+    #     MyJob.perform_later(foo: 'bar', other_arg: 'No need to check in the test')
+    #     assert_enqueued_with(job: MyJob, args: expected_args, queue: 'low')
+    #   end
+    #
+    # If a block is passed, asserts that the block will cause the job to be
+    # enqueued with the given arguments.
+    #
+    #   def test_assert_enqueued_with
+    #     assert_enqueued_with(job: MyJob, args: [1,2,3], queue: 'low') do
+    #       MyJob.perform_later(1,2,3)
+    #     end
+    #
+    #     assert_enqueued_with(job: MyJob, at: Date.tomorrow.noon) do
+    #       MyJob.set(wait_until: Date.tomorrow.noon).perform_later
+    #     end
+    #   end
+    def assert_enqueued_with: (?queue: untyped? queue, ?at: untyped? at, ?args: untyped? args, ?job: untyped? job) { () -> untyped } -> untyped
+
+    # Asserts that the job has been performed with the given arguments.
+    #
+    #   def test_assert_performed_with
+    #     MyJob.perform_later(1,2,3)
+    #
+    #     perform_enqueued_jobs
+    #
+    #     assert_performed_with(job: MyJob, args: [1,2,3], queue: 'high')
+    #
+    #     MyJob.set(wait_until: Date.tomorrow.noon).perform_later
+    #
+    #     perform_enqueued_jobs
+    #
+    #     assert_performed_with(job: MyJob, at: Date.tomorrow.noon)
+    #   end
+    #
+    # The +at+ and +args+ arguments also accept a proc.
+    #
+    # To the +at+ proc, it will get passed the actual job's at argument.
+    #
+    #   def test_assert_enqueued_with
+    #     expected_time = ->(at) do
+    #       (Date.yesterday..Date.tomorrow).cover?(at)
+    #     end
+    #
+    #     MyJob.set(at: Date.today.noon).perform_later
+    #     assert_enqueued_with(job: MyJob, at: expected_time)
+    #   end
+    #
+    # To the +args+ proc, it will get passed the actual job's arguments
+    # Your proc needs to return a boolean value determining if
+    # the job's arguments matches your expectation. This is useful to check only
+    # for a subset of arguments.
+    #
+    #   def test_assert_performed_with
+    #     expected_args = ->(job_args) do
+    #       assert job_args.first.key?(:foo)
+    #     end
+    #     MyJob.perform_later(foo: 'bar', other_arg: 'No need to check in the test')
+    #
+    #     perform_enqueued_jobs
+    #
+    #     assert_performed_with(job: MyJob, args: expected_args, queue: 'high')
+    #   end
+    #
+    # If a block is passed, that block performs all of the jobs that were
+    # enqueued throughout the duration of the block and asserts that
+    # the job has been performed with the given arguments in the block.
+    #
+    #   def test_assert_performed_with
+    #     assert_performed_with(job: MyJob, args: [1,2,3], queue: 'high') do
+    #       MyJob.perform_later(1,2,3)
+    #     end
+    #
+    #     assert_performed_with(job: MyJob, at: Date.tomorrow.noon) do
+    #       MyJob.set(wait_until: Date.tomorrow.noon).perform_later
+    #     end
+    #   end
+    def assert_performed_with: (?queue: untyped? queue, ?at: untyped? at, ?args: untyped? args, ?job: untyped? job) { () -> untyped } -> untyped
+
+    # Performs all enqueued jobs. If a block is given, performs all of the jobs
+    # that were enqueued throughout the duration of the block. If a block is
+    # not given, performs all of the enqueued jobs up to this point in the test.
+    #
+    #   def test_perform_enqueued_jobs
+    #     perform_enqueued_jobs do
+    #       MyJob.perform_later(1, 2, 3)
+    #     end
+    #     assert_performed_jobs 1
+    #   end
+    #
+    #   def test_perform_enqueued_jobs_without_block
+    #     MyJob.perform_later(1, 2, 3)
+    #
+    #     perform_enqueued_jobs
+    #
+    #     assert_performed_jobs 1
+    #   end
+    #
+    # This method also supports filtering. If the +:only+ option is specified,
+    # then only the listed job(s) will be performed.
+    #
+    #   def test_perform_enqueued_jobs_with_only
+    #     perform_enqueued_jobs(only: MyJob) do
+    #       MyJob.perform_later(1, 2, 3) # will be performed
+    #       HelloJob.perform_later(1, 2, 3) # will not be performed
+    #     end
+    #     assert_performed_jobs 1
+    #   end
+    #
+    # Also if the +:except+ option is specified,
+    # then the job(s) except specific class will be performed.
+    #
+    #   def test_perform_enqueued_jobs_with_except
+    #     perform_enqueued_jobs(except: HelloJob) do
+    #       MyJob.perform_later(1, 2, 3) # will be performed
+    #       HelloJob.perform_later(1, 2, 3) # will not be performed
+    #     end
+    #     assert_performed_jobs 1
+    #   end
+    #
+    # +:only+ and +:except+ options accepts Class, Array of Class or Proc. When passed a Proc,
+    # an instance of the job will be passed as argument.
+    #
+    # If the +:queue+ option is specified,
+    # then only the job(s) enqueued to a specific queue will be performed.
+    #
+    #   def test_perform_enqueued_jobs_with_queue
+    #     perform_enqueued_jobs queue: :some_queue do
+    #       MyJob.set(queue: :some_queue).perform_later(1, 2, 3) # will be performed
+    #       HelloJob.set(queue: :other_queue).perform_later(1, 2, 3) # will not be performed
+    #     end
+    #     assert_performed_jobs 1
+    #   end
+    #
+    def perform_enqueued_jobs: (?queue: untyped? queue, ?except: untyped? except, ?only: untyped? only) { () -> untyped } -> untyped
+
+    # Accesses the queue_adapter set by ActiveJob::Base.
+    #
+    #   def test_assert_job_has_custom_queue_adapter_set
+    #     assert_instance_of CustomQueueAdapter, HelloJob.queue_adapter
+    #   end
+    def queue_adapter: () -> untyped
+
+    def clear_enqueued_jobs: () -> untyped
+
+    def clear_performed_jobs: () -> untyped
+
+    def jobs_with: (untyped jobs, ?queue: untyped? queue, ?except: untyped? except, ?only: untyped? only) { (untyped) -> untyped } -> untyped
+
+    def filter_as_proc: (untyped filter) -> untyped
+
+    def enqueued_jobs_with: (?queue: untyped? queue, ?except: untyped? except, ?only: untyped? only) { () -> untyped } -> untyped
+
+    def performed_jobs_with: (?queue: untyped? queue, ?except: untyped? except, ?only: untyped? only) { () -> untyped } -> untyped
+
+    def flush_enqueued_jobs: (?queue: untyped? queue, ?except: untyped? except, ?only: untyped? only) -> untyped
+
+    def prepare_args_for_assertion: (untyped args) -> untyped
+
+    def round_time_arguments: (untyped argument) -> untyped
+
+    def deserialize_args_for_assertion: (untyped job) -> untyped
+
+    def instantiate_job: (untyped payload) -> untyped
+
+    def queue_adapter_changed_jobs: () -> untyped
+
+    def validate_option: (?except: untyped? except, ?only: untyped? only) -> untyped
+  end
+end
+
+module ActiveJob
+  module Timezones
+    # nodoc:
+    extend ActiveSupport::Concern
+  end
+end
+
+module ActiveJob
+  module Translation
+    # nodoc:
+    extend ActiveSupport::Concern
+  end
+end
+
+module ActiveJob
+  # Returns the version of the currently loaded Active Job as a <tt>Gem::Version</tt>
+  def self.version: () -> untyped
+end
+
+module ActiveJob
+  extend ActiveSupport::Autoload
+end
+
+module Rails
+  module Generators
+    class JobGenerator < Rails::Generators::NamedBase
+      def self.default_generator_root: () -> untyped
+
+      def create_job_file: () -> untyped
+
+      def file_name: () -> untyped
+
+      def application_job_file_name: () -> untyped
+    end
+  end
+end
+

--- a/gems/activemodel/6.0.3.2/activemodel-generated.rbs
+++ b/gems/activemodel/6.0.3.2/activemodel-generated.rbs
@@ -1,3 +1,27 @@
+# The generated code is based on Ruby on Rails source code
+# You can find the license of Ruby on Rails from following.
+
+#Copyright (c) 2005-2019 David Heinemeier Hansson
+#
+#Permission is hereby granted, free of charge, to any person obtaining
+#a copy of this software and associated documentation files (the
+#"Software"), to deal in the Software without restriction, including
+#without limitation the rights to use, copy, modify, merge, publish,
+#distribute, sublicense, and/or sell copies of the Software, and to
+#permit persons to whom the Software is furnished to do so, subject to
+#the following conditions:
+#
+#The above copyright notice and this permission notice shall be
+#included in all copies or substantial portions of the Software.
+#
+#THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+#EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+#MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+#LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+#OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+#WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 module ActiveModel
   class Attribute
     class UserProvidedDefault < FromUser

--- a/gems/activemodel/6.0.3.2/activemodel-generated.rbs
+++ b/gems/activemodel/6.0.3.2/activemodel-generated.rbs
@@ -1,0 +1,4205 @@
+module ActiveModel
+  class Attribute
+    class UserProvidedDefault < FromUser
+      # :nodoc:
+      # :nodoc:
+      def initialize: (untyped name, untyped value, untyped `type`, untyped database_default) -> untyped
+
+      def value_before_type_cast: () -> untyped
+
+      def with_type: (untyped `type`) -> untyped
+
+      def marshal_dump: () -> untyped
+
+      def marshal_load: (untyped values) -> untyped
+
+      attr_reader user_provided_value: untyped
+    end
+  end
+end
+
+module ActiveModel
+  class Attribute
+    def self.from_database: (untyped name, untyped value, untyped `type`) -> FromDatabase
+
+    def self.from_user: (untyped name, untyped value, untyped `type`, ?untyped? original_attribute) -> FromUser
+
+    def self.with_cast_value: (untyped name, untyped value, untyped `type`) -> WithCastValue
+
+    def self.null: (untyped name) -> Null
+
+    def self.uninitialized: (untyped name, untyped `type`) -> Uninitialized
+
+    attr_reader name: untyped
+
+    attr_reader value_before_type_cast: untyped
+
+    attr_reader type: untyped
+
+    # This method should not be called directly.
+    # Use #from_database or #from_user
+    def initialize: (untyped name, untyped value_before_type_cast, untyped `type`, ?untyped? original_attribute) -> untyped
+
+    def value: () -> untyped
+
+    def original_value: () -> untyped
+
+    def value_for_database: () -> untyped
+
+    def changed?: () -> untyped
+
+    def changed_in_place?: () -> untyped
+
+    def forgetting_assignment: () -> untyped
+
+    def with_value_from_user: (untyped value) -> untyped
+
+    def with_value_from_database: (untyped value) -> untyped
+
+    def with_cast_value: (untyped value) -> untyped
+
+    def with_type: (untyped `type`) -> untyped
+
+    def type_cast: () -> untyped
+
+    def initialized?: () -> ::TrueClass
+
+    def came_from_user?: () -> ::FalseClass
+
+    def has_been_read?: () -> untyped
+
+    def ==: (untyped other) -> untyped
+
+    alias eql? ==
+
+    def hash: () -> untyped
+
+    def init_with: (untyped coder) -> untyped
+
+    def encode_with: (untyped coder) -> untyped
+
+    def original_value_for_database: () -> untyped
+
+    attr_reader original_attribute: untyped
+
+    alias assigned? original_attribute
+
+    def initialize_dup: (untyped other) -> untyped
+
+    def changed_from_assignment?: () -> untyped
+
+    def _original_value_for_database: () -> untyped
+
+    class FromDatabase < Attribute
+      # :nodoc:
+      def type_cast: (untyped value) -> untyped
+
+      def _original_value_for_database: () -> untyped
+    end
+
+    class FromUser < Attribute
+      # :nodoc:
+      def type_cast: (untyped value) -> untyped
+
+      def came_from_user?: () -> untyped
+    end
+
+    class WithCastValue < Attribute
+      # :nodoc:
+      def type_cast: (untyped value) -> untyped
+
+      def changed_in_place?: () -> ::FalseClass
+    end
+
+    class Null < Attribute
+      # :nodoc:
+      def initialize: (untyped name) -> untyped
+
+      def type_cast: () -> nil
+
+      def with_type: (untyped `type`) -> untyped
+
+      def with_value_from_database: (untyped value) -> untyped
+
+      alias with_value_from_user with_value_from_database
+
+      alias with_cast_value with_value_from_database
+    end
+
+    class Uninitialized < Attribute
+      # :nodoc:
+      UNINITIALIZED_ORIGINAL_VALUE: untyped
+
+      def initialize: (untyped name, untyped `type`) -> untyped
+
+      def value: () { (untyped) -> untyped } -> untyped
+
+      def original_value: () -> untyped
+
+      def value_for_database: () -> nil
+
+      def initialized?: () -> ::FalseClass
+
+      def forgetting_assignment: () -> untyped
+
+      def with_type: (untyped `type`) -> untyped
+    end
+  end
+end
+
+module ActiveModel
+  module AttributeAssignment
+    include ActiveModel::ForbiddenAttributesProtection
+
+    # Allows you to set all the attributes by passing in a hash of attributes with
+    # keys matching the attribute names.
+    #
+    # If the passed hash responds to <tt>permitted?</tt> method and the return value
+    # of this method is +false+ an <tt>ActiveModel::ForbiddenAttributesError</tt>
+    # exception is raised.
+    #
+    #   class Cat
+    #     include ActiveModel::AttributeAssignment
+    #     attr_accessor :name, :status
+    #   end
+    #
+    #   cat = Cat.new
+    #   cat.assign_attributes(name: "Gorby", status: "yawning")
+    #   cat.name # => 'Gorby'
+    #   cat.status # => 'yawning'
+    #   cat.assign_attributes(status: "sleeping")
+    #   cat.name # => 'Gorby'
+    #   cat.status # => 'sleeping'
+    def assign_attributes: (untyped new_attributes) -> (nil | untyped)
+
+    alias attributes= assign_attributes
+
+    def _assign_attributes: (untyped attributes) -> untyped
+
+    def _assign_attribute: (untyped k, untyped v) -> untyped
+  end
+end
+
+module ActiveModel
+  # Raised when an attribute is not defined.
+  #
+  #   class User < ActiveRecord::Base
+  #     has_many :pets
+  #   end
+  #
+  #   user = User.first
+  #   user.pets.select(:id).first.user_id
+  #   # => ActiveModel::MissingAttributeError: missing attribute: user_id
+  class MissingAttributeError[T] < NoMethodError[T]
+  end
+
+  # == Active \Model \Attribute \Methods
+  #
+  # Provides a way to add prefixes and suffixes to your methods as
+  # well as handling the creation of <tt>ActiveRecord::Base</tt>-like
+  # class methods such as +table_name+.
+  #
+  # The requirements to implement <tt>ActiveModel::AttributeMethods</tt> are to:
+  #
+  # * <tt>include ActiveModel::AttributeMethods</tt> in your class.
+  # * Call each of its methods you want to add, such as +attribute_method_suffix+
+  #   or +attribute_method_prefix+.
+  # * Call +define_attribute_methods+ after the other methods are called.
+  # * Define the various generic +_attribute+ methods that you have declared.
+  # * Define an +attributes+ method which returns a hash with each
+  #   attribute name in your model as hash key and the attribute value as hash value.
+  #   Hash keys must be strings.
+  #
+  # A minimal implementation could be:
+  #
+  #   class Person
+  #     include ActiveModel::AttributeMethods
+  #
+  #     attribute_method_affix  prefix: 'reset_', suffix: '_to_default!'
+  #     attribute_method_suffix '_contrived?'
+  #     attribute_method_prefix 'clear_'
+  #     define_attribute_methods :name
+  #
+  #     attr_accessor :name
+  #
+  #     def attributes
+  #       { 'name' => @name }
+  #     end
+  #
+  #     private
+  #
+  #     def attribute_contrived?(attr)
+  #       true
+  #     end
+  #
+  #     def clear_attribute(attr)
+  #       send("#{attr}=", nil)
+  #     end
+  #
+  #     def reset_attribute_to_default!(attr)
+  #       send("#{attr}=", 'Default Name')
+  #     end
+  #   end
+  module AttributeMethods
+    extend ActiveSupport::Concern
+
+    NAME_COMPILABLE_REGEXP: untyped
+
+    CALL_COMPILABLE_REGEXP: untyped
+
+    module ClassMethods
+      # Declares a method available for all attributes with the given prefix.
+      # Uses +method_missing+ and <tt>respond_to?</tt> to rewrite the method.
+      #
+      #   #{prefix}#{attr}(*args, &block)
+      #
+      # to
+      #
+      #   #{prefix}attribute(#{attr}, *args, &block)
+      #
+      # An instance method <tt>#{prefix}attribute</tt> must exist and accept
+      # at least the +attr+ argument.
+      #
+      #   class Person
+      #     include ActiveModel::AttributeMethods
+      #
+      #     attr_accessor :name
+      #     attribute_method_prefix 'clear_'
+      #     define_attribute_methods :name
+      #
+      #     private
+      #
+      #     def clear_attribute(attr)
+      #       send("#{attr}=", nil)
+      #     end
+      #   end
+      #
+      #   person = Person.new
+      #   person.name = 'Bob'
+      #   person.name          # => "Bob"
+      #   person.clear_name
+      #   person.name          # => nil
+      def attribute_method_prefix: (*untyped prefixes) -> untyped
+
+      # Declares a method available for all attributes with the given suffix.
+      # Uses +method_missing+ and <tt>respond_to?</tt> to rewrite the method.
+      #
+      #   #{attr}#{suffix}(*args, &block)
+      #
+      # to
+      #
+      #   attribute#{suffix}(#{attr}, *args, &block)
+      #
+      # An <tt>attribute#{suffix}</tt> instance method must exist and accept at
+      # least the +attr+ argument.
+      #
+      #   class Person
+      #     include ActiveModel::AttributeMethods
+      #
+      #     attr_accessor :name
+      #     attribute_method_suffix '_short?'
+      #     define_attribute_methods :name
+      #
+      #     private
+      #
+      #     def attribute_short?(attr)
+      #       send(attr).length < 5
+      #     end
+      #   end
+      #
+      #   person = Person.new
+      #   person.name = 'Bob'
+      #   person.name          # => "Bob"
+      #   person.name_short?   # => true
+      def attribute_method_suffix: (*untyped suffixes) -> untyped
+
+      # Declares a method available for all attributes with the given prefix
+      # and suffix. Uses +method_missing+ and <tt>respond_to?</tt> to rewrite
+      # the method.
+      #
+      #   #{prefix}#{attr}#{suffix}(*args, &block)
+      #
+      # to
+      #
+      #   #{prefix}attribute#{suffix}(#{attr}, *args, &block)
+      #
+      # An <tt>#{prefix}attribute#{suffix}</tt> instance method must exist and
+      # accept at least the +attr+ argument.
+      #
+      #   class Person
+      #     include ActiveModel::AttributeMethods
+      #
+      #     attr_accessor :name
+      #     attribute_method_affix prefix: 'reset_', suffix: '_to_default!'
+      #     define_attribute_methods :name
+      #
+      #     private
+      #
+      #     def reset_attribute_to_default!(attr)
+      #       send("#{attr}=", 'Default Name')
+      #     end
+      #   end
+      #
+      #   person = Person.new
+      #   person.name                         # => 'Gem'
+      #   person.reset_name_to_default!
+      #   person.name                         # => 'Default Name'
+      def attribute_method_affix: (*untyped affixes) -> untyped
+
+      # Allows you to make aliases for attributes.
+      #
+      #   class Person
+      #     include ActiveModel::AttributeMethods
+      #
+      #     attr_accessor :name
+      #     attribute_method_suffix '_short?'
+      #     define_attribute_methods :name
+      #
+      #     alias_attribute :nickname, :name
+      #
+      #     private
+      #
+      #     def attribute_short?(attr)
+      #       send(attr).length < 5
+      #     end
+      #   end
+      #
+      #   person = Person.new
+      #   person.name = 'Bob'
+      #   person.name            # => "Bob"
+      #   person.nickname        # => "Bob"
+      #   person.name_short?     # => true
+      #   person.nickname_short? # => true
+      def alias_attribute: (untyped new_name, untyped old_name) -> untyped
+
+      # Is +new_name+ an alias?
+      def attribute_alias?: (untyped new_name) -> untyped
+
+      # Returns the original name for the alias +name+
+      def attribute_alias: (untyped name) -> untyped
+
+      # Declares the attributes that should be prefixed and suffixed by
+      # <tt>ActiveModel::AttributeMethods</tt>.
+      #
+      # To use, pass attribute names (as strings or symbols). Be sure to declare
+      # +define_attribute_methods+ after you define any prefix, suffix or affix
+      # methods, or they will not hook in.
+      #
+      #   class Person
+      #     include ActiveModel::AttributeMethods
+      #
+      #     attr_accessor :name, :age, :address
+      #     attribute_method_prefix 'clear_'
+      #
+      #     # Call to define_attribute_methods must appear after the
+      #     # attribute_method_prefix, attribute_method_suffix or
+      #     # attribute_method_affix declarations.
+      #     define_attribute_methods :name, :age, :address
+      #
+      #     private
+      #
+      #     def clear_attribute(attr)
+      #       send("#{attr}=", nil)
+      #     end
+      #   end
+      def define_attribute_methods: (*untyped attr_names) -> untyped
+
+      # Declares an attribute that should be prefixed and suffixed by
+      # <tt>ActiveModel::AttributeMethods</tt>.
+      #
+      # To use, pass an attribute name (as string or symbol). Be sure to declare
+      # +define_attribute_method+ after you define any prefix, suffix or affix
+      # method, or they will not hook in.
+      #
+      #   class Person
+      #     include ActiveModel::AttributeMethods
+      #
+      #     attr_accessor :name
+      #     attribute_method_suffix '_short?'
+      #
+      #     # Call to define_attribute_method must appear after the
+      #     # attribute_method_prefix, attribute_method_suffix or
+      #     # attribute_method_affix declarations.
+      #     define_attribute_method :name
+      #
+      #     private
+      #
+      #     def attribute_short?(attr)
+      #       send(attr).length < 5
+      #     end
+      #   end
+      #
+      #   person = Person.new
+      #   person.name = 'Bob'
+      #   person.name        # => "Bob"
+      #   person.name_short? # => true
+      def define_attribute_method: (untyped attr_name) -> untyped
+
+      # Removes all the previously dynamically defined methods from the class.
+      #
+      #   class Person
+      #     include ActiveModel::AttributeMethods
+      #
+      #     attr_accessor :name
+      #     attribute_method_suffix '_short?'
+      #     define_attribute_method :name
+      #
+      #     private
+      #
+      #     def attribute_short?(attr)
+      #       send(attr).length < 5
+      #     end
+      #   end
+      #
+      #   person = Person.new
+      #   person.name = 'Bob'
+      #   person.name_short? # => true
+      #
+      #   Person.undefine_attribute_methods
+      #
+      #   person.name_short? # => NoMethodError
+      def undefine_attribute_methods: () -> untyped
+
+      def generated_attribute_methods: () -> untyped
+
+      def instance_method_already_implemented?: (untyped method_name) -> untyped
+
+      # The methods +method_missing+ and +respond_to?+ of this module are
+      # invoked often in a typical rails, both of which invoke the method
+      # +matched_attribute_method+. The latter method iterates through an
+      # array doing regular expression matches, which results in a lot of
+      # object creations. Most of the time it returns a +nil+ match. As the
+      # match result is always the same given a +method_name+, this cache is
+      # used to alleviate the GC, which ultimately also speeds up the app
+      # significantly (in our case our test suite finishes 10% faster with
+      # this cache).
+      def attribute_method_matchers_cache: () -> untyped
+
+      def attribute_method_matchers_matching: (untyped method_name) -> untyped
+
+      # Define a method `name` in `mod` that dispatches to `send`
+      # using the given `extra` args. This falls back on `define_method`
+      # and `send` if the given names cannot be compiled.
+      def define_proxy_call: (untyped include_private, untyped mod, untyped name, untyped target, *untyped extra) -> untyped
+
+      class AttributeMethodMatcher
+        # nodoc:
+        attr_reader prefix: untyped
+
+        # nodoc:
+        attr_reader suffix: untyped
+
+        # nodoc:
+        attr_reader target: untyped
+
+        class AttributeMethodMatch[T] < ::Struct[T]
+          attr_accessor target(): untyped
+
+          attr_accessor attr_name(): untyped
+        end
+
+        def initialize: (?::Hash[untyped, untyped] options) -> untyped
+
+        def match: (untyped method_name) -> untyped
+
+        def method_name: (untyped attr_name) -> untyped
+
+        def plain?: () -> untyped
+      end
+    end
+
+    # Allows access to the object attributes, which are held in the hash
+    # returned by <tt>attributes</tt>, as though they were first-class
+    # methods. So a +Person+ class with a +name+ attribute can for example use
+    # <tt>Person#name</tt> and <tt>Person#name=</tt> and never directly use
+    # the attributes hash -- except for multiple assignments with
+    # <tt>ActiveRecord::Base#attributes=</tt>.
+    #
+    # It's also possible to instantiate related objects, so a <tt>Client</tt>
+    # class belonging to the +clients+ table with a +master_id+ foreign key
+    # can instantiate master through <tt>Client#master</tt>.
+    def method_missing: (untyped method, *untyped args) { () -> untyped } -> untyped
+
+    # +attribute_missing+ is like +method_missing+, but for attributes. When
+    # +method_missing+ is called we check to see if there is a matching
+    # attribute method. If so, we tell +attribute_missing+ to dispatch the
+    # attribute. This method can be overloaded to customize the behavior.
+    def attribute_missing: (untyped match, *untyped args) { () -> untyped } -> untyped
+
+    # A +Person+ instance with a +name+ attribute can ask
+    # <tt>person.respond_to?(:name)</tt>, <tt>person.respond_to?(:name=)</tt>,
+    # and <tt>person.respond_to?(:name?)</tt> which will all return +true+.
+    alias respond_to_without_attributes? respond_to?
+
+    def respond_to?: (untyped method, ?bool include_private_methods) -> untyped
+
+    def attribute_method?: (untyped attr_name) -> untyped
+
+    # Returns a struct representing the matching attribute method.
+    # The struct's attributes are prefix, base and suffix.
+    def matched_attribute_method: (untyped method_name) -> untyped
+
+    def missing_attribute: (untyped attr_name, untyped stack) -> untyped
+
+    def _read_attribute: (untyped attr) -> untyped
+
+    module AttrNames
+      # :nodoc:
+      DEF_SAFE_NAME: untyped
+
+      # We want to generate the methods via module_eval rather than
+      # define_method, because define_method is slower on dispatch.
+      # Evaluating many similar methods may use more memory as the instruction
+      # sequences are duplicated and cached (in MRI).  define_method may
+      # be slower on dispatch, but if you're careful about the closure
+      # created, then define_method will consume much less memory.
+      #
+      # But sometimes the database might return columns with
+      # characters that are not allowed in normal method names (like
+      # 'my_column(omg)'. So to work around this we first define with
+      # the __temp__ identifier, and then use alias method to rename
+      # it to what we want.
+      #
+      # We are also defining a constant to hold the frozen string of
+      # the attribute name. Using a constant means that we do not have
+      # to allocate an object on each call to the attribute method.
+      # Making it frozen means that it doesn't get duped when used to
+      # key the @attributes in read_attribute.
+      def self.define_attribute_accessor_method: (untyped mod, untyped attr_name, ?writer: bool writer) { (untyped, untyped) -> untyped } -> untyped
+    end
+  end
+end
+
+module ActiveModel
+  class AttributeMutationTracker
+    # :nodoc:
+    OPTION_NOT_GIVEN: untyped
+
+    def initialize: (untyped attributes, ?untyped forced_changes) -> untyped
+
+    def changed_attribute_names: () -> untyped
+
+    def changed_values: () -> untyped
+
+    def changes: () -> untyped
+
+    def change_to_attribute: (untyped attr_name) -> untyped
+
+    def any_changes?: () -> untyped
+
+    def changed?: (untyped attr_name, ?to: untyped to, ?from: untyped from) -> untyped
+
+    def changed_in_place?: (untyped attr_name) -> untyped
+
+    def forget_change: (untyped attr_name) -> untyped
+
+    def original_value: (untyped attr_name) -> untyped
+
+    def force_change: (untyped attr_name) -> untyped
+
+    attr_reader attributes: untyped
+
+    attr_reader forced_changes: untyped
+
+    def attr_names: () -> untyped
+
+    def attribute_changed?: (untyped attr_name) -> untyped
+
+    def fetch_value: (untyped attr_name) -> untyped
+  end
+
+  class ForcedMutationTracker < AttributeMutationTracker
+    # :nodoc:
+    def initialize: (untyped attributes, ?::Hash[untyped, untyped] forced_changes) -> untyped
+
+    def changed_in_place?: (untyped attr_name) -> ::FalseClass
+
+    def change_to_attribute: (untyped attr_name) -> untyped
+
+    def forget_change: (untyped attr_name) -> untyped
+
+    def original_value: (untyped attr_name) -> untyped
+
+    def force_change: (untyped attr_name) -> untyped
+
+    def finalize_changes: () -> untyped
+
+    attr_reader finalized_changes: untyped
+
+    def attr_names: () -> untyped
+
+    def attribute_changed?: (untyped attr_name) -> untyped
+
+    def fetch_value: (untyped attr_name) -> untyped
+
+    def clone_value: (untyped attr_name) -> untyped
+  end
+
+  class NullMutationTracker
+    # :nodoc:
+    include Singleton
+
+    def changed_attribute_names: () -> ::Array[untyped]
+
+    def changed_values: () -> ::Hash[untyped, untyped]
+
+    def changes: () -> ::Hash[untyped, untyped]
+
+    def change_to_attribute: (untyped attr_name) -> nil
+
+    def any_changes?: () -> ::FalseClass
+
+    def changed?: (untyped attr_name) -> ::FalseClass
+
+    def changed_in_place?: (untyped attr_name) -> ::FalseClass
+
+    def original_value: (untyped attr_name) -> nil
+  end
+end
+
+module ActiveModel
+  class AttributeSet
+    class Builder
+      # :nodoc:
+      # :nodoc:
+      attr_reader types: untyped
+
+      # :nodoc:
+      # :nodoc:
+      attr_reader default_attributes: untyped
+
+      def initialize: (untyped types, ?::Hash[untyped, untyped] default_attributes) -> untyped
+
+      def build_from_database: (?::Hash[untyped, untyped] values, ?::Hash[untyped, untyped] additional_types) -> AttributeSet
+    end
+  end
+
+  class LazyAttributeHash
+    def initialize: (untyped types, untyped values, untyped additional_types, untyped default_attributes, ?::Hash[untyped, untyped] delegate_hash) -> untyped
+
+    def key?: (untyped key) -> untyped
+
+    def []: (untyped key) -> untyped
+
+    def []=: (untyped key, untyped value) -> untyped
+
+    def deep_dup: () -> untyped
+
+    def initialize_dup: (untyped _) -> untyped
+
+    def select: () { (untyped, untyped) -> untyped } -> untyped
+
+    def ==: (untyped other) -> untyped
+
+    def marshal_dump: () -> ::Array[untyped]
+
+    def marshal_load: (untyped values) -> untyped
+
+    def materialize: () -> untyped
+
+    attr_reader types: untyped
+
+    attr_reader values: untyped
+
+    attr_reader additional_types: untyped
+
+    attr_reader delegate_hash: untyped
+
+    attr_reader default_attributes: untyped
+
+    def assign_default_value: (untyped name) -> untyped
+  end
+end
+
+module ActiveModel
+  class AttributeSet
+    class YAMLEncoder
+      # Attempts to do more intelligent YAML dumping of an
+      # ActiveModel::AttributeSet to reduce the size of the resulting string
+      # :nodoc:
+      def initialize: (untyped default_types) -> untyped
+
+      def encode: (untyped attribute_set, untyped coder) -> untyped
+
+      def decode: (untyped coder) -> untyped
+
+      attr_reader default_types: untyped
+    end
+  end
+end
+
+module ActiveModel
+  class AttributeSet
+    def initialize: (untyped attributes) -> untyped
+
+    def []: (untyped name) -> untyped
+
+    def []=: (untyped name, untyped value) -> untyped
+
+    def values_before_type_cast: () -> untyped
+
+    def to_hash: () -> untyped
+
+    alias to_h to_hash
+
+    def key?: (untyped name) -> untyped
+
+    def keys: () -> untyped
+
+    def fetch_value: (untyped name) { () -> untyped } -> untyped
+
+    def write_from_database: (untyped name, untyped value) -> untyped
+
+    def write_from_user: (untyped name, untyped value) -> untyped
+
+    def write_cast_value: (untyped name, untyped value) -> untyped
+
+    def freeze: () -> untyped
+
+    def deep_dup: () -> untyped
+
+    def initialize_dup: (untyped _) -> untyped
+
+    def initialize_clone: (untyped _) -> untyped
+
+    def reset: (untyped key) -> untyped
+
+    def accessed: () -> untyped
+
+    def map: () { () -> untyped } -> AttributeSet
+
+    def ==: (untyped other) -> untyped
+
+    attr_reader attributes: untyped
+
+    def initialized_attributes: () -> untyped
+  end
+end
+
+module ActiveModel
+  module Attributes
+    # nodoc:
+    extend ActiveSupport::Concern
+
+    include ActiveModel::AttributeMethods
+
+    module ClassMethods
+      def attribute: (untyped name, ?untyped `type`, **untyped options) -> untyped
+
+      # Returns an array of attribute names as strings
+      #
+      #   class Person
+      #     include ActiveModel::Attributes
+      #
+      #     attribute :name, :string
+      #     attribute :age, :integer
+      #   end
+      #
+      #   Person.attribute_names
+      #   # => ["name", "age"]
+      def attribute_names: () -> untyped
+
+      def define_method_attribute=: (untyped name) -> untyped
+
+      NO_DEFAULT_PROVIDED: untyped
+
+      def define_default_attribute: (untyped name, untyped value, untyped `type`) -> untyped
+    end
+
+    def initialize: () -> untyped
+
+    # Returns a hash of all the attributes with their names as keys and the values of the attributes as values.
+    #
+    #   class Person
+    #     include ActiveModel::Model
+    #     include ActiveModel::Attributes
+    #
+    #     attribute :name, :string
+    #     attribute :age, :integer
+    #   end
+    #
+    #   person = Person.new(name: 'Francesco', age: 22)
+    #   person.attributes
+    #   # => {"name"=>"Francesco", "age"=>22}
+    def attributes: () -> untyped
+
+    # Returns an array of attribute names as strings
+    #
+    #   class Person
+    #     include ActiveModel::Attributes
+    #
+    #     attribute :name, :string
+    #     attribute :age, :integer
+    #   end
+    #
+    #   person = Person.new
+    #   person.attribute_names
+    #   # => ["name", "age"]
+    def attribute_names: () -> untyped
+
+    def write_attribute: (untyped attr_name, untyped value) -> untyped
+
+    def attribute: (untyped attr_name) -> untyped
+
+    # Dispatch target for <tt>*=</tt> attribute methods.
+    def attribute=: (untyped attribute_name, untyped value) -> untyped
+  end
+end
+
+module ActiveModel
+  # == Active \Model \Callbacks
+  #
+  # Provides an interface for any class to have Active Record like callbacks.
+  #
+  # Like the Active Record methods, the callback chain is aborted as soon as
+  # one of the methods throws +:abort+.
+  #
+  # First, extend ActiveModel::Callbacks from the class you are creating:
+  #
+  #   class MyModel
+  #     extend ActiveModel::Callbacks
+  #   end
+  #
+  # Then define a list of methods that you want callbacks attached to:
+  #
+  #   define_model_callbacks :create, :update
+  #
+  # This will provide all three standard callbacks (before, around and after)
+  # for both the <tt>:create</tt> and <tt>:update</tt> methods. To implement,
+  # you need to wrap the methods you want callbacks on in a block so that the
+  # callbacks get a chance to fire:
+  #
+  #   def create
+  #     run_callbacks :create do
+  #       # Your create action methods here
+  #     end
+  #   end
+  #
+  # Then in your class, you can use the +before_create+, +after_create+ and
+  # +around_create+ methods, just as you would in an Active Record model.
+  #
+  #   before_create :action_before_create
+  #
+  #   def action_before_create
+  #     # Your code here
+  #   end
+  #
+  # When defining an around callback remember to yield to the block, otherwise
+  # it won't be executed:
+  #
+  #  around_create :log_status
+  #
+  #  def log_status
+  #    puts 'going to call the block...'
+  #    yield
+  #    puts 'block successfully called.'
+  #  end
+  #
+  # You can choose to have only specific callbacks by passing a hash to the
+  # +define_model_callbacks+ method.
+  #
+  #   define_model_callbacks :create, only: [:after, :before]
+  #
+  # Would only create the +after_create+ and +before_create+ callback methods in
+  # your class.
+  #
+  # NOTE: Calling the same callback multiple times will overwrite previous callback definitions.
+  #
+  module Callbacks
+    def self.extended: (untyped base) -> untyped
+
+    # define_model_callbacks accepts the same options +define_callbacks+ does,
+    # in case you want to overwrite a default. Besides that, it also accepts an
+    # <tt>:only</tt> option, where you can choose if you want all types (before,
+    # around or after) or just some.
+    #
+    #   define_model_callbacks :initializer, only: :after
+    #
+    # Note, the <tt>only: <type></tt> hash will apply to all callbacks defined
+    # on that method call. To get around this you can call the define_model_callbacks
+    # method as many times as you need.
+    #
+    #   define_model_callbacks :create,  only: :after
+    #   define_model_callbacks :update,  only: :before
+    #   define_model_callbacks :destroy, only: :around
+    #
+    # Would create +after_create+, +before_update+ and +around_destroy+ methods
+    # only.
+    #
+    # You can pass in a class to before_<type>, after_<type> and around_<type>,
+    # in which case the callback will call that class's <action>_<type> method
+    # passing the object that the callback is being called on.
+    #
+    #   class MyModel
+    #     extend ActiveModel::Callbacks
+    #     define_model_callbacks :create
+    #
+    #     before_create AnotherClass
+    #   end
+    #
+    #   class AnotherClass
+    #     def self.before_create( obj )
+    #       # obj is the MyModel instance that the callback is being called on
+    #     end
+    #   end
+    #
+    # NOTE: +method_name+ passed to define_model_callbacks must not end with
+    # <tt>!</tt>, <tt>?</tt> or <tt>=</tt>.
+    def define_model_callbacks: (*untyped callbacks) -> untyped
+
+    def _define_before_model_callback: (untyped klass, untyped callback) -> untyped
+
+    def _define_around_model_callback: (untyped klass, untyped callback) -> untyped
+
+    def _define_after_model_callback: (untyped klass, untyped callback) -> untyped
+  end
+end
+
+module ActiveModel
+  # == Active \Model \Conversion
+  #
+  # Handles default conversions: to_model, to_key, to_param, and to_partial_path.
+  #
+  # Let's take for example this non-persisted object.
+  #
+  #   class ContactMessage
+  #     include ActiveModel::Conversion
+  #
+  #     # ContactMessage are never persisted in the DB
+  #     def persisted?
+  #       false
+  #     end
+  #   end
+  #
+  #   cm = ContactMessage.new
+  #   cm.to_model == cm  # => true
+  #   cm.to_key          # => nil
+  #   cm.to_param        # => nil
+  #   cm.to_partial_path # => "contact_messages/contact_message"
+  module Conversion
+    extend ActiveSupport::Concern
+
+    # If your object is already designed to implement all of the \Active \Model
+    # you can use the default <tt>:to_model</tt> implementation, which simply
+    # returns +self+.
+    #
+    #   class Person
+    #     include ActiveModel::Conversion
+    #   end
+    #
+    #   person = Person.new
+    #   person.to_model == person # => true
+    #
+    # If your model does not act like an \Active \Model object, then you should
+    # define <tt>:to_model</tt> yourself returning a proxy object that wraps
+    # your object with \Active \Model compliant methods.
+    def to_model: () -> untyped
+
+    # Returns an Array of all key attributes if any of the attributes is set, whether or not
+    # the object is persisted. Returns +nil+ if there are no key attributes.
+    #
+    #   class Person
+    #     include ActiveModel::Conversion
+    #     attr_accessor :id
+    #
+    #     def initialize(id)
+    #       @id = id
+    #     end
+    #   end
+    #
+    #   person = Person.new(1)
+    #   person.to_key # => [1]
+    def to_key: () -> untyped
+
+    # Returns a +string+ representing the object's key suitable for use in URLs,
+    # or +nil+ if <tt>persisted?</tt> is +false+.
+    #
+    #   class Person
+    #     include ActiveModel::Conversion
+    #     attr_accessor :id
+    #
+    #     def initialize(id)
+    #       @id = id
+    #     end
+    #
+    #     def persisted?
+    #       true
+    #     end
+    #   end
+    #
+    #   person = Person.new(1)
+    #   person.to_param # => "1"
+    def to_param: () -> untyped
+
+    # Returns a +string+ identifying the path associated with the object.
+    # ActionPack uses this to find a suitable partial to represent the object.
+    #
+    #   class Person
+    #     include ActiveModel::Conversion
+    #   end
+    #
+    #   person = Person.new
+    #   person.to_partial_path # => "people/person"
+    def to_partial_path: () -> untyped
+
+    module ClassMethods
+      def _to_partial_path: () -> untyped
+    end
+  end
+end
+
+module ActiveModel
+  # == Active \Model \Dirty
+  #
+  # Provides a way to track changes in your object in the same way as
+  # Active Record does.
+  #
+  # The requirements for implementing ActiveModel::Dirty are:
+  #
+  # * <tt>include ActiveModel::Dirty</tt> in your object.
+  # * Call <tt>define_attribute_methods</tt> passing each method you want to
+  #   track.
+  # * Call <tt>[attr_name]_will_change!</tt> before each change to the tracked
+  #   attribute.
+  # * Call <tt>changes_applied</tt> after the changes are persisted.
+  # * Call <tt>clear_changes_information</tt> when you want to reset the changes
+  #   information.
+  # * Call <tt>restore_attributes</tt> when you want to restore previous data.
+  #
+  # A minimal implementation could be:
+  #
+  #   class Person
+  #     include ActiveModel::Dirty
+  #
+  #     define_attribute_methods :name
+  #
+  #     def initialize
+  #       @name = nil
+  #     end
+  #
+  #     def name
+  #       @name
+  #     end
+  #
+  #     def name=(val)
+  #       name_will_change! unless val == @name
+  #       @name = val
+  #     end
+  #
+  #     def save
+  #       # do persistence work
+  #
+  #       changes_applied
+  #     end
+  #
+  #     def reload!
+  #       # get the values from the persistence layer
+  #
+  #       clear_changes_information
+  #     end
+  #
+  #     def rollback!
+  #       restore_attributes
+  #     end
+  #   end
+  #
+  # A newly instantiated +Person+ object is unchanged:
+  #
+  #   person = Person.new
+  #   person.changed? # => false
+  #
+  # Change the name:
+  #
+  #   person.name = 'Bob'
+  #   person.changed?       # => true
+  #   person.name_changed?  # => true
+  #   person.name_changed?(from: nil, to: "Bob") # => true
+  #   person.name_was       # => nil
+  #   person.name_change    # => [nil, "Bob"]
+  #   person.name = 'Bill'
+  #   person.name_change    # => [nil, "Bill"]
+  #
+  # Save the changes:
+  #
+  #   person.save
+  #   person.changed?      # => false
+  #   person.name_changed? # => false
+  #
+  # Reset the changes:
+  #
+  #   person.previous_changes         # => {"name" => [nil, "Bill"]}
+  #   person.name_previously_changed? # => true
+  #   person.name_previous_change     # => [nil, "Bill"]
+  #   person.reload!
+  #   person.previous_changes         # => {}
+  #
+  # Rollback the changes:
+  #
+  #   person.name = "Uncle Bob"
+  #   person.rollback!
+  #   person.name          # => "Bill"
+  #   person.name_changed? # => false
+  #
+  # Assigning the same value leaves the attribute unchanged:
+  #
+  #   person.name = 'Bill'
+  #   person.name_changed? # => false
+  #   person.name_change   # => nil
+  #
+  # Which attributes have changed?
+  #
+  #   person.name = 'Bob'
+  #   person.changed # => ["name"]
+  #   person.changes # => {"name" => ["Bill", "Bob"]}
+  #
+  # If an attribute is modified in-place then make use of
+  # <tt>[attribute_name]_will_change!</tt> to mark that the attribute is changing.
+  # Otherwise \Active \Model can't track changes to in-place attributes. Note
+  # that Active Record can detect in-place modifications automatically. You do
+  # not need to call <tt>[attribute_name]_will_change!</tt> on Active Record models.
+  #
+  #   person.name_will_change!
+  #   person.name_change # => ["Bill", "Bill"]
+  #   person.name << 'y'
+  #   person.name_change # => ["Bill", "Billy"]
+  module Dirty
+    extend ActiveSupport::Concern
+
+    include ActiveModel::AttributeMethods
+
+    def initialize_dup: (untyped other) -> untyped
+
+    # Clears dirty data and moves +changes+ to +previously_changed+ and
+    # +mutations_from_database+ to +mutations_before_last_save+ respectively.
+    def changes_applied: () -> untyped
+
+    # Returns +true+ if any of the attributes has unsaved changes, +false+ otherwise.
+    #
+    #   person.changed? # => false
+    #   person.name = 'bob'
+    #   person.changed? # => true
+    def changed?: () -> untyped
+
+    # Returns an array with the name of the attributes with unsaved changes.
+    #
+    #   person.changed # => []
+    #   person.name = 'bob'
+    #   person.changed # => ["name"]
+    def changed: () -> untyped
+
+    def attribute_changed?: (untyped attr_name, **untyped options) -> untyped
+
+    def attribute_was: (untyped attr_name) -> untyped
+
+    def attribute_previously_changed?: (untyped attr_name) -> untyped
+
+    # Restore all previous data of the provided attributes.
+    def restore_attributes: (?untyped attr_names) -> untyped
+
+    # Clears all dirty data: current changes and previous changes.
+    def clear_changes_information: () -> untyped
+
+    def clear_attribute_changes: (untyped attr_names) -> untyped
+
+    # Returns a hash of the attributes with unsaved changes indicating their original
+    # values like <tt>attr => original value</tt>.
+    #
+    #   person.name # => "bob"
+    #   person.name = 'robert'
+    #   person.changed_attributes # => {"name" => "bob"}
+    def changed_attributes: () -> untyped
+
+    # Returns a hash of changed attributes indicating their original
+    # and new values like <tt>attr => [original value, new value]</tt>.
+    #
+    #   person.changes # => {}
+    #   person.name = 'bob'
+    #   person.changes # => { "name" => ["bill", "bob"] }
+    def changes: () -> untyped
+
+    # Returns a hash of attributes that were changed before the model was saved.
+    #
+    #   person.name # => "bob"
+    #   person.name = 'robert'
+    #   person.save
+    #   person.previous_changes # => {"name" => ["bob", "robert"]}
+    def previous_changes: () -> untyped
+
+    def attribute_changed_in_place?: (untyped attr_name) -> untyped
+
+    def clear_attribute_change: (untyped attr_name) -> untyped
+
+    def mutations_from_database: () -> untyped
+
+    def forget_attribute_assignments: () -> untyped
+
+    def mutations_before_last_save: () -> untyped
+
+    # Dispatch target for <tt>*_change</tt> attribute methods.
+    def attribute_change: (untyped attr_name) -> untyped
+
+    # Dispatch target for <tt>*_previous_change</tt> attribute methods.
+    def attribute_previous_change: (untyped attr_name) -> untyped
+
+    # Dispatch target for <tt>*_will_change!</tt> attribute methods.
+    def attribute_will_change!: (untyped attr_name) -> untyped
+
+    # Dispatch target for <tt>restore_*!</tt> attribute methods.
+    def restore_attribute!: (untyped attr_name) -> untyped
+  end
+end
+
+module ActiveModel
+  # == Active \Model \Errors
+  #
+  # Provides a modified +Hash+ that you can include in your object
+  # for handling error messages and interacting with Action View helpers.
+  #
+  # A minimal implementation could be:
+  #
+  #   class Person
+  #     # Required dependency for ActiveModel::Errors
+  #     extend ActiveModel::Naming
+  #
+  #     def initialize
+  #       @errors = ActiveModel::Errors.new(self)
+  #     end
+  #
+  #     attr_accessor :name
+  #     attr_reader   :errors
+  #
+  #     def validate!
+  #       errors.add(:name, :blank, message: "cannot be nil") if name.nil?
+  #     end
+  #
+  #     # The following methods are needed to be minimally implemented
+  #
+  #     def read_attribute_for_validation(attr)
+  #       send(attr)
+  #     end
+  #
+  #     def self.human_attribute_name(attr, options = {})
+  #       attr
+  #     end
+  #
+  #     def self.lookup_ancestors
+  #       [self]
+  #     end
+  #   end
+  #
+  # The last three methods are required in your object for +Errors+ to be
+  # able to generate error messages correctly and also handle multiple
+  # languages. Of course, if you extend your object with <tt>ActiveModel::Translation</tt>
+  # you will not need to implement the last two. Likewise, using
+  # <tt>ActiveModel::Validations</tt> will handle the validation related methods
+  # for you.
+  #
+  # The above allows you to do:
+  #
+  #   person = Person.new
+  #   person.validate!            # => ["cannot be nil"]
+  #   person.errors.full_messages # => ["name cannot be nil"]
+  #   # etc..
+  class Errors
+    include Enumerable[untyped]
+
+    CALLBACKS_OPTIONS: ::Array[untyped]
+
+    MESSAGE_OPTIONS: ::Array[untyped]
+
+    attr_accessor i18n_customize_full_message: untyped
+
+    attr_reader messages: untyped
+
+    attr_reader details: untyped
+
+    # Pass in the instance of the object that is using the errors object.
+    #
+    #   class Person
+    #     def initialize
+    #       @errors = ActiveModel::Errors.new(self)
+    #     end
+    #   end
+    def initialize: (untyped base) -> untyped
+
+    def initialize_dup: (untyped other) -> untyped
+
+    def copy!: (untyped other) -> untyped
+
+    # Merges the errors from <tt>other</tt>.
+    #
+    # other - The ActiveModel::Errors instance.
+    #
+    # Examples
+    #
+    #   person.errors.merge!(other)
+    def merge!: (untyped other) -> untyped
+
+    # Removes all errors except the given keys. Returns a hash containing the removed errors.
+    #
+    #   person.errors.keys                  # => [:name, :age, :gender, :city]
+    #   person.errors.slice!(:age, :gender) # => { :name=>["cannot be nil"], :city=>["cannot be nil"] }
+    #   person.errors.keys                  # => [:age, :gender]
+    def slice!: (*untyped keys) -> untyped
+
+    # Clear the error messages.
+    #
+    #   person.errors.full_messages # => ["name cannot be nil"]
+    #   person.errors.clear
+    #   person.errors.full_messages # => []
+    def clear: () -> untyped
+
+    # Returns +true+ if the error messages include an error for the given key
+    # +attribute+, +false+ otherwise.
+    #
+    #   person.errors.messages        # => {:name=>["cannot be nil"]}
+    #   person.errors.include?(:name) # => true
+    #   person.errors.include?(:age)  # => false
+    def include?: (untyped attribute) -> untyped
+
+    alias has_key? include?
+
+    alias key? include?
+
+    # Delete messages for +key+. Returns the deleted messages.
+    #
+    #   person.errors[:name]        # => ["cannot be nil"]
+    #   person.errors.delete(:name) # => ["cannot be nil"]
+    #   person.errors[:name]        # => []
+    def delete: (untyped key) -> untyped
+
+    # When passed a symbol or a name of a method, returns an array of errors
+    # for the method.
+    #
+    #   person.errors[:name]  # => ["cannot be nil"]
+    #   person.errors['name'] # => ["cannot be nil"]
+    def []: (untyped attribute) -> untyped
+
+    # Iterates through each error key, value pair in the error messages hash.
+    # Yields the attribute and the error for that attribute. If the attribute
+    # has more than one error message, yields once for each error message.
+    #
+    #   person.errors.add(:name, :blank, message: "can't be blank")
+    #   person.errors.each do |attribute, error|
+    #     # Will yield :name and "can't be blank"
+    #   end
+    #
+    #   person.errors.add(:name, :not_specified, message: "must be specified")
+    #   person.errors.each do |attribute, error|
+    #     # Will yield :name and "can't be blank"
+    #     # then yield :name and "must be specified"
+    #   end
+    def each: () { (untyped, untyped) -> untyped } -> untyped
+
+    # Returns the number of error messages.
+    #
+    #   person.errors.add(:name, :blank, message: "can't be blank")
+    #   person.errors.size # => 1
+    #   person.errors.add(:name, :not_specified, message: "must be specified")
+    #   person.errors.size # => 2
+    def size: () -> untyped
+
+    alias count size
+
+    # Returns all message values.
+    #
+    #   person.errors.messages # => {:name=>["cannot be nil", "must be specified"]}
+    #   person.errors.values   # => [["cannot be nil", "must be specified"]]
+    def values: () -> untyped
+
+    # Returns all message keys.
+    #
+    #   person.errors.messages # => {:name=>["cannot be nil", "must be specified"]}
+    #   person.errors.keys     # => [:name]
+    def keys: () -> untyped
+
+    # Returns +true+ if no errors are found, +false+ otherwise.
+    # If the error message is a string it can be empty.
+    #
+    #   person.errors.full_messages # => ["name cannot be nil"]
+    #   person.errors.empty?        # => false
+    def empty?: () -> untyped
+
+    alias blank? empty?
+
+    # Returns an xml formatted representation of the Errors hash.
+    #
+    #   person.errors.add(:name, :blank, message: "can't be blank")
+    #   person.errors.add(:name, :not_specified, message: "must be specified")
+    #   person.errors.to_xml
+    #   # =>
+    #   #  <?xml version=\"1.0\" encoding=\"UTF-8\"?>
+    #   #  <errors>
+    #   #    <error>name can't be blank</error>
+    #   #    <error>name must be specified</error>
+    #   #  </errors>
+    def to_xml: (?::Hash[untyped, untyped] options) -> untyped
+
+    # Returns a Hash that can be used as the JSON representation for this
+    # object. You can pass the <tt>:full_messages</tt> option. This determines
+    # if the json object should contain full messages or not (false by default).
+    #
+    #   person.errors.as_json                      # => {:name=>["cannot be nil"]}
+    #   person.errors.as_json(full_messages: true) # => {:name=>["name cannot be nil"]}
+    def as_json: (?untyped? options) -> untyped
+
+    # Returns a Hash of attributes with their error messages. If +full_messages+
+    # is +true+, it will contain full messages (see +full_message+).
+    #
+    #   person.errors.to_hash       # => {:name=>["cannot be nil"]}
+    #   person.errors.to_hash(true) # => {:name=>["name cannot be nil"]}
+    def to_hash: (?bool full_messages) -> untyped
+
+    # Adds +message+ to the error messages and used validator type to +details+ on +attribute+.
+    # More than one error can be added to the same +attribute+.
+    # If no +message+ is supplied, <tt>:invalid</tt> is assumed.
+    #
+    #   person.errors.add(:name)
+    #   # => ["is invalid"]
+    #   person.errors.add(:name, :not_implemented, message: "must be implemented")
+    #   # => ["is invalid", "must be implemented"]
+    #
+    #   person.errors.messages
+    #   # => {:name=>["is invalid", "must be implemented"]}
+    #
+    #   person.errors.details
+    #   # => {:name=>[{error: :not_implemented}, {error: :invalid}]}
+    #
+    # If +message+ is a symbol, it will be translated using the appropriate
+    # scope (see +generate_message+).
+    #
+    # If +message+ is a proc, it will be called, allowing for things like
+    # <tt>Time.now</tt> to be used within an error.
+    #
+    # If the <tt>:strict</tt> option is set to +true+, it will raise
+    # ActiveModel::StrictValidationFailed instead of adding the error.
+    # <tt>:strict</tt> option can also be set to any other exception.
+    #
+    #   person.errors.add(:name, :invalid, strict: true)
+    #   # => ActiveModel::StrictValidationFailed: Name is invalid
+    #   person.errors.add(:name, :invalid, strict: NameIsInvalid)
+    #   # => NameIsInvalid: Name is invalid
+    #
+    #   person.errors.messages # => {}
+    #
+    # +attribute+ should be set to <tt>:base</tt> if the error is not
+    # directly associated with a single attribute.
+    #
+    #   person.errors.add(:base, :name_or_email_blank,
+    #     message: "either name or email must be present")
+    #   person.errors.messages
+    #   # => {:base=>["either name or email must be present"]}
+    #   person.errors.details
+    #   # => {:base=>[{error: :name_or_email_blank}]}
+    def add: (untyped attribute, ?::Symbol message, ?::Hash[untyped, untyped] options) -> untyped
+
+    # Returns +true+ if an error on the attribute with the given message is
+    # present, or +false+ otherwise. +message+ is treated the same as for +add+.
+    #
+    #   person.errors.add :name, :blank
+    #   person.errors.added? :name, :blank           # => true
+    #   person.errors.added? :name, "can't be blank" # => true
+    #
+    # If the error message requires options, then it returns +true+ with
+    # the correct options, or +false+ with incorrect or missing options.
+    #
+    #   person.errors.add :name, :too_long, { count: 25 }
+    #   person.errors.added? :name, :too_long, count: 25                     # => true
+    #   person.errors.added? :name, "is too long (maximum is 25 characters)" # => true
+    #   person.errors.added? :name, :too_long, count: 24                     # => false
+    #   person.errors.added? :name, :too_long                                # => false
+    #   person.errors.added? :name, "is too long"                            # => false
+    def added?: (untyped attribute, ?::Symbol message, ?::Hash[untyped, untyped] options) -> untyped
+
+    # Returns +true+ if an error on the attribute with the given message is
+    # present, or +false+ otherwise. +message+ is treated the same as for +add+.
+    #
+    #   person.errors.add :age
+    #   person.errors.add :name, :too_long, { count: 25 }
+    #   person.errors.of_kind? :age                                            # => true
+    #   person.errors.of_kind? :name                                           # => false
+    #   person.errors.of_kind? :name, :too_long                                # => true
+    #   person.errors.of_kind? :name, "is too long (maximum is 25 characters)" # => true
+    #   person.errors.of_kind? :name, :not_too_long                            # => false
+    #   person.errors.of_kind? :name, "is too long"                            # => false
+    def of_kind?: (untyped attribute, ?::Symbol message) -> untyped
+
+    # Returns all the full error messages in an array.
+    #
+    #   class Person
+    #     validates_presence_of :name, :address, :email
+    #     validates_length_of :name, in: 5..30
+    #   end
+    #
+    #   person = Person.create(address: '123 First St.')
+    #   person.errors.full_messages
+    #   # => ["Name is too short (minimum is 5 characters)", "Name can't be blank", "Email can't be blank"]
+    def full_messages: () -> untyped
+
+    alias to_a full_messages
+
+    # Returns all the full error messages for a given attribute in an array.
+    #
+    #   class Person
+    #     validates_presence_of :name, :email
+    #     validates_length_of :name, in: 5..30
+    #   end
+    #
+    #   person = Person.create()
+    #   person.errors.full_messages_for(:name)
+    #   # => ["Name is too short (minimum is 5 characters)", "Name can't be blank"]
+    def full_messages_for: (untyped attribute) -> untyped
+
+    # Returns a full message for a given attribute.
+    #
+    #   person.errors.full_message(:name, 'is invalid') # => "Name is invalid"
+    #
+    # The `"%{attribute} %{message}"` error format can be overridden with either
+    #
+    # * <tt>activemodel.errors.models.person/contacts/addresses.attributes.street.format</tt>
+    # * <tt>activemodel.errors.models.person/contacts/addresses.format</tt>
+    # * <tt>activemodel.errors.models.person.attributes.name.format</tt>
+    # * <tt>activemodel.errors.models.person.format</tt>
+    # * <tt>errors.format</tt>
+    def full_message: (untyped attribute, untyped message) -> untyped
+
+    # Translates an error message in its default scope
+    # (<tt>activemodel.errors.messages</tt>).
+    #
+    # Error messages are first looked up in <tt>activemodel.errors.models.MODEL.attributes.ATTRIBUTE.MESSAGE</tt>,
+    # if it's not there, it's looked up in <tt>activemodel.errors.models.MODEL.MESSAGE</tt> and if
+    # that is not there also, it returns the translation of the default message
+    # (e.g. <tt>activemodel.errors.messages.MESSAGE</tt>). The translated model
+    # name, translated attribute name and the value are available for
+    # interpolation.
+    #
+    # When using inheritance in your models, it will check all the inherited
+    # models too, but only if the model itself hasn't been found. Say you have
+    # <tt>class Admin < User; end</tt> and you wanted the translation for
+    # the <tt>:blank</tt> error message for the <tt>title</tt> attribute,
+    # it looks for these translations:
+    #
+    # * <tt>activemodel.errors.models.admin.attributes.title.blank</tt>
+    # * <tt>activemodel.errors.models.admin.blank</tt>
+    # * <tt>activemodel.errors.models.user.attributes.title.blank</tt>
+    # * <tt>activemodel.errors.models.user.blank</tt>
+    # * any default you provided through the +options+ hash (in the <tt>activemodel.errors</tt> scope)
+    # * <tt>activemodel.errors.messages.blank</tt>
+    # * <tt>errors.attributes.title.blank</tt>
+    # * <tt>errors.messages.blank</tt>
+    def generate_message: (untyped attribute, ?::Symbol `type`, ?::Hash[untyped, untyped] options) -> untyped
+
+    def marshal_dump: () -> ::Array[untyped]
+
+    def marshal_load: (untyped array) -> untyped
+
+    def init_with: (untyped coder) -> untyped
+
+    def normalize_message: (untyped attribute, untyped message, untyped options) -> untyped
+
+    def normalize_detail: (untyped message, untyped options) -> untyped
+
+    def without_default_proc: (untyped hash) -> untyped
+
+    def apply_default_array: (untyped hash) -> untyped
+  end
+
+  # Raised when a validation cannot be corrected by end users and are considered
+  # exceptional.
+  #
+  #   class Person
+  #     include ActiveModel::Validations
+  #
+  #     attr_accessor :name
+  #
+  #     validates_presence_of :name, strict: true
+  #   end
+  #
+  #   person = Person.new
+  #   person.name = nil
+  #   person.valid?
+  #   # => ActiveModel::StrictValidationFailed: Name can't be blank
+  class StrictValidationFailed < StandardError
+  end
+
+  # Raised when attribute values are out of range.
+  class RangeError < ::RangeError
+  end
+
+  # Raised when unknown attributes are supplied via mass assignment.
+  #
+  #   class Person
+  #     include ActiveModel::AttributeAssignment
+  #     include ActiveModel::Validations
+  #   end
+  #
+  #   person = Person.new
+  #   person.assign_attributes(name: 'Gorby')
+  #   # => ActiveModel::UnknownAttributeError: unknown attribute 'name' for Person.
+  class UnknownAttributeError[T] < NoMethodError[T]
+    attr_reader record: untyped
+
+    attr_reader attribute: untyped
+
+    def initialize: (untyped record, untyped attribute) -> untyped
+  end
+end
+
+module ActiveModel
+  # Raised when forbidden attributes are used for mass assignment.
+  #
+  #   class Person < ActiveRecord::Base
+  #   end
+  #
+  #   params = ActionController::Parameters.new(name: 'Bob')
+  #   Person.new(params)
+  #   # => ActiveModel::ForbiddenAttributesError
+  #
+  #   params.permit!
+  #   Person.new(params)
+  #   # => #<Person id: nil, name: "Bob">
+  class ForbiddenAttributesError < StandardError
+  end
+
+  module ForbiddenAttributesProtection
+    def sanitize_for_mass_assignment: (untyped attributes) -> untyped
+
+    alias sanitize_forbidden_attributes sanitize_for_mass_assignment
+  end
+end
+
+module ActiveModel
+  # Returns the version of the currently loaded \Active \Model as a <tt>Gem::Version</tt>
+  def self.gem_version: () -> Gem::Version
+
+  module VERSION
+    MAJOR: ::Integer
+
+    MINOR: ::Integer
+
+    TINY: ::Integer
+
+    PRE: ::String
+
+    STRING: untyped
+  end
+end
+
+module ActiveModel
+  module Lint
+    # == Active \Model \Lint \Tests
+    #
+    # You can test whether an object is compliant with the Active \Model API by
+    # including <tt>ActiveModel::Lint::Tests</tt> in your TestCase. It will
+    # include tests that tell you whether your object is fully compliant,
+    # or if not, which aspects of the API are not implemented.
+    #
+    # Note an object is not required to implement all APIs in order to work
+    # with Action Pack. This module only intends to provide guidance in case
+    # you want all features out of the box.
+    #
+    # These tests do not attempt to determine the semantic correctness of the
+    # returned values. For instance, you could implement <tt>valid?</tt> to
+    # always return +true+, and the tests would pass. It is up to you to ensure
+    # that the values are semantically meaningful.
+    #
+    # Objects you pass in are expected to return a compliant object from a call
+    # to <tt>to_model</tt>. It is perfectly fine for <tt>to_model</tt> to return
+    # +self+.
+    module Tests
+      # Passes if the object's model responds to <tt>to_key</tt> and if calling
+      # this method returns +nil+ when the object is not persisted.
+      # Fails otherwise.
+      #
+      # <tt>to_key</tt> returns an Enumerable of all (primary) key attributes
+      # of the model, and is used to a generate unique DOM id for the object.
+      def test_to_key: () -> untyped
+
+      # Passes if the object's model responds to <tt>to_param</tt> and if
+      # calling this method returns +nil+ when the object is not persisted.
+      # Fails otherwise.
+      #
+      # <tt>to_param</tt> is used to represent the object's key in URLs.
+      # Implementers can decide to either raise an exception or provide a
+      # default in case the record uses a composite primary key. There are no
+      # tests for this behavior in lint because it doesn't make sense to force
+      # any of the possible implementation strategies on the implementer.
+      def test_to_param: () -> untyped
+
+      # Passes if the object's model responds to <tt>to_partial_path</tt> and if
+      # calling this method returns a string. Fails otherwise.
+      #
+      # <tt>to_partial_path</tt> is used for looking up partials. For example,
+      # a BlogPost model might return "blog_posts/blog_post".
+      def test_to_partial_path: () -> untyped
+
+      # Passes if the object's model responds to <tt>persisted?</tt> and if
+      # calling this method returns either +true+ or +false+. Fails otherwise.
+      #
+      # <tt>persisted?</tt> is used when calculating the URL for an object.
+      # If the object is not persisted, a form for that object, for instance,
+      # will route to the create action. If it is persisted, a form for the
+      # object will route to the update action.
+      def test_persisted?: () -> untyped
+
+      # Passes if the object's model responds to <tt>model_name</tt> both as
+      # an instance method and as a class method, and if calling this method
+      # returns a string with some convenience methods: <tt>:human</tt>,
+      # <tt>:singular</tt> and <tt>:plural</tt>.
+      #
+      # Check ActiveModel::Naming for more information.
+      def test_model_naming: () -> untyped
+
+      # Passes if the object's model responds to <tt>errors</tt> and if calling
+      # <tt>[](attribute)</tt> on the result of this method returns an array.
+      # Fails otherwise.
+      #
+      # <tt>errors[attribute]</tt> is used to retrieve the errors of a model
+      # for a given attribute. If errors are present, the method should return
+      # an array of strings that are the errors for the attribute in question.
+      # If localization is used, the strings should be localized for the current
+      # locale. If no error is present, the method should return an empty array.
+      def test_errors_aref: () -> untyped
+
+      def model: () -> untyped
+
+      def assert_boolean: (untyped result, untyped name) -> untyped
+    end
+  end
+end
+
+module ActiveModel
+  # == Active \Model \Basic \Model
+  #
+  # Includes the required interface for an object to interact with
+  # Action Pack and Action View, using different Active Model modules.
+  # It includes model name introspections, conversions, translations and
+  # validations. Besides that, it allows you to initialize the object with a
+  # hash of attributes, pretty much like Active Record does.
+  #
+  # A minimal implementation could be:
+  #
+  #   class Person
+  #     include ActiveModel::Model
+  #     attr_accessor :name, :age
+  #   end
+  #
+  #   person = Person.new(name: 'bob', age: '18')
+  #   person.name # => "bob"
+  #   person.age  # => "18"
+  #
+  # Note that, by default, <tt>ActiveModel::Model</tt> implements <tt>persisted?</tt>
+  # to return +false+, which is the most common case. You may want to override
+  # it in your class to simulate a different scenario:
+  #
+  #   class Person
+  #     include ActiveModel::Model
+  #     attr_accessor :id, :name
+  #
+  #     def persisted?
+  #       self.id == 1
+  #     end
+  #   end
+  #
+  #   person = Person.new(id: 1, name: 'bob')
+  #   person.persisted? # => true
+  #
+  # Also, if for some reason you need to run code on <tt>initialize</tt>, make
+  # sure you call +super+ if you want the attributes hash initialization to
+  # happen.
+  #
+  #   class Person
+  #     include ActiveModel::Model
+  #     attr_accessor :id, :name, :omg
+  #
+  #     def initialize(attributes={})
+  #       super
+  #       @omg ||= true
+  #     end
+  #   end
+  #
+  #   person = Person.new(id: 1, name: 'bob')
+  #   person.omg # => true
+  #
+  # For more detailed information on other functionalities available, please
+  # refer to the specific modules included in <tt>ActiveModel::Model</tt>
+  # (see below).
+  module Model
+    extend ActiveSupport::Concern
+
+    include ActiveModel::AttributeAssignment
+
+    include ActiveModel::Validations
+
+    include ActiveModel::Conversion
+
+    extend ActiveModel::Naming
+
+    extend ActiveModel::Translation
+
+    # Initializes a new model with the given +params+.
+    #
+    #   class Person
+    #     include ActiveModel::Model
+    #     attr_accessor :name, :age
+    #   end
+    #
+    #   person = Person.new(name: 'bob', age: '18')
+    #   person.name # => "bob"
+    #   person.age  # => "18"
+    def initialize: (?::Hash[untyped, untyped] attributes) -> untyped
+
+    # Indicates if the model is persisted. Default is +false+.
+    #
+    #  class Person
+    #    include ActiveModel::Model
+    #    attr_accessor :id, :name
+    #  end
+    #
+    #  person = Person.new(id: 1, name: 'bob')
+    #  person.persisted? # => false
+    def persisted?: () -> ::FalseClass
+  end
+end
+
+module ActiveModel
+  class Name
+    include Comparable
+
+    attr_reader singular: untyped
+
+    attr_reader plural: untyped
+
+    attr_reader element: untyped
+
+    attr_reader collection: untyped
+
+    attr_reader singular_route_key: untyped
+
+    attr_reader route_key: untyped
+
+    attr_reader param_key: untyped
+
+    attr_reader i18n_key: untyped
+
+    attr_reader name: untyped
+
+    alias cache_key collection
+
+    # Returns a new ActiveModel::Name instance. By default, the +namespace+
+    # and +name+ option will take the namespace and name of the given class
+    # respectively.
+    #
+    #   module Foo
+    #     class Bar
+    #     end
+    #   end
+    #
+    #   ActiveModel::Name.new(Foo::Bar).to_s
+    #   # => "Foo::Bar"
+    def initialize: (untyped klass, ?untyped? namespace, ?untyped? name) -> untyped
+
+    # Transform the model name into a more human format, using I18n. By default,
+    # it will underscore then humanize the class name.
+    #
+    #   class BlogPost
+    #     extend ActiveModel::Naming
+    #   end
+    #
+    #   BlogPost.model_name.human # => "Blog post"
+    #
+    # Specify +options+ with additional translating options.
+    def human: (?::Hash[untyped, untyped] options) -> untyped
+
+    def _singularize: (untyped string) -> untyped
+  end
+
+  # == Active \Model \Naming
+  #
+  # Creates a +model_name+ method on your object.
+  #
+  # To implement, just extend ActiveModel::Naming in your object:
+  #
+  #   class BookCover
+  #     extend ActiveModel::Naming
+  #   end
+  #
+  #   BookCover.model_name.name   # => "BookCover"
+  #   BookCover.model_name.human  # => "Book cover"
+  #
+  #   BookCover.model_name.i18n_key              # => :book_cover
+  #   BookModule::BookCover.model_name.i18n_key  # => :"book_module/book_cover"
+  #
+  # Providing the functionality that ActiveModel::Naming provides in your object
+  # is required to pass the \Active \Model Lint test. So either extending the
+  # provided method below, or rolling your own is required.
+  module Naming
+    def self.extended: (untyped base) -> untyped
+
+    # Returns an ActiveModel::Name object for module. It can be
+    # used to retrieve all kinds of naming-related information
+    # (See ActiveModel::Name for more information).
+    #
+    #   class Person
+    #     extend ActiveModel::Naming
+    #   end
+    #
+    #   Person.model_name.name     # => "Person"
+    #   Person.model_name.class    # => ActiveModel::Name
+    #   Person.model_name.singular # => "person"
+    #   Person.model_name.plural   # => "people"
+    def model_name: () -> untyped
+
+    # Returns the plural class name of a record or class.
+    #
+    #   ActiveModel::Naming.plural(post)             # => "posts"
+    #   ActiveModel::Naming.plural(Highrise::Person) # => "highrise_people"
+    def self.plural: (untyped record_or_class) -> untyped
+
+    # Returns the singular class name of a record or class.
+    #
+    #   ActiveModel::Naming.singular(post)             # => "post"
+    #   ActiveModel::Naming.singular(Highrise::Person) # => "highrise_person"
+    def self.singular: (untyped record_or_class) -> untyped
+
+    # Identifies whether the class name of a record or class is uncountable.
+    #
+    #   ActiveModel::Naming.uncountable?(Sheep) # => true
+    #   ActiveModel::Naming.uncountable?(Post)  # => false
+    def self.uncountable?: (untyped record_or_class) -> untyped
+
+    # Returns string to use while generating route names. It differs for
+    # namespaced models regarding whether it's inside isolated engine.
+    #
+    #   # For isolated engine:
+    #   ActiveModel::Naming.singular_route_key(Blog::Post) # => "post"
+    #
+    #   # For shared engine:
+    #   ActiveModel::Naming.singular_route_key(Blog::Post) # => "blog_post"
+    def self.singular_route_key: (untyped record_or_class) -> untyped
+
+    # Returns string to use while generating route names. It differs for
+    # namespaced models regarding whether it's inside isolated engine.
+    #
+    #   # For isolated engine:
+    #   ActiveModel::Naming.route_key(Blog::Post) # => "posts"
+    #
+    #   # For shared engine:
+    #   ActiveModel::Naming.route_key(Blog::Post) # => "blog_posts"
+    #
+    # The route key also considers if the noun is uncountable and, in
+    # such cases, automatically appends _index.
+    def self.route_key: (untyped record_or_class) -> untyped
+
+    # Returns string to use for params names. It differs for
+    # namespaced models regarding whether it's inside isolated engine.
+    #
+    #   # For isolated engine:
+    #   ActiveModel::Naming.param_key(Blog::Post) # => "post"
+    #
+    #   # For shared engine:
+    #   ActiveModel::Naming.param_key(Blog::Post) # => "blog_post"
+    def self.param_key: (untyped record_or_class) -> untyped
+
+    def self.model_name_from_record_or_class: (untyped record_or_class) -> untyped
+  end
+end
+
+module ActiveModel
+  class Railtie < Rails::Railtie
+  end
+end
+
+module ActiveModel
+  module SecurePassword
+    extend ActiveSupport::Concern
+
+    # BCrypt hash function can handle maximum 72 bytes, and if we pass
+    # password of length more than 72 bytes it ignores extra characters.
+    # Hence need to put a restriction on password length.
+    MAX_PASSWORD_LENGTH_ALLOWED: ::Integer
+
+    attr_accessor min_cost: untyped
+
+    module ClassMethods
+      # Adds methods to set and authenticate against a BCrypt password.
+      # This mechanism requires you to have a +XXX_digest+ attribute.
+      # Where +XXX+ is the attribute name of your desired password.
+      #
+      # The following validations are added automatically:
+      # * Password must be present on creation
+      # * Password length should be less than or equal to 72 bytes
+      # * Confirmation of password (using a +XXX_confirmation+ attribute)
+      #
+      # If confirmation validation is not needed, simply leave out the
+      # value for +XXX_confirmation+ (i.e. don't provide a form field for
+      # it). When this attribute has a +nil+ value, the validation will not be
+      # triggered.
+      #
+      # For further customizability, it is possible to suppress the default
+      # validations by passing <tt>validations: false</tt> as an argument.
+      #
+      # Add bcrypt (~> 3.1.7) to Gemfile to use #has_secure_password:
+      #
+      #   gem 'bcrypt', '~> 3.1.7'
+      #
+      # Example using Active Record (which automatically includes ActiveModel::SecurePassword):
+      #
+      #   # Schema: User(name:string, password_digest:string, recovery_password_digest:string)
+      #   class User < ActiveRecord::Base
+      #     has_secure_password
+      #     has_secure_password :recovery_password, validations: false
+      #   end
+      #
+      #   user = User.new(name: 'david', password: '', password_confirmation: 'nomatch')
+      #   user.save                                                       # => false, password required
+      #   user.password = 'mUc3m00RsqyRe'
+      #   user.save                                                       # => false, confirmation doesn't match
+      #   user.password_confirmation = 'mUc3m00RsqyRe'
+      #   user.save                                                       # => true
+      #   user.recovery_password = "42password"
+      #   user.recovery_password_digest                                   # => "$2a$04$iOfhwahFymCs5weB3BNH/uXkTG65HR.qpW.bNhEjFP3ftli3o5DQC"
+      #   user.save                                                       # => true
+      #   user.authenticate('notright')                                   # => false
+      #   user.authenticate('mUc3m00RsqyRe')                              # => user
+      #   user.authenticate_recovery_password('42password')               # => user
+      #   User.find_by(name: 'david').try(:authenticate, 'notright')      # => false
+      #   User.find_by(name: 'david').try(:authenticate, 'mUc3m00RsqyRe') # => user
+      def has_secure_password: (?::Symbol attribute, ?validations: bool validations) -> untyped
+    end
+
+    class InstanceMethodsOnActivation < Module
+      def initialize: (untyped attribute) -> untyped
+    end
+  end
+end
+
+module ActiveModel
+  # == Active \Model \Serialization
+  #
+  # Provides a basic serialization to a serializable_hash for your objects.
+  #
+  # A minimal implementation could be:
+  #
+  #   class Person
+  #     include ActiveModel::Serialization
+  #
+  #     attr_accessor :name
+  #
+  #     def attributes
+  #       {'name' => nil}
+  #     end
+  #   end
+  #
+  # Which would provide you with:
+  #
+  #   person = Person.new
+  #   person.serializable_hash   # => {"name"=>nil}
+  #   person.name = "Bob"
+  #   person.serializable_hash   # => {"name"=>"Bob"}
+  #
+  # An +attributes+ hash must be defined and should contain any attributes you
+  # need to be serialized. Attributes must be strings, not symbols.
+  # When called, serializable hash will use instance methods that match the name
+  # of the attributes hash's keys. In order to override this behavior, take a look
+  # at the private method +read_attribute_for_serialization+.
+  #
+  # ActiveModel::Serializers::JSON module automatically includes
+  # the <tt>ActiveModel::Serialization</tt> module, so there is no need to
+  # explicitly include <tt>ActiveModel::Serialization</tt>.
+  #
+  # A minimal implementation including JSON would be:
+  #
+  #   class Person
+  #     include ActiveModel::Serializers::JSON
+  #
+  #     attr_accessor :name
+  #
+  #     def attributes
+  #       {'name' => nil}
+  #     end
+  #   end
+  #
+  # Which would provide you with:
+  #
+  #   person = Person.new
+  #   person.serializable_hash   # => {"name"=>nil}
+  #   person.as_json             # => {"name"=>nil}
+  #   person.to_json             # => "{\"name\":null}"
+  #
+  #   person.name = "Bob"
+  #   person.serializable_hash   # => {"name"=>"Bob"}
+  #   person.as_json             # => {"name"=>"Bob"}
+  #   person.to_json             # => "{\"name\":\"Bob\"}"
+  #
+  # Valid options are <tt>:only</tt>, <tt>:except</tt>, <tt>:methods</tt> and
+  # <tt>:include</tt>. The following are all valid examples:
+  #
+  #   person.serializable_hash(only: 'name')
+  #   person.serializable_hash(include: :address)
+  #   person.serializable_hash(include: { address: { only: 'city' }})
+  module Serialization
+    # Returns a serialized hash of your object.
+    #
+    #   class Person
+    #     include ActiveModel::Serialization
+    #
+    #     attr_accessor :name, :age
+    #
+    #     def attributes
+    #       {'name' => nil, 'age' => nil}
+    #     end
+    #
+    #     def capitalized_name
+    #       name.capitalize
+    #     end
+    #   end
+    #
+    #   person = Person.new
+    #   person.name = 'bob'
+    #   person.age  = 22
+    #   person.serializable_hash                # => {"name"=>"bob", "age"=>22}
+    #   person.serializable_hash(only: :name)   # => {"name"=>"bob"}
+    #   person.serializable_hash(except: :name) # => {"age"=>22}
+    #   person.serializable_hash(methods: :capitalized_name)
+    #   # => {"name"=>"bob", "age"=>22, "capitalized_name"=>"Bob"}
+    #
+    # Example with <tt>:include</tt> option
+    #
+    #   class User
+    #     include ActiveModel::Serializers::JSON
+    #     attr_accessor :name, :notes # Emulate has_many :notes
+    #     def attributes
+    #       {'name' => nil}
+    #     end
+    #   end
+    #
+    #   class Note
+    #     include ActiveModel::Serializers::JSON
+    #     attr_accessor :title, :text
+    #     def attributes
+    #       {'title' => nil, 'text' => nil}
+    #     end
+    #   end
+    #
+    #   note = Note.new
+    #   note.title = 'Battle of Austerlitz'
+    #   note.text = 'Some text here'
+    #
+    #   user = User.new
+    #   user.name = 'Napoleon'
+    #   user.notes = [note]
+    #
+    #   user.serializable_hash
+    #   # => {"name" => "Napoleon"}
+    #   user.serializable_hash(include: { notes: { only: 'title' }})
+    #   # => {"name" => "Napoleon", "notes" => [{"title"=>"Battle of Austerlitz"}]}
+    def serializable_hash: (?untyped? options) -> untyped
+
+    # Hook method defining how an attribute value should be retrieved for
+    # serialization. By default this is assumed to be an instance named after
+    # the attribute. Override this method in subclasses should you need to
+    # retrieve the value for a given attribute differently:
+    #
+    #   class MyClass
+    #     include ActiveModel::Serialization
+    #
+    #     def initialize(data = {})
+    #       @data = data
+    #     end
+    #
+    #     def read_attribute_for_serialization(key)
+    #       @data[key]
+    #     end
+    #   end
+    alias read_attribute_for_serialization send
+
+    def serializable_add_includes: (?::Hash[untyped, untyped] options) { (untyped, untyped, untyped) -> untyped } -> (nil | untyped)
+  end
+end
+
+module ActiveModel
+  module Serializers
+    # == Active \Model \JSON \Serializer
+    module JSON
+      extend ActiveSupport::Concern
+
+      include ActiveModel::Serialization
+
+      extend ActiveModel::Naming
+
+      # Returns a hash representing the model. Some configuration can be
+      # passed through +options+.
+      #
+      # The option <tt>include_root_in_json</tt> controls the top-level behavior
+      # of +as_json+. If +true+, +as_json+ will emit a single root node named
+      # after the object's type. The default value for <tt>include_root_in_json</tt>
+      # option is +false+.
+      #
+      #   user = User.find(1)
+      #   user.as_json
+      #   # => { "id" => 1, "name" => "Konata Izumi", "age" => 16,
+      #   #     "created_at" => "2006-08-01T17:27:133.000Z", "awesome" => true}
+      #
+      #   ActiveRecord::Base.include_root_in_json = true
+      #
+      #   user.as_json
+      #   # => { "user" => { "id" => 1, "name" => "Konata Izumi", "age" => 16,
+      #   #                  "created_at" => "2006-08-01T17:27:13.000Z", "awesome" => true } }
+      #
+      # This behavior can also be achieved by setting the <tt>:root</tt> option
+      # to +true+ as in:
+      #
+      #   user = User.find(1)
+      #   user.as_json(root: true)
+      #   # => { "user" => { "id" => 1, "name" => "Konata Izumi", "age" => 16,
+      #   #                  "created_at" => "2006-08-01T17:27:13.000Z", "awesome" => true } }
+      #
+      # Without any +options+, the returned Hash will include all the model's
+      # attributes.
+      #
+      #   user = User.find(1)
+      #   user.as_json
+      #   # => { "id" => 1, "name" => "Konata Izumi", "age" => 16,
+      #   #      "created_at" => "2006-08-01T17:27:13.000Z", "awesome" => true}
+      #
+      # The <tt>:only</tt> and <tt>:except</tt> options can be used to limit
+      # the attributes included, and work similar to the +attributes+ method.
+      #
+      #   user.as_json(only: [:id, :name])
+      #   # => { "id" => 1, "name" => "Konata Izumi" }
+      #
+      #   user.as_json(except: [:id, :created_at, :age])
+      #   # => { "name" => "Konata Izumi", "awesome" => true }
+      #
+      # To include the result of some method calls on the model use <tt>:methods</tt>:
+      #
+      #   user.as_json(methods: :permalink)
+      #   # => { "id" => 1, "name" => "Konata Izumi", "age" => 16,
+      #   #      "created_at" => "2006-08-01T17:27:13.000Z", "awesome" => true,
+      #   #      "permalink" => "1-konata-izumi" }
+      #
+      # To include associations use <tt>:include</tt>:
+      #
+      #   user.as_json(include: :posts)
+      #   # => { "id" => 1, "name" => "Konata Izumi", "age" => 16,
+      #   #      "created_at" => "2006-08-01T17:27:13.000Z", "awesome" => true,
+      #   #      "posts" => [ { "id" => 1, "author_id" => 1, "title" => "Welcome to the weblog" },
+      #   #                   { "id" => 2, "author_id" => 1, "title" => "So I was thinking" } ] }
+      #
+      # Second level and higher order associations work as well:
+      #
+      #   user.as_json(include: { posts: {
+      #                              include: { comments: {
+      #                                             only: :body } },
+      #                              only: :title } })
+      #   # => { "id" => 1, "name" => "Konata Izumi", "age" => 16,
+      #   #      "created_at" => "2006-08-01T17:27:13.000Z", "awesome" => true,
+      #   #      "posts" => [ { "comments" => [ { "body" => "1st post!" }, { "body" => "Second!" } ],
+      #   #                     "title" => "Welcome to the weblog" },
+      #   #                   { "comments" => [ { "body" => "Don't think too hard" } ],
+      #   #                     "title" => "So I was thinking" } ] }
+      def as_json: (?untyped? options) -> untyped
+
+      # Sets the model +attributes+ from a JSON string. Returns +self+.
+      #
+      #   class Person
+      #     include ActiveModel::Serializers::JSON
+      #
+      #     attr_accessor :name, :age, :awesome
+      #
+      #     def attributes=(hash)
+      #       hash.each do |key, value|
+      #         send("#{key}=", value)
+      #       end
+      #     end
+      #
+      #     def attributes
+      #       instance_values
+      #     end
+      #   end
+      #
+      #   json = { name: 'bob', age: 22, awesome:true }.to_json
+      #   person = Person.new
+      #   person.from_json(json) # => #<Person:0x007fec5e7a0088 @age=22, @awesome=true, @name="bob">
+      #   person.name            # => "bob"
+      #   person.age             # => 22
+      #   person.awesome         # => true
+      #
+      # The default value for +include_root+ is +false+. You can change it to
+      # +true+ if the given JSON string includes a single root node.
+      #
+      #   json = { person: { name: 'bob', age: 22, awesome:true } }.to_json
+      #   person = Person.new
+      #   person.from_json(json, true) # => #<Person:0x007fec5e7a0088 @age=22, @awesome=true, @name="bob">
+      #   person.name                  # => "bob"
+      #   person.age                   # => 22
+      #   person.awesome               # => true
+      def from_json: (untyped json, ?untyped include_root) -> untyped
+    end
+  end
+end
+
+module ActiveModel
+  # == Active \Model \Translation
+  #
+  # Provides integration between your object and the Rails internationalization
+  # (i18n) framework.
+  #
+  # A minimal implementation could be:
+  #
+  #   class TranslatedPerson
+  #     extend ActiveModel::Translation
+  #   end
+  #
+  #   TranslatedPerson.human_attribute_name('my_attribute')
+  #   # => "My attribute"
+  #
+  # This also provides the required class methods for hooking into the
+  # Rails internationalization API, including being able to define a
+  # class based +i18n_scope+ and +lookup_ancestors+ to find translations in
+  # parent classes.
+  module Translation
+    include ActiveModel::Naming
+
+    # Returns the +i18n_scope+ for the class. Overwrite if you want custom lookup.
+    def i18n_scope: () -> :activemodel
+
+    # When localizing a string, it goes through the lookup returned by this
+    # method, which is used in ActiveModel::Name#human,
+    # ActiveModel::Errors#full_messages and
+    # ActiveModel::Translation#human_attribute_name.
+    def lookup_ancestors: () -> untyped
+
+    # Transforms attribute names into a more human format, such as "First name"
+    # instead of "first_name".
+    #
+    #   Person.human_attribute_name("first_name") # => "First name"
+    #
+    # Specify +options+ with additional translating options.
+    def human_attribute_name: (untyped attribute, ?::Hash[untyped, untyped] options) -> untyped
+  end
+end
+
+module ActiveModel
+  module Type
+    class BigInteger < Integer
+      def max_value: () -> untyped
+    end
+  end
+end
+
+module ActiveModel
+  module Type
+    class Binary < Value
+      # :nodoc:
+      def `type`: () -> :binary
+
+      def binary?: () -> ::TrueClass
+
+      def cast: (untyped value) -> untyped
+
+      def serialize: (untyped value) -> (nil | Data)
+
+      def changed_in_place?: (untyped raw_old_value, untyped value) -> untyped
+
+      class Data
+        # :nodoc:
+        def initialize: (untyped value) -> untyped
+
+        def to_s: () -> untyped
+
+        alias to_str to_s
+
+        def hex: () -> untyped
+
+        def ==: (untyped other) -> untyped
+      end
+    end
+  end
+end
+
+module ActiveModel
+  module Type
+    # == Active \Model \Type \Boolean
+    #
+    # A class that behaves like a boolean type, including rules for coercion of user input.
+    #
+    # === Coercion
+    # Values set from user input will first be coerced into the appropriate ruby type.
+    # Coercion behavior is roughly mapped to Ruby's boolean semantics.
+    #
+    # - "false", "f" , "0", +0+ or any other value in +FALSE_VALUES+ will be coerced to +false+
+    # - Empty strings are coerced to +nil+
+    # - All other values will be coerced to +true+
+    class Boolean < Value
+      FALSE_VALUES: untyped
+
+      def `type`: () -> :boolean
+
+      def serialize: (untyped value) -> untyped
+
+      def cast_value: (untyped value) -> untyped
+    end
+  end
+end
+
+module ActiveModel
+  module Type
+    class Date < Value
+      # :nodoc:
+      include Helpers::Timezone
+
+      def `type`: () -> :date
+
+      def type_cast_for_schema: (untyped value) -> untyped
+
+      def cast_value: (untyped value) -> untyped
+
+      ISO_DATE: untyped
+
+      def fast_string_to_date: (untyped string) -> untyped
+
+      def fallback_string_to_date: (untyped string) -> untyped
+
+      def new_date: (untyped year, untyped mon, untyped mday) -> untyped
+
+      def value_from_multiparameter_assignment: () -> untyped
+    end
+  end
+end
+
+module ActiveModel
+  module Type
+    class DateTime < Value
+      # :nodoc:
+      include Helpers::Timezone
+
+      include Helpers::TimeValue
+
+      def `type`: () -> :datetime
+
+      def cast_value: (untyped value) -> (untyped | nil)
+
+      # '0.123456' -> 123456
+      # '1.123456' -> 123456
+      def microseconds: (untyped time) -> untyped
+
+      def fallback_string_to_time: (untyped string) -> untyped
+
+      def value_from_multiparameter_assignment: (untyped values_hash) -> untyped
+    end
+  end
+end
+
+module ActiveModel
+  module Type
+    class Decimal < Value
+      # :nodoc:
+      include Helpers::Numeric
+
+      BIGDECIMAL_PRECISION: ::Integer
+
+      def `type`: () -> :decimal
+
+      def type_cast_for_schema: (untyped value) -> untyped
+
+      def cast_value: (untyped value) -> untyped
+
+      def convert_float_to_big_decimal: (untyped value) -> untyped
+
+      def float_precision: () -> untyped
+
+      def apply_scale: (untyped value) -> untyped
+    end
+  end
+end
+
+module ActiveModel
+  module Type
+    class Float < Value
+      # :nodoc:
+      include Helpers::Numeric
+
+      def `type`: () -> :float
+
+      def type_cast_for_schema: (untyped value) -> ("::Float::NAN" | untyped)
+
+      def cast_value: (untyped value) -> untyped
+    end
+  end
+end
+
+module ActiveModel
+  module Type
+    module Helpers
+      # :nodoc: all
+      class AcceptsMultiparameterTime < Module
+        def initialize: (?defaults: ::Hash[untyped, untyped] defaults) -> (nil | untyped)
+      end
+    end
+  end
+end
+
+module ActiveModel
+  module Type
+    module Helpers
+      # :nodoc: all
+      module Mutable
+        def cast: (untyped value) -> untyped
+
+        # +raw_old_value+ will be the `_before_type_cast` version of the
+        # value (likely a string). +new_value+ will be the current, type
+        # cast value.
+        def changed_in_place?: (untyped raw_old_value, untyped new_value) -> untyped
+      end
+    end
+  end
+end
+
+module ActiveModel
+  module Type
+    module Helpers
+      # :nodoc: all
+      module Numeric
+        def serialize: (untyped value) -> untyped
+
+        def cast: (untyped value) -> untyped
+
+        def changed?: (untyped old_value, untyped _new_value, untyped new_value_before_type_cast) -> untyped
+
+        def number_to_non_number?: (untyped old_value, untyped new_value_before_type_cast) -> untyped
+
+        def non_numeric_string?: (untyped value) -> untyped
+
+        NUMERIC_REGEX: untyped
+      end
+    end
+  end
+end
+
+module ActiveModel
+  module Type
+    module Helpers
+      # :nodoc: all
+      module TimeValue
+        def serialize: (untyped value) -> untyped
+
+        def apply_seconds_precision: (untyped value) -> untyped
+
+        def type_cast_for_schema: (untyped value) -> untyped
+
+        def user_input_in_time_zone: (untyped value) -> untyped
+
+        def new_time: (untyped year, untyped mon, untyped mday, untyped hour, untyped min, untyped sec, untyped microsec, ?untyped? offset) -> (nil | untyped)
+
+        ISO_DATETIME: untyped
+
+        # Doesn't handle time zones.
+        def fast_string_to_time: (untyped string) -> untyped
+      end
+    end
+  end
+end
+
+module ActiveModel
+  module Type
+    module Helpers
+      # :nodoc: all
+      module Timezone
+        def is_utc?: () -> untyped
+
+        def default_timezone: () -> untyped
+      end
+    end
+  end
+end
+
+module ActiveModel
+  module Type
+    class ImmutableString < Value
+      # :nodoc:
+      def `type`: () -> :string
+
+      def serialize: (untyped value) -> untyped
+
+      def cast_value: (untyped value) -> untyped
+    end
+  end
+end
+
+module ActiveModel
+  module Type
+    class Integer < Value
+      # :nodoc:
+      include Helpers::Numeric
+
+      # Column storage size in bytes.
+      # 4 bytes means an integer as opposed to smallint etc.
+      DEFAULT_LIMIT: ::Integer
+
+      def initialize: () -> untyped
+
+      def `type`: () -> :integer
+
+      def deserialize: (untyped value) -> (nil | untyped)
+
+      def serialize: (untyped value) -> (nil | untyped)
+
+      attr_reader range: untyped
+
+      def cast_value: (untyped value) -> untyped
+
+      def ensure_in_range: (untyped value) -> untyped
+
+      def max_value: () -> untyped
+
+      def min_value: () -> untyped
+
+      def _limit: () -> untyped
+    end
+  end
+end
+
+module ActiveModel
+  # :stopdoc:
+  module Type
+    class Registry
+      def initialize: () -> untyped
+
+      def register: (untyped type_name, ?untyped? klass, **untyped options) { () -> untyped } -> untyped
+
+      def lookup: (untyped symbol, *untyped args, **untyped kwargs) -> untyped
+
+      attr_reader registrations: untyped
+
+      def registration_klass: () -> untyped
+
+      def find_registration: (untyped symbol, *untyped args) -> untyped
+    end
+
+    class Registration
+      # Options must be taken because of https://bugs.ruby-lang.org/issues/10856
+      def initialize: (untyped name, untyped block) -> untyped
+
+      def call: (untyped _registry, *untyped args, **untyped kwargs) -> untyped
+
+      def matches?: (untyped type_name, *untyped args, **untyped kwargs) -> untyped
+
+      attr_reader name: untyped
+
+      attr_reader block: untyped
+    end
+  end
+end
+
+module ActiveModel
+  module Type
+    class String < ImmutableString
+      # :nodoc:
+      def changed_in_place?: (untyped raw_old_value, untyped new_value) -> untyped
+
+      def cast_value: (untyped value) -> untyped
+    end
+  end
+end
+
+module ActiveModel
+  module Type
+    class Time < Value
+      # :nodoc:
+      include Helpers::Timezone
+
+      include Helpers::TimeValue
+
+      def `type`: () -> :time
+
+      def user_input_in_time_zone: (untyped value) -> (nil | untyped)
+
+      def cast_value: (untyped value) -> (untyped | nil)
+    end
+  end
+end
+
+module ActiveModel
+  module Type
+    class Value
+      attr_reader precision: untyped
+
+      attr_reader scale: untyped
+
+      attr_reader limit: untyped
+
+      def initialize: (?scale: untyped? scale, ?limit: untyped? limit, ?precision: untyped? precision) -> untyped
+
+      def `type`: () -> nil
+
+      # Converts a value from database input to the appropriate ruby type. The
+      # return value of this method will be returned from
+      # ActiveRecord::AttributeMethods::Read#read_attribute. The default
+      # implementation just calls Value#cast.
+      #
+      # +value+ The raw input, as provided from the database.
+      def deserialize: (untyped value) -> untyped
+
+      # Type casts a value from user input (e.g. from a setter). This value may
+      # be a string from the form builder, or a ruby object passed to a setter.
+      # There is currently no way to differentiate between which source it came
+      # from.
+      #
+      # The return value of this method will be returned from
+      # ActiveRecord::AttributeMethods::Read#read_attribute. See also:
+      # Value#cast_value.
+      #
+      # +value+ The raw input, as provided to the attribute setter.
+      def cast: (untyped value) -> untyped
+
+      # Casts a value from the ruby type to a type that the database knows how
+      # to understand. The returned value from this method should be a
+      # +String+, +Numeric+, +Date+, +Time+, +Symbol+, +true+, +false+, or
+      # +nil+.
+      def serialize: (untyped value) -> untyped
+
+      def type_cast_for_schema: (untyped value) -> untyped
+
+      def binary?: () -> ::FalseClass
+
+      # Determines whether a value has changed for dirty checking. +old_value+
+      # and +new_value+ will always be type-cast. Types should not need to
+      # override this method.
+      def changed?: (untyped old_value, untyped new_value, untyped _new_value_before_type_cast) -> untyped
+
+      # Determines whether the mutable value has been modified since it was
+      # read. Returns +false+ by default. If your type returns an object
+      # which could be mutated, you should override this method. You will need
+      # to either:
+      #
+      # - pass +new_value+ to Value#serialize and compare it to
+      #   +raw_old_value+
+      #
+      # or
+      #
+      # - pass +raw_old_value+ to Value#deserialize and compare it to
+      #   +new_value+
+      #
+      # +raw_old_value+ The original value, before being passed to
+      # +deserialize+.
+      #
+      # +new_value+ The current value, after type casting.
+      def changed_in_place?: (untyped raw_old_value, untyped new_value) -> ::FalseClass
+
+      def value_constructed_by_mass_assignment?: (untyped _value) -> ::FalseClass
+
+      def force_equality?: (untyped _value) -> ::FalseClass
+
+      def map: (untyped value) { (untyped) -> untyped } -> untyped
+
+      def ==: (untyped other) -> untyped
+
+      alias eql? ==
+
+      def hash: () -> untyped
+
+      def assert_valid_value: () -> nil
+
+      def cast_value: (untyped value) -> untyped
+    end
+  end
+end
+
+module ActiveModel
+  module Type
+    attr_accessor registry: untyped
+
+    # Add a new type to the registry, allowing it to be gotten through ActiveModel::Type#lookup
+    def self.register: (untyped type_name, ?untyped? klass, **untyped options) { () -> untyped } -> untyped
+
+    def self.lookup: (*untyped args, **untyped kwargs) -> untyped
+
+    def self.default_value: () -> untyped
+  end
+end
+
+module ActiveModel
+  module Validations
+    class AbsenceValidator < EachValidator
+      # == \Active \Model Absence Validator
+      # nodoc:
+      def validate_each: (untyped record, untyped attr_name, untyped value) -> untyped
+    end
+
+    module HelperMethods
+      # Validates that the specified attributes are blank (as defined by
+      # Object#present?). Happens by default on save.
+      #
+      #   class Person < ActiveRecord::Base
+      #     validates_absence_of :first_name
+      #   end
+      #
+      # The first_name attribute must be in the object and it must be blank.
+      #
+      # Configuration options:
+      # * <tt>:message</tt> - A custom error message (default is: "must be blank").
+      #
+      # There is also a list of default options supported by every validator:
+      # +:if+, +:unless+, +:on+, +:allow_nil+, +:allow_blank+, and +:strict+.
+      # See <tt>ActiveModel::Validations#validates</tt> for more information
+      def validates_absence_of: (*untyped attr_names) -> untyped
+    end
+  end
+end
+
+module ActiveModel
+  module Validations
+    class AcceptanceValidator < EachValidator
+      # :nodoc:
+      def initialize: (untyped options) -> untyped
+
+      def validate_each: (untyped record, untyped attribute, untyped value) -> untyped
+
+      def setup!: (untyped klass) -> untyped
+
+      def acceptable_option?: (untyped value) -> untyped
+
+      class LazilyDefineAttributes < Module
+        def initialize: (untyped attributes) -> untyped
+
+        def included: (untyped klass) -> untyped
+
+        def matches?: (untyped method_name) -> untyped
+
+        def define_on: (untyped klass) -> untyped
+
+        def ==: (untyped other) -> untyped
+
+        attr_reader attributes: untyped
+      end
+    end
+
+    module HelperMethods
+      # Encapsulates the pattern of wanting to validate the acceptance of a
+      # terms of service check box (or similar agreement).
+      #
+      #   class Person < ActiveRecord::Base
+      #     validates_acceptance_of :terms_of_service
+      #     validates_acceptance_of :eula, message: 'must be abided'
+      #   end
+      #
+      # If the database column does not exist, the +terms_of_service+ attribute
+      # is entirely virtual. This check is performed only if +terms_of_service+
+      # is not +nil+ and by default on save.
+      #
+      # Configuration options:
+      # * <tt>:message</tt> - A custom error message (default is: "must be
+      #   accepted").
+      # * <tt>:accept</tt> - Specifies a value that is considered accepted.
+      #   Also accepts an array of possible values. The default value is
+      #   an array ["1", true], which makes it easy to relate to an HTML
+      #   checkbox. This should be set to, or include, +true+ if you are validating
+      #   a database column, since the attribute is typecast from "1" to +true+
+      #   before validation.
+      #
+      # There is also a list of default options supported by every validator:
+      # +:if+, +:unless+, +:on+, +:allow_nil+, +:allow_blank+, and +:strict+.
+      # See <tt>ActiveModel::Validations#validates</tt> for more information.
+      def validates_acceptance_of: (*untyped attr_names) -> untyped
+    end
+  end
+end
+
+module ActiveModel
+  module Validations
+    # == Active \Model \Validation \Callbacks
+    #
+    # Provides an interface for any class to have +before_validation+ and
+    # +after_validation+ callbacks.
+    #
+    # First, include ActiveModel::Validations::Callbacks from the class you are
+    # creating:
+    #
+    #   class MyModel
+    #     include ActiveModel::Validations::Callbacks
+    #
+    #     before_validation :do_stuff_before_validation
+    #     after_validation  :do_stuff_after_validation
+    #   end
+    #
+    # Like other <tt>before_*</tt> callbacks if +before_validation+ throws
+    # +:abort+ then <tt>valid?</tt> will not be called.
+    module Callbacks
+      extend ActiveSupport::Concern
+
+      include ActiveSupport::Callbacks
+
+      module ClassMethods
+        # Defines a callback that will get called right before validation.
+        #
+        #   class Person
+        #     include ActiveModel::Validations
+        #     include ActiveModel::Validations::Callbacks
+        #
+        #     attr_accessor :name
+        #
+        #     validates_length_of :name, maximum: 6
+        #
+        #     before_validation :remove_whitespaces
+        #
+        #     private
+        #
+        #     def remove_whitespaces
+        #       name.strip!
+        #     end
+        #   end
+        #
+        #   person = Person.new
+        #   person.name = '  bob  '
+        #   person.valid? # => true
+        #   person.name   # => "bob"
+        def before_validation: (*untyped args) { () -> untyped } -> untyped
+
+        # Defines a callback that will get called right after validation.
+        #
+        #   class Person
+        #     include ActiveModel::Validations
+        #     include ActiveModel::Validations::Callbacks
+        #
+        #     attr_accessor :name, :status
+        #
+        #     validates_presence_of :name
+        #
+        #     after_validation :set_status
+        #
+        #     private
+        #
+        #     def set_status
+        #       self.status = errors.empty?
+        #     end
+        #   end
+        #
+        #   person = Person.new
+        #   person.name = ''
+        #   person.valid? # => false
+        #   person.status # => false
+        #   person.name = 'bob'
+        #   person.valid? # => true
+        #   person.status # => true
+        def after_validation: (*untyped args) { () -> untyped } -> untyped
+      end
+
+      # Overwrite run validations to include callbacks.
+      def run_validations!: () -> untyped
+    end
+  end
+end
+
+module ActiveModel
+  module Validations
+    module Clusivity
+      # nodoc:
+      ERROR_MESSAGE: ::String
+
+      def check_validity!: () -> untyped
+
+      def include?: (untyped record, untyped value) -> untyped
+
+      def delimiter: () -> untyped
+
+      # After Ruby 2.2, <tt>Range#include?</tt> on non-number-or-time-ish ranges checks all
+      # possible values in the range for equality, which is slower but more accurate.
+      # <tt>Range#cover?</tt> uses the previous logic of comparing a value with the range
+      # endpoints, which is fast but is only accurate on Numeric, Time, Date,
+      # or DateTime ranges.
+      def inclusion_method: (untyped enumerable) -> untyped
+    end
+  end
+end
+
+module ActiveModel
+  module Validations
+    class ConfirmationValidator < EachValidator
+      # :nodoc:
+      def initialize: (untyped options) -> untyped
+
+      def validate_each: (untyped record, untyped attribute, untyped value) -> untyped
+
+      def setup!: (untyped klass) -> untyped
+
+      def confirmation_value_equal?: (untyped record, untyped attribute, untyped value, untyped confirmed) -> untyped
+    end
+
+    module HelperMethods
+      # Encapsulates the pattern of wanting to validate a password or email
+      # address field with a confirmation.
+      #
+      #   Model:
+      #     class Person < ActiveRecord::Base
+      #       validates_confirmation_of :user_name, :password
+      #       validates_confirmation_of :email_address,
+      #                                 message: 'should match confirmation'
+      #     end
+      #
+      #   View:
+      #     <%= password_field "person", "password" %>
+      #     <%= password_field "person", "password_confirmation" %>
+      #
+      # The added +password_confirmation+ attribute is virtual; it exists only
+      # as an in-memory attribute for validating the password. To achieve this,
+      # the validation adds accessors to the model for the confirmation
+      # attribute.
+      #
+      # NOTE: This check is performed only if +password_confirmation+ is not
+      # +nil+. To require confirmation, make sure to add a presence check for
+      # the confirmation attribute:
+      #
+      #   validates_presence_of :password_confirmation, if: :password_changed?
+      #
+      # Configuration options:
+      # * <tt>:message</tt> - A custom error message (default is: "doesn't match
+      #   <tt>%{translated_attribute_name}</tt>").
+      # * <tt>:case_sensitive</tt> - Looks for an exact match. Ignored by
+      #   non-text columns (+true+ by default).
+      #
+      # There is also a list of default options supported by every validator:
+      # +:if+, +:unless+, +:on+, +:allow_nil+, +:allow_blank+, and +:strict+.
+      # See <tt>ActiveModel::Validations#validates</tt> for more information
+      def validates_confirmation_of: (*untyped attr_names) -> untyped
+    end
+  end
+end
+
+module ActiveModel
+  module Validations
+    class ExclusionValidator < EachValidator
+      # :nodoc:
+      include Clusivity
+
+      def validate_each: (untyped record, untyped attribute, untyped value) -> untyped
+    end
+
+    module HelperMethods
+      # Validates that the value of the specified attribute is not in a
+      # particular enumerable object.
+      #
+      #   class Person < ActiveRecord::Base
+      #     validates_exclusion_of :username, in: %w( admin superuser ), message: "You don't belong here"
+      #     validates_exclusion_of :age, in: 30..60, message: 'This site is only for under 30 and over 60'
+      #     validates_exclusion_of :format, in: %w( mov avi ), message: "extension %{value} is not allowed"
+      #     validates_exclusion_of :password, in: ->(person) { [person.username, person.first_name] },
+      #                            message: 'should not be the same as your username or first name'
+      #     validates_exclusion_of :karma, in: :reserved_karmas
+      #   end
+      #
+      # Configuration options:
+      # * <tt>:in</tt> - An enumerable object of items that the value shouldn't
+      #   be part of. This can be supplied as a proc, lambda or symbol which returns an
+      #   enumerable. If the enumerable is a numerical, time or datetime range the test
+      #   is performed with <tt>Range#cover?</tt>, otherwise with <tt>include?</tt>. When
+      #   using a proc or lambda the instance under validation is passed as an argument.
+      # * <tt>:within</tt> - A synonym(or alias) for <tt>:in</tt>
+      #   <tt>Range#cover?</tt>, otherwise with <tt>include?</tt>.
+      # * <tt>:message</tt> - Specifies a custom error message (default is: "is
+      #   reserved").
+      #
+      # There is also a list of default options supported by every validator:
+      # +:if+, +:unless+, +:on+, +:allow_nil+, +:allow_blank+, and +:strict+.
+      # See <tt>ActiveModel::Validations#validates</tt> for more information
+      def validates_exclusion_of: (*untyped attr_names) -> untyped
+    end
+  end
+end
+
+module ActiveModel
+  module Validations
+    class FormatValidator < EachValidator
+      # :nodoc:
+      def validate_each: (untyped record, untyped attribute, untyped value) -> untyped
+
+      def check_validity!: () -> untyped
+
+      def option_call: (untyped record, untyped name) -> untyped
+
+      def record_error: (untyped record, untyped attribute, untyped name, untyped value) -> untyped
+
+      def check_options_validity: (untyped name) -> untyped
+
+      def regexp_using_multiline_anchors?: (untyped regexp) -> untyped
+    end
+
+    module HelperMethods
+      # Validates whether the value of the specified attribute is of the correct
+      # form, going by the regular expression provided. You can require that the
+      # attribute matches the regular expression:
+      #
+      #   class Person < ActiveRecord::Base
+      #     validates_format_of :email, with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i, on: :create
+      #   end
+      #
+      # Alternatively, you can require that the specified attribute does _not_
+      # match the regular expression:
+      #
+      #   class Person < ActiveRecord::Base
+      #     validates_format_of :email, without: /NOSPAM/
+      #   end
+      #
+      # You can also provide a proc or lambda which will determine the regular
+      # expression that will be used to validate the attribute.
+      #
+      #   class Person < ActiveRecord::Base
+      #     # Admin can have number as a first letter in their screen name
+      #     validates_format_of :screen_name,
+      #                         with: ->(person) { person.admin? ? /\A[a-z0-9][a-z0-9_\-]*\z/i : /\A[a-z][a-z0-9_\-]*\z/i }
+      #   end
+      #
+      # Note: use <tt>\A</tt> and <tt>\z</tt> to match the start and end of the
+      # string, <tt>^</tt> and <tt>$</tt> match the start/end of a line.
+      #
+      # Due to frequent misuse of <tt>^</tt> and <tt>$</tt>, you need to pass
+      # the <tt>multiline: true</tt> option in case you use any of these two
+      # anchors in the provided regular expression. In most cases, you should be
+      # using <tt>\A</tt> and <tt>\z</tt>.
+      #
+      # You must pass either <tt>:with</tt> or <tt>:without</tt> as an option.
+      # In addition, both must be a regular expression or a proc or lambda, or
+      # else an exception will be raised.
+      #
+      # Configuration options:
+      # * <tt>:message</tt> - A custom error message (default is: "is invalid").
+      # * <tt>:with</tt> - Regular expression that if the attribute matches will
+      #   result in a successful validation. This can be provided as a proc or
+      #   lambda returning regular expression which will be called at runtime.
+      # * <tt>:without</tt> - Regular expression that if the attribute does not
+      #   match will result in a successful validation. This can be provided as
+      #   a proc or lambda returning regular expression which will be called at
+      #   runtime.
+      # * <tt>:multiline</tt> - Set to true if your regular expression contains
+      #   anchors that match the beginning or end of lines as opposed to the
+      #   beginning or end of the string. These anchors are <tt>^</tt> and <tt>$</tt>.
+      #
+      # There is also a list of default options supported by every validator:
+      # +:if+, +:unless+, +:on+, +:allow_nil+, +:allow_blank+, and +:strict+.
+      # See <tt>ActiveModel::Validations#validates</tt> for more information
+      def validates_format_of: (*untyped attr_names) -> untyped
+    end
+  end
+end
+
+module ActiveModel
+  module Validations
+    module HelperMethods
+      def _merge_attributes: (untyped attr_names) -> untyped
+    end
+  end
+end
+
+module ActiveModel
+  module Validations
+    class InclusionValidator < EachValidator
+      # :nodoc:
+      include Clusivity
+
+      def validate_each: (untyped record, untyped attribute, untyped value) -> untyped
+    end
+
+    module HelperMethods
+      # Validates whether the value of the specified attribute is available in a
+      # particular enumerable object.
+      #
+      #   class Person < ActiveRecord::Base
+      #     validates_inclusion_of :role, in: %w( admin contributor )
+      #     validates_inclusion_of :age, in: 0..99
+      #     validates_inclusion_of :format, in: %w( jpg gif png ), message: "extension %{value} is not included in the list"
+      #     validates_inclusion_of :states, in: ->(person) { STATES[person.country] }
+      #     validates_inclusion_of :karma, in: :available_karmas
+      #   end
+      #
+      # Configuration options:
+      # * <tt>:in</tt> - An enumerable object of available items. This can be
+      #   supplied as a proc, lambda or symbol which returns an enumerable. If the
+      #   enumerable is a numerical, time or datetime range the test is performed
+      #   with <tt>Range#cover?</tt>, otherwise with <tt>include?</tt>. When using
+      #   a proc or lambda the instance under validation is passed as an argument.
+      # * <tt>:within</tt> - A synonym(or alias) for <tt>:in</tt>
+      # * <tt>:message</tt> - Specifies a custom error message (default is: "is
+      #   not included in the list").
+      #
+      # There is also a list of default options supported by every validator:
+      # +:if+, +:unless+, +:on+, +:allow_nil+, +:allow_blank+, and +:strict+.
+      # See <tt>ActiveModel::Validations#validates</tt> for more information
+      def validates_inclusion_of: (*untyped attr_names) -> untyped
+    end
+  end
+end
+
+module ActiveModel
+  module Validations
+    class LengthValidator < EachValidator
+      # :nodoc:
+      MESSAGES: untyped
+
+      CHECKS: untyped
+
+      RESERVED_OPTIONS: ::Array[untyped]
+
+      def initialize: (untyped options) -> untyped
+
+      def check_validity!: () -> untyped
+
+      def validate_each: (untyped record, untyped attribute, untyped value) -> untyped
+
+      def skip_nil_check?: (untyped key) -> untyped
+    end
+
+    module HelperMethods
+      # Validates that the specified attributes match the length restrictions
+      # supplied. Only one constraint option can be used at a time apart from
+      # +:minimum+ and +:maximum+ that can be combined together:
+      #
+      #   class Person < ActiveRecord::Base
+      #     validates_length_of :first_name, maximum: 30
+      #     validates_length_of :last_name, maximum: 30, message: "less than 30 if you don't mind"
+      #     validates_length_of :fax, in: 7..32, allow_nil: true
+      #     validates_length_of :phone, in: 7..32, allow_blank: true
+      #     validates_length_of :user_name, within: 6..20, too_long: 'pick a shorter name', too_short: 'pick a longer name'
+      #     validates_length_of :zip_code, minimum: 5, too_short: 'please enter at least 5 characters'
+      #     validates_length_of :smurf_leader, is: 4, message: "papa is spelled with 4 characters... don't play me."
+      #     validates_length_of :words_in_essay, minimum: 100, too_short: 'Your essay must be at least 100 words.'
+      #
+      #     private
+      #
+      #     def words_in_essay
+      #       essay.scan(/\w+/)
+      #     end
+      #   end
+      #
+      # Constraint options:
+      #
+      # * <tt>:minimum</tt> - The minimum size of the attribute.
+      # * <tt>:maximum</tt> - The maximum size of the attribute. Allows +nil+ by
+      #   default if not used with +:minimum+.
+      # * <tt>:is</tt> - The exact size of the attribute.
+      # * <tt>:within</tt> - A range specifying the minimum and maximum size of
+      #   the attribute.
+      # * <tt>:in</tt> - A synonym (or alias) for <tt>:within</tt>.
+      #
+      # Other options:
+      #
+      # * <tt>:allow_nil</tt> - Attribute may be +nil+; skip validation.
+      # * <tt>:allow_blank</tt> - Attribute may be blank; skip validation.
+      # * <tt>:too_long</tt> - The error message if the attribute goes over the
+      #   maximum (default is: "is too long (maximum is %{count} characters)").
+      # * <tt>:too_short</tt> - The error message if the attribute goes under the
+      #   minimum (default is: "is too short (minimum is %{count} characters)").
+      # * <tt>:wrong_length</tt> - The error message if using the <tt>:is</tt>
+      #   method and the attribute is the wrong size (default is: "is the wrong
+      #   length (should be %{count} characters)").
+      # * <tt>:message</tt> - The error message to use for a <tt>:minimum</tt>,
+      #   <tt>:maximum</tt>, or <tt>:is</tt> violation. An alias of the appropriate
+      #   <tt>too_long</tt>/<tt>too_short</tt>/<tt>wrong_length</tt> message.
+      #
+      # There is also a list of default options supported by every validator:
+      # +:if+, +:unless+, +:on+ and +:strict+.
+      # See <tt>ActiveModel::Validations#validates</tt> for more information
+      def validates_length_of: (*untyped attr_names) -> untyped
+
+      alias validates_size_of validates_length_of
+    end
+  end
+end
+
+module ActiveModel
+  module Validations
+    class NumericalityValidator < EachValidator
+      # :nodoc:
+      CHECKS: untyped
+
+      RESERVED_OPTIONS: untyped
+
+      INTEGER_REGEX: untyped
+
+      HEXADECIMAL_REGEX: untyped
+
+      def check_validity!: () -> untyped
+
+      def validate_each: (untyped record, untyped attr_name, untyped value) -> (nil | untyped)
+
+      def is_number?: (untyped raw_value) -> untyped
+
+      def parse_as_number: (untyped raw_value) -> untyped
+
+      def is_integer?: (untyped raw_value) -> untyped
+
+      def is_hexadecimal_literal?: (untyped raw_value) -> untyped
+
+      def filtered_options: (untyped value) -> untyped
+
+      def allow_only_integer?: (untyped record) -> untyped
+
+      def record_attribute_changed_in_place?: (untyped record, untyped attr_name) -> untyped
+    end
+
+    module HelperMethods
+      # Validates whether the value of the specified attribute is numeric by
+      # trying to convert it to a float with Kernel.Float (if <tt>only_integer</tt>
+      # is +false+) or applying it to the regular expression <tt>/\A[\+\-]?\d+\z/</tt>
+      # (if <tt>only_integer</tt> is set to +true+).
+      #
+      #   class Person < ActiveRecord::Base
+      #     validates_numericality_of :value, on: :create
+      #   end
+      #
+      # Configuration options:
+      # * <tt>:message</tt> - A custom error message (default is: "is not a number").
+      # * <tt>:only_integer</tt> - Specifies whether the value has to be an
+      #   integer, e.g. an integral value (default is +false+).
+      # * <tt>:allow_nil</tt> - Skip validation if attribute is +nil+ (default is
+      #   +false+). Notice that for Integer and Float columns empty strings are
+      #   converted to +nil+.
+      # * <tt>:greater_than</tt> - Specifies the value must be greater than the
+      #   supplied value.
+      # * <tt>:greater_than_or_equal_to</tt> - Specifies the value must be
+      #   greater than or equal the supplied value.
+      # * <tt>:equal_to</tt> - Specifies the value must be equal to the supplied
+      #   value.
+      # * <tt>:less_than</tt> - Specifies the value must be less than the
+      #   supplied value.
+      # * <tt>:less_than_or_equal_to</tt> - Specifies the value must be less
+      #   than or equal the supplied value.
+      # * <tt>:other_than</tt> - Specifies the value must be other than the
+      #   supplied value.
+      # * <tt>:odd</tt> - Specifies the value must be an odd number.
+      # * <tt>:even</tt> - Specifies the value must be an even number.
+      #
+      # There is also a list of default options supported by every validator:
+      # +:if+, +:unless+, +:on+, +:allow_nil+, +:allow_blank+, and +:strict+ .
+      # See <tt>ActiveModel::Validations#validates</tt> for more information
+      #
+      # The following checks can also be supplied with a proc or a symbol which
+      # corresponds to a method:
+      #
+      # * <tt>:greater_than</tt>
+      # * <tt>:greater_than_or_equal_to</tt>
+      # * <tt>:equal_to</tt>
+      # * <tt>:less_than</tt>
+      # * <tt>:less_than_or_equal_to</tt>
+      # * <tt>:only_integer</tt>
+      #
+      # For example:
+      #
+      #   class Person < ActiveRecord::Base
+      #     validates_numericality_of :width, less_than: ->(person) { person.height }
+      #     validates_numericality_of :width, greater_than: :minimum_weight
+      #   end
+      def validates_numericality_of: (*untyped attr_names) -> untyped
+    end
+  end
+end
+
+module ActiveModel
+  module Validations
+    class PresenceValidator < EachValidator
+      # :nodoc:
+      def validate_each: (untyped record, untyped attr_name, untyped value) -> untyped
+    end
+
+    module HelperMethods
+      # Validates that the specified attributes are not blank (as defined by
+      # Object#blank?). Happens by default on save.
+      #
+      #   class Person < ActiveRecord::Base
+      #     validates_presence_of :first_name
+      #   end
+      #
+      # The first_name attribute must be in the object and it cannot be blank.
+      #
+      # If you want to validate the presence of a boolean field (where the real
+      # values are +true+ and +false+), you will want to use
+      # <tt>validates_inclusion_of :field_name, in: [true, false]</tt>.
+      #
+      # This is due to the way Object#blank? handles boolean values:
+      # <tt>false.blank? # => true</tt>.
+      #
+      # Configuration options:
+      # * <tt>:message</tt> - A custom error message (default is: "can't be blank").
+      #
+      # There is also a list of default options supported by every validator:
+      # +:if+, +:unless+, +:on+, +:allow_nil+, +:allow_blank+, and +:strict+.
+      # See <tt>ActiveModel::Validations#validates</tt> for more information
+      def validates_presence_of: (*untyped attr_names) -> untyped
+    end
+  end
+end
+
+module ActiveModel
+  module Validations
+    module ClassMethods
+      # This method is a shortcut to all default validators and any custom
+      # validator classes ending in 'Validator'. Note that Rails default
+      # validators can be overridden inside specific classes by creating
+      # custom validator classes in their place such as PresenceValidator.
+      #
+      # Examples of using the default rails validators:
+      #
+      #   validates :terms, acceptance: true
+      #   validates :password, confirmation: true
+      #   validates :username, exclusion: { in: %w(admin superuser) }
+      #   validates :email, format: { with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i, on: :create }
+      #   validates :age, inclusion: { in: 0..9 }
+      #   validates :first_name, length: { maximum: 30 }
+      #   validates :age, numericality: true
+      #   validates :username, presence: true
+      #
+      # The power of the +validates+ method comes when using custom validators
+      # and default validators in one call for a given attribute.
+      #
+      #   class EmailValidator < ActiveModel::EachValidator
+      #     def validate_each(record, attribute, value)
+      #       record.errors.add attribute, (options[:message] || "is not an email") unless
+      #         value =~ /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
+      #     end
+      #   end
+      #
+      #   class Person
+      #     include ActiveModel::Validations
+      #     attr_accessor :name, :email
+      #
+      #     validates :name, presence: true, length: { maximum: 100 }
+      #     validates :email, presence: true, email: true
+      #   end
+      #
+      # Validator classes may also exist within the class being validated
+      # allowing custom modules of validators to be included as needed.
+      #
+      #   class Film
+      #     include ActiveModel::Validations
+      #
+      #     class TitleValidator < ActiveModel::EachValidator
+      #       def validate_each(record, attribute, value)
+      #         record.errors.add attribute, "must start with 'the'" unless value =~ /\Athe/i
+      #       end
+      #     end
+      #
+      #     validates :name, title: true
+      #   end
+      #
+      # Additionally validator classes may be in another namespace and still
+      # used within any class.
+      #
+      #   validates :name, :'film/title' => true
+      #
+      # The validators hash can also handle regular expressions, ranges, arrays
+      # and strings in shortcut form.
+      #
+      #   validates :email, format: /@/
+      #   validates :role, inclusion: %(admin contributor)
+      #   validates :password, length: 6..20
+      #
+      # When using shortcut form, ranges and arrays are passed to your
+      # validator's initializer as <tt>options[:in]</tt> while other types
+      # including regular expressions and strings are passed as <tt>options[:with]</tt>.
+      #
+      # There is also a list of options that could be used along with validators:
+      #
+      # * <tt>:on</tt> - Specifies the contexts where this validation is active.
+      #   Runs in all validation contexts by default +nil+. You can pass a symbol
+      #   or an array of symbols. (e.g. <tt>on: :create</tt> or
+      #   <tt>on: :custom_validation_context</tt> or
+      #   <tt>on: [:create, :custom_validation_context]</tt>)
+      # * <tt>:if</tt> - Specifies a method, proc or string to call to determine
+      #   if the validation should occur (e.g. <tt>if: :allow_validation</tt>,
+      #   or <tt>if: Proc.new { |user| user.signup_step > 2 }</tt>). The method,
+      #   proc or string should return or evaluate to a +true+ or +false+ value.
+      # * <tt>:unless</tt> - Specifies a method, proc or string to call to determine
+      #   if the validation should not occur (e.g. <tt>unless: :skip_validation</tt>,
+      #   or <tt>unless: Proc.new { |user| user.signup_step <= 2 }</tt>). The
+      #   method, proc or string should return or evaluate to a +true+ or
+      #   +false+ value.
+      # * <tt>:allow_nil</tt> - Skip validation if the attribute is +nil+.
+      # * <tt>:allow_blank</tt> - Skip validation if the attribute is blank.
+      # * <tt>:strict</tt> - If the <tt>:strict</tt> option is set to true
+      #   will raise ActiveModel::StrictValidationFailed instead of adding the error.
+      #   <tt>:strict</tt> option can also be set to any other exception.
+      #
+      # Example:
+      #
+      #   validates :password, presence: true, confirmation: true, if: :password_required?
+      #   validates :token, length: 24, strict: TokenLengthException
+      #
+      #
+      # Finally, the options +:if+, +:unless+, +:on+, +:allow_blank+, +:allow_nil+, +:strict+
+      # and +:message+ can be given to one specific validator, as a hash:
+      #
+      #   validates :password, presence: { if: :password_required?, message: 'is forgotten.' }, confirmation: true
+      def validates: (*untyped attributes) -> untyped
+
+      # This method is used to define validations that cannot be corrected by end
+      # users and are considered exceptional. So each validator defined with bang
+      # or <tt>:strict</tt> option set to <tt>true</tt> will always raise
+      # <tt>ActiveModel::StrictValidationFailed</tt> instead of adding error
+      # when validation fails. See <tt>validates</tt> for more information about
+      # the validation itself.
+      #
+      #   class Person
+      #     include ActiveModel::Validations
+      #
+      #     attr_accessor :name
+      #     validates! :name, presence: true
+      #   end
+      #
+      #   person = Person.new
+      #   person.name = ''
+      #   person.valid?
+      #   # => ActiveModel::StrictValidationFailed: Name can't be blank
+      def validates!: (*untyped attributes) -> untyped
+
+      # When creating custom validators, it might be useful to be able to specify
+      # additional default keys. This can be done by overwriting this method.
+      def _validates_default_keys: () -> ::Array[:if | :unless | :on | :allow_blank | :allow_nil | :strict]
+
+      def _parse_validates_options: (untyped options) -> untyped
+    end
+  end
+end
+
+module ActiveModel
+  module Validations
+    class WithValidator < EachValidator
+      # :nodoc:
+      def validate_each: (untyped record, untyped attr, untyped val) -> untyped
+    end
+
+    module ClassMethods
+      # Passes the record off to the class or classes specified and allows them
+      # to add errors based on more complex conditions.
+      #
+      #   class Person
+      #     include ActiveModel::Validations
+      #     validates_with MyValidator
+      #   end
+      #
+      #   class MyValidator < ActiveModel::Validator
+      #     def validate(record)
+      #       if some_complex_logic
+      #         record.errors.add :base, 'This record is invalid'
+      #       end
+      #     end
+      #
+      #     private
+      #       def some_complex_logic
+      #         # ...
+      #       end
+      #   end
+      #
+      # You may also pass it multiple classes, like so:
+      #
+      #   class Person
+      #     include ActiveModel::Validations
+      #     validates_with MyValidator, MyOtherValidator, on: :create
+      #   end
+      #
+      # Configuration options:
+      # * <tt>:on</tt> - Specifies the contexts where this validation is active.
+      #   Runs in all validation contexts by default +nil+. You can pass a symbol
+      #   or an array of symbols. (e.g. <tt>on: :create</tt> or
+      #   <tt>on: :custom_validation_context</tt> or
+      #   <tt>on: [:create, :custom_validation_context]</tt>)
+      # * <tt>:if</tt> - Specifies a method, proc or string to call to determine
+      #   if the validation should occur (e.g. <tt>if: :allow_validation</tt>,
+      #   or <tt>if: Proc.new { |user| user.signup_step > 2 }</tt>).
+      #   The method, proc or string should return or evaluate to a +true+ or
+      #   +false+ value.
+      # * <tt>:unless</tt> - Specifies a method, proc or string to call to
+      #   determine if the validation should not occur
+      #   (e.g. <tt>unless: :skip_validation</tt>, or
+      #   <tt>unless: Proc.new { |user| user.signup_step <= 2 }</tt>).
+      #   The method, proc or string should return or evaluate to a +true+ or
+      #   +false+ value.
+      # * <tt>:strict</tt> - Specifies whether validation should be strict.
+      #   See <tt>ActiveModel::Validations#validates!</tt> for more information.
+      #
+      # If you pass any additional configuration options, they will be passed
+      # to the class and available as +options+:
+      #
+      #   class Person
+      #     include ActiveModel::Validations
+      #     validates_with MyValidator, my_custom_key: 'my custom value'
+      #   end
+      #
+      #   class MyValidator < ActiveModel::Validator
+      #     def validate(record)
+      #       options[:my_custom_key] # => "my custom value"
+      #     end
+      #   end
+      def validates_with: (*untyped args) { () -> untyped } -> untyped
+    end
+
+    # Passes the record off to the class or classes specified and allows them
+    # to add errors based on more complex conditions.
+    #
+    #   class Person
+    #     include ActiveModel::Validations
+    #
+    #     validate :instance_validations
+    #
+    #     def instance_validations
+    #       validates_with MyValidator
+    #     end
+    #   end
+    #
+    # Please consult the class method documentation for more information on
+    # creating your own validator.
+    #
+    # You may also pass it multiple classes, like so:
+    #
+    #   class Person
+    #     include ActiveModel::Validations
+    #
+    #     validate :instance_validations, on: :create
+    #
+    #     def instance_validations
+    #       validates_with MyValidator, MyOtherValidator
+    #     end
+    #   end
+    #
+    # Standard configuration options (<tt>:on</tt>, <tt>:if</tt> and
+    # <tt>:unless</tt>), which are available on the class version of
+    # +validates_with+, should instead be placed on the +validates+ method
+    # as these are applied and tested in the callback.
+    #
+    # If you pass any additional configuration options, they will be passed
+    # to the class and available as +options+, please refer to the
+    # class version of this method for more information.
+    def validates_with: (*untyped args) { () -> untyped } -> untyped
+  end
+end
+
+module ActiveModel
+  # == Active \Model \Validations
+  #
+  # Provides a full validation framework to your objects.
+  #
+  # A minimal implementation could be:
+  #
+  #   class Person
+  #     include ActiveModel::Validations
+  #
+  #     attr_accessor :first_name, :last_name
+  #
+  #     validates_each :first_name, :last_name do |record, attr, value|
+  #       record.errors.add attr, 'starts with z.' if value.to_s[0] == ?z
+  #     end
+  #   end
+  #
+  # Which provides you with the full standard validation stack that you
+  # know from Active Record:
+  #
+  #   person = Person.new
+  #   person.valid?                   # => true
+  #   person.invalid?                 # => false
+  #
+  #   person.first_name = 'zoolander'
+  #   person.valid?                   # => false
+  #   person.invalid?                 # => true
+  #   person.errors.messages          # => {first_name:["starts with z."]}
+  #
+  # Note that <tt>ActiveModel::Validations</tt> automatically adds an +errors+
+  # method to your instances initialized with a new <tt>ActiveModel::Errors</tt>
+  # object, so there is no need for you to do this manually.
+  module Validations
+    extend ActiveSupport::Concern
+
+    extend ActiveModel::Naming
+
+    extend ActiveModel::Callbacks
+
+    extend ActiveModel::Translation
+
+    extend HelperMethods
+
+    include HelperMethods
+
+    attr_accessor validation_context: untyped
+
+    module ClassMethods
+      # Validates each attribute against a block.
+      #
+      #   class Person
+      #     include ActiveModel::Validations
+      #
+      #     attr_accessor :first_name, :last_name
+      #
+      #     validates_each :first_name, :last_name, allow_blank: true do |record, attr, value|
+      #       record.errors.add attr, 'starts with z.' if value.to_s[0] == ?z
+      #     end
+      #   end
+      #
+      # Options:
+      # * <tt>:on</tt> - Specifies the contexts where this validation is active.
+      #   Runs in all validation contexts by default +nil+. You can pass a symbol
+      #   or an array of symbols. (e.g. <tt>on: :create</tt> or
+      #   <tt>on: :custom_validation_context</tt> or
+      #   <tt>on: [:create, :custom_validation_context]</tt>)
+      # * <tt>:allow_nil</tt> - Skip validation if attribute is +nil+.
+      # * <tt>:allow_blank</tt> - Skip validation if attribute is blank.
+      # * <tt>:if</tt> - Specifies a method, proc or string to call to determine
+      #   if the validation should occur (e.g. <tt>if: :allow_validation</tt>,
+      #   or <tt>if: Proc.new { |user| user.signup_step > 2 }</tt>). The method,
+      #   proc or string should return or evaluate to a +true+ or +false+ value.
+      # * <tt>:unless</tt> - Specifies a method, proc or string to call to
+      #   determine if the validation should not occur (e.g. <tt>unless: :skip_validation</tt>,
+      #   or <tt>unless: Proc.new { |user| user.signup_step <= 2 }</tt>). The
+      #   method, proc or string should return or evaluate to a +true+ or +false+
+      #   value.
+      def validates_each: (*untyped attr_names) { () -> untyped } -> untyped
+
+      VALID_OPTIONS_FOR_VALIDATE: untyped
+
+      # Adds a validation method or block to the class. This is useful when
+      # overriding the +validate+ instance method becomes too unwieldy and
+      # you're looking for more descriptive declaration of your validations.
+      #
+      # This can be done with a symbol pointing to a method:
+      #
+      #   class Comment
+      #     include ActiveModel::Validations
+      #
+      #     validate :must_be_friends
+      #
+      #     def must_be_friends
+      #       errors.add(:base, 'Must be friends to leave a comment') unless commenter.friend_of?(commentee)
+      #     end
+      #   end
+      #
+      # With a block which is passed with the current record to be validated:
+      #
+      #   class Comment
+      #     include ActiveModel::Validations
+      #
+      #     validate do |comment|
+      #       comment.must_be_friends
+      #     end
+      #
+      #     def must_be_friends
+      #       errors.add(:base, 'Must be friends to leave a comment') unless commenter.friend_of?(commentee)
+      #     end
+      #   end
+      #
+      # Or with a block where self points to the current record to be validated:
+      #
+      #   class Comment
+      #     include ActiveModel::Validations
+      #
+      #     validate do
+      #       errors.add(:base, 'Must be friends to leave a comment') unless commenter.friend_of?(commentee)
+      #     end
+      #   end
+      #
+      # Note that the return value of validation methods is not relevant.
+      # It's not possible to halt the validate callback chain.
+      #
+      # Options:
+      # * <tt>:on</tt> - Specifies the contexts where this validation is active.
+      #   Runs in all validation contexts by default +nil+. You can pass a symbol
+      #   or an array of symbols. (e.g. <tt>on: :create</tt> or
+      #   <tt>on: :custom_validation_context</tt> or
+      #   <tt>on: [:create, :custom_validation_context]</tt>)
+      # * <tt>:if</tt> - Specifies a method, proc or string to call to determine
+      #   if the validation should occur (e.g. <tt>if: :allow_validation</tt>,
+      #   or <tt>if: Proc.new { |user| user.signup_step > 2 }</tt>). The method,
+      #   proc or string should return or evaluate to a +true+ or +false+ value.
+      # * <tt>:unless</tt> - Specifies a method, proc or string to call to
+      #   determine if the validation should not occur (e.g. <tt>unless: :skip_validation</tt>,
+      #   or <tt>unless: Proc.new { |user| user.signup_step <= 2 }</tt>). The
+      #   method, proc or string should return or evaluate to a +true+ or +false+
+      #   value.
+      #
+      # NOTE: Calling +validate+ multiple times on the same method will overwrite previous definitions.
+      #
+      def validate: (*untyped args) { () -> untyped } -> untyped
+
+      # List all validators that are being used to validate the model using
+      # +validates_with+ method.
+      #
+      #   class Person
+      #     include ActiveModel::Validations
+      #
+      #     validates_with MyValidator
+      #     validates_with OtherValidator, on: :create
+      #     validates_with StrictValidator, strict: true
+      #   end
+      #
+      #   Person.validators
+      #   # => [
+      #   #      #<MyValidator:0x007fbff403e808 @options={}>,
+      #   #      #<OtherValidator:0x007fbff403d930 @options={on: :create}>,
+      #   #      #<StrictValidator:0x007fbff3204a30 @options={strict:true}>
+      #   #    ]
+      def validators: () -> untyped
+
+      # Clears all of the validators and validations.
+      #
+      # Note that this will clear anything that is being used to validate
+      # the model for both the +validates_with+ and +validate+ methods.
+      # It clears the validators that are created with an invocation of
+      # +validates_with+ and the callbacks that are set by an invocation
+      # of +validate+.
+      #
+      #   class Person
+      #     include ActiveModel::Validations
+      #
+      #     validates_with MyValidator
+      #     validates_with OtherValidator, on: :create
+      #     validates_with StrictValidator, strict: true
+      #     validate :cannot_be_robot
+      #
+      #     def cannot_be_robot
+      #       errors.add(:base, 'A person cannot be a robot') if person_is_robot
+      #     end
+      #   end
+      #
+      #   Person.validators
+      #   # => [
+      #   #      #<MyValidator:0x007fbff403e808 @options={}>,
+      #   #      #<OtherValidator:0x007fbff403d930 @options={on: :create}>,
+      #   #      #<StrictValidator:0x007fbff3204a30 @options={strict:true}>
+      #   #    ]
+      #
+      # If one runs <tt>Person.clear_validators!</tt> and then checks to see what
+      # validators this class has, you would obtain:
+      #
+      #   Person.validators # => []
+      #
+      # Also, the callback set by <tt>validate :cannot_be_robot</tt> will be erased
+      # so that:
+      #
+      #   Person._validate_callbacks.empty?  # => true
+      #
+      def clear_validators!: () -> untyped
+
+      # List all validators that are being used to validate a specific attribute.
+      #
+      #   class Person
+      #     include ActiveModel::Validations
+      #
+      #     attr_accessor :name , :age
+      #
+      #     validates_presence_of :name
+      #     validates_inclusion_of :age, in: 0..99
+      #   end
+      #
+      #   Person.validators_on(:name)
+      #   # => [
+      #   #       #<ActiveModel::Validations::PresenceValidator:0x007fe604914e60 @attributes=[:name], @options={}>,
+      #   #    ]
+      def validators_on: (*untyped attributes) -> untyped
+
+      # Returns +true+ if +attribute+ is an attribute method, +false+ otherwise.
+      #
+      #  class Person
+      #    include ActiveModel::Validations
+      #
+      #    attr_accessor :name
+      #  end
+      #
+      #  User.attribute_method?(:name) # => true
+      #  User.attribute_method?(:age)  # => false
+      def attribute_method?: (untyped attribute) -> untyped
+
+      def inherited: (untyped base) -> untyped
+    end
+
+    def initialize_dup: (untyped other) -> untyped
+
+    # Returns the +Errors+ object that holds all information about attribute
+    # error messages.
+    #
+    #   class Person
+    #     include ActiveModel::Validations
+    #
+    #     attr_accessor :name
+    #     validates_presence_of :name
+    #   end
+    #
+    #   person = Person.new
+    #   person.valid? # => false
+    #   person.errors # => #<ActiveModel::Errors:0x007fe603816640 @messages={name:["can't be blank"]}>
+    def errors: () -> untyped
+
+    # Runs all the specified validations and returns +true+ if no errors were
+    # added otherwise +false+.
+    #
+    #   class Person
+    #     include ActiveModel::Validations
+    #
+    #     attr_accessor :name
+    #     validates_presence_of :name
+    #   end
+    #
+    #   person = Person.new
+    #   person.name = ''
+    #   person.valid? # => false
+    #   person.name = 'david'
+    #   person.valid? # => true
+    #
+    # Context can optionally be supplied to define which callbacks to test
+    # against (the context is defined on the validations using <tt>:on</tt>).
+    #
+    #   class Person
+    #     include ActiveModel::Validations
+    #
+    #     attr_accessor :name
+    #     validates_presence_of :name, on: :new
+    #   end
+    #
+    #   person = Person.new
+    #   person.valid?       # => true
+    #   person.valid?(:new) # => false
+    def valid?: (?untyped? context) -> untyped
+
+    alias validate valid?
+
+    # Performs the opposite of <tt>valid?</tt>. Returns +true+ if errors were
+    # added, +false+ otherwise.
+    #
+    #   class Person
+    #     include ActiveModel::Validations
+    #
+    #     attr_accessor :name
+    #     validates_presence_of :name
+    #   end
+    #
+    #   person = Person.new
+    #   person.name = ''
+    #   person.invalid? # => true
+    #   person.name = 'david'
+    #   person.invalid? # => false
+    #
+    # Context can optionally be supplied to define which callbacks to test
+    # against (the context is defined on the validations using <tt>:on</tt>).
+    #
+    #   class Person
+    #     include ActiveModel::Validations
+    #
+    #     attr_accessor :name
+    #     validates_presence_of :name, on: :new
+    #   end
+    #
+    #   person = Person.new
+    #   person.invalid?       # => false
+    #   person.invalid?(:new) # => true
+    def invalid?: (?untyped? context) -> untyped
+
+    # Runs all the validations within the specified context. Returns +true+ if
+    # no errors are found, raises +ValidationError+ otherwise.
+    #
+    # Validations with no <tt>:on</tt> option will run no matter the context. Validations with
+    # some <tt>:on</tt> option will only run in the specified context.
+    def validate!: (?untyped? context) -> untyped
+
+    # Hook method defining how an attribute value should be retrieved. By default
+    # this is assumed to be an instance named after the attribute. Override this
+    # method in subclasses should you need to retrieve the value for a given
+    # attribute differently:
+    #
+    #   class MyClass
+    #     include ActiveModel::Validations
+    #
+    #     def initialize(data = {})
+    #       @data = data
+    #     end
+    #
+    #     def read_attribute_for_validation(key)
+    #       @data[key]
+    #     end
+    #   end
+    alias read_attribute_for_validation send
+
+    def run_validations!: () -> untyped
+
+    def raise_validation_error: () -> untyped
+  end
+
+  # = Active Model ValidationError
+  #
+  # Raised by <tt>validate!</tt> when the model is invalid. Use the
+  # +model+ method to retrieve the record which did not validate.
+  #
+  #   begin
+  #     complex_operation_that_internally_calls_validate!
+  #   rescue ActiveModel::ValidationError => invalid
+  #     puts invalid.model.errors
+  #   end
+  class ValidationError < StandardError
+    attr_reader model: untyped
+
+    def initialize: (untyped model) -> untyped
+  end
+end
+
+module ActiveModel
+  # == Active \Model \Validator
+  #
+  # A simple base class that can be used along with
+  # ActiveModel::Validations::ClassMethods.validates_with
+  #
+  #   class Person
+  #     include ActiveModel::Validations
+  #     validates_with MyValidator
+  #   end
+  #
+  #   class MyValidator < ActiveModel::Validator
+  #     def validate(record)
+  #       if some_complex_logic
+  #         record.errors.add(:base, "This record is invalid")
+  #       end
+  #     end
+  #
+  #     private
+  #       def some_complex_logic
+  #         # ...
+  #       end
+  #   end
+  #
+  # Any class that inherits from ActiveModel::Validator must implement a method
+  # called +validate+ which accepts a +record+.
+  #
+  #   class Person
+  #     include ActiveModel::Validations
+  #     validates_with MyValidator
+  #   end
+  #
+  #   class MyValidator < ActiveModel::Validator
+  #     def validate(record)
+  #       record # => The person instance being validated
+  #       options # => Any non-standard options passed to validates_with
+  #     end
+  #   end
+  #
+  # To cause a validation error, you must add to the +record+'s errors directly
+  # from within the validators message.
+  #
+  #   class MyValidator < ActiveModel::Validator
+  #     def validate(record)
+  #       record.errors.add :base, "This is some custom error message"
+  #       record.errors.add :first_name, "This is some complex validation"
+  #       # etc...
+  #     end
+  #   end
+  #
+  # To add behavior to the initialize method, use the following signature:
+  #
+  #   class MyValidator < ActiveModel::Validator
+  #     def initialize(options)
+  #       super
+  #       @my_custom_field = options[:field_name] || :first_name
+  #     end
+  #   end
+  #
+  # Note that the validator is initialized only once for the whole application
+  # life cycle, and not on each validation run.
+  #
+  # The easiest way to add custom validators for validating individual attributes
+  # is with the convenient <tt>ActiveModel::EachValidator</tt>.
+  #
+  #   class TitleValidator < ActiveModel::EachValidator
+  #     def validate_each(record, attribute, value)
+  #       record.errors.add attribute, 'must be Mr., Mrs., or Dr.' unless %w(Mr. Mrs. Dr.).include?(value)
+  #     end
+  #   end
+  #
+  # This can now be used in combination with the +validates+ method
+  # (see <tt>ActiveModel::Validations::ClassMethods.validates</tt> for more on this).
+  #
+  #   class Person
+  #     include ActiveModel::Validations
+  #     attr_accessor :title
+  #
+  #     validates :title, presence: true, title: true
+  #   end
+  #
+  # It can be useful to access the class that is using that validator when there are prerequisites such
+  # as an +attr_accessor+ being present. This class is accessible via <tt>options[:class]</tt> in the constructor.
+  # To setup your validator override the constructor.
+  #
+  #   class MyValidator < ActiveModel::Validator
+  #     def initialize(options={})
+  #       super
+  #       options[:class].attr_accessor :custom_attribute
+  #     end
+  #   end
+  class Validator
+    attr_reader options: untyped
+
+    # Returns the kind of the validator.
+    #
+    #   PresenceValidator.kind   # => :presence
+    #   AcceptanceValidator.kind # => :acceptance
+    def self.kind: () -> untyped
+
+    # Accepts options that will be made available through the +options+ reader.
+    def initialize: (?::Hash[untyped, untyped] options) -> untyped
+
+    # Returns the kind for this validator.
+    #
+    #   PresenceValidator.new(attributes: [:username]).kind # => :presence
+    #   AcceptanceValidator.new(attributes: [:terms]).kind  # => :acceptance
+    def kind: () -> untyped
+
+    # Override this method in subclasses with validation logic, adding errors
+    # to the records +errors+ array where necessary.
+    def validate: (untyped record) -> untyped
+  end
+
+  class EachValidator < Validator
+    # +EachValidator+ is a validator which iterates through the attributes given
+    # in the options hash invoking the <tt>validate_each</tt> method passing in the
+    # record, attribute and value.
+    #
+    # All \Active \Model validations are built on top of this validator.
+    # nodoc:
+    attr_reader attributes: untyped
+
+    # Returns a new validator instance. All options will be available via the
+    # +options+ reader, however the <tt>:attributes</tt> option will be removed
+    # and instead be made available through the +attributes+ reader.
+    def initialize: (untyped options) -> untyped
+
+    # Performs validation on the supplied record. By default this will call
+    # +validate_each+ to determine validity therefore subclasses should
+    # override +validate_each+ with validation logic.
+    def validate: (untyped record) -> untyped
+
+    # Override this method in subclasses with the validation logic, adding
+    # errors to the records +errors+ array where necessary.
+    def validate_each: (untyped record, untyped attribute, untyped value) -> untyped
+
+    # Hook method that gets called by the initializer allowing verification
+    # that the arguments supplied are valid. You could for example raise an
+    # +ArgumentError+ when invalid options are supplied.
+    def check_validity!: () -> nil
+  end
+
+  class BlockValidator < EachValidator
+    # +BlockValidator+ is a special +EachValidator+ which receives a block on initialization
+    # and call this block for each attribute being validated. +validates_each+ uses this validator.
+    # nodoc:
+    def initialize: (untyped options) { () -> untyped } -> untyped
+
+    def validate_each: (untyped record, untyped attribute, untyped value) -> untyped
+  end
+end
+
+module ActiveModel
+  # Returns the version of the currently loaded \Active \Model as a <tt>Gem::Version</tt>
+  def self.version: () -> untyped
+end
+
+module ActiveModel
+  extend ActiveSupport::Autoload
+
+  module Serializers
+    extend ActiveSupport::Autoload
+  end
+
+  def self.eager_load!: () -> untyped
+end
+

--- a/gems/activemodel/6.0.3.2/activemodel-generated.rbs
+++ b/gems/activemodel/6.0.3.2/activemodel-generated.rbs
@@ -37,6 +37,8 @@ module ActiveModel
 
       def marshal_load: (untyped values) -> untyped
 
+      private
+
       attr_reader user_provided_value: untyped
     end
   end
@@ -103,6 +105,8 @@ module ActiveModel
     def encode_with: (untyped coder) -> untyped
 
     def original_value_for_database: () -> untyped
+
+    private
 
     attr_reader original_attribute: untyped
 
@@ -197,6 +201,8 @@ module ActiveModel
     def assign_attributes: (untyped new_attributes) -> (nil | untyped)
 
     alias attributes= assign_attributes
+
+    private
 
     def _assign_attributes: (untyped attributes) -> untyped
 
@@ -484,6 +490,8 @@ module ActiveModel
       #   person.name_short? # => NoMethodError
       def undefine_attribute_methods: () -> untyped
 
+      private
+
       def generated_attribute_methods: () -> untyped
 
       def instance_method_already_implemented?: (untyped method_name) -> untyped
@@ -557,6 +565,8 @@ module ActiveModel
 
     def respond_to?: (untyped method, ?bool include_private_methods) -> untyped
 
+    private
+
     def attribute_method?: (untyped attr_name) -> untyped
 
     # Returns a struct representing the matching attribute method.
@@ -621,6 +631,8 @@ module ActiveModel
 
     def force_change: (untyped attr_name) -> untyped
 
+    private
+
     attr_reader attributes: untyped
 
     attr_reader forced_changes: untyped
@@ -647,6 +659,8 @@ module ActiveModel
     def force_change: (untyped attr_name) -> untyped
 
     def finalize_changes: () -> untyped
+
+    private
 
     attr_reader finalized_changes: untyped
 
@@ -721,6 +735,8 @@ module ActiveModel
 
     def materialize: () -> untyped
 
+    private
+
     attr_reader types: untyped
 
     attr_reader values: untyped
@@ -746,6 +762,8 @@ module ActiveModel
       def encode: (untyped attribute_set, untyped coder) -> untyped
 
       def decode: (untyped coder) -> untyped
+
+      private
 
       attr_reader default_types: untyped
     end
@@ -796,6 +814,8 @@ module ActiveModel
 
     attr_reader attributes: untyped
 
+    private
+
     def initialized_attributes: () -> untyped
   end
 end
@@ -822,6 +842,8 @@ module ActiveModel
       #   Person.attribute_names
       #   # => ["name", "age"]
       def attribute_names: () -> untyped
+
+      private
 
       def define_method_attribute=: (untyped name) -> untyped
 
@@ -860,6 +882,8 @@ module ActiveModel
     #   person.attribute_names
     #   # => ["name", "age"]
     def attribute_names: () -> untyped
+
+    private
 
     def write_attribute: (untyped attr_name, untyped value) -> untyped
 
@@ -970,6 +994,8 @@ module ActiveModel
     # NOTE: +method_name+ passed to define_model_callbacks must not end with
     # <tt>!</tt>, <tt>?</tt> or <tt>=</tt>.
     def define_model_callbacks: (*untyped callbacks) -> untyped
+
+    private
 
     def _define_before_model_callback: (untyped klass, untyped callback) -> untyped
 
@@ -1250,6 +1276,8 @@ module ActiveModel
     def previous_changes: () -> untyped
 
     def attribute_changed_in_place?: (untyped attr_name) -> untyped
+
+    private
 
     def clear_attribute_change: (untyped attr_name) -> untyped
 
@@ -1619,6 +1647,8 @@ module ActiveModel
 
     def init_with: (untyped coder) -> untyped
 
+    private
+
     def normalize_message: (untyped attribute, untyped message, untyped options) -> untyped
 
     def normalize_detail: (untyped message, untyped options) -> untyped
@@ -1686,6 +1716,8 @@ module ActiveModel
   end
 
   module ForbiddenAttributesProtection
+    private
+
     def sanitize_for_mass_assignment: (untyped attributes) -> untyped
 
     alias sanitize_forbidden_attributes sanitize_for_mass_assignment
@@ -1784,6 +1816,8 @@ module ActiveModel
       # If localization is used, the strings should be localized for the current
       # locale. If no error is present, the method should return an empty array.
       def test_errors_aref: () -> untyped
+
+      private
 
       def model: () -> untyped
 
@@ -1934,6 +1968,8 @@ module ActiveModel
     #
     # Specify +options+ with additional translating options.
     def human: (?::Hash[untyped, untyped] options) -> untyped
+
+    private
 
     def _singularize: (untyped string) -> untyped
   end
@@ -2220,6 +2256,8 @@ module ActiveModel
     #   # => {"name" => "Napoleon", "notes" => [{"title"=>"Battle of Austerlitz"}]}
     def serializable_hash: (?untyped? options) -> untyped
 
+    private
+
     # Hook method defining how an attribute value should be retrieved for
     # serialization. By default this is assumed to be an instance named after
     # the attribute. Override this method in subclasses should you need to
@@ -2408,6 +2446,8 @@ end
 module ActiveModel
   module Type
     class BigInteger < Integer
+      private
+
       def max_value: () -> untyped
     end
   end
@@ -2463,6 +2503,8 @@ module ActiveModel
 
       def serialize: (untyped value) -> untyped
 
+      private
+
       def cast_value: (untyped value) -> untyped
     end
   end
@@ -2477,6 +2519,8 @@ module ActiveModel
       def `type`: () -> :date
 
       def type_cast_for_schema: (untyped value) -> untyped
+
+      private
 
       def cast_value: (untyped value) -> untyped
 
@@ -2503,6 +2547,8 @@ module ActiveModel
 
       def `type`: () -> :datetime
 
+      private
+
       def cast_value: (untyped value) -> (untyped | nil)
 
       # '0.123456' -> 123456
@@ -2528,6 +2574,8 @@ module ActiveModel
 
       def type_cast_for_schema: (untyped value) -> untyped
 
+      private
+
       def cast_value: (untyped value) -> untyped
 
       def convert_float_to_big_decimal: (untyped value) -> untyped
@@ -2548,6 +2596,8 @@ module ActiveModel
       def `type`: () -> :float
 
       def type_cast_for_schema: (untyped value) -> ("::Float::NAN" | untyped)
+
+      private
 
       def cast_value: (untyped value) -> untyped
     end
@@ -2592,6 +2642,8 @@ module ActiveModel
 
         def changed?: (untyped old_value, untyped _new_value, untyped new_value_before_type_cast) -> untyped
 
+        private
+
         def number_to_non_number?: (untyped old_value, untyped new_value_before_type_cast) -> untyped
 
         def non_numeric_string?: (untyped value) -> untyped
@@ -2614,6 +2666,8 @@ module ActiveModel
         def type_cast_for_schema: (untyped value) -> untyped
 
         def user_input_in_time_zone: (untyped value) -> untyped
+
+        private
 
         def new_time: (untyped year, untyped mon, untyped mday, untyped hour, untyped min, untyped sec, untyped microsec, ?untyped? offset) -> (nil | untyped)
 
@@ -2647,6 +2701,8 @@ module ActiveModel
 
       def serialize: (untyped value) -> untyped
 
+      private
+
       def cast_value: (untyped value) -> untyped
     end
   end
@@ -2669,6 +2725,8 @@ module ActiveModel
       def deserialize: (untyped value) -> (nil | untyped)
 
       def serialize: (untyped value) -> (nil | untyped)
+
+      private
 
       attr_reader range: untyped
 
@@ -2695,6 +2753,8 @@ module ActiveModel
 
       def lookup: (untyped symbol, *untyped args, **untyped kwargs) -> untyped
 
+      private
+
       attr_reader registrations: untyped
 
       def registration_klass: () -> untyped
@@ -2710,6 +2770,8 @@ module ActiveModel
 
       def matches?: (untyped type_name, *untyped args, **untyped kwargs) -> untyped
 
+      private
+
       attr_reader name: untyped
 
       attr_reader block: untyped
@@ -2722,6 +2784,8 @@ module ActiveModel
     class String < ImmutableString
       # :nodoc:
       def changed_in_place?: (untyped raw_old_value, untyped new_value) -> untyped
+
+      private
 
       def cast_value: (untyped value) -> untyped
     end
@@ -2739,6 +2803,8 @@ module ActiveModel
       def `type`: () -> :time
 
       def user_input_in_time_zone: (untyped value) -> (nil | untyped)
+
+      private
 
       def cast_value: (untyped value) -> (untyped | nil)
     end
@@ -2826,6 +2892,8 @@ module ActiveModel
 
       def assert_valid_value: () -> nil
 
+      private
+
       def cast_value: (untyped value) -> untyped
     end
   end
@@ -2880,6 +2948,8 @@ module ActiveModel
       def initialize: (untyped options) -> untyped
 
       def validate_each: (untyped record, untyped attribute, untyped value) -> untyped
+
+      private
 
       def setup!: (untyped klass) -> untyped
 
@@ -3010,6 +3080,8 @@ module ActiveModel
         def after_validation: (*untyped args) { () -> untyped } -> untyped
       end
 
+      private
+
       # Overwrite run validations to include callbacks.
       def run_validations!: () -> untyped
     end
@@ -3023,6 +3095,8 @@ module ActiveModel
       ERROR_MESSAGE: ::String
 
       def check_validity!: () -> untyped
+
+      private
 
       def include?: (untyped record, untyped value) -> untyped
 
@@ -3045,6 +3119,8 @@ module ActiveModel
       def initialize: (untyped options) -> untyped
 
       def validate_each: (untyped record, untyped attribute, untyped value) -> untyped
+
+      private
 
       def setup!: (untyped klass) -> untyped
 
@@ -3140,6 +3216,8 @@ module ActiveModel
 
       def check_validity!: () -> untyped
 
+      private
+
       def option_call: (untyped record, untyped name) -> untyped
 
       def record_error: (untyped record, untyped attribute, untyped name, untyped value) -> untyped
@@ -3210,6 +3288,8 @@ end
 module ActiveModel
   module Validations
     module HelperMethods
+      private
+
       def _merge_attributes: (untyped attr_names) -> untyped
     end
   end
@@ -3269,6 +3349,8 @@ module ActiveModel
       def check_validity!: () -> untyped
 
       def validate_each: (untyped record, untyped attribute, untyped value) -> untyped
+
+      private
 
       def skip_nil_check?: (untyped key) -> untyped
     end
@@ -3345,6 +3427,8 @@ module ActiveModel
       def check_validity!: () -> untyped
 
       def validate_each: (untyped record, untyped attr_name, untyped value) -> (nil | untyped)
+
+      private
 
       def is_number?: (untyped raw_value) -> untyped
 
@@ -3574,6 +3658,8 @@ module ActiveModel
       #   person.valid?
       #   # => ActiveModel::StrictValidationFailed: Name can't be blank
       def validates!: (*untyped attributes) -> untyped
+
+      private
 
       # When creating custom validators, it might be useful to be able to specify
       # additional default keys. This can be done by overwriting this method.
@@ -4037,6 +4123,8 @@ module ActiveModel
     #   end
     alias read_attribute_for_validation send
 
+    private
+
     def run_validations!: () -> untyped
 
     def raise_validation_error: () -> untyped
@@ -4207,6 +4295,8 @@ module ActiveModel
     # and call this block for each attribute being validated. +validates_each+ uses this validator.
     # nodoc:
     def initialize: (untyped options) { () -> untyped } -> untyped
+
+    private
 
     def validate_each: (untyped record, untyped attribute, untyped value) -> untyped
   end

--- a/gems/activemodel/6.0.3.2/patch.rbs
+++ b/gems/activemodel/6.0.3.2/patch.rbs
@@ -1,0 +1,11 @@
+module ActiveModel
+  module Serialization
+    # alias bug: https://github.com/ruby/rbs/issues/458
+    def `send`: (String name, *untyped args) ?{ (*untyped) -> untyped } -> untyped
+  end
+
+  module Validations
+    # alias bug: https://github.com/ruby/rbs/issues/458
+    def `send`: (String name, *untyped args) ?{ (*untyped) -> untyped } -> untyped
+  end
+end

--- a/gems/activerecord/6.0.3.2/activerecord-generated.rbs
+++ b/gems/activerecord/6.0.3.2/activerecord-generated.rbs
@@ -1,3 +1,27 @@
+# The generated code is based on Ruby on Rails source code
+# You can find the license of Ruby on Rails from following.
+
+#Copyright (c) 2005-2019 David Heinemeier Hansson
+#
+#Permission is hereby granted, free of charge, to any person obtaining
+#a copy of this software and associated documentation files (the
+#"Software"), to deal in the Software without restriction, including
+#without limitation the rights to use, copy, modify, merge, publish,
+#distribute, sublicense, and/or sell copies of the Software, and to
+#permit persons to whom the Software is furnished to do so, subject to
+#the following conditions:
+#
+#The above copyright notice and this permission notice shall be
+#included in all copies or substantial portions of the Software.
+#
+#THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+#EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+#MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+#LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+#OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+#WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 module ActiveRecord
   class AdvisoryLockBase < ActiveRecord::Base
     def self._internal?: () -> ::TrueClass

--- a/gems/activerecord/6.0.3.2/activerecord-generated.rbs
+++ b/gems/activerecord/6.0.3.2/activerecord-generated.rbs
@@ -35,6 +35,8 @@ module ActiveRecord
 
     def reload: () -> untyped
 
+    private
+
     def clear_aggregation_cache: () -> untyped
 
     def init_internals: () -> untyped
@@ -237,6 +239,8 @@ module ActiveRecord
       #
       def composed_of: (untyped part_id, ?::Hash[untyped, untyped] options) -> untyped
 
+      private
+
       def reader_method: (untyped name, untyped class_name, untyped mapping, untyped allow_nil, untyped constructor) -> untyped
 
       def writer_method: (untyped name, untyped class_name, untyped mapping, untyped allow_nil, untyped converter) -> untyped
@@ -260,6 +264,8 @@ module ActiveRecord
 
     def create!: (?untyped? attributes) { () -> untyped } -> untyped
 
+    private
+
     def exec_queries: () { (untyped) -> untyped } -> untyped
   end
 end
@@ -279,6 +285,8 @@ module ActiveRecord
       def aliased_table_for: (untyped table_name, untyped aliased_name, untyped type_caster) -> untyped
 
       attr_reader aliases: untyped
+
+      private
 
       def truncate: (untyped name) -> untyped
     end
@@ -458,6 +466,8 @@ module ActiveRecord
 
       def create!: (?::Hash[untyped, untyped] attributes) { () -> untyped } -> untyped
 
+      private
+
       def find_target: () -> untyped
 
       # The scope for this association.
@@ -541,6 +551,8 @@ module ActiveRecord
 
       def self.get_bind_values: (untyped owner, untyped chain) -> untyped
 
+      private
+
       attr_reader value_transformation: untyped
 
       def join: (untyped table, untyped constraint) -> untyped
@@ -594,6 +606,8 @@ module ActiveRecord
 
       def target_changed?: () -> untyped
 
+      private
+
       def replace: (untyped record) -> untyped
 
       def update_counters: (untyped by) -> untyped
@@ -627,6 +641,8 @@ module ActiveRecord
       def klass: () -> untyped
 
       def target_changed?: () -> untyped
+
+      private
 
       def replace_keys: (untyped record) -> untyped
 
@@ -749,6 +765,8 @@ module ActiveRecord::Associations::Builder
     def through_model: () -> untyped
 
     def middle_reflection: (untyped join_model) -> untyped
+
+    private
 
     def middle_options: (untyped join_model) -> untyped
 
@@ -938,6 +956,8 @@ module ActiveRecord
       def null_scope?: () -> untyped
 
       def find_from_target?: () -> untyped
+
+      private
 
       # We have some records loaded from the database (persisted) and some that are
       # in-memory (memory). The same record may be represented in the persisted array
@@ -1667,6 +1687,8 @@ module ActiveRecord
 
       def reset_scope: () -> untyped
 
+      private
+
       def find_nth_with_limit: (untyped index, untyped limit) -> untyped
 
       def find_nth_from_last: (untyped index) -> untyped
@@ -1703,6 +1725,8 @@ module ActiveRecord
       def handle_dependency: () -> untyped
 
       def insert_record: (untyped record, ?bool validate, ?bool raise) -> untyped
+
+      private
 
       # Returns the number of records in this collection.
       #
@@ -1755,6 +1779,8 @@ module ActiveRecord
       def concat: (*untyped records) -> untyped
 
       def insert_record: (untyped record, ?bool validate, ?bool raise) -> (nil | untyped)
+
+      private
 
       def concat_records: (untyped records) -> untyped
 
@@ -1812,6 +1838,8 @@ module ActiveRecord
 
       def delete: (?untyped method) -> untyped
 
+      private
+
       def replace: (untyped record, ?bool save) -> untyped
 
       # The reason that the save param for replace is false, if for create (not just build),
@@ -1837,6 +1865,8 @@ module ActiveRecord
       # = Active Record Has One Through Association
       # nodoc:
       include ThroughAssociation
+
+      private
 
       def replace: (untyped record, ?bool save) -> untyped
 
@@ -1868,6 +1898,8 @@ module ActiveRecord
         def tables=: (untyped tables) -> untyped
 
         def readonly?: () -> untyped
+
+        private
 
         def append_constraints: (untyped join, untyped constraints) -> untyped
       end
@@ -1983,6 +2015,8 @@ module ActiveRecord
 
       attr_reader join_type: untyped
 
+      private
+
       attr_reader alias_tracker: untyped
 
       def explicit_selections: (untyped root_column_aliases, untyped result_set) -> untyped
@@ -2024,6 +2058,8 @@ module ActiveRecord
         def records_by_owner: () -> untyped
 
         def preloaded_records: () -> untyped
+
+        private
 
         attr_reader owners: untyped
 
@@ -2079,6 +2115,8 @@ module ActiveRecord
         def preloaded_records: () -> untyped
 
         def records_by_owner: () -> untyped
+
+        private
 
         def source_preloaders: () -> untyped
 
@@ -2178,6 +2216,8 @@ module ActiveRecord
       #   [ :books, { author: :avatar } ]
       def preload: (untyped records, untyped associations, ?untyped? preload_scope) -> untyped
 
+      private
+
       # Loads all the given data into +records+ for the +association+.
       def preloaders_on: (untyped association, untyped records, untyped scope, ?bool polymorphic_parent) -> untyped
 
@@ -2211,6 +2251,8 @@ module ActiveRecord
 
         def records_by_owner: () -> untyped
 
+        private
+
         attr_reader owners: untyped
 
         attr_reader reflection: untyped
@@ -2240,6 +2282,8 @@ module ActiveRecord
       # Foo.has_one :bar
       def force_reload_reader: () -> untyped
 
+      private
+
       def scope_for_create: () -> untyped
 
       def find_target: () -> untyped
@@ -2256,6 +2300,8 @@ end
 module ActiveRecord
   module Associations
     module ThroughAssociation
+      private
+
       def through_reflection: () -> untyped
 
       def through_association: () -> untyped
@@ -2407,6 +2453,8 @@ module ActiveRecord
     def initialize_dup: () -> untyped
 
     def reload: () -> untyped
+
+    private
 
     # Clears out the association cache.
     def clear_association_cache: () -> untyped
@@ -3966,6 +4014,8 @@ module ActiveRecord
   module AttributeAssignment
     include ActiveModel::AttributeAssignment
 
+    private
+
     def _assign_attributes: (untyped attributes) -> untyped
 
     # Assign any deferred nested attributes after the base attributes have been set.
@@ -4022,6 +4072,8 @@ module ActiveRecord
       # used to ensure that class macros are idempotent.
       def decorate_matching_attribute_types: (untyped matcher, untyped decorator_name) { () -> untyped } -> untyped
 
+      private
+
       def load_schema!: () -> untyped
     end
 
@@ -4031,6 +4083,8 @@ module ActiveRecord
       def merge: (*untyped args) -> TypeDecorator
 
       def apply: (untyped name, untyped `type`) -> untyped
+
+      private
 
       def decorators_for: (untyped name, untyped `type`) -> untyped
 
@@ -4092,6 +4146,8 @@ module ActiveRecord
       #   task.attributes_before_type_cast
       #   # => {"id"=>nil, "title"=>nil, "is_done"=>true, "completed_on"=>"2012-10-21", "created_at"=>nil, "updated_at"=>nil}
       def attributes_before_type_cast: () -> untyped
+
+      private
 
       # Dispatch target for <tt>*_before_type_cast</tt> attribute methods.
       def attribute_before_type_cast: (untyped attribute_name) -> untyped
@@ -4208,6 +4264,8 @@ module ActiveRecord
       # values about to be saved).
       def attributes_in_database: () -> untyped
 
+      private
+
       def mutations_from_database: () -> untyped
 
       def mutations_before_last_save: () -> untyped
@@ -4252,6 +4310,8 @@ module ActiveRecord
       # Returns the primary key column's value from the database.
       def id_in_database: () -> untyped
 
+      private
+
       def attribute_method?: (untyped attr_name) -> untyped
 
       module ClassMethods
@@ -4291,6 +4351,8 @@ module ActiveRecord
         #   Project.primary_key # => "foo_id"
         def primary_key=: (untyped value) -> untyped
 
+        private
+
         def suppress_composite_primary_key: (untyped pk) -> untyped
       end
     end
@@ -4304,6 +4366,8 @@ module ActiveRecord
 
       def query_attribute: (untyped attr_name) -> (::FalseClass | untyped)
 
+      private
+
       # Dispatch target for <tt>*?</tt> attribute methods.
       def attribute?: (untyped attribute_name) -> untyped
     end
@@ -4316,6 +4380,8 @@ module ActiveRecord
       extend ActiveSupport::Concern
 
       module ClassMethods
+        private
+
         def define_method_attribute: (untyped name) -> untyped
       end
 
@@ -4384,6 +4450,8 @@ module ActiveRecord
         #   end
         def serialize: (untyped attr_name, ?untyped class_name_or_coder) -> untyped
 
+        private
+
         def type_incompatible_with_serialize?: (untyped `type`, untyped class_name) -> untyped
       end
     end
@@ -4399,6 +4467,8 @@ module ActiveRecord
 
         def cast: (untyped value) -> (nil | untyped)
 
+        private
+
         def convert_time_to_time_zone: (untyped value) -> (nil | untyped)
 
         def set_time_zone_without_conversion: (untyped value) -> untyped
@@ -4409,6 +4479,8 @@ module ActiveRecord
       extend ActiveSupport::Concern
 
       module ClassMethods
+        private
+
         def inherited: (untyped subclass) -> untyped
 
         def create_time_zone_conversion_attribute?: (untyped name, untyped cast_type) -> untyped
@@ -4423,6 +4495,8 @@ module ActiveRecord
       extend ActiveSupport::Concern
 
       module ClassMethods
+        private
+
         def define_method_attribute=: (untyped name) -> untyped
       end
 
@@ -4432,6 +4506,8 @@ module ActiveRecord
       def write_attribute: (untyped attr_name, untyped value) -> untyped
 
       def _write_attribute: (untyped attr_name, untyped value) -> untyped
+
+      private
 
       def write_attribute_without_type_cast: (untyped attr_name, untyped value) -> untyped
 
@@ -4699,6 +4775,8 @@ module ActiveRecord
     #   end
     def accessed_fields: () -> untyped
 
+    private
+
     def attribute_method?: (untyped attr_name) -> untyped
 
     def attributes_with_values: (untyped attribute_names) -> untyped
@@ -4941,6 +5019,8 @@ module ActiveRecord
 
       def load_schema!: () -> untyped
 
+      private
+
       NO_DEFAULT_PROVIDED: untyped
 
       def define_default_attribute: (untyped name, untyped value, untyped `type`, from_user: untyped from_user) -> untyped
@@ -5086,6 +5166,8 @@ module ActiveRecord
     end
 
     module ClassMethods
+      private
+
       def define_non_cyclic_method: (untyped name) { () -> untyped } -> (nil | untyped)
 
       # Adds validation and save callbacks for the association as specified by
@@ -5131,6 +5213,8 @@ module ActiveRecord
     # Returns whether or not this record has been changed in any way (including whether
     # any of its nested autosave associations are likewise changed)
     def changed_for_autosave?: () -> untyped
+
+    private
 
     # Returns the record for an association collection that should be validated
     # or saved. If +autosave+ is +false+ only new records will be returned,
@@ -5844,6 +5928,8 @@ module ActiveRecord
 
     def increment!: (untyped attribute, ?::Integer by, ?touch: untyped? touch) -> untyped
 
+    private
+
     def create_or_update: () -> untyped
 
     def _create_record: () -> untyped
@@ -5878,6 +5964,8 @@ module ActiveRecord
       def load: (untyped yaml) -> untyped
 
       def assert_valid_value: (untyped obj, action: untyped action) -> untyped
+
+      private
 
       def check_arity_of_constructor: () -> untyped
     end
@@ -6011,6 +6099,8 @@ module ActiveRecord
         # becomes available within +timeout+ seconds,
         def poll: (?untyped? timeout) -> untyped
 
+        private
+
         def internal_poll: (untyped timeout) -> untyped
 
         def synchronize: () { () -> untyped } -> untyped
@@ -6068,6 +6158,8 @@ module ActiveRecord
         # :nodoc:
         include BiasableQueue
 
+        private
+
         def internal_poll: (untyped timeout) -> untyped
       end
 
@@ -6085,6 +6177,8 @@ module ActiveRecord
         def initialize: (untyped pool, untyped frequency) -> untyped
 
         def self.register_pool: (untyped pool, untyped frequency) -> untyped
+
+        private
 
         def self.spawn_thread: (untyped frequency) -> untyped
 
@@ -6249,6 +6343,8 @@ module ActiveRecord
       #
       #    ActiveRecord::Base.connection_pool.stat # => { size: 15, connections: 1, busy: 1, dead: 0, idle: 0, waiting: 0, checkout_timeout: 5 }
       def stat: () -> untyped
+
+      private
 
       # -
       # this is unfortunately not concurrent
@@ -6423,6 +6519,8 @@ module ActiveRecord
       # When a connection is established or removed, we invalidate the cache.
       def retrieve_connection_pool: (untyped spec_name) -> untyped
 
+      private
+
       def owner_to_pool: () -> untyped
 
       def pool_from_any_process_for: (untyped spec_name) -> untyped
@@ -6474,6 +6572,8 @@ module ActiveRecord
       # Returns maximum number of joins in a single query.
       def joins_per_query: () -> 256
 
+      private
+
       def bind_params_length: () -> 65535
     end
   end
@@ -6488,7 +6588,11 @@ module ActiveRecord
       # Converts an arel AST to SQL
       def to_sql: (untyped arel_or_sql_string, ?untyped binds) -> untyped
 
+      private
+
       def to_sql_and_binds: (untyped arel_or_sql_string, ?untyped binds) -> untyped
+
+      public
 
       def cacheable_query: (untyped klass, untyped arel) -> ::Array[untyped]
 
@@ -6706,6 +6810,8 @@ module ActiveRecord
 
       def with_yaml_fallback: (untyped value) -> untyped
 
+      private
+
       def execute_batch: (untyped statements, ?untyped? name) -> untyped
 
       DEFAULT_INSERT_VALUE: untyped
@@ -6783,6 +6889,8 @@ module ActiveRecord
       def clear_query_cache: () -> untyped
 
       def select_all: (untyped arel, ?untyped? name, ?untyped binds, ?preparable: untyped? preparable) -> untyped
+
+      private
 
       def cache_sql: (untyped sql, untyped name, untyped binds) { () -> untyped } -> untyped
 
@@ -6880,6 +6988,8 @@ module ActiveRecord
       #   "#{column_name} NULLS LAST"
       COLUMN_NAME_WITH_ORDER: untyped
 
+      private
+
       def type_casted_binds: (untyped binds) -> untyped
 
       def lookup_cast_type: (untyped sql_type) -> untyped
@@ -6915,6 +7025,8 @@ module ActiveRecord
         def initialize: (untyped conn) -> untyped
 
         def accept: (untyped o) -> untyped
+
+        private
 
         def visit_AlterTable: (untyped o) -> untyped
 
@@ -7037,6 +7149,8 @@ module ActiveRecord
 
       def initialize: (untyped table, untyped name, ?bool unique, ?untyped columns, ?comment: untyped? comment, ?using: untyped? using, ?type: untyped? `type`, ?where: untyped? where, ?opclasses: ::Hash[untyped, untyped] opclasses, ?orders: ::Hash[untyped, untyped] orders, ?lengths: ::Hash[untyped, untyped] lengths) -> untyped
 
+      private
+
       def concise_options: (untyped options) -> untyped
     end
 
@@ -7099,6 +7213,8 @@ module ActiveRecord
 
       def defined_for?: (?to_table: untyped? to_table, **untyped options) -> untyped
 
+      private
+
       def default_primary_key: () -> "id"
     end
 
@@ -7107,6 +7223,8 @@ module ActiveRecord
       def initialize: (untyped name, ?type: ::Symbol `type`, ?foreign_key: bool foreign_key, ?index: bool index, ?polymorphic: bool polymorphic, **untyped options) -> untyped
 
       def add_to: (untyped table) -> untyped
+
+      private
 
       attr_reader name: untyped
 
@@ -7145,7 +7263,11 @@ module ActiveRecord
       def primary_key: (untyped name, ?::Symbol `type`, **untyped options) -> untyped
 
       module ClassMethods
+        private
+
         def define_column_methods: (*untyped column_types) -> untyped
+
+        public
       end
     end
 
@@ -7295,6 +7417,8 @@ module ActiveRecord
       alias belongs_to references
 
       def new_column_definition: (untyped name, untyped `type`, **untyped options) -> untyped
+
+      private
 
       def create_column_definition: (untyped name, untyped `type`, untyped options) -> ColumnDefinition[untyped]
 
@@ -7518,6 +7642,8 @@ module ActiveRecord
       # :nodoc:
       # :nodoc:
       def self.create: (untyped connection, untyped options) -> untyped
+
+      private
 
       def column_spec: (untyped column) -> ::Array[untyped]
 
@@ -8437,6 +8563,8 @@ module ActiveRecord
 
       def create_schema_dumper: (untyped options) -> untyped
 
+      private
+
       def column_options_keys: () -> ::Array[:limit | :precision | :scale | :default | :null | :collation | :comment]
 
       def add_index_sort_order: (untyped quoted_columns, **untyped options) -> untyped
@@ -8635,6 +8763,8 @@ module ActiveRecord
       def open_transactions: () -> untyped
 
       def current_transaction: () -> untyped
+
+      private
 
       NULL_TRANSACTION: untyped
 
@@ -8931,7 +9061,11 @@ module ActiveRecord
 
       def case_insensitive_comparison: (untyped attribute, untyped value) -> untyped
 
+      private
+
       def can_perform_case_insensitive_comparison_for?: (untyped column) -> ::TrueClass
+
+      public
 
       # Check the connection back in to the connection pool
       def close: () -> untyped
@@ -8947,6 +9081,8 @@ module ActiveRecord
       def database_version: () -> untyped
 
       def check_version: () -> nil
+
+      private
 
       def type_map: () -> untyped
 
@@ -8995,6 +9131,8 @@ module ActiveRecord
       NATIVE_DATABASE_TYPES: ::Hash[untyped, untyped]
 
       class StatementPool < ConnectionAdapters::StatementPool
+        private
+
         def dealloc: (untyped stmt) -> untyped
       end
 
@@ -9147,7 +9285,11 @@ module ActiveRecord
 
       def case_sensitive_comparison: (untyped attribute, untyped value) -> untyped
 
+      private
+
       def can_perform_case_insensitive_comparison_for?: (untyped column) -> untyped
+
+      public
 
       def columns_for_distinct: (untyped columns, untyped orders) -> untyped
 
@@ -9158,6 +9300,8 @@ module ActiveRecord
       def build_insert_sql: (untyped insert) -> untyped
 
       def check_version: () -> untyped
+
+      private
 
       def initialize_type_map: (?untyped m) -> untyped
 
@@ -9229,6 +9373,8 @@ module ActiveRecord
       class MysqlString < ActiveModel::Type::String
         # :nodoc:
         def serialize: (untyped value) -> untyped
+
+        private
 
         def cast_value: (untyped value) -> untyped
       end
@@ -9330,6 +9476,8 @@ module ActiveRecord
         # Converts the given URL to a full connection hash.
         def to_hash: () -> untyped
 
+        private
+
         attr_reader uri: untyped
 
         def uri_parser: () -> untyped
@@ -9391,6 +9539,8 @@ module ActiveRecord
         #   # => { "host" => "localhost", "database" => "foo", "adapter" => "sqlite3" }
         #
         def spec: (untyped config) -> ConnectionSpecification
+
+        private
 
         # Returns fully resolved connection, accepts hash, string or symbol.
         # Always returns a hash.
@@ -9504,6 +9654,8 @@ module ActiveRecord
 
         alias exec_update exec_delete
 
+        private
+
         def execute_batch: (untyped statements, ?untyped? name) -> untyped
 
         def default_insert_value: (untyped column) -> untyped
@@ -9547,6 +9699,8 @@ module ActiveRecord
         # This is an exercise in Ruby hyperrealism :).
         def pp: (untyped result, untyped elapsed) -> untyped
 
+        private
+
         def compute_column_widths: (untyped result) -> untyped
 
         def build_separator: (untyped widths) -> untyped
@@ -9584,6 +9738,8 @@ module ActiveRecord
 
         COLUMN_NAME_WITH_ORDER: untyped
 
+        private
+
         def _type_cast: (untyped value) -> untyped
       end
     end
@@ -9594,6 +9750,8 @@ module ActiveRecord
   module ConnectionAdapters
     module MySQL
       class SchemaCreation < AbstractAdapter::SchemaCreation
+        private
+
         def visit_DropForeignKey: (untyped name) -> ::String
 
         def visit_AddColumnDefinition: (untyped o) -> untyped
@@ -9624,6 +9782,8 @@ module ActiveRecord
 
         def new_column_definition: (untyped name, untyped `type`, **untyped options) -> untyped
 
+        private
+
         def aliased_types: (untyped name, untyped fallback) -> untyped
 
         def integer_like_primary_key_type: (untyped `type`, untyped options) -> untyped
@@ -9640,6 +9800,8 @@ module ActiveRecord
   module ConnectionAdapters
     module MySQL
       class SchemaDumper < ConnectionAdapters::SchemaDumper
+        private
+
         def prepare_column_options: (untyped column) -> untyped
 
         def column_spec_for_primary_key: (untyped column) -> untyped
@@ -9684,6 +9846,8 @@ module ActiveRecord
         def type_to_sql: (untyped `type`, ?unsigned: untyped? unsigned, ?size: untyped size, ?scale: untyped? scale, ?precision: untyped? precision, ?limit: untyped? limit) -> untyped
 
         def table_alias_length: () -> 256
+
+        private
 
         CHARSETS_OF_4BYTES_MAXLEN: ::Array[untyped]
 
@@ -9787,6 +9951,8 @@ module ActiveRecord
 
       def discard!: () -> untyped
 
+      private
+
       def connect: () -> untyped
 
       def configure_connection: () -> untyped
@@ -9848,7 +10014,11 @@ module ActiveRecord
 
         alias exec_update exec_delete
 
+        private
+
         def sql_for_insert: (untyped sql, untyped pk, untyped binds) -> untyped
+
+        public
 
         def exec_insert: (untyped sql, ?untyped? name, ?untyped binds, ?untyped? pk, ?untyped? sequence_name) -> untyped
 
@@ -9862,6 +10032,8 @@ module ActiveRecord
 
         # Aborts a transaction.
         def exec_rollback_db_transaction: () -> untyped
+
+        private
 
         def execute_batch: (untyped statements, ?untyped? name) -> untyped
 
@@ -9937,6 +10109,8 @@ module ActiveRecord
 
           def force_equality?: (untyped value) -> untyped
 
+          private
+
           def type_cast_array: (untyped value, untyped method) -> untyped
         end
       end
@@ -9965,6 +10139,8 @@ module ActiveRecord
             def binary?: () -> untyped
 
             def hex?: () -> untyped
+
+            private
 
             attr_reader value: untyped
           end
@@ -10073,6 +10249,8 @@ module ActiveRecord
           # :nodoc:
           def `type`: () -> :enum
 
+          private
+
           def cast_value: (untyped value) -> untyped
         end
       end
@@ -10102,6 +10280,8 @@ module ActiveRecord
           # the keys change between the two hashes, and they would not be marked
           # as equal.
           def changed_in_place?: (untyped raw_old_value, untyped new_value) -> untyped
+
+          private
 
           HstorePair: untyped
 
@@ -10154,6 +10334,8 @@ module ActiveRecord
           def cast: (untyped value) -> untyped
 
           def serialize: (untyped value) -> untyped
+
+          private
 
           def number_for_point: (untyped number) -> untyped
         end
@@ -10217,6 +10399,8 @@ module ActiveRecord
 
           def type_cast_for_schema: (untyped value) -> untyped
 
+          private
+
           def number_for_point: (untyped number) -> untyped
 
           def build_point: (untyped x, untyped y) -> ActiveRecord::Point[untyped]
@@ -10252,6 +10436,8 @@ module ActiveRecord
           def map: (untyped value) { (untyped) -> untyped } -> untyped
 
           def force_equality?: (untyped value) -> untyped
+
+          private
 
           def type_cast_single: (untyped value) -> untyped
 
@@ -10302,6 +10488,8 @@ module ActiveRecord
 
           def query_conditions_for_initial_load: () -> untyped
 
+          private
+
           def register_mapped_type: (untyped row) -> untyped
 
           def register_enum_type: (untyped row) -> untyped
@@ -10339,6 +10527,8 @@ module ActiveRecord
           alias serialize deserialize
 
           def `type`: () -> :uuid
+
+          private
 
           def cast_value: (untyped value) -> untyped
         end
@@ -10446,6 +10636,8 @@ module ActiveRecord
 
         COLUMN_NAME_WITH_ORDER: untyped
 
+        private
+
         def lookup_cast_type: (untyped sql_type) -> untyped
 
         def _quote: (untyped value) -> untyped
@@ -10482,6 +10674,8 @@ module ActiveRecord
   module ConnectionAdapters
     module PostgreSQL
       class SchemaCreation < AbstractAdapter::SchemaCreation
+        private
+
         def visit_AlterTable: (untyped o) -> untyped
 
         def visit_AddForeignKey: (untyped o) -> untyped
@@ -10554,6 +10748,8 @@ module ActiveRecord
 
         def initialize: () -> untyped
 
+        private
+
         def integer_like_primary_key_type: (untyped `type`, untyped options) -> untyped
       end
 
@@ -10576,6 +10772,8 @@ module ActiveRecord
   module ConnectionAdapters
     module PostgreSQL
       class SchemaDumper < ConnectionAdapters::SchemaDumper
+        private
+
         def extensions: (untyped stream) -> untyped
 
         def prepare_column_options: (untyped column) -> untyped
@@ -10744,6 +10942,8 @@ module ActiveRecord
         # The +options+ hash accepts the same keys as SchemaStatements#add_foreign_key.
         def validate_foreign_key: (untyped from_table, ?untyped? to_table, **untyped options) -> (nil | untyped)
 
+        private
+
         def schema_creation: () -> PostgreSQL::SchemaCreation
 
         def create_table_definition: (*untyped args, **untyped options) -> PostgreSQL::TableDefinition
@@ -10833,10 +11033,15 @@ module ActiveRecord
 
         def parts: () -> untyped
 
+        private
+
         def unquote: (untyped part) -> untyped
       end
 
       module Utils
+        # :nodoc:
+        extend ::ActiveRecord::ConnectionAdapters::PostgreSQL::Utils
+
         # Returns an instance of <tt>ActiveRecord::ConnectionAdapters::PostgreSQL::Name</tt>
         # extracted from +string+.
         # +schema+ is +nil+ if not specified in +string+.
@@ -10955,6 +11160,8 @@ module ActiveRecord
 
         def []=: (untyped sql, untyped key) -> untyped
 
+        private
+
         def dealloc: (untyped key) -> untyped
 
         def connection_active?: () -> untyped
@@ -11040,6 +11247,8 @@ module ActiveRecord
       def build_insert_sql: (untyped insert) -> untyped
 
       def check_version: () -> untyped
+
+      private
 
       # See https://www.postgresql.org/docs/current/static/errcodes-appendix.html
       VALUE_LIMIT_VIOLATION: ::String
@@ -11204,6 +11413,8 @@ module ActiveRecord
 
       def marshal_load: (untyped array) -> untyped
 
+      private
+
       def prepare_data_sources: () -> untyped
     end
   end
@@ -11255,6 +11466,8 @@ module ActiveRecord
         def commit_db_transaction: () -> untyped
 
         def exec_rollback_db_transaction: () -> untyped
+
+        private
 
         def execute_batch: (untyped statements, ?untyped? name) -> untyped
 
@@ -11318,6 +11531,8 @@ module ActiveRecord
 
         COLUMN_NAME_WITH_ORDER: untyped
 
+        private
+
         def _type_cast: (untyped value) -> untyped
       end
     end
@@ -11328,6 +11543,8 @@ module ActiveRecord
   module ConnectionAdapters
     module SQLite3
       class SchemaCreation < AbstractAdapter::SchemaCreation
+        private
+
         def add_column_options!: (untyped sql, untyped options) -> untyped
       end
     end
@@ -11342,6 +11559,8 @@ module ActiveRecord
 
         alias belongs_to references
 
+        private
+
         def integer_like_primary_key_type: (untyped `type`, untyped options) -> :primary_key
       end
     end
@@ -11352,6 +11571,8 @@ module ActiveRecord
   module ConnectionAdapters
     module SQLite3
       class SchemaDumper < ConnectionAdapters::SchemaDumper
+        private
+
         def default_primary_key?: (untyped column) -> untyped
 
         def explicit_primary_key_default?: (untyped column) -> untyped
@@ -11373,6 +11594,8 @@ module ActiveRecord
         def remove_foreign_key: (untyped from_table, ?untyped? to_table, **untyped options) -> untyped
 
         def create_schema_dumper: (untyped options) -> untyped
+
+        private
 
         def schema_creation: () -> SQLite3::SchemaCreation
 
@@ -11416,6 +11639,8 @@ module ActiveRecord
       def self.represent_boolean_as_integer=: (untyped value) -> untyped
 
       class StatementPool < ConnectionAdapters::StatementPool
+        private
+
         def dealloc: (untyped stmt) -> untyped
       end
 
@@ -11516,6 +11741,8 @@ module ActiveRecord
 
       def check_version: () -> untyped
 
+      private
+
       # See https://www.sqlite.org/limits.html,
       # the default value is 999 when not configured.
       def bind_params_length: () -> 999
@@ -11555,6 +11782,8 @@ module ActiveRecord
       def configure_connection: () -> untyped
 
       class SQLite3Integer < ActiveModel::Type::Integer
+        private
+
         def _limit: () -> untyped
       end
     end
@@ -11584,6 +11813,8 @@ module ActiveRecord
       def clear: () -> untyped
 
       def delete: (untyped key) -> untyped
+
+      private
 
       def cache: () -> untyped
 
@@ -11740,6 +11971,8 @@ module ActiveRecord
 
     def clear_cache!: () -> untyped
 
+    private
+
     def swap_connection_handler: (untyped handler) { () -> untyped } -> untyped
   end
 end
@@ -11813,6 +12046,8 @@ module ActiveRecord
       def type_caster: () -> TypeCaster::Map
 
       def _internal?: () -> ::FalseClass
+
+      private
 
       def cached_find_by_statement: (untyped key) { () -> untyped } -> untyped
 
@@ -11915,6 +12150,8 @@ module ActiveRecord
 
     # Returns a hash of the given methods with their names as keys and returned values as values.
     def slice: (*untyped methods) -> untyped
+
+    private
 
     # +Array#flatten+ will call +#to_ary+ (recursively) on each of the elements of
     # the array, and then rescues from the possible +NoMethodError+. If those elements are
@@ -12061,6 +12298,8 @@ module ActiveRecord
       def decrement_counter: (untyped counter_name, untyped id, ?touch: untyped? touch) -> untyped
     end
 
+    private
+
     def _create_record: (?untyped attribute_names) -> untyped
 
     def destroy_row: () -> untyped
@@ -12188,6 +12427,8 @@ module ActiveRecord
       # will return its value.
       def migrations_paths: () -> untyped
 
+      private
+
       def build_url_hash: (untyped url) -> untyped
 
       def build_config: (untyped original_config, untyped url) -> untyped
@@ -12256,6 +12497,8 @@ module ActiveRecord
 
     def first: () -> ::Array[untyped]
 
+    private
+
     def env_with_configs: (?untyped? env) -> untyped
 
     def build_configs: (untyped configs) -> untyped
@@ -12301,6 +12544,8 @@ end
 
 module ActiveRecord
   module DynamicMatchers
+    private
+
     def respond_to_missing?: (untyped name, untyped _) -> untyped
 
     def method_missing: (untyped name, *untyped arguments) { () -> untyped } -> untyped
@@ -12327,6 +12572,8 @@ module ActiveRecord
       def valid?: () -> untyped
 
       def define: () -> untyped
+
+      private
 
       def body: () -> ::String
 
@@ -12374,6 +12621,8 @@ module ActiveRecord
 
       def assert_valid_value: (untyped value) -> untyped
 
+      private
+
       attr_reader name: untyped
 
       attr_reader mapping: untyped
@@ -12382,6 +12631,8 @@ module ActiveRecord
     end
 
     def enum: (untyped definitions) -> untyped
+
+    private
 
     def _enum_methods_module: () -> untyped
 
@@ -12733,6 +12984,8 @@ module ActiveRecord
 
     def exec_explain: (untyped queries) -> untyped
 
+    private
+
     def render_bind: (untyped attr) -> ::Array[untyped]
   end
 end
@@ -12799,6 +13052,8 @@ module ActiveRecord
       def each: () { () -> untyped } -> untyped
 
       def model_class: () -> untyped
+
+      private
 
       def rows: () -> untyped
 
@@ -12870,6 +13125,8 @@ module ActiveRecord
 
       def to_hash: () -> untyped
 
+      private
+
       def model_metadata: () -> untyped
 
       def model_class: () -> untyped
@@ -12906,6 +13163,8 @@ module ActiveRecord
       def to_hash: () -> untyped
 
       def model_metadata: () -> untyped
+
+      private
 
       def build_table_rows_from: (untyped table_name, untyped fixtures, untyped config) -> untyped
     end
@@ -13341,6 +13600,8 @@ module ActiveRecord
 
       def []: (untyped fs_name) -> untyped
 
+      private
+
       def insert_class: (untyped class_names, untyped name, untyped klass) -> untyped
 
       def default_fixture_model: (untyped fs_name, untyped config) -> untyped
@@ -13372,6 +13633,8 @@ module ActiveRecord
 
     # Superclass for the evaluation contexts used by ERB fixtures.
     def self.context_class: () -> untyped
+
+    private
 
     def self.read_and_insert: (untyped fixtures_directory, untyped fixture_files, untyped class_names, untyped connection) -> untyped
 
@@ -13575,6 +13838,8 @@ module ActiveRecord
       # MyApp::Business::Account would appear as MyApp::Business::AccountSubclass.
       def compute_type: (untyped type_name) -> untyped
 
+      private
+
       # Called by +instantiate+ to decide which class to use for a new
       # record instance. For single-table inheritance, we check the record
       # for a +type+ column and return the corresponding class.
@@ -13592,6 +13857,8 @@ module ActiveRecord
     end
 
     def initialize_dup: (untyped other) -> untyped
+
+    private
 
     def initialize_internals_callback: () -> untyped
 
@@ -13638,6 +13905,8 @@ module ActiveRecord
 
     def map_key_with_value: () { (untyped, untyped) -> untyped } -> untyped
 
+    private
+
     def find_unique_index_for: (untyped unique_by) -> untyped
 
     def unique_indexes: () -> untyped
@@ -13667,6 +13936,8 @@ module ActiveRecord
       def conflict_target: () -> untyped
 
       def updatable_columns: () -> untyped
+
+      private
 
       attr_reader connection: untyped
 
@@ -13763,6 +14034,8 @@ module ActiveRecord
 
       def collection_cache_key: (?untyped collection, ?::Symbol timestamp_column) -> untyped
     end
+
+    private
 
     # Detects if the value before type cast
     # can be used to generate a cache_version.
@@ -13880,6 +14153,8 @@ module ActiveRecord
 
       def locking_enabled?: () -> untyped
 
+      private
+
       def _create_record: (?untyped attribute_names) -> untyped
 
       def _touch_row: (untyped attribute_names, untyped time) -> untyped
@@ -13908,6 +14183,8 @@ module ActiveRecord
         # Make sure the lock version column gets updated when counters are
         # updated.
         def update_counters: (untyped id, untyped counters) -> untyped
+
+        private
 
         # We need to apply this decorator here, rather than on module inclusion. The closure
         # created by the matcher would otherwise evaluate for `ActiveRecord::Base`, not the
@@ -14015,6 +14292,8 @@ module ActiveRecord
 
     def sql: (untyped event) -> (nil | untyped)
 
+    private
+
     def type_casted_binds: (untyped casted_binds) -> untyped
 
     def render_bind: (untyped attr, untyped value) -> ::Array[untyped]
@@ -14097,6 +14376,8 @@ module ActiveRecord
 
         def write: () { () -> untyped } -> untyped
 
+        private
+
         def read_from_primary: () { () -> untyped } -> untyped
 
         def read_from_replica: () { () -> untyped } -> untyped
@@ -14157,6 +14438,8 @@ module ActiveRecord
       # Middleware that determines which database connection to use in a multiple
       # database application.
       def call: (untyped env) -> untyped
+
+      private
 
       def select_database: (untyped request) { () -> untyped } -> untyped
 
@@ -14241,6 +14524,8 @@ module ActiveRecord
 
       def replay: (untyped migration) -> untyped
 
+      private
+
       module StraightReversions
       end
 
@@ -14315,6 +14600,8 @@ module ActiveRecord
 
         def add_timestamps: (untyped table_name, **untyped options) -> untyped
 
+        private
+
         def compatible_table_definition: (untyped t) -> untyped
 
         def command_recorder: () -> untyped
@@ -14345,6 +14632,8 @@ module ActiveRecord
 
         alias add_belongs_to add_reference
 
+        private
+
         def compatible_table_definition: (untyped t) -> untyped
       end
 
@@ -14367,6 +14656,8 @@ module ActiveRecord
 
         def remove_index: (untyped table_name, ?::Hash[untyped, untyped] options) -> untyped
 
+        private
+
         def compatible_table_definition: (untyped t) -> untyped
 
         def index_name_for_remove: (untyped table_name, ?::Hash[untyped, untyped] options) -> untyped
@@ -14378,6 +14669,8 @@ end
 module ActiveRecord
   class Migration
     module JoinTable
+      private
+
       def find_join_table_name: (untyped table_1, untyped table_2, ?::Hash[untyped, untyped] options) -> untyped
 
       def join_table_name: (untyped table_1, untyped table_2) -> untyped
@@ -14867,6 +15160,8 @@ module ActiveRecord
 
       def call: (untyped env) -> untyped
 
+      private
+
       def connection: () -> untyped
     end
 
@@ -15041,6 +15336,8 @@ module ActiveRecord
 
     def table_name_options: (?untyped config) -> { table_name_prefix: untyped, table_name_suffix: untyped }
 
+    private
+
     def execute_block: () { () -> untyped } -> untyped
 
     def command_recorder: () -> CommandRecorder
@@ -15062,6 +15359,8 @@ module ActiveRecord
     def basename: () -> untyped
 
     def mtime: () -> untyped
+
+    private
 
     def migration: () -> untyped
 
@@ -15118,6 +15417,8 @@ module ActiveRecord
 
     def last_stored_environment: () -> (nil | untyped)
 
+    private
+
     def migration_files: () -> untyped
 
     def parse_migration_filename: (untyped filename) -> untyped
@@ -15152,6 +15453,8 @@ module ActiveRecord
     def migrated: () -> untyped
 
     def load_migrated: () -> untyped
+
+    private
 
     # Used for running a specific migration.
     def run_without_lock: () -> untyped
@@ -15394,6 +15697,8 @@ module ActiveRecord
       def reset_column_information: () -> untyped
 
       def initialize_load_schema_monitor: () -> untyped
+
+      private
 
       def inherited: (untyped child_class) -> untyped
 
@@ -15738,6 +16043,8 @@ module ActiveRecord
       #   accepts_nested_attributes_for :avatar, :posts, allow_destroy: true
       def accepts_nested_attributes_for: (*untyped attr_names) -> untyped
 
+      private
+
       # Generates a writer method for this association. Serves as a point for
       # accessing the objects in the association. For example, this method
       # could generate the following:
@@ -15758,6 +16065,8 @@ module ActiveRecord
     #
     # See ActionView::Helpers::FormHelper::fields_for for more info.
     def _destroy: () -> untyped
+
+    private
 
     # Attribute hash keys that should not be assigned as normal attributes.
     # These hash keys are nested attributes implementation details.
@@ -15870,6 +16179,8 @@ module ActiveRecord
 
     def self.applied_to?: (untyped klass) -> untyped
 
+    private
+
     def self.klasses: () -> untyped
 
     # Returns +true+ if the class has +no_touching+ set, +false+ otherwise.
@@ -15915,6 +16226,8 @@ module ActiveRecord
     def exists?: (?::Symbol _conditions) -> ::FalseClass
 
     def or: (untyped other) -> untyped
+
+    private
 
     def exec_queries: () -> untyped
   end
@@ -16219,6 +16532,8 @@ module ActiveRecord
       def _update_record: (untyped values, untyped constraints) -> untyped
 
       def _delete_record: (untyped constraints) -> untyped
+
+      private
 
       # Given a class, an attributes hash, +instantiate_instance_of+ returns a
       # new instance of the class. Accepts only keys as strings.
@@ -16535,6 +16850,8 @@ module ActiveRecord
     #
     def touch: (*untyped names, ?time: untyped? time) -> untyped
 
+    private
+
     # A hook to be overridden by association modules.
     def destroy_associations: () -> nil
 
@@ -16667,6 +16984,8 @@ module ActiveRecord
         def log_process_action: (untyped payload) -> untyped
       end
 
+      private
+
       def process_action: (untyped action, *untyped args) -> untyped
 
       def cleanup_view_runtime: () -> untyped
@@ -16702,6 +17021,8 @@ module ActiveRecord
     def self.add_reflection: (untyped ar, untyped name, untyped reflection) -> untyped
 
     def self.add_aggregate_reflection: (untyped ar, untyped name, untyped reflection) -> untyped
+
+    private
 
     def self.reflection_class_for: (untyped macro) -> untyped
 
@@ -16849,6 +17170,8 @@ module ActiveRecord
 
       def actual_source_reflection: () -> untyped
 
+      private
+
       def predicate_builder: (untyped table) -> PredicateBuilder
 
       def primary_key: (untyped klass) -> untyped
@@ -16903,6 +17226,8 @@ module ActiveRecord
       def ==: (untyped other_aggregation) -> untyped
 
       def scope_for: (untyped relation, ?untyped? owner) -> untyped
+
+      private
 
       def derive_class_name: () -> untyped
     end
@@ -17012,6 +17337,8 @@ module ActiveRecord
 
       def extensions: () -> untyped
 
+      private
+
       def calculate_constructable: (untyped macro, untyped options) -> ::TrueClass
 
       # Attempts to find the inverse association name automatically.
@@ -17065,6 +17392,8 @@ module ActiveRecord
 
       def association_class: () -> untyped
 
+      private
+
       def calculate_constructable: (untyped macro, untyped options) -> untyped
     end
 
@@ -17079,6 +17408,8 @@ module ActiveRecord
       def join_primary_key: (?untyped? klass) -> untyped
 
       def join_foreign_key: () -> untyped
+
+      private
 
       def can_find_inverse_of_automatically?: (untyped _) -> untyped
 
@@ -17198,6 +17529,8 @@ module ActiveRecord
 
       def actual_source_reflection: () -> untyped
 
+      private
+
       attr_reader delegate_reflection: untyped
 
       def collect_join_reflections: (untyped seed) -> untyped
@@ -17213,6 +17546,8 @@ module ActiveRecord
       def join_scopes: (untyped table, untyped predicate_builder) -> untyped
 
       def constraints: () -> untyped
+
+      private
 
       def source_type_scope: () -> untyped
     end
@@ -17444,6 +17779,8 @@ module ActiveRecord
     # other processes are modifying the database.
     def in_batches: (?error_on_ignore: untyped? error_on_ignore, ?load: bool load, ?finish: untyped? finish, ?start: untyped? start, ?of: ::Integer of) { (untyped) -> untyped } -> (BatchEnumerator | untyped)
 
+    private
+
     def apply_limits: (untyped relation, untyped start, untyped finish) -> untyped
 
     def apply_start_limit: (untyped relation, untyped start) -> untyped
@@ -17615,6 +17952,8 @@ module ActiveRecord
     #   Person.joins(:companies).ids # SELECT people.id FROM people INNER JOIN companies ON companies.person_id = people.id
     def ids: () -> untyped
 
+    private
+
     def has_include?: (untyped column_name) -> untyped
 
     def perform_calculation: (untyped operation, untyped column_name) -> untyped
@@ -17663,6 +18002,8 @@ module ActiveRecord
 
       def include_relation_methods: (untyped delegate) -> untyped
 
+      private
+
       def generated_relation_methods: () -> untyped
     end
 
@@ -17684,6 +18025,8 @@ module ActiveRecord
         def name: () -> untyped
       end
 
+      private
+
       def method_missing: (untyped method, *untyped args) { () -> untyped } -> untyped
     end
 
@@ -17691,8 +18034,12 @@ module ActiveRecord
       # :nodoc:
       def create: (untyped klass, *untyped args, **untyped kwargs) -> untyped
 
+      private
+
       def relation_class_for: (untyped klass) -> untyped
     end
+
+    private
 
     def respond_to_missing?: (untyped method, untyped _) -> untyped
   end
@@ -17941,6 +18288,8 @@ module ActiveRecord
 
     def raise_record_not_found_exception!: (?untyped? ids, ?untyped? result_size, ?untyped? expected_size, ?untyped key, ?untyped? not_found_ids) -> untyped
 
+    private
+
     def offset_index: () -> untyped
 
     def construct_relation_for_exists: (untyped conditions) -> untyped
@@ -18035,6 +18384,8 @@ module ActiveRecord
 
       def merge: () -> untyped
 
+      private
+
       def merge_preloads: () -> (nil | untyped)
 
       def merge_joins: () -> (nil | untyped)
@@ -18060,6 +18411,8 @@ module ActiveRecord
 
       def call: (untyped attribute, untyped value) -> untyped
 
+      private
+
       attr_reader predicate_builder: untyped
 
       module NullPredicate
@@ -18077,6 +18430,8 @@ module ActiveRecord
       def initialize: (untyped associated_table, untyped value) -> untyped
 
       def queries: () -> ::Array[::Hash[untyped, untyped]]
+
+      private
 
       attr_reader associated_table: untyped
 
@@ -18099,6 +18454,8 @@ module ActiveRecord
 
       def call: (untyped attribute, untyped value) -> untyped
 
+      private
+
       attr_reader predicate_builder: untyped
     end
   end
@@ -18112,6 +18469,8 @@ module ActiveRecord
 
       def call: (untyped attribute, untyped value) -> untyped
 
+      private
+
       attr_reader predicate_builder: untyped
     end
   end
@@ -18124,6 +18483,8 @@ module ActiveRecord
       def initialize: (untyped associated_table, untyped values) -> untyped
 
       def queries: () -> untyped
+
+      private
 
       attr_reader associated_table: untyped
 
@@ -18155,6 +18516,8 @@ module ActiveRecord
       def initialize: (untyped predicate_builder) -> untyped
 
       def call: (untyped attribute, untyped value) -> untyped
+
+      private
 
       attr_reader predicate_builder: untyped
     end
@@ -18197,6 +18560,8 @@ module ActiveRecord
 
     def expand_from_hash: (untyped attributes) -> (::Array["1=0"] | untyped)
 
+    private
+
     attr_reader table: untyped
 
     def convert_dot_notation_to_hash: (untyped attributes) -> untyped
@@ -18220,6 +18585,8 @@ module ActiveRecord
       def infinite?: () -> untyped
 
       def unboundable?: () -> untyped
+
+      private
 
       def infinity?: (untyped value) -> untyped
     end
@@ -18260,6 +18627,8 @@ module ActiveRecord
       #    User.where.not(name: %w(Ko1 Nobu))
       #    # SELECT * FROM users WHERE name NOT IN ('Ko1', 'Nobu')
       def not: (untyped opts, *untyped rest) -> untyped
+
+      private
 
       def not_behaves_as_nor?: (untyped opts) -> (::FalseClass | untyped)
     end
@@ -18918,6 +19287,8 @@ module ActiveRecord
 
     def build_subquery: (untyped subquery_alias, untyped select_value) -> untyped
 
+    private
+
     def assert_mutability!: () -> untyped
 
     def build_arel: (untyped aliases) -> untyped
@@ -19052,6 +19423,8 @@ module ActiveRecord
     #   Post.order('id asc').only(:where, :order) # uses the specified order
     def only: (*untyped onlies) -> untyped
 
+    private
+
     def relation_with: (untyped values) -> untyped
   end
 end
@@ -19085,6 +19458,8 @@ module ActiveRecord
 
       def referenced_columns: () -> untyped
 
+      private
+
       def equalities: (untyped predicates) -> untyped
 
       def predicates_unreferenced_by: (untyped other) -> untyped
@@ -19115,6 +19490,8 @@ module ActiveRecord
       def initialize: (untyped klass, untyped predicate_builder) -> untyped
 
       def build: (untyped opts, untyped other) -> WhereClause
+
+      private
 
       attr_reader klass: untyped
 
@@ -19370,7 +19747,11 @@ module ActiveRecord
     #   Product.where("name like ?", "%Game%").cache_key(:last_reviewed_at)
     def cache_key: (?::Symbol timestamp_column) -> untyped
 
+    private
+
     def compute_cache_key: (?::Symbol timestamp_column) -> untyped
+
+    public
 
     # Returns a cache version that can be used together with the cache key to form
     # a recyclable caching scheme. The cache version is built with the number of records
@@ -19384,7 +19765,11 @@ module ActiveRecord
     #    SELECT COUNT(*), MAX("products"."updated_at") FROM "products" WHERE (name like '%Cosmic Encounter%')
     def cache_version: (?::Symbol timestamp_column) -> untyped
 
+    private
+
     def compute_cache_version: (untyped timestamp_column) -> untyped
+
+    public
 
     # Returns a cache key along with the version.
     def cache_key_with_version: () -> untyped
@@ -19581,6 +19966,8 @@ module ActiveRecord
 
     def null_relation?: () -> untyped
 
+    private
+
     def already_in_scope?: () -> untyped
 
     def _deprecated_spawn: (untyped name) -> untyped
@@ -19686,6 +20073,8 @@ module ActiveRecord
     def cast_values: (?::Hash[untyped, untyped] type_overrides) -> untyped
 
     def initialize_copy: (untyped other) -> untyped
+
+    private
 
     def column_type: (untyped name, ?::Hash[untyped, untyped] type_overrides) -> untyped
 
@@ -19798,6 +20187,8 @@ module ActiveRecord
 
       def disallow_raw_sql!: (untyped args, ?permit: untyped permit) -> (nil | untyped)
 
+      private
+
       def replace_bind_variables: (untyped statement, untyped values) -> untyped
 
       def replace_bind_variable: (untyped value, ?untyped c) -> untyped
@@ -19862,6 +20253,8 @@ end
 module ActiveRecord
   class SchemaDumper
     def self.dump: (?untyped connection, ?untyped stream, ?untyped config) -> untyped
+
+    private
 
     def self.generate_options: (untyped config) -> { table_name_prefix: untyped, table_name_suffix: untyped }
 
@@ -19961,6 +20354,8 @@ module ActiveRecord
         def scope_attributes?: () -> untyped
 
         def before_remove_const: () -> untyped
+
+        private
 
         def default_scope: (?untyped? scope) { () -> untyped } -> untyped
 
@@ -20110,6 +20505,8 @@ module ActiveRecord
         #   Article.featured.titles
         def scope: (untyped name, untyped body) { () -> untyped } -> untyped
 
+        private
+
         def valid_scope_name?: (untyped name) -> untyped
       end
     end
@@ -20177,6 +20574,8 @@ module ActiveRecord
 
       # Sets the +value+ for a given +scope_type+ and +model+.
       def set_value_for: (untyped scope_type, untyped model, untyped value) -> untyped
+
+      private
 
       def raise_invalid_scope_type!: (untyped scope_type) -> untyped
     end
@@ -20281,6 +20680,8 @@ module ActiveRecord
     def execute: (untyped params, untyped connection) { () -> untyped } -> untyped
 
     def self.unsupported_value?: (untyped value) -> untyped
+
+    private
 
     attr_reader query_builder: untyped
 
@@ -20393,6 +20794,8 @@ module ActiveRecord
 
       def stored_attributes: () -> untyped
     end
+
+    private
 
     def read_store_attribute: (untyped store_attribute, untyped key) -> untyped
 
@@ -20509,6 +20912,8 @@ module ActiveRecord
 
     def predicate_builder: () -> untyped
 
+    private
+
     attr_reader klass: untyped
 
     attr_reader types: untyped
@@ -20557,6 +20962,8 @@ module ActiveRecord
     #
     #   DatabaseTasks.create_current('production')
     module DatabaseTasks
+      extend ::ActiveRecord::Tasks::DatabaseTasks
+
       attr_writer current_config: untyped
 
       attr_writer db_dir: untyped
@@ -20613,7 +21020,11 @@ module ActiveRecord
 
       def drop_current: (?untyped environment) -> untyped
 
+      private
+
       def truncate_tables: (untyped configuration) -> untyped
+
+      public
 
       def truncate_all: (?untyped environment) -> untyped
 
@@ -20671,6 +21082,8 @@ module ActiveRecord
       #   ActiveRecord::Tasks::DatabaseTasks.dump_schema_cache(ActiveRecord::Base.connection, "tmp/schema_dump.yaml")
       def dump_schema_cache: (untyped conn, untyped filename) -> untyped
 
+      private
+
       def verbose?: () -> untyped
 
       def class_for_adapter: (untyped adapter) -> untyped
@@ -20708,6 +21121,8 @@ module ActiveRecord
       def structure_dump: (untyped filename, untyped extra_flags) -> untyped
 
       def structure_load: (untyped filename, untyped extra_flags) -> untyped
+
+      private
 
       attr_reader configuration: untyped
 
@@ -20751,6 +21166,8 @@ module ActiveRecord
 
       def structure_load: (untyped filename, untyped extra_flags) -> untyped
 
+      private
+
       attr_reader configuration: untyped
 
       def encoding: () -> untyped
@@ -20784,6 +21201,8 @@ module ActiveRecord
       def structure_dump: (untyped filename, untyped extra_flags) -> untyped
 
       def structure_load: (untyped filename, untyped extra_flags) -> untyped
+
+      private
 
       attr_reader configuration: untyped
 
@@ -20837,6 +21256,8 @@ module ActiveRecord
     def teardown_fixtures: () -> untyped
 
     def enlist_fixture_connections: () -> untyped
+
+    private
 
     # Shares the writing connection pool with connections on
     # other handlers.
@@ -20911,12 +21332,16 @@ module ActiveRecord
 
       def current_time_from_proper_timezone: () -> untyped
 
+      private
+
       def timestamp_attributes_for_create: () -> ::Array["created_at" | "created_on"]
 
       def timestamp_attributes_for_update: () -> ::Array["updated_at" | "updated_on"]
 
       def reload_schema_from_cache: () -> untyped
     end
+
+    private
 
     def _create_record: () -> untyped
 
@@ -20950,6 +21375,8 @@ module ActiveRecord
     def touch_later: (*untyped names) -> untyped
 
     def touch: (*untyped names, ?time: untyped? time) -> untyped
+
+    private
 
     def surreptitiously_touch: (untyped attrs) -> untyped
 
@@ -21202,6 +21629,8 @@ module ActiveRecord
 
       def after_rollback_without_transaction_enrollment: (*untyped args) { () -> untyped } -> untyped
 
+      private
+
       def set_options_for_callbacks!: (untyped args, ?::Hash[untyped, untyped] enforced_options) -> untyped
 
       def assert_valid_transaction_action: (untyped actions) -> untyped
@@ -21233,6 +21662,8 @@ module ActiveRecord
     def with_transaction_returning_status: () { () -> untyped } -> untyped
 
     def trigger_transactional_callbacks?: () -> untyped
+
+    private
 
     attr_reader _committed_already_called: untyped
 
@@ -21294,6 +21725,8 @@ module ActiveRecord
     class AdapterSpecificRegistry < ActiveModel::Type::Registry
       def add_modifier: (untyped options, untyped klass, **untyped args) -> untyped
 
+      private
+
       def registration_klass: () -> untyped
 
       def find_registration: (untyped symbol, *untyped args, **untyped kwargs) -> untyped
@@ -21320,6 +21753,8 @@ module ActiveRecord
 
       def priority_except_adapter: () -> untyped
 
+      private
+
       def matches_adapter?: (?adapter: untyped? adapter) -> untyped
 
       def conflicts_with?: (untyped other) -> untyped
@@ -21337,6 +21772,8 @@ module ActiveRecord
       def matches?: (*untyped args, **untyped kwargs) -> untyped
 
       def priority: () -> untyped
+
+      private
 
       attr_reader options: untyped
 
@@ -21386,6 +21823,8 @@ module ActiveRecord
       def key?: (untyped key) -> untyped
 
       def keys: () -> untyped
+
+      private
 
       def perform_fetch: (untyped `type`, *untyped args) { () -> untyped } -> untyped
     end
@@ -21448,6 +21887,8 @@ module ActiveRecord
 
       def force_equality?: (untyped value) -> untyped
 
+      private
+
       def default_value?: (untyped value) -> untyped
 
       def encoded: (untyped value) -> untyped
@@ -21493,6 +21934,8 @@ module ActiveRecord
 
       def clear: () -> untyped
 
+      private
+
       def perform_fetch: (untyped lookup_key, *untyped args) { (untyped, untyped) -> untyped } -> untyped
     end
   end
@@ -21501,6 +21944,8 @@ end
 module ActiveRecord
   module Type
     class UnsignedInteger < ActiveModel::Type::Integer
+      private
+
       def max_value: () -> untyped
 
       def min_value: () -> 0
@@ -21525,6 +21970,8 @@ module ActiveRecord
     def self.lookup: (*untyped args, ?adapter: untyped adapter, **untyped kwargs) -> untyped
 
     def self.default_value: () -> untyped
+
+    private
 
     def self.current_adapter_name: () -> untyped
 
@@ -21556,6 +22003,8 @@ module ActiveRecord
 
       def type_for_attribute: (untyped attr_name) -> untyped
 
+      private
+
       attr_reader table_name: untyped
     end
   end
@@ -21568,6 +22017,8 @@ module ActiveRecord
       def initialize: (untyped types) -> untyped
 
       def type_cast_for_database: (untyped attr_name, untyped value) -> untyped
+
+      private
 
       attr_reader types: untyped
     end
@@ -21602,6 +22053,8 @@ module ActiveRecord
     class AssociatedValidator < ActiveModel::EachValidator
       # nodoc:
       def validate_each: (untyped record, untyped attribute, untyped value) -> untyped
+
+      private
 
       def valid_object?: (untyped record) -> untyped
     end
@@ -21734,6 +22187,8 @@ module ActiveRecord
       def initialize: (untyped options) -> untyped
 
       def validate_each: (untyped record, untyped attribute, untyped value) -> untyped
+
+      private
 
       # The check for an existing value should be run from a class that
       # isn't abstract. This means working down from the current class
@@ -21933,6 +22388,8 @@ module ActiveRecord
 
     alias validate valid?
 
+    private
+
     def default_validation_context: () -> untyped
 
     def raise_validation_error: () -> untyped
@@ -22071,6 +22528,8 @@ module Arel
 
       def value: () -> ::Array[untyped]
 
+      private
+
       attr_reader left: untyped
 
       attr_reader right: untyped
@@ -22113,6 +22572,8 @@ module Arel
       def add_bind: (untyped bind) -> untyped
 
       def value: () -> untyped
+
+      private
 
       attr_reader quoter: untyped
 
@@ -23211,6 +23672,8 @@ module Arel
 
     def concat: (untyped other) -> Nodes::Concat
 
+    private
+
     def grouping_any: (untyped method_id, untyped others, *untyped extras) -> Nodes::Grouping
 
     def grouping_all: (untyped method_id, untyped others, *untyped extras) -> Nodes::Grouping
@@ -23316,6 +23779,8 @@ module Arel
 
     def comment: (*untyped values) -> untyped
 
+    private
+
     def collapse: (untyped exprs) -> untyped
   end
 end
@@ -23371,6 +23836,8 @@ module Arel
     def type_cast_for_database: (untyped attribute_name, untyped value) -> untyped
 
     def able_to_type_cast?: () -> untyped
+
+    private
 
     attr_reader type_caster: untyped
   end
@@ -23431,6 +23898,8 @@ module Arel
   module Visitors
     class DepthFirst < Arel::Visitors::Visitor
       def initialize: (?untyped? block) -> untyped
+
+      private
 
       def visit: (untyped o, ?untyped? _) -> untyped
 
@@ -23665,6 +24134,8 @@ module Arel
 
       def accept: (untyped object, untyped collector) -> untyped
 
+      private
+
       def visit_Arel_Nodes_Ordering: (untyped o) -> untyped
 
       def visit_Arel_Nodes_TableAlias: (untyped o) -> untyped
@@ -23870,6 +24341,8 @@ module Arel
   # :nodoc: all
   module Visitors
     class IBM_DB < Arel::Visitors::ToSql
+      private
+
       def visit_Arel_Nodes_SelectCore: (untyped o, untyped collector) -> untyped
 
       def visit_Arel_Nodes_OptimizerHints: (untyped o, untyped collector) -> untyped
@@ -23887,6 +24360,8 @@ module Arel
   # :nodoc: all
   module Visitors
     class Informix < Arel::Visitors::ToSql
+      private
+
       def visit_Arel_Nodes_SelectStatement: (untyped o, untyped collector) -> untyped
 
       def visit_Arel_Nodes_SelectCore: (untyped o, untyped collector) -> untyped
@@ -23909,6 +24384,8 @@ module Arel
       end
 
       def initialize: () -> untyped
+
+      private
 
       def visit_Arel_Nodes_IsNotDistinctFrom: (untyped o, untyped collector) -> untyped
 
@@ -23946,6 +24423,8 @@ module Arel
   # :nodoc: all
   module Visitors
     class MySQL < Arel::Visitors::ToSql
+      private
+
       def visit_Arel_Nodes_Bin: (untyped o, untyped collector) -> untyped
 
       def visit_Arel_Nodes_UnqualifiedColumn: (untyped o, untyped collector) -> untyped
@@ -23981,6 +24460,8 @@ module Arel
   # :nodoc: all
   module Visitors
     class Oracle < Arel::Visitors::ToSql
+      private
+
       def visit_Arel_Nodes_SelectStatement: (untyped o, untyped collector) -> untyped
 
       def visit_Arel_Nodes_Limit: (untyped o, untyped collector) -> untyped
@@ -24010,6 +24491,8 @@ module Arel
   # :nodoc: all
   module Visitors
     class Oracle12 < Arel::Visitors::ToSql
+      private
+
       def visit_Arel_Nodes_SelectStatement: (untyped o, untyped collector) -> untyped
 
       def visit_Arel_Nodes_SelectOptions: (untyped o, untyped collector) -> untyped
@@ -24033,6 +24516,8 @@ module Arel
   # :nodoc: all
   module Visitors
     class PostgreSQL < Arel::Visitors::ToSql
+      private
+
       def visit_Arel_Nodes_Matches: (untyped o, untyped collector) -> untyped
 
       def visit_Arel_Nodes_DoesNotMatch: (untyped o, untyped collector) -> untyped
@@ -24073,6 +24558,8 @@ module Arel
   # :nodoc: all
   module Visitors
     class SQLite < Arel::Visitors::ToSql
+      private
+
       # Locks are not supported in SQLite
       def visit_Arel_Nodes_Lock: (untyped o, untyped collector) -> untyped
 
@@ -24100,6 +24587,8 @@ module Arel
       def initialize: (untyped connection) -> untyped
 
       def compile: (untyped node, ?untyped collector) -> untyped
+
+      private
 
       def visit_Arel_Nodes_DeleteStatement: (untyped o, untyped collector) -> untyped
 
@@ -24384,6 +24873,8 @@ module Arel
 
       def accept: (untyped object, ?untyped? collector) -> untyped
 
+      private
+
       attr_reader dispatch: untyped
 
       def self.dispatch_cache: () -> untyped
@@ -24400,6 +24891,8 @@ module Arel
   module Visitors
     class WhereSql < Arel::Visitors::ToSql
       def initialize: (untyped inner_visitor, *untyped args) { () -> untyped } -> untyped
+
+      private
 
       def visit_Arel_Nodes_SelectCore: (untyped o, untyped collector) -> untyped
     end
@@ -24446,6 +24939,8 @@ module ActiveRecord
       # FIXME: Change this file to a symlink once RubyGems 2.5.0 is required.
       def create_application_record: () -> untyped
 
+      private
+
       def application_record_file_name: () -> untyped
     end
   end
@@ -24455,6 +24950,8 @@ module ActiveRecord
   module Generators
     class MigrationGenerator < Base
       def create_migration_file: () -> untyped
+
+      private
 
       attr_reader migration_action: untyped
 
@@ -24493,6 +24990,8 @@ module ActiveRecord
         def next_migration_number: (untyped dirname) -> untyped
       end
 
+      private
+
       def primary_key_type: () -> untyped
 
       def db_migrate_path: () -> untyped
@@ -24513,6 +25012,8 @@ module ActiveRecord
       def create_model_file: () -> untyped
 
       def create_module_file: () -> (nil | untyped)
+
+      private
 
       def attributes_with_index: () -> untyped
 

--- a/gems/activerecord/6.0.3.2/activerecord-generated.rbs
+++ b/gems/activerecord/6.0.3.2/activerecord-generated.rbs
@@ -16986,6 +16986,8 @@ module ActiveRecord
 
       private
 
+      attr_accessor db_runtime(@_db_runtime): untyped
+
       def process_action: (untyped action, *untyped args) -> untyped
 
       def cleanup_view_runtime: () -> untyped

--- a/gems/activerecord/6.0.3.2/activerecord-generated.rbs
+++ b/gems/activerecord/6.0.3.2/activerecord-generated.rbs
@@ -1,0 +1,24513 @@
+module ActiveRecord
+  class AdvisoryLockBase < ActiveRecord::Base
+    def self._internal?: () -> ::TrueClass
+  end
+end
+
+module ActiveRecord
+  # See ActiveRecord::Aggregations::ClassMethods for documentation
+  module Aggregations
+    def initialize_dup: () -> untyped
+
+    def reload: () -> untyped
+
+    def clear_aggregation_cache: () -> untyped
+
+    def init_internals: () -> untyped
+
+    # Active Record implements aggregation through a macro-like class method called #composed_of
+    # for representing attributes as value objects. It expresses relationships like "Account [is]
+    # composed of Money [among other things]" or "Person [is] composed of [an] address". Each call
+    # to the macro adds a description of how the value objects are created from the attributes of
+    # the entity object (when the entity is initialized either as a new object or from finding an
+    # existing object) and how it can be turned back into attributes (when the entity is saved to
+    # the database).
+    #
+    #   class Customer < ActiveRecord::Base
+    #     composed_of :balance, class_name: "Money", mapping: %w(balance amount)
+    #     composed_of :address, mapping: [ %w(address_street street), %w(address_city city) ]
+    #   end
+    #
+    # The customer class now has the following methods to manipulate the value objects:
+    # * <tt>Customer#balance, Customer#balance=(money)</tt>
+    # * <tt>Customer#address, Customer#address=(address)</tt>
+    #
+    # These methods will operate with value objects like the ones described below:
+    #
+    #  class Money
+    #    include Comparable
+    #    attr_reader :amount, :currency
+    #    EXCHANGE_RATES = { "USD_TO_DKK" => 6 }
+    #
+    #    def initialize(amount, currency = "USD")
+    #      @amount, @currency = amount, currency
+    #    end
+    #
+    #    def exchange_to(other_currency)
+    #      exchanged_amount = (amount * EXCHANGE_RATES["#{currency}_TO_#{other_currency}"]).floor
+    #      Money.new(exchanged_amount, other_currency)
+    #    end
+    #
+    #    def ==(other_money)
+    #      amount == other_money.amount && currency == other_money.currency
+    #    end
+    #
+    #    def <=>(other_money)
+    #      if currency == other_money.currency
+    #        amount <=> other_money.amount
+    #      else
+    #        amount <=> other_money.exchange_to(currency).amount
+    #      end
+    #    end
+    #  end
+    #
+    #  class Address
+    #    attr_reader :street, :city
+    #    def initialize(street, city)
+    #      @street, @city = street, city
+    #    end
+    #
+    #    def close_to?(other_address)
+    #      city == other_address.city
+    #    end
+    #
+    #    def ==(other_address)
+    #      city == other_address.city && street == other_address.street
+    #    end
+    #  end
+    #
+    # Now it's possible to access attributes from the database through the value objects instead. If
+    # you choose to name the composition the same as the attribute's name, it will be the only way to
+    # access that attribute. That's the case with our +balance+ attribute. You interact with the value
+    # objects just like you would with any other attribute:
+    #
+    #   customer.balance = Money.new(20)     # sets the Money value object and the attribute
+    #   customer.balance                     # => Money value object
+    #   customer.balance.exchange_to("DKK")  # => Money.new(120, "DKK")
+    #   customer.balance > Money.new(10)     # => true
+    #   customer.balance == Money.new(20)    # => true
+    #   customer.balance < Money.new(5)      # => false
+    #
+    # Value objects can also be composed of multiple attributes, such as the case of Address. The order
+    # of the mappings will determine the order of the parameters.
+    #
+    #   customer.address_street = "Hyancintvej"
+    #   customer.address_city   = "Copenhagen"
+    #   customer.address        # => Address.new("Hyancintvej", "Copenhagen")
+    #
+    #   customer.address = Address.new("May Street", "Chicago")
+    #   customer.address_street # => "May Street"
+    #   customer.address_city   # => "Chicago"
+    #
+    # == Writing value objects
+    #
+    # Value objects are immutable and interchangeable objects that represent a given value, such as
+    # a Money object representing $5. Two Money objects both representing $5 should be equal (through
+    # methods such as <tt>==</tt> and <tt><=></tt> from Comparable if ranking makes sense). This is
+    # unlike entity objects where equality is determined by identity. An entity class such as Customer can
+    # easily have two different objects that both have an address on Hyancintvej. Entity identity is
+    # determined by object or relational unique identifiers (such as primary keys). Normal
+    # ActiveRecord::Base classes are entity objects.
+    #
+    # It's also important to treat the value objects as immutable. Don't allow the Money object to have
+    # its amount changed after creation. Create a new Money object with the new value instead. The
+    # <tt>Money#exchange_to</tt> method is an example of this. It returns a new value object instead of changing
+    # its own values. Active Record won't persist value objects that have been changed through means
+    # other than the writer method.
+    #
+    # The immutable requirement is enforced by Active Record by freezing any object assigned as a value
+    # object. Attempting to change it afterwards will result in a +RuntimeError+.
+    #
+    # Read more about value objects on http://c2.com/cgi/wiki?ValueObject and on the dangers of not
+    # keeping value objects immutable on http://c2.com/cgi/wiki?ValueObjectsShouldBeImmutable
+    #
+    # == Custom constructors and converters
+    #
+    # By default value objects are initialized by calling the <tt>new</tt> constructor of the value
+    # class passing each of the mapped attributes, in the order specified by the <tt>:mapping</tt>
+    # option, as arguments. If the value class doesn't support this convention then #composed_of allows
+    # a custom constructor to be specified.
+    #
+    # When a new value is assigned to the value object, the default assumption is that the new value
+    # is an instance of the value class. Specifying a custom converter allows the new value to be automatically
+    # converted to an instance of value class if necessary.
+    #
+    # For example, the +NetworkResource+ model has +network_address+ and +cidr_range+ attributes that should be
+    # aggregated using the +NetAddr::CIDR+ value class (http://www.rubydoc.info/gems/netaddr/1.5.0/NetAddr/CIDR).
+    # The constructor for the value class is called +create+ and it expects a CIDR address string as a parameter.
+    # New values can be assigned to the value object using either another +NetAddr::CIDR+ object, a string
+    # or an array. The <tt>:constructor</tt> and <tt>:converter</tt> options can be used to meet
+    # these requirements:
+    #
+    #   class NetworkResource < ActiveRecord::Base
+    #     composed_of :cidr,
+    #                 class_name: 'NetAddr::CIDR',
+    #                 mapping: [ %w(network_address network), %w(cidr_range bits) ],
+    #                 allow_nil: true,
+    #                 constructor: Proc.new { |network_address, cidr_range| NetAddr::CIDR.create("#{network_address}/#{cidr_range}") },
+    #                 converter: Proc.new { |value| NetAddr::CIDR.create(value.is_a?(Array) ? value.join('/') : value) }
+    #   end
+    #
+    #   # This calls the :constructor
+    #   network_resource = NetworkResource.new(network_address: '192.168.0.1', cidr_range: 24)
+    #
+    #   # These assignments will both use the :converter
+    #   network_resource.cidr = [ '192.168.2.1', 8 ]
+    #   network_resource.cidr = '192.168.0.1/24'
+    #
+    #   # This assignment won't use the :converter as the value is already an instance of the value class
+    #   network_resource.cidr = NetAddr::CIDR.create('192.168.2.1/8')
+    #
+    #   # Saving and then reloading will use the :constructor on reload
+    #   network_resource.save
+    #   network_resource.reload
+    #
+    # == Finding records by a value object
+    #
+    # Once a #composed_of relationship is specified for a model, records can be loaded from the database
+    # by specifying an instance of the value object in the conditions hash. The following example
+    # finds all customers with +address_street+ equal to "May Street" and +address_city+ equal to "Chicago":
+    #
+    #   Customer.where(address: Address.new("May Street", "Chicago"))
+    #
+    module ClassMethods
+      # Adds reader and writer methods for manipulating a value object:
+      # <tt>composed_of :address</tt> adds <tt>address</tt> and <tt>address=(new_address)</tt> methods.
+      #
+      # Options are:
+      # * <tt>:class_name</tt> - Specifies the class name of the association. Use it only if that name
+      #   can't be inferred from the part id. So <tt>composed_of :address</tt> will by default be linked
+      #   to the Address class, but if the real class name is +CompanyAddress+, you'll have to specify it
+      #   with this option.
+      # * <tt>:mapping</tt> - Specifies the mapping of entity attributes to attributes of the value
+      #   object. Each mapping is represented as an array where the first item is the name of the
+      #   entity attribute and the second item is the name of the attribute in the value object. The
+      #   order in which mappings are defined determines the order in which attributes are sent to the
+      #   value class constructor.
+      # * <tt>:allow_nil</tt> - Specifies that the value object will not be instantiated when all mapped
+      #   attributes are +nil+. Setting the value object to +nil+ has the effect of writing +nil+ to all
+      #   mapped attributes.
+      #   This defaults to +false+.
+      # * <tt>:constructor</tt> - A symbol specifying the name of the constructor method or a Proc that
+      #   is called to initialize the value object. The constructor is passed all of the mapped attributes,
+      #   in the order that they are defined in the <tt>:mapping option</tt>, as arguments and uses them
+      #   to instantiate a <tt>:class_name</tt> object.
+      #   The default is <tt>:new</tt>.
+      # * <tt>:converter</tt> - A symbol specifying the name of a class method of <tt>:class_name</tt>
+      #   or a Proc that is called when a new value is assigned to the value object. The converter is
+      #   passed the single value that is used in the assignment and is only called if the new value is
+      #   not an instance of <tt>:class_name</tt>. If <tt>:allow_nil</tt> is set to true, the converter
+      #   can return +nil+ to skip the assignment.
+      #
+      # Option examples:
+      #   composed_of :temperature, mapping: %w(reading celsius)
+      #   composed_of :balance, class_name: "Money", mapping: %w(balance amount)
+      #   composed_of :address, mapping: [ %w(address_street street), %w(address_city city) ]
+      #   composed_of :gps_location
+      #   composed_of :gps_location, allow_nil: true
+      #   composed_of :ip_address,
+      #               class_name: 'IPAddr',
+      #               mapping: %w(ip to_i),
+      #               constructor: Proc.new { |ip| IPAddr.new(ip, Socket::AF_INET) },
+      #               converter: Proc.new { |ip| ip.is_a?(Integer) ? IPAddr.new(ip, Socket::AF_INET) : IPAddr.new(ip.to_s) }
+      #
+      def composed_of: (untyped part_id, ?::Hash[untyped, untyped] options) -> untyped
+
+      def reader_method: (untyped name, untyped class_name, untyped mapping, untyped allow_nil, untyped constructor) -> untyped
+
+      def writer_method: (untyped name, untyped class_name, untyped mapping, untyped allow_nil, untyped converter) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  class AssociationRelation < Relation
+    def initialize: (untyped klass, untyped association) -> untyped
+
+    def proxy_association: () -> untyped
+
+    def ==: (untyped other) -> untyped
+
+    def build: (?untyped? attributes) { () -> untyped } -> untyped
+
+    alias new build
+
+    def create: (?untyped? attributes) { () -> untyped } -> untyped
+
+    def create!: (?untyped? attributes) { () -> untyped } -> untyped
+
+    def exec_queries: () { (untyped) -> untyped } -> untyped
+  end
+end
+
+module ActiveRecord
+  module Associations
+    class AliasTracker
+      # Keeps track of table aliases for ActiveRecord::Associations::JoinDependency
+      # :nodoc:
+      def self.create: (untyped connection, untyped initial_table, untyped joins) -> untyped
+
+      def self.initial_count_for: (untyped connection, untyped name, untyped table_joins) -> untyped
+
+      # table_joins is an array of arel joins which might conflict with the aliases we assign here
+      def initialize: (untyped connection, untyped aliases) -> untyped
+
+      def aliased_table_for: (untyped table_name, untyped aliased_name, untyped type_caster) -> untyped
+
+      attr_reader aliases: untyped
+
+      def truncate: (untyped name) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module Associations
+    class Association
+      # = Active Record Associations
+      #
+      # This is the root class of all associations ('+ Foo' signifies an included module Foo):
+      #
+      #   Association
+      #     SingularAssociation
+      #       HasOneAssociation + ForeignAssociation
+      #         HasOneThroughAssociation + ThroughAssociation
+      #       BelongsToAssociation
+      #         BelongsToPolymorphicAssociation
+      #     CollectionAssociation
+      #       HasManyAssociation + ForeignAssociation
+      #         HasManyThroughAssociation + ThroughAssociation
+      #
+      # Associations in Active Record are middlemen between the object that
+      # holds the association, known as the <tt>owner</tt>, and the associated
+      # result set, known as the <tt>target</tt>. Association metadata is available in
+      # <tt>reflection</tt>, which is an instance of <tt>ActiveRecord::Reflection::AssociationReflection</tt>.
+      #
+      # For example, given
+      #
+      #   class Blog < ActiveRecord::Base
+      #     has_many :posts
+      #   end
+      #
+      #   blog = Blog.first
+      #
+      # The association of <tt>blog.posts</tt> has the object +blog+ as its
+      # <tt>owner</tt>, the collection of its posts as <tt>target</tt>, and
+      # the <tt>reflection</tt> object represents a <tt>:has_many</tt> macro.
+      # nodoc:
+      attr_reader owner: untyped
+
+      # = Active Record Associations
+      #
+      # This is the root class of all associations ('+ Foo' signifies an included module Foo):
+      #
+      #   Association
+      #     SingularAssociation
+      #       HasOneAssociation + ForeignAssociation
+      #         HasOneThroughAssociation + ThroughAssociation
+      #       BelongsToAssociation
+      #         BelongsToPolymorphicAssociation
+      #     CollectionAssociation
+      #       HasManyAssociation + ForeignAssociation
+      #         HasManyThroughAssociation + ThroughAssociation
+      #
+      # Associations in Active Record are middlemen between the object that
+      # holds the association, known as the <tt>owner</tt>, and the associated
+      # result set, known as the <tt>target</tt>. Association metadata is available in
+      # <tt>reflection</tt>, which is an instance of <tt>ActiveRecord::Reflection::AssociationReflection</tt>.
+      #
+      # For example, given
+      #
+      #   class Blog < ActiveRecord::Base
+      #     has_many :posts
+      #   end
+      #
+      #   blog = Blog.first
+      #
+      # The association of <tt>blog.posts</tt> has the object +blog+ as its
+      # <tt>owner</tt>, the collection of its posts as <tt>target</tt>, and
+      # the <tt>reflection</tt> object represents a <tt>:has_many</tt> macro.
+      # nodoc:
+      attr_reader target: untyped
+
+      # = Active Record Associations
+      #
+      # This is the root class of all associations ('+ Foo' signifies an included module Foo):
+      #
+      #   Association
+      #     SingularAssociation
+      #       HasOneAssociation + ForeignAssociation
+      #         HasOneThroughAssociation + ThroughAssociation
+      #       BelongsToAssociation
+      #         BelongsToPolymorphicAssociation
+      #     CollectionAssociation
+      #       HasManyAssociation + ForeignAssociation
+      #         HasManyThroughAssociation + ThroughAssociation
+      #
+      # Associations in Active Record are middlemen between the object that
+      # holds the association, known as the <tt>owner</tt>, and the associated
+      # result set, known as the <tt>target</tt>. Association metadata is available in
+      # <tt>reflection</tt>, which is an instance of <tt>ActiveRecord::Reflection::AssociationReflection</tt>.
+      #
+      # For example, given
+      #
+      #   class Blog < ActiveRecord::Base
+      #     has_many :posts
+      #   end
+      #
+      #   blog = Blog.first
+      #
+      # The association of <tt>blog.posts</tt> has the object +blog+ as its
+      # <tt>owner</tt>, the collection of its posts as <tt>target</tt>, and
+      # the <tt>reflection</tt> object represents a <tt>:has_many</tt> macro.
+      # nodoc:
+      attr_reader reflection: untyped
+
+      def initialize: (untyped owner, untyped reflection) -> untyped
+
+      # Resets the \loaded flag to +false+ and sets the \target to +nil+.
+      def reset: () -> untyped
+
+      # Reloads the \target and returns +self+ on success.
+      # The QueryCache is cleared if +force+ is true.
+      def reload: (?bool force) -> untyped
+
+      # Has the \target been already \loaded?
+      def loaded?: () -> untyped
+
+      # Asserts the \target has been loaded setting the \loaded flag to +true+.
+      def loaded!: () -> untyped
+
+      # The target is stale if the target no longer points to the record(s) that the
+      # relevant foreign_key(s) refers to. If stale, the association accessor method
+      # on the owner will reload the target. It's up to subclasses to implement the
+      # stale_state method if relevant.
+      #
+      # Note that if the target has not been loaded, it is not considered stale.
+      def stale_target?: () -> untyped
+
+      # Sets the target of this association to <tt>\target</tt>, and the \loaded flag to +true+.
+      def target=: (untyped target) -> untyped
+
+      def scope: () -> untyped
+
+      def reset_scope: () -> untyped
+
+      # Set the inverse association, if possible
+      def set_inverse_instance: (untyped record) -> untyped
+
+      def set_inverse_instance_from_queries: (untyped record) -> untyped
+
+      # Remove the inverse association, if possible
+      def remove_inverse_instance: (untyped record) -> untyped
+
+      def inversed_from: (untyped record) -> untyped
+
+      alias inversed_from_queries inversed_from
+
+      # Returns the class of the target. belongs_to polymorphic overrides this to look at the
+      # polymorphic_type field on the owner.
+      def klass: () -> untyped
+
+      def extensions: () -> untyped
+
+      # Loads the \target if needed and returns it.
+      #
+      # This method is abstract in the sense that it relies on +find_target+,
+      # which is expected to be provided by descendants.
+      #
+      # If the \target is already \loaded it is just returned. Thus, you can call
+      # +load_target+ unconditionally to get the \target.
+      #
+      # ActiveRecord::RecordNotFound is rescued within the method, and it is
+      # not reraised. The proxy is \reset and +nil+ is the return value.
+      def load_target: () -> untyped
+
+      # We can't dump @reflection and @through_reflection since it contains the scope proc
+      def marshal_dump: () -> ::Array[untyped]
+
+      def marshal_load: (untyped data) -> untyped
+
+      def initialize_attributes: (untyped record, ?untyped? except_from_scope_attributes) -> untyped
+
+      def create: (?::Hash[untyped, untyped] attributes) { () -> untyped } -> untyped
+
+      def create!: (?::Hash[untyped, untyped] attributes) { () -> untyped } -> untyped
+
+      def find_target: () -> untyped
+
+      # The scope for this association.
+      #
+      # Note that the association_scope is merged into the target_scope only when the
+      # scope method is called. This is because at that point the call may be surrounded
+      # by scope.scoping { ... } or unscoped { ... } etc, which affects the scope which
+      # actually gets built.
+      def association_scope: () -> untyped
+
+      # Can be overridden (i.e. in ThroughAssociation) to merge in other scopes (i.e. the
+      # through association's scope)
+      def target_scope: () -> untyped
+
+      def scope_for_create: () -> untyped
+
+      def find_target?: () -> untyped
+
+      def creation_attributes: () -> untyped
+
+      # Sets the owner attributes on the given record
+      def set_owner_attributes: (untyped record) -> untyped
+
+      # Returns true if there is a foreign key present on the owner which
+      # references the target. This is used to determine whether we can load
+      # the target if the owner is currently a new record (and therefore
+      # without a key). If the owner is a new record then foreign_key must
+      # be present in order to load target.
+      #
+      # Currently implemented by belongs_to (vanilla and polymorphic) and
+      # has_one/has_many :through associations which go through a belongs_to.
+      def foreign_key_present?: () -> ::FalseClass
+
+      # Raises ActiveRecord::AssociationTypeMismatch unless +record+ is of
+      # the kind of the class of the associated objects. Meant to be used as
+      # a sanity check when you are about to assign an associated record.
+      def raise_on_type_mismatch!: (untyped record) -> untyped
+
+      def inverse_association_for: (untyped record) -> untyped
+
+      # Can be redefined by subclasses, notably polymorphic belongs_to
+      # The record parameter is necessary to support polymorphic inverses as we must check for
+      # the association in the specific class of the record.
+      def inverse_reflection_for: (untyped record) -> untyped
+
+      # Returns true if inverse association on the given record needs to be set.
+      # This method is redefined by subclasses.
+      def invertible_for?: (untyped record) -> untyped
+
+      # Returns true if record contains the foreign_key
+      def foreign_key_for?: (untyped record) -> untyped
+
+      # This should be implemented to return the values of the relevant key(s) on the owner,
+      # so that when stale_state is different from the value stored on the last find_target,
+      # the target is stale.
+      #
+      # This is only relevant to certain associations, which is why it returns +nil+ by default.
+      def stale_state: () -> nil
+
+      def build_record: (untyped attributes) { (untyped) -> untyped } -> untyped
+
+      # Returns true if statement cache should be skipped on the association reader.
+      def skip_statement_cache?: (untyped scope) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module Associations
+    class AssociationScope
+      # nodoc:
+      def self.scope: (untyped association) -> untyped
+
+      def self.create: () { () -> untyped } -> untyped
+
+      def initialize: (untyped value_transformation) -> untyped
+
+      INSTANCE: untyped
+
+      def scope: (untyped association) -> untyped
+
+      def self.get_bind_values: (untyped owner, untyped chain) -> untyped
+
+      attr_reader value_transformation: untyped
+
+      def join: (untyped table, untyped constraint) -> untyped
+
+      def last_chain_scope: (untyped scope, untyped reflection, untyped owner) -> untyped
+
+      def transform_value: (untyped value) -> untyped
+
+      def next_chain_scope: (untyped scope, untyped reflection, untyped next_reflection) -> untyped
+
+      class ReflectionProxy < SimpleDelegator
+        # :nodoc:
+        attr_reader aliased_table: untyped
+
+        def initialize: (untyped reflection, untyped aliased_table) -> untyped
+
+        def all_includes: () -> nil
+      end
+
+      def get_chain: (untyped reflection, untyped association, untyped tracker) -> untyped
+
+      def add_constraints: (untyped scope, untyped owner, untyped chain) -> untyped
+
+      def apply_scope: (untyped scope, untyped table, untyped key, untyped value) -> untyped
+
+      def eval_scope: (untyped reflection, untyped scope, untyped owner) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module Associations
+    class BelongsToAssociation < SingularAssociation
+      # = Active Record Belongs To Association
+      # nodoc:
+      def handle_dependency: () -> (nil | untyped)
+
+      def inversed_from: (untyped record) -> untyped
+
+      def default: () { () -> untyped } -> untyped
+
+      def reset: () -> untyped
+
+      def updated?: () -> untyped
+
+      def decrement_counters: () -> untyped
+
+      def increment_counters: () -> untyped
+
+      def decrement_counters_before_last_save: () -> untyped
+
+      def target_changed?: () -> untyped
+
+      def replace: (untyped record) -> untyped
+
+      def update_counters: (untyped by) -> untyped
+
+      def update_counters_via_scope: (untyped klass, untyped foreign_key, untyped by) -> untyped
+
+      def find_target?: () -> untyped
+
+      def require_counter_update?: () -> untyped
+
+      def replace_keys: (untyped record) -> untyped
+
+      def primary_key: (untyped klass) -> untyped
+
+      def foreign_key_present?: () -> untyped
+
+      # NOTE - for now, we're only supporting inverse setting from belongs_to back onto
+      # has_one associations.
+      def invertible_for?: (untyped record) -> untyped
+
+      def stale_state: () -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module Associations
+    class BelongsToPolymorphicAssociation < BelongsToAssociation
+      # = Active Record Belongs To Polymorphic Association
+      # nodoc:
+      def klass: () -> untyped
+
+      def target_changed?: () -> untyped
+
+      def replace_keys: (untyped record) -> untyped
+
+      def inverse_reflection_for: (untyped record) -> untyped
+
+      def raise_on_type_mismatch!: (untyped record) -> nil
+
+      def stale_state: () -> untyped
+    end
+  end
+end
+
+module ActiveRecord::Associations::Builder
+  class Association
+    attr_accessor extensions: untyped
+
+    VALID_OPTIONS: ::Array[untyped]
+
+    def self.build: (untyped model, untyped name, untyped scope, untyped options) { () -> untyped } -> untyped
+
+    def self.create_reflection: (untyped model, untyped name, untyped scope, untyped options) { () -> untyped } -> untyped
+
+    def self.build_scope: (untyped scope) -> untyped
+
+    def self.macro: () -> untyped
+
+    def self.valid_options: (untyped options) -> untyped
+
+    def self.validate_options: (untyped options) -> untyped
+
+    def self.define_extensions: (untyped model, untyped name) -> nil
+
+    def self.define_callbacks: (untyped model, untyped reflection) -> untyped
+
+    # Defines the setter and getter methods for the association
+    # class Post < ActiveRecord::Base
+    #   has_many :comments
+    # end
+    #
+    # Post.first.comments and Post.first.comments= methods are defined by this method...
+    def self.define_accessors: (untyped model, untyped reflection) -> untyped
+
+    def self.define_readers: (untyped mixin, untyped name) -> untyped
+
+    def self.define_writers: (untyped mixin, untyped name) -> untyped
+
+    def self.define_validations: (untyped model, untyped reflection) -> nil
+
+    def self.valid_dependent_options: () -> untyped
+
+    def self.check_dependent_options: (untyped dependent) -> untyped
+
+    def self.add_destroy_callbacks: (untyped model, untyped reflection) -> untyped
+  end
+end
+
+module ActiveRecord::Associations::Builder
+  class BelongsTo < SingularAssociation
+    # :nodoc:
+    # nodoc:
+    def self.macro: () -> :belongs_to
+
+    def self.valid_options: (untyped options) -> untyped
+
+    def self.valid_dependent_options: () -> ::Array[:destroy | :delete]
+
+    def self.define_callbacks: (untyped model, untyped reflection) -> untyped
+
+    def self.add_counter_cache_callbacks: (untyped model, untyped reflection) -> untyped
+
+    def self.touch_record: (untyped o, untyped changes, untyped foreign_key, untyped name, untyped touch, untyped touch_method) -> untyped
+
+    def self.add_touch_callbacks: (untyped model, untyped reflection) -> untyped
+
+    def self.add_default_callbacks: (untyped model, untyped reflection) -> untyped
+
+    def self.add_destroy_callbacks: (untyped model, untyped reflection) -> untyped
+
+    def self.define_validations: (untyped model, untyped reflection) -> untyped
+  end
+end
+
+module ActiveRecord::Associations::Builder
+  class CollectionAssociation < Association
+    # :nodoc:
+    # nodoc:
+    CALLBACKS: ::Array[untyped]
+
+    def self.valid_options: (untyped options) -> untyped
+
+    def self.define_callbacks: (untyped model, untyped reflection) -> untyped
+
+    def self.define_extensions: (untyped model, untyped name) { () -> untyped } -> untyped
+
+    def self.define_callback: (untyped model, untyped callback_name, untyped name, untyped options) -> untyped
+
+    # Defines the setter and getter methods for the collection_singular_ids.
+    def self.define_readers: (untyped mixin, untyped name) -> untyped
+
+    def self.define_writers: (untyped mixin, untyped name) -> untyped
+  end
+end
+
+module ActiveRecord::Associations::Builder
+  class HasAndBelongsToMany
+    # :nodoc:
+    # :nodoc:
+    attr_reader lhs_model: untyped
+
+    # :nodoc:
+    # :nodoc:
+    attr_reader association_name: untyped
+
+    # :nodoc:
+    # :nodoc:
+    attr_reader options: untyped
+
+    def initialize: (untyped association_name, untyped lhs_model, untyped options) -> untyped
+
+    def through_model: () -> untyped
+
+    def middle_reflection: (untyped join_model) -> untyped
+
+    def middle_options: (untyped join_model) -> untyped
+
+    def table_name: () -> untyped
+
+    def belongs_to_options: (untyped options) -> untyped
+  end
+end
+
+module ActiveRecord::Associations::Builder
+  class HasMany < CollectionAssociation
+    # :nodoc:
+    # nodoc:
+    def self.macro: () -> :has_many
+
+    def self.valid_options: (untyped options) -> untyped
+
+    def self.valid_dependent_options: () -> ::Array[:destroy | :delete_all | :nullify | :restrict_with_error | :restrict_with_exception]
+  end
+end
+
+module ActiveRecord::Associations::Builder
+  class HasOne < SingularAssociation
+    # :nodoc:
+    # nodoc:
+    def self.macro: () -> :has_one
+
+    def self.valid_options: (untyped options) -> untyped
+
+    def self.valid_dependent_options: () -> ::Array[:destroy | :delete | :nullify | :restrict_with_error | :restrict_with_exception]
+
+    def self.define_callbacks: (untyped model, untyped reflection) -> untyped
+
+    def self.add_destroy_callbacks: (untyped model, untyped reflection) -> untyped
+
+    def self.define_validations: (untyped model, untyped reflection) -> untyped
+
+    def self.touch_record: (untyped o, untyped name, untyped touch) -> (nil | untyped)
+
+    def self.add_touch_callbacks: (untyped model, untyped reflection) -> untyped
+  end
+end
+
+module ActiveRecord::Associations::Builder
+  class SingularAssociation < Association
+    # :nodoc:
+    # nodoc:
+    def self.valid_options: (untyped options) -> untyped
+
+    def self.define_accessors: (untyped model, untyped reflection) -> untyped
+
+    # Defines the (build|create)_association methods for belongs_to or has_one association
+    def self.define_constructors: (untyped mixin, untyped name) -> untyped
+  end
+end
+
+module ActiveRecord
+  module Associations
+    class CollectionAssociation < Association
+      # = Active Record Association Collection
+      #
+      # CollectionAssociation is an abstract class that provides common stuff to
+      # ease the implementation of association proxies that represent
+      # collections. See the class hierarchy in Association.
+      #
+      #   CollectionAssociation:
+      #     HasManyAssociation => has_many
+      #       HasManyThroughAssociation + ThroughAssociation => has_many :through
+      #
+      # The CollectionAssociation class provides common methods to the collections
+      # defined by +has_and_belongs_to_many+, +has_many+ or +has_many+ with
+      # the +:through association+ option.
+      #
+      # You need to be careful with assumptions regarding the target: The proxy
+      # does not fetch records from the database until it needs them, but new
+      # ones created with +build+ are added to the target. So, the target may be
+      # non-empty and still lack children waiting to be read from the database.
+      # If you look directly to the database you cannot assume that's the entire
+      # collection because new records may have been added to the target, etc.
+      #
+      # If you need to work on all current children, new and existing records,
+      # +load_target+ and the +loaded+ flag are your friends.
+      # nodoc:
+      # Implements the reader method, e.g. foo.items for Foo.has_many :items
+      def reader: () -> untyped
+
+      # Implements the writer method, e.g. foo.items= for Foo.has_many :items
+      def writer: (untyped records) -> untyped
+
+      # Implements the ids reader method, e.g. foo.item_ids for Foo.has_many :items
+      def ids_reader: () -> untyped
+
+      # Implements the ids writer method, e.g. foo.item_ids= for Foo.has_many :items
+      def ids_writer: (untyped ids) -> untyped
+
+      def reset: () -> untyped
+
+      def find: (*untyped args) -> untyped
+
+      def build: (?::Hash[untyped, untyped] attributes) { () -> untyped } -> untyped
+
+      # Add +records+ to this association. Since +<<+ flattens its argument list
+      # and inserts each record, +push+ and +concat+ behave identically.
+      def concat: (*untyped records) -> untyped
+
+      # Starts a transaction in the association class's database connection.
+      #
+      #   class Author < ActiveRecord::Base
+      #     has_many :books
+      #   end
+      #
+      #   Author.first.books.transaction do
+      #     # same effect as calling Book.transaction
+      #   end
+      def transaction: (*untyped args) { () -> untyped } -> untyped
+
+      # Removes all records from the association without calling callbacks
+      # on the associated records. It honors the +:dependent+ option. However
+      # if the +:dependent+ value is +:destroy+ then in that case the +:delete_all+
+      # deletion strategy for the association is applied.
+      #
+      # You can force a particular deletion strategy by passing a parameter.
+      #
+      # Example:
+      #
+      # @author.books.delete_all(:nullify)
+      # @author.books.delete_all(:delete_all)
+      #
+      # See delete for more info.
+      def delete_all: (?untyped? dependent) -> untyped
+
+      # Destroy all the records from this association.
+      #
+      # See destroy for more info.
+      def destroy_all: () -> untyped
+
+      # Removes +records+ from this association calling +before_remove+ and
+      # +after_remove+ callbacks.
+      #
+      # This method is abstract in the sense that +delete_records+ has to be
+      # provided by descendants. Note this method does not imply the records
+      # are actually removed from the database, that depends precisely on
+      # +delete_records+. They are in any case removed from the collection.
+      def delete: (*untyped records) -> untyped
+
+      # Deletes the +records+ and removes them from this association calling
+      # +before_remove+ , +after_remove+ , +before_destroy+ and +after_destroy+ callbacks.
+      #
+      # Note that this method removes records from the database ignoring the
+      # +:dependent+ option.
+      def destroy: (*untyped records) -> untyped
+
+      # Returns the size of the collection by executing a SELECT COUNT(*)
+      # query if the collection hasn't been loaded, and calling
+      # <tt>collection.size</tt> if it has.
+      #
+      # If the collection has been already loaded +size+ and +length+ are
+      # equivalent. If not and you are going to need the records anyway
+      # +length+ will take one less query. Otherwise +size+ is more efficient.
+      #
+      # This method is abstract in the sense that it relies on
+      # +count_records+, which is a method descendants have to provide.
+      def size: () -> untyped
+
+      # Returns true if the collection is empty.
+      #
+      # If the collection has been loaded
+      # it is equivalent to <tt>collection.size.zero?</tt>. If the
+      # collection has not been loaded, it is equivalent to
+      # <tt>collection.exists?</tt>. If the collection has not already been
+      # loaded and you are going to fetch the records anyway it is better to
+      # check <tt>collection.length.zero?</tt>.
+      def empty?: () -> untyped
+
+      # Replace this collection with +other_array+. This will perform a diff
+      # and delete/add only records that have changed.
+      def replace: (untyped other_array) -> untyped
+
+      def include?: (untyped record) -> untyped
+
+      def load_target: () -> untyped
+
+      def add_to_target: (untyped record, ?bool skip_callbacks) { () -> untyped } -> untyped
+
+      def scope: () -> untyped
+
+      def null_scope?: () -> untyped
+
+      def find_from_target?: () -> untyped
+
+      # We have some records loaded from the database (persisted) and some that are
+      # in-memory (memory). The same record may be represented in the persisted array
+      # and in the memory array.
+      #
+      # So the task of this method is to merge them according to the following rules:
+      #
+      #   * The final array must not have duplicates
+      #   * The order of the persisted array is to be preserved
+      #   * Any changes made to attributes on objects in the memory array are to be preserved
+      #   * Otherwise, attributes should have the value found in the database
+      def merge_target_lists: (untyped persisted, untyped memory) -> untyped
+
+      def _create_record: (untyped attributes, ?bool raise) { () -> untyped } -> untyped
+
+      # Do the relevant stuff to insert the given record into the association collection.
+      def insert_record: (untyped record, ?bool validate, ?bool raise) { () -> untyped } -> untyped
+
+      def delete_or_destroy: (untyped records, untyped method) -> (nil | untyped)
+
+      def remove_records: (untyped existing_records, untyped records, untyped method) -> (nil | untyped)
+
+      # Delete the given records from the association,
+      # using one of the methods +:destroy+, +:delete_all+
+      # or +:nullify+ (or +nil+, in which case a default is used).
+      def delete_records: (untyped records, untyped method) -> untyped
+
+      def replace_records: (untyped new_target, untyped original_target) -> untyped
+
+      def replace_common_records_in_memory: (untyped new_target, untyped original_target) -> untyped
+
+      def concat_records: (untyped records, ?bool raise) -> untyped
+
+      def replace_on_target: (untyped record, untyped index, untyped skip_callbacks) { (untyped) -> untyped } -> untyped
+
+      def callback: (untyped method, untyped record) -> untyped
+
+      def callbacks_for: (untyped callback_name) -> untyped
+
+      def include_in_memory?: (untyped record) -> untyped
+
+      # If the :inverse_of option has been
+      # specified, then #find scans the entire collection.
+      def find_by_scan: (*untyped args) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module Associations
+    # Collection proxies in Active Record are middlemen between an
+    # <tt>association</tt>, and its <tt>target</tt> result set.
+    #
+    # For example, given
+    #
+    #   class Blog < ActiveRecord::Base
+    #     has_many :posts
+    #   end
+    #
+    #   blog = Blog.first
+    #
+    # The collection proxy returned by <tt>blog.posts</tt> is built from a
+    # <tt>:has_many</tt> <tt>association</tt>, and delegates to a collection
+    # of posts as the <tt>target</tt>.
+    #
+    # This class delegates unknown methods to the <tt>association</tt>'s
+    # relation class via a delegate cache.
+    #
+    # The <tt>target</tt> result set is not loaded until needed. For example,
+    #
+    #   blog.posts.count
+    #
+    # is computed directly through SQL and does not trigger by itself the
+    # instantiation of the actual post records.
+    class CollectionProxy < Relation
+      def initialize: (untyped klass, untyped association) -> untyped
+
+      def target: () -> untyped
+
+      def load_target: () -> untyped
+
+      # Returns +true+ if the association has been loaded, otherwise +false+.
+      #
+      #   person.pets.loaded? # => false
+      #   person.pets
+      #   person.pets.loaded? # => true
+      def loaded?: () -> untyped
+
+      # Finds an object in the collection responding to the +id+. Uses the same
+      # rules as ActiveRecord::Base.find. Returns ActiveRecord::RecordNotFound
+      # error if the object cannot be found.
+      #
+      #   class Person < ActiveRecord::Base
+      #     has_many :pets
+      #   end
+      #
+      #   person.pets
+      #   # => [
+      #   #       #<Pet id: 1, name: "Fancy-Fancy", person_id: 1>,
+      #   #       #<Pet id: 2, name: "Spook", person_id: 1>,
+      #   #       #<Pet id: 3, name: "Choo-Choo", person_id: 1>
+      #   #    ]
+      #
+      #   person.pets.find(1) # => #<Pet id: 1, name: "Fancy-Fancy", person_id: 1>
+      #   person.pets.find(4) # => ActiveRecord::RecordNotFound: Couldn't find Pet with 'id'=4
+      #
+      #   person.pets.find(2) { |pet| pet.name.downcase! }
+      #   # => #<Pet id: 2, name: "fancy-fancy", person_id: 1>
+      #
+      #   person.pets.find(2, 3)
+      #   # => [
+      #   #       #<Pet id: 2, name: "Spook", person_id: 1>,
+      #   #       #<Pet id: 3, name: "Choo-Choo", person_id: 1>
+      #   #    ]
+      def find: (*untyped args) -> untyped
+
+      # Returns the last record, or the last +n+ records, from the collection.
+      # If the collection is empty, the first form returns +nil+, and the second
+      # form returns an empty array.
+      #
+      #   class Person < ActiveRecord::Base
+      #     has_many :pets
+      #   end
+      #
+      #   person.pets
+      #   # => [
+      #   #       #<Pet id: 1, name: "Fancy-Fancy", person_id: 1>,
+      #   #       #<Pet id: 2, name: "Spook", person_id: 1>,
+      #   #       #<Pet id: 3, name: "Choo-Choo", person_id: 1>
+      #   #    ]
+      #
+      #   person.pets.last # => #<Pet id: 3, name: "Choo-Choo", person_id: 1>
+      #
+      #   person.pets.last(2)
+      #   # => [
+      #   #      #<Pet id: 2, name: "Spook", person_id: 1>,
+      #   #      #<Pet id: 3, name: "Choo-Choo", person_id: 1>
+      #   #    ]
+      #
+      #   another_person_without.pets         # => []
+      #   another_person_without.pets.last    # => nil
+      #   another_person_without.pets.last(3) # => []
+      def last: (?untyped? limit) -> untyped
+
+      # Gives a record (or N records if a parameter is supplied) from the collection
+      # using the same rules as <tt>ActiveRecord::Base.take</tt>.
+      #
+      #   class Person < ActiveRecord::Base
+      #     has_many :pets
+      #   end
+      #
+      #   person.pets
+      #   # => [
+      #   #       #<Pet id: 1, name: "Fancy-Fancy", person_id: 1>,
+      #   #       #<Pet id: 2, name: "Spook", person_id: 1>,
+      #   #       #<Pet id: 3, name: "Choo-Choo", person_id: 1>
+      #   #    ]
+      #
+      #   person.pets.take # => #<Pet id: 1, name: "Fancy-Fancy", person_id: 1>
+      #
+      #   person.pets.take(2)
+      #   # => [
+      #   #      #<Pet id: 1, name: "Fancy-Fancy", person_id: 1>,
+      #   #      #<Pet id: 2, name: "Spook", person_id: 1>
+      #   #    ]
+      #
+      #   another_person_without.pets         # => []
+      #   another_person_without.pets.take    # => nil
+      #   another_person_without.pets.take(2) # => []
+      def take: (?untyped? limit) -> untyped
+
+      # Returns a new object of the collection type that has been instantiated
+      # with +attributes+ and linked to this object, but have not yet been saved.
+      # You can pass an array of attributes hashes, this will return an array
+      # with the new objects.
+      #
+      #   class Person
+      #     has_many :pets
+      #   end
+      #
+      #   person.pets.build
+      #   # => #<Pet id: nil, name: nil, person_id: 1>
+      #
+      #   person.pets.build(name: 'Fancy-Fancy')
+      #   # => #<Pet id: nil, name: "Fancy-Fancy", person_id: 1>
+      #
+      #   person.pets.build([{name: 'Spook'}, {name: 'Choo-Choo'}, {name: 'Brain'}])
+      #   # => [
+      #   #      #<Pet id: nil, name: "Spook", person_id: 1>,
+      #   #      #<Pet id: nil, name: "Choo-Choo", person_id: 1>,
+      #   #      #<Pet id: nil, name: "Brain", person_id: 1>
+      #   #    ]
+      #
+      #   person.pets.size  # => 5 # size of the collection
+      #   person.pets.count # => 0 # count from database
+      def build: (?::Hash[untyped, untyped] attributes) { () -> untyped } -> untyped
+
+      alias new build
+
+      # Returns a new object of the collection type that has been instantiated with
+      # attributes, linked to this object and that has already been saved (if it
+      # passes the validations).
+      #
+      #   class Person
+      #     has_many :pets
+      #   end
+      #
+      #   person.pets.create(name: 'Fancy-Fancy')
+      #   # => #<Pet id: 1, name: "Fancy-Fancy", person_id: 1>
+      #
+      #   person.pets.create([{name: 'Spook'}, {name: 'Choo-Choo'}])
+      #   # => [
+      #   #      #<Pet id: 2, name: "Spook", person_id: 1>,
+      #   #      #<Pet id: 3, name: "Choo-Choo", person_id: 1>
+      #   #    ]
+      #
+      #   person.pets.size  # => 3
+      #   person.pets.count # => 3
+      #
+      #   person.pets.find(1, 2, 3)
+      #   # => [
+      #   #       #<Pet id: 1, name: "Fancy-Fancy", person_id: 1>,
+      #   #       #<Pet id: 2, name: "Spook", person_id: 1>,
+      #   #       #<Pet id: 3, name: "Choo-Choo", person_id: 1>
+      #   #    ]
+      def create: (?::Hash[untyped, untyped] attributes) { () -> untyped } -> untyped
+
+      # Like #create, except that if the record is invalid, raises an exception.
+      #
+      #   class Person
+      #     has_many :pets
+      #   end
+      #
+      #   class Pet
+      #     validates :name, presence: true
+      #   end
+      #
+      #   person.pets.create!(name: nil)
+      #   # => ActiveRecord::RecordInvalid: Validation failed: Name can't be blank
+      def create!: (?::Hash[untyped, untyped] attributes) { () -> untyped } -> untyped
+
+      # Replaces this collection with +other_array+. This will perform a diff
+      # and delete/add only records that have changed.
+      #
+      #   class Person < ActiveRecord::Base
+      #     has_many :pets
+      #   end
+      #
+      #   person.pets
+      #   # => [#<Pet id: 1, name: "Gorby", group: "cats", person_id: 1>]
+      #
+      #   other_pets = [Pet.new(name: 'Puff', group: 'celebrities']
+      #
+      #   person.pets.replace(other_pets)
+      #
+      #   person.pets
+      #   # => [#<Pet id: 2, name: "Puff", group: "celebrities", person_id: 1>]
+      #
+      # If the supplied array has an incorrect association type, it raises
+      # an <tt>ActiveRecord::AssociationTypeMismatch</tt> error:
+      #
+      #   person.pets.replace(["doo", "ggie", "gaga"])
+      #   # => ActiveRecord::AssociationTypeMismatch: Pet expected, got String
+      def replace: (untyped other_array) -> untyped
+
+      # Deletes all the records from the collection according to the strategy
+      # specified by the +:dependent+ option. If no +:dependent+ option is given,
+      # then it will follow the default strategy.
+      #
+      # For <tt>has_many :through</tt> associations, the default deletion strategy is
+      # +:delete_all+.
+      #
+      # For +has_many+ associations, the default deletion strategy is +:nullify+.
+      # This sets the foreign keys to +NULL+.
+      #
+      #   class Person < ActiveRecord::Base
+      #     has_many :pets # dependent: :nullify option by default
+      #   end
+      #
+      #   person.pets.size # => 3
+      #   person.pets
+      #   # => [
+      #   #       #<Pet id: 1, name: "Fancy-Fancy", person_id: 1>,
+      #   #       #<Pet id: 2, name: "Spook", person_id: 1>,
+      #   #       #<Pet id: 3, name: "Choo-Choo", person_id: 1>
+      #   #    ]
+      #
+      #   person.pets.delete_all
+      #   # => [
+      #   #       #<Pet id: 1, name: "Fancy-Fancy", person_id: 1>,
+      #   #       #<Pet id: 2, name: "Spook", person_id: 1>,
+      #   #       #<Pet id: 3, name: "Choo-Choo", person_id: 1>
+      #   #    ]
+      #
+      #   person.pets.size # => 0
+      #   person.pets      # => []
+      #
+      #   Pet.find(1, 2, 3)
+      #   # => [
+      #   #       #<Pet id: 1, name: "Fancy-Fancy", person_id: nil>,
+      #   #       #<Pet id: 2, name: "Spook", person_id: nil>,
+      #   #       #<Pet id: 3, name: "Choo-Choo", person_id: nil>
+      #   #    ]
+      #
+      # Both +has_many+ and <tt>has_many :through</tt> dependencies default to the
+      # +:delete_all+ strategy if the +:dependent+ option is set to +:destroy+.
+      # Records are not instantiated and callbacks will not be fired.
+      #
+      #   class Person < ActiveRecord::Base
+      #     has_many :pets, dependent: :destroy
+      #   end
+      #
+      #   person.pets.size # => 3
+      #   person.pets
+      #   # => [
+      #   #       #<Pet id: 1, name: "Fancy-Fancy", person_id: 1>,
+      #   #       #<Pet id: 2, name: "Spook", person_id: 1>,
+      #   #       #<Pet id: 3, name: "Choo-Choo", person_id: 1>
+      #   #    ]
+      #
+      #   person.pets.delete_all
+      #
+      #   Pet.find(1, 2, 3)
+      #   # => ActiveRecord::RecordNotFound: Couldn't find all Pets with 'id': (1, 2, 3)
+      #
+      # If it is set to <tt>:delete_all</tt>, all the objects are deleted
+      # *without* calling their +destroy+ method.
+      #
+      #   class Person < ActiveRecord::Base
+      #     has_many :pets, dependent: :delete_all
+      #   end
+      #
+      #   person.pets.size # => 3
+      #   person.pets
+      #   # => [
+      #   #       #<Pet id: 1, name: "Fancy-Fancy", person_id: 1>,
+      #   #       #<Pet id: 2, name: "Spook", person_id: 1>,
+      #   #       #<Pet id: 3, name: "Choo-Choo", person_id: 1>
+      #   #    ]
+      #
+      #   person.pets.delete_all
+      #
+      #   Pet.find(1, 2, 3)
+      #   # => ActiveRecord::RecordNotFound: Couldn't find all Pets with 'id': (1, 2, 3)
+      def delete_all: (?untyped? dependent) -> untyped
+
+      # Deletes the records of the collection directly from the database
+      # ignoring the +:dependent+ option. Records are instantiated and it
+      # invokes +before_remove+, +after_remove+ , +before_destroy+ and
+      # +after_destroy+ callbacks.
+      #
+      #   class Person < ActiveRecord::Base
+      #     has_many :pets
+      #   end
+      #
+      #   person.pets.size # => 3
+      #   person.pets
+      #   # => [
+      #   #       #<Pet id: 1, name: "Fancy-Fancy", person_id: 1>,
+      #   #       #<Pet id: 2, name: "Spook", person_id: 1>,
+      #   #       #<Pet id: 3, name: "Choo-Choo", person_id: 1>
+      #   #    ]
+      #
+      #   person.pets.destroy_all
+      #
+      #   person.pets.size # => 0
+      #   person.pets      # => []
+      #
+      #   Pet.find(1) # => Couldn't find Pet with id=1
+      def destroy_all: () -> untyped
+
+      # Deletes the +records+ supplied from the collection according to the strategy
+      # specified by the +:dependent+ option. If no +:dependent+ option is given,
+      # then it will follow the default strategy. Returns an array with the
+      # deleted records.
+      #
+      # For <tt>has_many :through</tt> associations, the default deletion strategy is
+      # +:delete_all+.
+      #
+      # For +has_many+ associations, the default deletion strategy is +:nullify+.
+      # This sets the foreign keys to +NULL+.
+      #
+      #   class Person < ActiveRecord::Base
+      #     has_many :pets # dependent: :nullify option by default
+      #   end
+      #
+      #   person.pets.size # => 3
+      #   person.pets
+      #   # => [
+      #   #       #<Pet id: 1, name: "Fancy-Fancy", person_id: 1>,
+      #   #       #<Pet id: 2, name: "Spook", person_id: 1>,
+      #   #       #<Pet id: 3, name: "Choo-Choo", person_id: 1>
+      #   #    ]
+      #
+      #   person.pets.delete(Pet.find(1))
+      #   # => [#<Pet id: 1, name: "Fancy-Fancy", person_id: 1>]
+      #
+      #   person.pets.size # => 2
+      #   person.pets
+      #   # => [
+      #   #       #<Pet id: 2, name: "Spook", person_id: 1>,
+      #   #       #<Pet id: 3, name: "Choo-Choo", person_id: 1>
+      #   #    ]
+      #
+      #   Pet.find(1)
+      #   # => #<Pet id: 1, name: "Fancy-Fancy", person_id: nil>
+      #
+      # If it is set to <tt>:destroy</tt> all the +records+ are removed by calling
+      # their +destroy+ method. See +destroy+ for more information.
+      #
+      #   class Person < ActiveRecord::Base
+      #     has_many :pets, dependent: :destroy
+      #   end
+      #
+      #   person.pets.size # => 3
+      #   person.pets
+      #   # => [
+      #   #       #<Pet id: 1, name: "Fancy-Fancy", person_id: 1>,
+      #   #       #<Pet id: 2, name: "Spook", person_id: 1>,
+      #   #       #<Pet id: 3, name: "Choo-Choo", person_id: 1>
+      #   #    ]
+      #
+      #   person.pets.delete(Pet.find(1), Pet.find(3))
+      #   # => [
+      #   #       #<Pet id: 1, name: "Fancy-Fancy", person_id: 1>,
+      #   #       #<Pet id: 3, name: "Choo-Choo", person_id: 1>
+      #   #    ]
+      #
+      #   person.pets.size # => 1
+      #   person.pets
+      #   # => [#<Pet id: 2, name: "Spook", person_id: 1>]
+      #
+      #   Pet.find(1, 3)
+      #   # => ActiveRecord::RecordNotFound: Couldn't find all Pets with 'id': (1, 3)
+      #
+      # If it is set to <tt>:delete_all</tt>, all the +records+ are deleted
+      # *without* calling their +destroy+ method.
+      #
+      #   class Person < ActiveRecord::Base
+      #     has_many :pets, dependent: :delete_all
+      #   end
+      #
+      #   person.pets.size # => 3
+      #   person.pets
+      #   # => [
+      #   #       #<Pet id: 1, name: "Fancy-Fancy", person_id: 1>,
+      #   #       #<Pet id: 2, name: "Spook", person_id: 1>,
+      #   #       #<Pet id: 3, name: "Choo-Choo", person_id: 1>
+      #   #    ]
+      #
+      #   person.pets.delete(Pet.find(1))
+      #   # => [#<Pet id: 1, name: "Fancy-Fancy", person_id: 1>]
+      #
+      #   person.pets.size # => 2
+      #   person.pets
+      #   # => [
+      #   #       #<Pet id: 2, name: "Spook", person_id: 1>,
+      #   #       #<Pet id: 3, name: "Choo-Choo", person_id: 1>
+      #   #    ]
+      #
+      #   Pet.find(1)
+      #   # => ActiveRecord::RecordNotFound: Couldn't find Pet with 'id'=1
+      #
+      # You can pass +Integer+ or +String+ values, it finds the records
+      # responding to the +id+ and executes delete on them.
+      #
+      #   class Person < ActiveRecord::Base
+      #     has_many :pets
+      #   end
+      #
+      #   person.pets.size # => 3
+      #   person.pets
+      #   # => [
+      #   #       #<Pet id: 1, name: "Fancy-Fancy", person_id: 1>,
+      #   #       #<Pet id: 2, name: "Spook", person_id: 1>,
+      #   #       #<Pet id: 3, name: "Choo-Choo", person_id: 1>
+      #   #    ]
+      #
+      #   person.pets.delete("1")
+      #   # => [#<Pet id: 1, name: "Fancy-Fancy", person_id: 1>]
+      #
+      #   person.pets.delete(2, 3)
+      #   # => [
+      #   #       #<Pet id: 2, name: "Spook", person_id: 1>,
+      #   #       #<Pet id: 3, name: "Choo-Choo", person_id: 1>
+      #   #    ]
+      def delete: (*untyped records) -> untyped
+
+      # Destroys the +records+ supplied and removes them from the collection.
+      # This method will _always_ remove record from the database ignoring
+      # the +:dependent+ option. Returns an array with the removed records.
+      #
+      #   class Person < ActiveRecord::Base
+      #     has_many :pets
+      #   end
+      #
+      #   person.pets.size # => 3
+      #   person.pets
+      #   # => [
+      #   #       #<Pet id: 1, name: "Fancy-Fancy", person_id: 1>,
+      #   #       #<Pet id: 2, name: "Spook", person_id: 1>,
+      #   #       #<Pet id: 3, name: "Choo-Choo", person_id: 1>
+      #   #    ]
+      #
+      #   person.pets.destroy(Pet.find(1))
+      #   # => [#<Pet id: 1, name: "Fancy-Fancy", person_id: 1>]
+      #
+      #   person.pets.size # => 2
+      #   person.pets
+      #   # => [
+      #   #       #<Pet id: 2, name: "Spook", person_id: 1>,
+      #   #       #<Pet id: 3, name: "Choo-Choo", person_id: 1>
+      #   #    ]
+      #
+      #   person.pets.destroy(Pet.find(2), Pet.find(3))
+      #   # => [
+      #   #       #<Pet id: 2, name: "Spook", person_id: 1>,
+      #   #       #<Pet id: 3, name: "Choo-Choo", person_id: 1>
+      #   #    ]
+      #
+      #   person.pets.size  # => 0
+      #   person.pets       # => []
+      #
+      #   Pet.find(1, 2, 3) # => ActiveRecord::RecordNotFound: Couldn't find all Pets with 'id': (1, 2, 3)
+      #
+      # You can pass +Integer+ or +String+ values, it finds the records
+      # responding to the +id+ and then deletes them from the database.
+      #
+      #   person.pets.size # => 3
+      #   person.pets
+      #   # => [
+      #   #       #<Pet id: 4, name: "Benny", person_id: 1>,
+      #   #       #<Pet id: 5, name: "Brain", person_id: 1>,
+      #   #       #<Pet id: 6, name: "Boss",  person_id: 1>
+      #   #    ]
+      #
+      #   person.pets.destroy("4")
+      #   # => #<Pet id: 4, name: "Benny", person_id: 1>
+      #
+      #   person.pets.size # => 2
+      #   person.pets
+      #   # => [
+      #   #       #<Pet id: 5, name: "Brain", person_id: 1>,
+      #   #       #<Pet id: 6, name: "Boss",  person_id: 1>
+      #   #    ]
+      #
+      #   person.pets.destroy(5, 6)
+      #   # => [
+      #   #       #<Pet id: 5, name: "Brain", person_id: 1>,
+      #   #       #<Pet id: 6, name: "Boss",  person_id: 1>
+      #   #    ]
+      #
+      #   person.pets.size  # => 0
+      #   person.pets       # => []
+      #
+      #   Pet.find(4, 5, 6) # => ActiveRecord::RecordNotFound: Couldn't find all Pets with 'id': (4, 5, 6)
+      def destroy: (*untyped records) -> untyped
+
+      # -
+      def calculate: (untyped operation, untyped column_name) -> untyped
+
+      def pluck: (*untyped column_names) -> untyped
+
+      # Returns the size of the collection. If the collection hasn't been loaded,
+      # it executes a <tt>SELECT COUNT(*)</tt> query. Else it calls <tt>collection.size</tt>.
+      #
+      # If the collection has been already loaded +size+ and +length+ are
+      # equivalent. If not and you are going to need the records anyway
+      # +length+ will take one less query. Otherwise +size+ is more efficient.
+      #
+      #   class Person < ActiveRecord::Base
+      #     has_many :pets
+      #   end
+      #
+      #   person.pets.size # => 3
+      #   # executes something like SELECT COUNT(*) FROM "pets" WHERE "pets"."person_id" = 1
+      #
+      #   person.pets # This will execute a SELECT * FROM query
+      #   # => [
+      #   #       #<Pet id: 1, name: "Fancy-Fancy", person_id: 1>,
+      #   #       #<Pet id: 2, name: "Spook", person_id: 1>,
+      #   #       #<Pet id: 3, name: "Choo-Choo", person_id: 1>
+      #   #    ]
+      #
+      #   person.pets.size # => 3
+      #   # Because the collection is already loaded, this will behave like
+      #   # collection.size and no SQL count query is executed.
+      def size: () -> untyped
+
+      # Returns +true+ if the collection is empty. If the collection has been
+      # loaded it is equivalent
+      # to <tt>collection.size.zero?</tt>. If the collection has not been loaded,
+      # it is equivalent to <tt>!collection.exists?</tt>. If the collection has
+      # not already been loaded and you are going to fetch the records anyway it
+      # is better to check <tt>collection.length.zero?</tt>.
+      #
+      #   class Person < ActiveRecord::Base
+      #     has_many :pets
+      #   end
+      #
+      #   person.pets.count  # => 1
+      #   person.pets.empty? # => false
+      #
+      #   person.pets.delete_all
+      #
+      #   person.pets.count  # => 0
+      #   person.pets.empty? # => true
+      def empty?: () -> untyped
+
+      # Returns +true+ if the given +record+ is present in the collection.
+      #
+      #   class Person < ActiveRecord::Base
+      #     has_many :pets
+      #   end
+      #
+      #   person.pets # => [#<Pet id: 20, name: "Snoop">]
+      #
+      #   person.pets.include?(Pet.find(20)) # => true
+      #   person.pets.include?(Pet.find(21)) # => false
+      def include?: (untyped record) -> untyped
+
+      def proxy_association: () -> untyped
+
+      # Returns a <tt>Relation</tt> object for the records in this association
+      def scope: () -> untyped
+
+      # Equivalent to <tt>Array#==</tt>. Returns +true+ if the two arrays
+      # contain the same number of elements and if each element is equal
+      # to the corresponding element in the +other+ array, otherwise returns
+      # +false+.
+      #
+      #   class Person < ActiveRecord::Base
+      #     has_many :pets
+      #   end
+      #
+      #   person.pets
+      #   # => [
+      #   #      #<Pet id: 1, name: "Fancy-Fancy", person_id: 1>,
+      #   #      #<Pet id: 2, name: "Spook", person_id: 1>
+      #   #    ]
+      #
+      #   other = person.pets.to_ary
+      #
+      #   person.pets == other
+      #   # => true
+      #
+      #   other = [Pet.new(id: 1), Pet.new(id: 2)]
+      #
+      #   person.pets == other
+      #   # => false
+      def ==: (untyped other) -> untyped
+
+      def records: () -> untyped
+
+      # Adds one or more +records+ to the collection by setting their foreign keys
+      # to the association's primary key. Since <tt><<</tt> flattens its argument list and
+      # inserts each record, +push+ and +concat+ behave identically. Returns +self+
+      # so several appends may be chained together.
+      #
+      #   class Person < ActiveRecord::Base
+      #     has_many :pets
+      #   end
+      #
+      #   person.pets.size # => 0
+      #   person.pets << Pet.new(name: 'Fancy-Fancy')
+      #   person.pets << [Pet.new(name: 'Spook'), Pet.new(name: 'Choo-Choo')]
+      #   person.pets.size # => 3
+      #
+      #   person.id # => 1
+      #   person.pets
+      #   # => [
+      #   #      #<Pet id: 1, name: "Fancy-Fancy", person_id: 1>,
+      #   #      #<Pet id: 2, name: "Spook", person_id: 1>,
+      #   #      #<Pet id: 3, name: "Choo-Choo", person_id: 1>
+      #   #    ]
+      def <<: (*untyped records) -> untyped
+
+      alias push <<
+
+      alias append <<
+
+      alias concat <<
+
+      def `prepend`: (*untyped args) -> untyped
+
+      # Equivalent to +delete_all+. The difference is that returns +self+, instead
+      # of an array with the deleted objects, so methods can be chained. See
+      # +delete_all+ for more information.
+      # Note that because +delete_all+ removes records by directly
+      # running an SQL query into the database, the +updated_at+ column of
+      # the object is not changed.
+      def clear: () -> untyped
+
+      # Reloads the collection from the database. Returns +self+.
+      #
+      #   class Person < ActiveRecord::Base
+      #     has_many :pets
+      #   end
+      #
+      #   person.pets # fetches pets from the database
+      #   # => [#<Pet id: 1, name: "Snoop", group: "dogs", person_id: 1>]
+      #
+      #   person.pets # uses the pets cache
+      #   # => [#<Pet id: 1, name: "Snoop", group: "dogs", person_id: 1>]
+      #
+      #   person.pets.reload # fetches pets from the database
+      #   # => [#<Pet id: 1, name: "Snoop", group: "dogs", person_id: 1>]
+      def reload: () -> untyped
+
+      # Unloads the association. Returns +self+.
+      #
+      #   class Person < ActiveRecord::Base
+      #     has_many :pets
+      #   end
+      #
+      #   person.pets # fetches pets from the database
+      #   # => [#<Pet id: 1, name: "Snoop", group: "dogs", person_id: 1>]
+      #
+      #   person.pets # uses the pets cache
+      #   # => [#<Pet id: 1, name: "Snoop", group: "dogs", person_id: 1>]
+      #
+      #   person.pets.reset # clears the pets cache
+      #
+      #   person.pets  # fetches pets from the database
+      #   # => [#<Pet id: 1, name: "Snoop", group: "dogs", person_id: 1>]
+      def reset: () -> untyped
+
+      def reset_scope: () -> untyped
+
+      def find_nth_with_limit: (untyped index, untyped limit) -> untyped
+
+      def find_nth_from_last: (untyped index) -> untyped
+
+      def null_scope?: () -> untyped
+
+      def find_from_target?: () -> untyped
+
+      def exec_queries: () -> untyped
+    end
+  end
+end
+
+module ActiveRecord::Associations
+  module ForeignAssociation
+    # :nodoc:
+    def foreign_key_present?: () -> untyped
+
+    def nullified_owner_attributes: () -> untyped
+  end
+end
+
+module ActiveRecord
+  module Associations
+    class HasManyAssociation < CollectionAssociation
+      # = Active Record Has Many Association
+      # This is the proxy that handles a has many association.
+      #
+      # If the association has a <tt>:through</tt> option further specialization
+      # is provided by its child HasManyThroughAssociation.
+      # nodoc:
+      include ForeignAssociation
+
+      def handle_dependency: () -> untyped
+
+      def insert_record: (untyped record, ?bool validate, ?bool raise) -> untyped
+
+      # Returns the number of records in this collection.
+      #
+      # If the association has a counter cache it gets that value. Otherwise
+      # it will attempt to do a count via SQL, bounded to <tt>:limit</tt> if
+      # there's one. Some configuration options like :group make it impossible
+      # to do an SQL count, in those cases the array count will be used.
+      #
+      # That does not depend on whether the collection has already been loaded
+      # or not. The +size+ method is the one that takes the loaded flag into
+      # account and delegates to +count_records+ if needed.
+      #
+      # If the collection is empty the target is set to an empty array and
+      # the loaded flag is set to true as well.
+      def count_records: () -> untyped
+
+      def update_counter: (untyped difference, ?untyped reflection) -> untyped
+
+      def update_counter_in_memory: (untyped difference, ?untyped reflection) -> untyped
+
+      def delete_count: (untyped method, untyped scope) -> untyped
+
+      def delete_or_nullify_all_records: (untyped method) -> untyped
+
+      # Deletes the records according to the <tt>:dependent</tt> option.
+      def delete_records: (untyped records, untyped method) -> untyped
+
+      def concat_records: (untyped records) -> untyped
+
+      def _create_record: (untyped attributes) -> untyped
+
+      def update_counter_if_success: (untyped saved_successfully, untyped difference) -> untyped
+
+      def difference: (untyped a, untyped b) -> untyped
+
+      def intersection: (untyped a, untyped b) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module Associations
+    class HasManyThroughAssociation < HasManyAssociation
+      # = Active Record Has Many Through Association
+      # nodoc:
+      include ThroughAssociation
+
+      def initialize: (untyped owner, untyped reflection) -> untyped
+
+      def concat: (*untyped records) -> untyped
+
+      def insert_record: (untyped record, ?bool validate, ?bool raise) -> (nil | untyped)
+
+      def concat_records: (untyped records) -> untyped
+
+      # The through record (built with build_record) is temporarily cached
+      # so that it may be reused if insert_record is subsequently called.
+      #
+      # However, after insert_record has been called, the cache is cleared in
+      # order to allow multiple instances of the same record in an association.
+      def build_through_record: (untyped record) -> untyped
+
+      def through_scope_attributes: () -> untyped
+
+      def save_through_record: (untyped record) -> untyped
+
+      def build_record: (untyped attributes) -> untyped
+
+      def remove_records: (untyped existing_records, untyped records, untyped method) -> untyped
+
+      def target_reflection_has_associated_record?: () -> untyped
+
+      def update_through_counter?: (untyped method) -> untyped
+
+      def delete_or_nullify_all_records: (untyped method) -> untyped
+
+      def delete_records: (untyped records, untyped method) -> untyped
+
+      def difference: (untyped a, untyped b) -> untyped
+
+      def intersection: (untyped a, untyped b) -> untyped
+
+      def mark_occurrence: (untyped distribution, untyped record) -> untyped
+
+      def distribution: (untyped array) -> untyped
+
+      def through_records_for: (untyped record) -> untyped
+
+      def delete_through_records: (untyped records) -> untyped
+
+      def find_target: () -> (::Array[untyped] | untyped)
+
+      # NOTE - not sure that we can actually cope with inverses here
+      def invertible_for?: (untyped record) -> ::FalseClass
+    end
+  end
+end
+
+module ActiveRecord
+  module Associations
+    class HasOneAssociation < SingularAssociation
+      # = Active Record Has One Association
+      # nodoc:
+      include ForeignAssociation
+
+      def handle_dependency: () -> untyped
+
+      def delete: (?untyped method) -> untyped
+
+      def replace: (untyped record, ?bool save) -> untyped
+
+      # The reason that the save param for replace is false, if for create (not just build),
+      # is because the setting of the foreign keys is actually handled by the scoping when
+      # the record is instantiated, and so they are set straight away and do not need to be
+      # updated within replace.
+      def set_new_record: (untyped record) -> untyped
+
+      def remove_target!: (untyped method) -> untyped
+
+      def nullify_owner_attributes: (untyped record) -> untyped
+
+      def transaction_if: (untyped value) { () -> untyped } -> untyped
+
+      def _create_record: (untyped attributes, ?bool raise_error) { () -> untyped } -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module Associations
+    class HasOneThroughAssociation < HasOneAssociation
+      # = Active Record Has One Through Association
+      # nodoc:
+      include ThroughAssociation
+
+      def replace: (untyped record, ?bool save) -> untyped
+
+      def create_through_record: (untyped record, untyped save) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module Associations
+    class JoinDependency
+      class JoinAssociation < JoinPart
+        # :nodoc:
+        # :nodoc:
+        attr_reader reflection: untyped
+
+        # :nodoc:
+        # :nodoc:
+        attr_reader tables: untyped
+
+        attr_accessor table: untyped
+
+        def initialize: (untyped reflection, untyped children) -> untyped
+
+        def match?: (untyped other) -> (::TrueClass | untyped)
+
+        def join_constraints: (untyped foreign_table, untyped foreign_klass, untyped join_type, untyped alias_tracker) -> untyped
+
+        def tables=: (untyped tables) -> untyped
+
+        def readonly?: () -> untyped
+
+        def append_constraints: (untyped join, untyped constraints) -> untyped
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module Associations
+    class JoinDependency
+      class JoinBase < JoinPart
+        # :nodoc:
+        # :nodoc:
+        attr_reader table: untyped
+
+        def initialize: (untyped base_klass, untyped table, untyped children) -> untyped
+
+        def match?: (untyped other) -> (::TrueClass | untyped)
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module Associations
+    class JoinDependency
+      class JoinPart
+        # :nodoc:
+        # A JoinPart represents a part of a JoinDependency. It is inherited
+        # by JoinBase and JoinAssociation. A JoinBase represents the Active Record which
+        # everything else is being joined onto. A JoinAssociation represents an association which
+        # is joining to the base. A JoinAssociation may result in more than one actual join
+        # operations (for example a has_and_belongs_to_many JoinAssociation would result in
+        # two; one for the join table and one for the target table).
+        # :nodoc:
+        include Enumerable[untyped]
+
+        # The Active Record class which this join part is associated 'about'; for a JoinBase
+        # this is the actual base model, for a JoinAssociation this is the target model of the
+        # association.
+        attr_reader base_klass: untyped
+
+        # The Active Record class which this join part is associated 'about'; for a JoinBase
+        # this is the actual base model, for a JoinAssociation this is the target model of the
+        # association.
+        attr_reader children: untyped
+
+        def initialize: (untyped base_klass, untyped children) -> untyped
+
+        def match?: (untyped other) -> untyped
+
+        def each: () { (untyped) -> untyped } -> untyped
+
+        def each_children: () { (untyped, untyped) -> untyped } -> untyped
+
+        # An Arel::Table for the active_record
+        def table: () -> untyped
+
+        def extract_record: (untyped row, untyped column_names_with_alias) -> untyped
+
+        def instantiate: (untyped row, untyped aliases) { () -> untyped } -> untyped
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module Associations
+    class JoinDependency
+      class Aliases
+        # :nodoc:
+        def initialize: (untyped tables) -> untyped
+
+        def columns: () -> untyped
+
+        def column_aliases: (untyped node) -> untyped
+
+        def column_alias: (untyped node, untyped column) -> untyped
+
+        class Table[T] < ::Struct[T]
+          attr_accessor node(): untyped
+
+          attr_accessor columns(): untyped
+
+          # :nodoc:
+          def column_aliases: () -> untyped
+        end
+
+        class Column[T] < ::Struct[T]
+          attr_accessor name(): untyped
+
+          attr_accessor alias(): untyped
+        end
+      end
+
+      def self.make_tree: (untyped associations) -> untyped
+
+      def self.walk_tree: (untyped associations, untyped hash) -> untyped
+
+      def initialize: (untyped base, untyped table, untyped associations, untyped join_type) -> untyped
+
+      def base_klass: () -> untyped
+
+      def reflections: () -> untyped
+
+      def join_constraints: (untyped joins_to_add, untyped alias_tracker) -> untyped
+
+      def instantiate: (untyped result_set) { () -> untyped } -> untyped
+
+      def apply_column_aliases: (untyped relation) -> untyped
+
+      attr_reader join_root: untyped
+
+      attr_reader join_type: untyped
+
+      attr_reader alias_tracker: untyped
+
+      def explicit_selections: (untyped root_column_aliases, untyped result_set) -> untyped
+
+      def aliases: () -> untyped
+
+      def construct_tables!: (untyped join_root) -> untyped
+
+      def make_join_constraints: (untyped join_root, untyped join_type) -> untyped
+
+      def make_constraints: (untyped parent, untyped child, untyped join_type) -> untyped
+
+      def table_aliases_for: (untyped parent, untyped node) -> untyped
+
+      def table_alias_for: (untyped reflection, untyped parent, untyped join) -> untyped
+
+      def walk: (untyped left, untyped right, untyped join_type) -> untyped
+
+      def find_reflection: (untyped klass, untyped name) -> untyped
+
+      def build: (untyped associations, untyped base_klass) -> untyped
+
+      def construct: (untyped ar_parent, untyped parent, untyped row, untyped seen, untyped model_cache) -> (nil | untyped)
+
+      def construct_model: (untyped record, untyped node, untyped row, untyped model_cache, untyped id) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module Associations
+    class Preloader
+      class Association
+        # nodoc:
+        def initialize: (untyped klass, untyped owners, untyped reflection, untyped preload_scope) -> untyped
+
+        def run: () -> untyped
+
+        def records_by_owner: () -> untyped
+
+        def preloaded_records: () -> untyped
+
+        attr_reader owners: untyped
+
+        attr_reader reflection: untyped
+
+        attr_reader preload_scope: untyped
+
+        attr_reader model: untyped
+
+        attr_reader klass: untyped
+
+        # The name of the key on the associated records
+        def association_key_name: () -> untyped
+
+        # The name of the key on the model which declares the association
+        def owner_key_name: () -> untyped
+
+        def associate_records_to_owner: (untyped owner, untyped records) -> untyped
+
+        def owner_keys: () -> untyped
+
+        def owners_by_key: () -> untyped
+
+        def key_conversion_required?: () -> untyped
+
+        def convert_key: (untyped key) -> untyped
+
+        def association_key_type: () -> untyped
+
+        def owner_key_type: () -> untyped
+
+        def records_for: (untyped ids) -> untyped
+
+        def scope: () -> untyped
+
+        def reflection_scope: () -> untyped
+
+        def build_scope: () -> untyped
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module Associations
+    class Preloader
+      class ThroughAssociation < Association
+        # :nodoc:
+        PRELOADER: untyped
+
+        def initialize: () -> untyped
+
+        def preloaded_records: () -> untyped
+
+        def records_by_owner: () -> untyped
+
+        def source_preloaders: () -> untyped
+
+        def middle_records: () -> untyped
+
+        def through_preloaders: () -> untyped
+
+        def through_reflection: () -> untyped
+
+        def source_reflection: () -> untyped
+
+        def preload_index: () -> untyped
+
+        def through_scope: () -> untyped
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module Associations
+    class Preloader
+      # Implements the details of eager loading of Active Record associations.
+      #
+      # Suppose that you have the following two Active Record models:
+      #
+      #   class Author < ActiveRecord::Base
+      #     # columns: name, age
+      #     has_many :books
+      #   end
+      #
+      #   class Book < ActiveRecord::Base
+      #     # columns: title, sales, author_id
+      #   end
+      #
+      # When you load an author with all associated books Active Record will make
+      # multiple queries like this:
+      #
+      #   Author.includes(:books).where(name: ['bell hooks', 'Homer']).to_a
+      #
+      #   => SELECT `authors`.* FROM `authors` WHERE `name` IN ('bell hooks', 'Homer')
+      #   => SELECT `books`.* FROM `books` WHERE `author_id` IN (2, 5)
+      #
+      # Active Record saves the ids of the records from the first query to use in
+      # the second. Depending on the number of associations involved there can be
+      # arbitrarily many SQL queries made.
+      #
+      # However, if there is a WHERE clause that spans across tables Active
+      # Record will fall back to a slightly more resource-intensive single query:
+      #
+      #   Author.includes(:books).where(books: {title: 'Illiad'}).to_a
+      #   => SELECT `authors`.`id` AS t0_r0, `authors`.`name` AS t0_r1, `authors`.`age` AS t0_r2,
+      #             `books`.`id`   AS t1_r0, `books`.`title`  AS t1_r1, `books`.`sales` AS t1_r2
+      #      FROM `authors`
+      #      LEFT OUTER JOIN `books` ON `authors`.`id` =  `books`.`author_id`
+      #      WHERE `books`.`title` = 'Illiad'
+      #
+      # This could result in many rows that contain redundant data and it performs poorly at scale
+      # and is therefore only used when necessary.
+      #
+      # nodoc:
+      extend ActiveSupport::Autoload
+
+      # Eager loads the named associations for the given Active Record record(s).
+      #
+      # In this description, 'association name' shall refer to the name passed
+      # to an association creation method. For example, a model that specifies
+      # <tt>belongs_to :author</tt>, <tt>has_many :buyers</tt> has association
+      # names +:author+ and +:buyers+.
+      #
+      # == Parameters
+      # +records+ is an array of ActiveRecord::Base. This array needs not be flat,
+      # i.e. +records+ itself may also contain arrays of records. In any case,
+      # +preload_associations+ will preload the all associations records by
+      # flattening +records+.
+      #
+      # +associations+ specifies one or more associations that you want to
+      # preload. It may be:
+      # - a Symbol or a String which specifies a single association name. For
+      #   example, specifying +:books+ allows this method to preload all books
+      #   for an Author.
+      # - an Array which specifies multiple association names. This array
+      #   is processed recursively. For example, specifying <tt>[:avatar, :books]</tt>
+      #   allows this method to preload an author's avatar as well as all of his
+      #   books.
+      # - a Hash which specifies multiple association names, as well as
+      #   association names for the to-be-preloaded association objects. For
+      #   example, specifying <tt>{ author: :avatar }</tt> will preload a
+      #   book's author, as well as that author's avatar.
+      #
+      # +:associations+ has the same format as the +:include+ option for
+      # <tt>ActiveRecord::Base.find</tt>. So +associations+ could look like this:
+      #
+      #   :books
+      #   [ :books, :author ]
+      #   { author: :avatar }
+      #   [ :books, { author: :avatar } ]
+      def preload: (untyped records, untyped associations, ?untyped? preload_scope) -> untyped
+
+      # Loads all the given data into +records+ for the +association+.
+      def preloaders_on: (untyped association, untyped records, untyped scope, ?bool polymorphic_parent) -> untyped
+
+      def preloaders_for_hash: (untyped association, untyped records, untyped scope, untyped polymorphic_parent) -> untyped
+
+      # Loads all the given data into +records+ for a singular +association+.
+      #
+      # Functions by instantiating a preloader class such as Preloader::Association and
+      # call the +run+ method for each passed in class in the +records+ argument.
+      #
+      # Not all records have the same class, so group then preload group on the reflection
+      # itself so that if various subclass share the same association then we do not split
+      # them unnecessarily
+      #
+      # Additionally, polymorphic belongs_to associations can have multiple associated
+      # classes, depending on the polymorphic_type field. So we group by the classes as
+      # well.
+      def preloaders_for_one: (untyped association, untyped records, untyped scope, untyped polymorphic_parent) -> untyped
+
+      def preloaders_for_reflection: (untyped reflection, untyped records, untyped scope) -> untyped
+
+      def grouped_records: (untyped association, untyped records, untyped polymorphic_parent) -> untyped
+
+      class AlreadyLoaded
+        # :nodoc:
+        def initialize: (untyped klass, untyped owners, untyped reflection, untyped preload_scope) -> untyped
+
+        def run: () -> untyped
+
+        def preloaded_records: () -> untyped
+
+        def records_by_owner: () -> untyped
+
+        attr_reader owners: untyped
+
+        attr_reader reflection: untyped
+      end
+
+      # Returns a class containing the logic needed to load preload the data
+      # and attach it to a relation. The class returned implements a `run` method
+      # that accepts a preloader.
+      def preloader_for: (untyped reflection, untyped owners) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module Associations
+    class SingularAssociation < Association
+      # nodoc:
+      # Implements the reader method, e.g. foo.bar for Foo.has_one :bar
+      def reader: () -> untyped
+
+      # Implements the writer method, e.g. foo.bar= for Foo.belongs_to :bar
+      def writer: (untyped record) -> untyped
+
+      def build: (?::Hash[untyped, untyped] attributes) { () -> untyped } -> untyped
+
+      # Implements the reload reader method, e.g. foo.reload_bar for
+      # Foo.has_one :bar
+      def force_reload_reader: () -> untyped
+
+      def scope_for_create: () -> untyped
+
+      def find_target: () -> untyped
+
+      def replace: (untyped record) -> untyped
+
+      def set_new_record: (untyped record) -> untyped
+
+      def _create_record: (untyped attributes, ?bool raise_error) { () -> untyped } -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module Associations
+    module ThroughAssociation
+      def through_reflection: () -> untyped
+
+      def through_association: () -> untyped
+
+      # We merge in these scopes for two reasons:
+      #
+      #   1. To get the default_scope conditions for any of the other reflections in the chain
+      #   2. To get the type conditions for any STI models in the chain
+      def target_scope: () -> untyped
+
+      # Construct attributes for :through pointing to owner and associate. This is used by the
+      # methods which create and delete records on the association.
+      #
+      # We only support indirectly modifying through associations which have a belongs_to source.
+      # This is the "has_many :tags, through: :taggings" situation, where the join model
+      # typically has a belongs_to on both side. In other words, associations which could also
+      # be represented as has_and_belongs_to_many associations.
+      #
+      # We do not support creating/deleting records on the association where the source has
+      # some other type, because this opens up a whole can of worms, and in basically any
+      # situation it is more natural for the user to just create or modify their join records
+      # directly as required.
+      def construct_join_attributes: (*untyped records) -> untyped
+
+      # Note: this does not capture all cases, for example it would be crazy to try to
+      # properly support stale-checking for nested associations.
+      def stale_state: () -> untyped
+
+      def foreign_key_present?: () -> untyped
+
+      def ensure_mutable: () -> untyped
+
+      def ensure_not_nested: () -> untyped
+
+      def build_record: (untyped attributes) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  class AssociationNotFoundError < ConfigurationError
+    # nodoc:
+    def initialize: (?untyped? record, ?untyped? association_name) -> untyped
+  end
+
+  class InverseOfAssociationNotFoundError < ActiveRecordError
+    # nodoc:
+    def initialize: (?untyped? reflection, ?untyped? associated_class) -> untyped
+  end
+
+  class HasManyThroughAssociationNotFoundError < ActiveRecordError
+    # nodoc:
+    def initialize: (?untyped? owner_class_name, ?untyped? reflection) -> untyped
+  end
+
+  class HasManyThroughAssociationPolymorphicSourceError < ActiveRecordError
+    # nodoc:
+    def initialize: (?untyped? owner_class_name, ?untyped? reflection, ?untyped? source_reflection) -> untyped
+  end
+
+  class HasManyThroughAssociationPolymorphicThroughError < ActiveRecordError
+    # nodoc:
+    def initialize: (?untyped? owner_class_name, ?untyped? reflection) -> untyped
+  end
+
+  class HasManyThroughAssociationPointlessSourceTypeError < ActiveRecordError
+    # nodoc:
+    def initialize: (?untyped? owner_class_name, ?untyped? reflection, ?untyped? source_reflection) -> untyped
+  end
+
+  class HasOneThroughCantAssociateThroughCollection < ActiveRecordError
+    # nodoc:
+    def initialize: (?untyped? owner_class_name, ?untyped? reflection, ?untyped? through_reflection) -> untyped
+  end
+
+  class HasOneAssociationPolymorphicThroughError < ActiveRecordError
+    # nodoc:
+    def initialize: (?untyped? owner_class_name, ?untyped? reflection) -> untyped
+  end
+
+  class HasManyThroughSourceAssociationNotFoundError < ActiveRecordError
+    # nodoc:
+    def initialize: (?untyped? reflection) -> untyped
+  end
+
+  class HasManyThroughOrderError < ActiveRecordError
+    # nodoc:
+    def initialize: (?untyped? owner_class_name, ?untyped? reflection, ?untyped? through_reflection) -> untyped
+  end
+
+  class ThroughCantAssociateThroughHasOneOrManyReflection < ActiveRecordError
+    # nodoc:
+    def initialize: (?untyped? owner, ?untyped? reflection) -> untyped
+  end
+
+  class AmbiguousSourceReflectionForThroughAssociation < ActiveRecordError
+    # :nodoc:
+    def initialize: (untyped klass, untyped macro, untyped association_name, untyped options, untyped possible_sources) -> untyped
+  end
+
+  class HasManyThroughCantAssociateThroughHasOneOrManyReflection < ThroughCantAssociateThroughHasOneOrManyReflection
+  end
+
+  class HasOneThroughCantAssociateThroughHasOneOrManyReflection < ThroughCantAssociateThroughHasOneOrManyReflection
+  end
+
+  class ThroughNestedAssociationsAreReadonly < ActiveRecordError
+    # nodoc:
+    def initialize: (?untyped? owner, ?untyped? reflection) -> untyped
+  end
+
+  class HasManyThroughNestedAssociationsAreReadonly < ThroughNestedAssociationsAreReadonly
+  end
+
+  class HasOneThroughNestedAssociationsAreReadonly < ThroughNestedAssociationsAreReadonly
+  end
+
+  # This error is raised when trying to eager load a polymorphic association using a JOIN.
+  # Eager loading polymorphic associations is only possible with
+  # {ActiveRecord::Relation#preload}[rdoc-ref:QueryMethods#preload].
+  class EagerLoadPolymorphicError < ActiveRecordError
+    def initialize: (?untyped? reflection) -> untyped
+  end
+
+  class DeleteRestrictionError < ActiveRecordError
+    # This error is raised when trying to destroy a parent instance in N:1 or 1:1 associations
+    # (has_many, has_one) when there is at least 1 child associated instance.
+    # ex: if @project.tasks.size > 0, DeleteRestrictionError will be raised when trying to destroy @project
+    # nodoc:
+    def initialize: (?untyped? name) -> untyped
+  end
+
+  module Associations
+    # See ActiveRecord::Associations::ClassMethods for documentation.
+    # :nodoc:
+    extend ActiveSupport::Autoload
+
+    extend ActiveSupport::Concern
+
+    module Builder
+    end
+
+    def self.eager_load!: () -> untyped
+
+    def association: (untyped name) -> untyped
+
+    def association_cached?: (untyped name) -> untyped
+
+    def initialize_dup: () -> untyped
+
+    def reload: () -> untyped
+
+    # Clears out the association cache.
+    def clear_association_cache: () -> untyped
+
+    def init_internals: () -> untyped
+
+    # Returns the specified association instance if it exists, +nil+ otherwise.
+    def association_instance_get: (untyped name) -> untyped
+
+    # Set the specified association instance.
+    def association_instance_set: (untyped name, untyped association) -> untyped
+
+    # \Associations are a set of macro-like class methods for tying objects together through
+    # foreign keys. They express relationships like "Project has one Project Manager"
+    # or "Project belongs to a Portfolio". Each macro adds a number of methods to the
+    # class which are specialized according to the collection or association symbol and the
+    # options hash. It works much the same way as Ruby's own <tt>attr*</tt>
+    # methods.
+    #
+    #   class Project < ActiveRecord::Base
+    #     belongs_to              :portfolio
+    #     has_one                 :project_manager
+    #     has_many                :milestones
+    #     has_and_belongs_to_many :categories
+    #   end
+    #
+    # The project class now has the following methods (and more) to ease the traversal and
+    # manipulation of its relationships:
+    # * <tt>Project#portfolio</tt>, <tt>Project#portfolio=(portfolio)</tt>, <tt>Project#reload_portfolio</tt>
+    # * <tt>Project#project_manager</tt>, <tt>Project#project_manager=(project_manager)</tt>, <tt>Project#reload_project_manager</tt>
+    # * <tt>Project#milestones.empty?</tt>, <tt>Project#milestones.size</tt>, <tt>Project#milestones</tt>, <tt>Project#milestones<<(milestone)</tt>,
+    #   <tt>Project#milestones.delete(milestone)</tt>, <tt>Project#milestones.destroy(milestone)</tt>, <tt>Project#milestones.find(milestone_id)</tt>,
+    #   <tt>Project#milestones.build</tt>, <tt>Project#milestones.create</tt>
+    # * <tt>Project#categories.empty?</tt>, <tt>Project#categories.size</tt>, <tt>Project#categories</tt>, <tt>Project#categories<<(category1)</tt>,
+    #   <tt>Project#categories.delete(category1)</tt>, <tt>Project#categories.destroy(category1)</tt>
+    #
+    # === A word of warning
+    #
+    # Don't create associations that have the same name as {instance methods}[rdoc-ref:ActiveRecord::Core] of
+    # <tt>ActiveRecord::Base</tt>. Since the association adds a method with that name to
+    # its model, using an association with the same name as one provided by <tt>ActiveRecord::Base</tt> will override the method inherited through <tt>ActiveRecord::Base</tt> and will break things.
+    # For instance, +attributes+ and +connection+ would be bad choices for association names, because those names already exist in the list of <tt>ActiveRecord::Base</tt> instance methods.
+    #
+    # == Auto-generated methods
+    # See also Instance Public methods below for more details.
+    #
+    # === Singular associations (one-to-one)
+    #                                     |            |  belongs_to  |
+    #   generated methods                 | belongs_to | :polymorphic | has_one
+    #   ----------------------------------+------------+--------------+---------
+    #   other                             |     X      |      X       |    X
+    #   other=(other)                     |     X      |      X       |    X
+    #   build_other(attributes={})        |     X      |              |    X
+    #   create_other(attributes={})       |     X      |              |    X
+    #   create_other!(attributes={})      |     X      |              |    X
+    #   reload_other                      |     X      |      X       |    X
+    #
+    # === Collection associations (one-to-many / many-to-many)
+    #                                     |       |          | has_many
+    #   generated methods                 | habtm | has_many | :through
+    #   ----------------------------------+-------+----------+----------
+    #   others                            |   X   |    X     |    X
+    #   others=(other,other,...)          |   X   |    X     |    X
+    #   other_ids                         |   X   |    X     |    X
+    #   other_ids=(id,id,...)             |   X   |    X     |    X
+    #   others<<                          |   X   |    X     |    X
+    #   others.push                       |   X   |    X     |    X
+    #   others.concat                     |   X   |    X     |    X
+    #   others.build(attributes={})       |   X   |    X     |    X
+    #   others.create(attributes={})      |   X   |    X     |    X
+    #   others.create!(attributes={})     |   X   |    X     |    X
+    #   others.size                       |   X   |    X     |    X
+    #   others.length                     |   X   |    X     |    X
+    #   others.count                      |   X   |    X     |    X
+    #   others.sum(*args)                 |   X   |    X     |    X
+    #   others.empty?                     |   X   |    X     |    X
+    #   others.clear                      |   X   |    X     |    X
+    #   others.delete(other,other,...)    |   X   |    X     |    X
+    #   others.delete_all                 |   X   |    X     |    X
+    #   others.destroy(other,other,...)   |   X   |    X     |    X
+    #   others.destroy_all                |   X   |    X     |    X
+    #   others.find(*args)                |   X   |    X     |    X
+    #   others.exists?                    |   X   |    X     |    X
+    #   others.distinct                   |   X   |    X     |    X
+    #   others.reset                      |   X   |    X     |    X
+    #   others.reload                     |   X   |    X     |    X
+    #
+    # === Overriding generated methods
+    #
+    # Association methods are generated in a module included into the model
+    # class, making overrides easy. The original generated method can thus be
+    # called with +super+:
+    #
+    #   class Car < ActiveRecord::Base
+    #     belongs_to :owner
+    #     belongs_to :old_owner
+    #
+    #     def owner=(new_owner)
+    #       self.old_owner = self.owner
+    #       super
+    #     end
+    #   end
+    #
+    # The association methods module is included immediately after the
+    # generated attributes methods module, meaning an association will
+    # override the methods for an attribute with the same name.
+    #
+    # == Cardinality and associations
+    #
+    # Active Record associations can be used to describe one-to-one, one-to-many and many-to-many
+    # relationships between models. Each model uses an association to describe its role in
+    # the relation. The #belongs_to association is always used in the model that has
+    # the foreign key.
+    #
+    # === One-to-one
+    #
+    # Use #has_one in the base, and #belongs_to in the associated model.
+    #
+    #   class Employee < ActiveRecord::Base
+    #     has_one :office
+    #   end
+    #   class Office < ActiveRecord::Base
+    #     belongs_to :employee    # foreign key - employee_id
+    #   end
+    #
+    # === One-to-many
+    #
+    # Use #has_many in the base, and #belongs_to in the associated model.
+    #
+    #   class Manager < ActiveRecord::Base
+    #     has_many :employees
+    #   end
+    #   class Employee < ActiveRecord::Base
+    #     belongs_to :manager     # foreign key - manager_id
+    #   end
+    #
+    # === Many-to-many
+    #
+    # There are two ways to build a many-to-many relationship.
+    #
+    # The first way uses a #has_many association with the <tt>:through</tt> option and a join model, so
+    # there are two stages of associations.
+    #
+    #   class Assignment < ActiveRecord::Base
+    #     belongs_to :programmer  # foreign key - programmer_id
+    #     belongs_to :project     # foreign key - project_id
+    #   end
+    #   class Programmer < ActiveRecord::Base
+    #     has_many :assignments
+    #     has_many :projects, through: :assignments
+    #   end
+    #   class Project < ActiveRecord::Base
+    #     has_many :assignments
+    #     has_many :programmers, through: :assignments
+    #   end
+    #
+    # For the second way, use #has_and_belongs_to_many in both models. This requires a join table
+    # that has no corresponding model or primary key.
+    #
+    #   class Programmer < ActiveRecord::Base
+    #     has_and_belongs_to_many :projects       # foreign keys in the join table
+    #   end
+    #   class Project < ActiveRecord::Base
+    #     has_and_belongs_to_many :programmers    # foreign keys in the join table
+    #   end
+    #
+    # Choosing which way to build a many-to-many relationship is not always simple.
+    # If you need to work with the relationship model as its own entity,
+    # use #has_many <tt>:through</tt>. Use #has_and_belongs_to_many when working with legacy schemas or when
+    # you never work directly with the relationship itself.
+    #
+    # == Is it a #belongs_to or #has_one association?
+    #
+    # Both express a 1-1 relationship. The difference is mostly where to place the foreign
+    # key, which goes on the table for the class declaring the #belongs_to relationship.
+    #
+    #   class User < ActiveRecord::Base
+    #     # I reference an account.
+    #     belongs_to :account
+    #   end
+    #
+    #   class Account < ActiveRecord::Base
+    #     # One user references me.
+    #     has_one :user
+    #   end
+    #
+    # The tables for these classes could look something like:
+    #
+    #   CREATE TABLE users (
+    #     id bigint NOT NULL auto_increment,
+    #     account_id bigint default NULL,
+    #     name varchar default NULL,
+    #     PRIMARY KEY  (id)
+    #   )
+    #
+    #   CREATE TABLE accounts (
+    #     id bigint NOT NULL auto_increment,
+    #     name varchar default NULL,
+    #     PRIMARY KEY  (id)
+    #   )
+    #
+    # == Unsaved objects and associations
+    #
+    # You can manipulate objects and associations before they are saved to the database, but
+    # there is some special behavior you should be aware of, mostly involving the saving of
+    # associated objects.
+    #
+    # You can set the <tt>:autosave</tt> option on a #has_one, #belongs_to,
+    # #has_many, or #has_and_belongs_to_many association. Setting it
+    # to +true+ will _always_ save the members, whereas setting it to +false+ will
+    # _never_ save the members. More details about <tt>:autosave</tt> option is available at
+    # AutosaveAssociation.
+    #
+    # === One-to-one associations
+    #
+    # * Assigning an object to a #has_one association automatically saves that object and
+    #   the object being replaced (if there is one), in order to update their foreign
+    #   keys - except if the parent object is unsaved (<tt>new_record? == true</tt>).
+    # * If either of these saves fail (due to one of the objects being invalid), an
+    #   ActiveRecord::RecordNotSaved exception is raised and the assignment is
+    #   cancelled.
+    # * If you wish to assign an object to a #has_one association without saving it,
+    #   use the <tt>#build_association</tt> method (documented below). The object being
+    #   replaced will still be saved to update its foreign key.
+    # * Assigning an object to a #belongs_to association does not save the object, since
+    #   the foreign key field belongs on the parent. It does not save the parent either.
+    #
+    # === Collections
+    #
+    # * Adding an object to a collection (#has_many or #has_and_belongs_to_many) automatically
+    #   saves that object, except if the parent object (the owner of the collection) is not yet
+    #   stored in the database.
+    # * If saving any of the objects being added to a collection (via <tt>push</tt> or similar)
+    #   fails, then <tt>push</tt> returns +false+.
+    # * If saving fails while replacing the collection (via <tt>association=</tt>), an
+    #   ActiveRecord::RecordNotSaved exception is raised and the assignment is
+    #   cancelled.
+    # * You can add an object to a collection without automatically saving it by using the
+    #   <tt>collection.build</tt> method (documented below).
+    # * All unsaved (<tt>new_record? == true</tt>) members of the collection are automatically
+    #   saved when the parent is saved.
+    #
+    # == Customizing the query
+    #
+    # \Associations are built from <tt>Relation</tt> objects, and you can use the Relation syntax
+    # to customize them. For example, to add a condition:
+    #
+    #   class Blog < ActiveRecord::Base
+    #     has_many :published_posts, -> { where(published: true) }, class_name: 'Post'
+    #   end
+    #
+    # Inside the <tt>-> { ... }</tt> block you can use all of the usual Relation methods.
+    #
+    # === Accessing the owner object
+    #
+    # Sometimes it is useful to have access to the owner object when building the query. The owner
+    # is passed as a parameter to the block. For example, the following association would find all
+    # events that occur on the user's birthday:
+    #
+    #   class User < ActiveRecord::Base
+    #     has_many :birthday_events, ->(user) { where(starts_on: user.birthday) }, class_name: 'Event'
+    #   end
+    #
+    # Note: Joining, eager loading and preloading of these associations is not possible.
+    # These operations happen before instance creation and the scope will be called with a +nil+ argument.
+    #
+    # == Association callbacks
+    #
+    # Similar to the normal callbacks that hook into the life cycle of an Active Record object,
+    # you can also define callbacks that get triggered when you add an object to or remove an
+    # object from an association collection.
+    #
+    #   class Project
+    #     has_and_belongs_to_many :developers, after_add: :evaluate_velocity
+    #
+    #     def evaluate_velocity(developer)
+    #       ...
+    #     end
+    #   end
+    #
+    # It's possible to stack callbacks by passing them as an array. Example:
+    #
+    #   class Project
+    #     has_and_belongs_to_many :developers,
+    #                             after_add: [:evaluate_velocity, Proc.new { |p, d| p.shipping_date = Time.now}]
+    #   end
+    #
+    # Possible callbacks are: +before_add+, +after_add+, +before_remove+ and +after_remove+.
+    #
+    # If any of the +before_add+ callbacks throw an exception, the object will not be
+    # added to the collection.
+    #
+    # Similarly, if any of the +before_remove+ callbacks throw an exception, the object
+    # will not be removed from the collection.
+    #
+    # == Association extensions
+    #
+    # The proxy objects that control the access to associations can be extended through anonymous
+    # modules. This is especially beneficial for adding new finders, creators, and other
+    # factory-type methods that are only used as part of this association.
+    #
+    #   class Account < ActiveRecord::Base
+    #     has_many :people do
+    #       def find_or_create_by_name(name)
+    #         first_name, last_name = name.split(" ", 2)
+    #         find_or_create_by(first_name: first_name, last_name: last_name)
+    #       end
+    #     end
+    #   end
+    #
+    #   person = Account.first.people.find_or_create_by_name("David Heinemeier Hansson")
+    #   person.first_name # => "David"
+    #   person.last_name  # => "Heinemeier Hansson"
+    #
+    # If you need to share the same extensions between many associations, you can use a named
+    # extension module.
+    #
+    #   module FindOrCreateByNameExtension
+    #     def find_or_create_by_name(name)
+    #       first_name, last_name = name.split(" ", 2)
+    #       find_or_create_by(first_name: first_name, last_name: last_name)
+    #     end
+    #   end
+    #
+    #   class Account < ActiveRecord::Base
+    #     has_many :people, -> { extending FindOrCreateByNameExtension }
+    #   end
+    #
+    #   class Company < ActiveRecord::Base
+    #     has_many :people, -> { extending FindOrCreateByNameExtension }
+    #   end
+    #
+    # Some extensions can only be made to work with knowledge of the association's internals.
+    # Extensions can access relevant state using the following methods (where +items+ is the
+    # name of the association):
+    #
+    # * <tt>record.association(:items).owner</tt> - Returns the object the association is part of.
+    # * <tt>record.association(:items).reflection</tt> - Returns the reflection object that describes the association.
+    # * <tt>record.association(:items).target</tt> - Returns the associated object for #belongs_to and #has_one, or
+    #   the collection of associated objects for #has_many and #has_and_belongs_to_many.
+    #
+    # However, inside the actual extension code, you will not have access to the <tt>record</tt> as
+    # above. In this case, you can access <tt>proxy_association</tt>. For example,
+    # <tt>record.association(:items)</tt> and <tt>record.items.proxy_association</tt> will return
+    # the same object, allowing you to make calls like <tt>proxy_association.owner</tt> inside
+    # association extensions.
+    #
+    # == Association Join Models
+    #
+    # Has Many associations can be configured with the <tt>:through</tt> option to use an
+    # explicit join model to retrieve the data. This operates similarly to a
+    # #has_and_belongs_to_many association. The advantage is that you're able to add validations,
+    # callbacks, and extra attributes on the join model. Consider the following schema:
+    #
+    #   class Author < ActiveRecord::Base
+    #     has_many :authorships
+    #     has_many :books, through: :authorships
+    #   end
+    #
+    #   class Authorship < ActiveRecord::Base
+    #     belongs_to :author
+    #     belongs_to :book
+    #   end
+    #
+    #   @author = Author.first
+    #   @author.authorships.collect { |a| a.book } # selects all books that the author's authorships belong to
+    #   @author.books                              # selects all books by using the Authorship join model
+    #
+    # You can also go through a #has_many association on the join model:
+    #
+    #   class Firm < ActiveRecord::Base
+    #     has_many   :clients
+    #     has_many   :invoices, through: :clients
+    #   end
+    #
+    #   class Client < ActiveRecord::Base
+    #     belongs_to :firm
+    #     has_many   :invoices
+    #   end
+    #
+    #   class Invoice < ActiveRecord::Base
+    #     belongs_to :client
+    #   end
+    #
+    #   @firm = Firm.first
+    #   @firm.clients.flat_map { |c| c.invoices } # select all invoices for all clients of the firm
+    #   @firm.invoices                            # selects all invoices by going through the Client join model
+    #
+    # Similarly you can go through a #has_one association on the join model:
+    #
+    #   class Group < ActiveRecord::Base
+    #     has_many   :users
+    #     has_many   :avatars, through: :users
+    #   end
+    #
+    #   class User < ActiveRecord::Base
+    #     belongs_to :group
+    #     has_one    :avatar
+    #   end
+    #
+    #   class Avatar < ActiveRecord::Base
+    #     belongs_to :user
+    #   end
+    #
+    #   @group = Group.first
+    #   @group.users.collect { |u| u.avatar }.compact # select all avatars for all users in the group
+    #   @group.avatars                                # selects all avatars by going through the User join model.
+    #
+    # An important caveat with going through #has_one or #has_many associations on the
+    # join model is that these associations are *read-only*. For example, the following
+    # would not work following the previous example:
+    #
+    #   @group.avatars << Avatar.new   # this would work if User belonged_to Avatar rather than the other way around
+    #   @group.avatars.delete(@group.avatars.last)  # so would this
+    #
+    # == Setting Inverses
+    #
+    # If you are using a #belongs_to on the join model, it is a good idea to set the
+    # <tt>:inverse_of</tt> option on the #belongs_to, which will mean that the following example
+    # works correctly (where <tt>tags</tt> is a #has_many <tt>:through</tt> association):
+    #
+    #   @post = Post.first
+    #   @tag = @post.tags.build name: "ruby"
+    #   @tag.save
+    #
+    # The last line ought to save the through record (a <tt>Tagging</tt>). This will only work if the
+    # <tt>:inverse_of</tt> is set:
+    #
+    #   class Tagging < ActiveRecord::Base
+    #     belongs_to :post
+    #     belongs_to :tag, inverse_of: :taggings
+    #   end
+    #
+    # If you do not set the <tt>:inverse_of</tt> record, the association will
+    # do its best to match itself up with the correct inverse. Automatic
+    # inverse detection only works on #has_many, #has_one, and
+    # #belongs_to associations.
+    #
+    # Extra options on the associations, as defined in the
+    # <tt>AssociationReflection::INVALID_AUTOMATIC_INVERSE_OPTIONS</tt>
+    # constant, or a custom scope, will also prevent the association's inverse
+    # from being found automatically.
+    #
+    # The automatic guessing of the inverse association uses a heuristic based
+    # on the name of the class, so it may not work for all associations,
+    # especially the ones with non-standard names.
+    #
+    # You can turn off the automatic detection of inverse associations by setting
+    # the <tt>:inverse_of</tt> option to <tt>false</tt> like so:
+    #
+    #   class Tagging < ActiveRecord::Base
+    #     belongs_to :tag, inverse_of: false
+    #   end
+    #
+    # == Nested \Associations
+    #
+    # You can actually specify *any* association with the <tt>:through</tt> option, including an
+    # association which has a <tt>:through</tt> option itself. For example:
+    #
+    #   class Author < ActiveRecord::Base
+    #     has_many :posts
+    #     has_many :comments, through: :posts
+    #     has_many :commenters, through: :comments
+    #   end
+    #
+    #   class Post < ActiveRecord::Base
+    #     has_many :comments
+    #   end
+    #
+    #   class Comment < ActiveRecord::Base
+    #     belongs_to :commenter
+    #   end
+    #
+    #   @author = Author.first
+    #   @author.commenters # => People who commented on posts written by the author
+    #
+    # An equivalent way of setting up this association this would be:
+    #
+    #   class Author < ActiveRecord::Base
+    #     has_many :posts
+    #     has_many :commenters, through: :posts
+    #   end
+    #
+    #   class Post < ActiveRecord::Base
+    #     has_many :comments
+    #     has_many :commenters, through: :comments
+    #   end
+    #
+    #   class Comment < ActiveRecord::Base
+    #     belongs_to :commenter
+    #   end
+    #
+    # When using a nested association, you will not be able to modify the association because there
+    # is not enough information to know what modification to make. For example, if you tried to
+    # add a <tt>Commenter</tt> in the example above, there would be no way to tell how to set up the
+    # intermediate <tt>Post</tt> and <tt>Comment</tt> objects.
+    #
+    # == Polymorphic \Associations
+    #
+    # Polymorphic associations on models are not restricted on what types of models they
+    # can be associated with. Rather, they specify an interface that a #has_many association
+    # must adhere to.
+    #
+    #   class Asset < ActiveRecord::Base
+    #     belongs_to :attachable, polymorphic: true
+    #   end
+    #
+    #   class Post < ActiveRecord::Base
+    #     has_many :assets, as: :attachable         # The :as option specifies the polymorphic interface to use.
+    #   end
+    #
+    #   @asset.attachable = @post
+    #
+    # This works by using a type column in addition to a foreign key to specify the associated
+    # record. In the Asset example, you'd need an +attachable_id+ integer column and an
+    # +attachable_type+ string column.
+    #
+    # Using polymorphic associations in combination with single table inheritance (STI) is
+    # a little tricky. In order for the associations to work as expected, ensure that you
+    # store the base model for the STI models in the type column of the polymorphic
+    # association. To continue with the asset example above, suppose there are guest posts
+    # and member posts that use the posts table for STI. In this case, there must be a +type+
+    # column in the posts table.
+    #
+    # Note: The <tt>attachable_type=</tt> method is being called when assigning an +attachable+.
+    # The +class_name+ of the +attachable+ is passed as a String.
+    #
+    #   class Asset < ActiveRecord::Base
+    #     belongs_to :attachable, polymorphic: true
+    #
+    #     def attachable_type=(class_name)
+    #        super(class_name.constantize.base_class.to_s)
+    #     end
+    #   end
+    #
+    #   class Post < ActiveRecord::Base
+    #     # because we store "Post" in attachable_type now dependent: :destroy will work
+    #     has_many :assets, as: :attachable, dependent: :destroy
+    #   end
+    #
+    #   class GuestPost < Post
+    #   end
+    #
+    #   class MemberPost < Post
+    #   end
+    #
+    # == Caching
+    #
+    # All of the methods are built on a simple caching principle that will keep the result
+    # of the last query around unless specifically instructed not to. The cache is even
+    # shared across methods to make it even cheaper to use the macro-added methods without
+    # worrying too much about performance at the first go.
+    #
+    #   project.milestones             # fetches milestones from the database
+    #   project.milestones.size        # uses the milestone cache
+    #   project.milestones.empty?      # uses the milestone cache
+    #   project.milestones.reload.size # fetches milestones from the database
+    #   project.milestones             # uses the milestone cache
+    #
+    # == Eager loading of associations
+    #
+    # Eager loading is a way to find objects of a certain class and a number of named associations.
+    # It is one of the easiest ways to prevent the dreaded N+1 problem in which fetching 100
+    # posts that each need to display their author triggers 101 database queries. Through the
+    # use of eager loading, the number of queries will be reduced from 101 to 2.
+    #
+    #   class Post < ActiveRecord::Base
+    #     belongs_to :author
+    #     has_many   :comments
+    #   end
+    #
+    # Consider the following loop using the class above:
+    #
+    #   Post.all.each do |post|
+    #     puts "Post:            " + post.title
+    #     puts "Written by:      " + post.author.name
+    #     puts "Last comment on: " + post.comments.first.created_on
+    #   end
+    #
+    # To iterate over these one hundred posts, we'll generate 201 database queries. Let's
+    # first just optimize it for retrieving the author:
+    #
+    #   Post.includes(:author).each do |post|
+    #
+    # This references the name of the #belongs_to association that also used the <tt>:author</tt>
+    # symbol. After loading the posts, +find+ will collect the +author_id+ from each one and load
+    # all of the referenced authors with one query. Doing so will cut down the number of queries
+    # from 201 to 102.
+    #
+    # We can improve upon the situation further by referencing both associations in the finder with:
+    #
+    #   Post.includes(:author, :comments).each do |post|
+    #
+    # This will load all comments with a single query. This reduces the total number of queries
+    # to 3. In general, the number of queries will be 1 plus the number of associations
+    # named (except if some of the associations are polymorphic #belongs_to - see below).
+    #
+    # To include a deep hierarchy of associations, use a hash:
+    #
+    #   Post.includes(:author, { comments: { author: :gravatar } }).each do |post|
+    #
+    # The above code will load all the comments and all of their associated
+    # authors and gravatars. You can mix and match any combination of symbols,
+    # arrays, and hashes to retrieve the associations you want to load.
+    #
+    # All of this power shouldn't fool you into thinking that you can pull out huge amounts
+    # of data with no performance penalty just because you've reduced the number of queries.
+    # The database still needs to send all the data to Active Record and it still needs to
+    # be processed. So it's no catch-all for performance problems, but it's a great way to
+    # cut down on the number of queries in a situation as the one described above.
+    #
+    # Since only one table is loaded at a time, conditions or orders cannot reference tables
+    # other than the main one. If this is the case, Active Record falls back to the previously
+    # used <tt>LEFT OUTER JOIN</tt> based strategy. For example:
+    #
+    #   Post.includes([:author, :comments]).where(['comments.approved = ?', true])
+    #
+    # This will result in a single SQL query with joins along the lines of:
+    # <tt>LEFT OUTER JOIN comments ON comments.post_id = posts.id</tt> and
+    # <tt>LEFT OUTER JOIN authors ON authors.id = posts.author_id</tt>. Note that using conditions
+    # like this can have unintended consequences.
+    # In the above example, posts with no approved comments are not returned at all because
+    # the conditions apply to the SQL statement as a whole and not just to the association.
+    #
+    # You must disambiguate column references for this fallback to happen, for example
+    # <tt>order: "author.name DESC"</tt> will work but <tt>order: "name DESC"</tt> will not.
+    #
+    # If you want to load all posts (including posts with no approved comments), then write
+    # your own <tt>LEFT OUTER JOIN</tt> query using <tt>ON</tt>:
+    #
+    #   Post.joins("LEFT OUTER JOIN comments ON comments.post_id = posts.id AND comments.approved = '1'")
+    #
+    # In this case, it is usually more natural to include an association which has conditions defined on it:
+    #
+    #   class Post < ActiveRecord::Base
+    #     has_many :approved_comments, -> { where(approved: true) }, class_name: 'Comment'
+    #   end
+    #
+    #   Post.includes(:approved_comments)
+    #
+    # This will load posts and eager load the +approved_comments+ association, which contains
+    # only those comments that have been approved.
+    #
+    # If you eager load an association with a specified <tt>:limit</tt> option, it will be ignored,
+    # returning all the associated objects:
+    #
+    #   class Picture < ActiveRecord::Base
+    #     has_many :most_recent_comments, -> { order('id DESC').limit(10) }, class_name: 'Comment'
+    #   end
+    #
+    #   Picture.includes(:most_recent_comments).first.most_recent_comments # => returns all associated comments.
+    #
+    # Eager loading is supported with polymorphic associations.
+    #
+    #   class Address < ActiveRecord::Base
+    #     belongs_to :addressable, polymorphic: true
+    #   end
+    #
+    # A call that tries to eager load the addressable model
+    #
+    #   Address.includes(:addressable)
+    #
+    # This will execute one query to load the addresses and load the addressables with one
+    # query per addressable type.
+    # For example, if all the addressables are either of class Person or Company, then a total
+    # of 3 queries will be executed. The list of addressable types to load is determined on
+    # the back of the addresses loaded. This is not supported if Active Record has to fallback
+    # to the previous implementation of eager loading and will raise ActiveRecord::EagerLoadPolymorphicError.
+    # The reason is that the parent model's type is a column value so its corresponding table
+    # name cannot be put in the +FROM+/+JOIN+ clauses of that query.
+    #
+    # == Table Aliasing
+    #
+    # Active Record uses table aliasing in the case that a table is referenced multiple times
+    # in a join. If a table is referenced only once, the standard table name is used. The
+    # second time, the table is aliased as <tt>#{reflection_name}_#{parent_table_name}</tt>.
+    # Indexes are appended for any more successive uses of the table name.
+    #
+    #   Post.joins(:comments)
+    #   # => SELECT ... FROM posts INNER JOIN comments ON ...
+    #   Post.joins(:special_comments) # STI
+    #   # => SELECT ... FROM posts INNER JOIN comments ON ... AND comments.type = 'SpecialComment'
+    #   Post.joins(:comments, :special_comments) # special_comments is the reflection name, posts is the parent table name
+    #   # => SELECT ... FROM posts INNER JOIN comments ON ... INNER JOIN comments special_comments_posts
+    #
+    # Acts as tree example:
+    #
+    #   TreeMixin.joins(:children)
+    #   # => SELECT ... FROM mixins INNER JOIN mixins childrens_mixins ...
+    #   TreeMixin.joins(children: :parent)
+    #   # => SELECT ... FROM mixins INNER JOIN mixins childrens_mixins ...
+    #                               INNER JOIN parents_mixins ...
+    #   TreeMixin.joins(children: {parent: :children})
+    #   # => SELECT ... FROM mixins INNER JOIN mixins childrens_mixins ...
+    #                               INNER JOIN parents_mixins ...
+    #                               INNER JOIN mixins childrens_mixins_2
+    #
+    # Has and Belongs to Many join tables use the same idea, but add a <tt>_join</tt> suffix:
+    #
+    #   Post.joins(:categories)
+    #   # => SELECT ... FROM posts INNER JOIN categories_posts ... INNER JOIN categories ...
+    #   Post.joins(categories: :posts)
+    #   # => SELECT ... FROM posts INNER JOIN categories_posts ... INNER JOIN categories ...
+    #                              INNER JOIN categories_posts posts_categories_join INNER JOIN posts posts_categories
+    #   Post.joins(categories: {posts: :categories})
+    #   # => SELECT ... FROM posts INNER JOIN categories_posts ... INNER JOIN categories ...
+    #                              INNER JOIN categories_posts posts_categories_join INNER JOIN posts posts_categories
+    #                              INNER JOIN categories_posts categories_posts_join INNER JOIN categories categories_posts_2
+    #
+    # If you wish to specify your own custom joins using ActiveRecord::QueryMethods#joins method, those table
+    # names will take precedence over the eager associations:
+    #
+    #   Post.joins(:comments).joins("inner join comments ...")
+    #   # => SELECT ... FROM posts INNER JOIN comments_posts ON ... INNER JOIN comments ...
+    #   Post.joins(:comments, :special_comments).joins("inner join comments ...")
+    #   # => SELECT ... FROM posts INNER JOIN comments comments_posts ON ...
+    #                              INNER JOIN comments special_comments_posts ...
+    #                              INNER JOIN comments ...
+    #
+    # Table aliases are automatically truncated according to the maximum length of table identifiers
+    # according to the specific database.
+    #
+    # == Modules
+    #
+    # By default, associations will look for objects within the current module scope. Consider:
+    #
+    #   module MyApplication
+    #     module Business
+    #       class Firm < ActiveRecord::Base
+    #         has_many :clients
+    #       end
+    #
+    #       class Client < ActiveRecord::Base; end
+    #     end
+    #   end
+    #
+    # When <tt>Firm#clients</tt> is called, it will in turn call
+    # <tt>MyApplication::Business::Client.find_all_by_firm_id(firm.id)</tt>.
+    # If you want to associate with a class in another module scope, this can be done by
+    # specifying the complete class name.
+    #
+    #   module MyApplication
+    #     module Business
+    #       class Firm < ActiveRecord::Base; end
+    #     end
+    #
+    #     module Billing
+    #       class Account < ActiveRecord::Base
+    #         belongs_to :firm, class_name: "MyApplication::Business::Firm"
+    #       end
+    #     end
+    #   end
+    #
+    # == Bi-directional associations
+    #
+    # When you specify an association, there is usually an association on the associated model
+    # that specifies the same relationship in reverse. For example, with the following models:
+    #
+    #    class Dungeon < ActiveRecord::Base
+    #      has_many :traps
+    #      has_one :evil_wizard
+    #    end
+    #
+    #    class Trap < ActiveRecord::Base
+    #      belongs_to :dungeon
+    #    end
+    #
+    #    class EvilWizard < ActiveRecord::Base
+    #      belongs_to :dungeon
+    #    end
+    #
+    # The +traps+ association on +Dungeon+ and the +dungeon+ association on +Trap+ are
+    # the inverse of each other, and the inverse of the +dungeon+ association on +EvilWizard+
+    # is the +evil_wizard+ association on +Dungeon+ (and vice-versa). By default,
+    # Active Record can guess the inverse of the association based on the name
+    # of the class. The result is the following:
+    #
+    #    d = Dungeon.first
+    #    t = d.traps.first
+    #    d.object_id == t.dungeon.object_id # => true
+    #
+    # The +Dungeon+ instances +d+ and <tt>t.dungeon</tt> in the above example refer to
+    # the same in-memory instance since the association matches the name of the class.
+    # The result would be the same if we added +:inverse_of+ to our model definitions:
+    #
+    #    class Dungeon < ActiveRecord::Base
+    #      has_many :traps, inverse_of: :dungeon
+    #      has_one :evil_wizard, inverse_of: :dungeon
+    #    end
+    #
+    #    class Trap < ActiveRecord::Base
+    #      belongs_to :dungeon, inverse_of: :traps
+    #    end
+    #
+    #    class EvilWizard < ActiveRecord::Base
+    #      belongs_to :dungeon, inverse_of: :evil_wizard
+    #    end
+    #
+    # For more information, see the documentation for the +:inverse_of+ option.
+    #
+    # == Deleting from associations
+    #
+    # === Dependent associations
+    #
+    # #has_many, #has_one, and #belongs_to associations support the <tt>:dependent</tt> option.
+    # This allows you to specify that associated records should be deleted when the owner is
+    # deleted.
+    #
+    # For example:
+    #
+    #     class Author
+    #       has_many :posts, dependent: :destroy
+    #     end
+    #     Author.find(1).destroy # => Will destroy all of the author's posts, too
+    #
+    # The <tt>:dependent</tt> option can have different values which specify how the deletion
+    # is done. For more information, see the documentation for this option on the different
+    # specific association types. When no option is given, the behavior is to do nothing
+    # with the associated records when destroying a record.
+    #
+    # Note that <tt>:dependent</tt> is implemented using Rails' callback
+    # system, which works by processing callbacks in order. Therefore, other
+    # callbacks declared either before or after the <tt>:dependent</tt> option
+    # can affect what it does.
+    #
+    # Note that <tt>:dependent</tt> option is ignored for #has_one <tt>:through</tt> associations.
+    #
+    # === Delete or destroy?
+    #
+    # #has_many and #has_and_belongs_to_many associations have the methods <tt>destroy</tt>,
+    # <tt>delete</tt>, <tt>destroy_all</tt> and <tt>delete_all</tt>.
+    #
+    # For #has_and_belongs_to_many, <tt>delete</tt> and <tt>destroy</tt> are the same: they
+    # cause the records in the join table to be removed.
+    #
+    # For #has_many, <tt>destroy</tt> and <tt>destroy_all</tt> will always call the <tt>destroy</tt> method of the
+    # record(s) being removed so that callbacks are run. However <tt>delete</tt> and <tt>delete_all</tt> will either
+    # do the deletion according to the strategy specified by the <tt>:dependent</tt> option, or
+    # if no <tt>:dependent</tt> option is given, then it will follow the default strategy.
+    # The default strategy is to do nothing (leave the foreign keys with the parent ids set), except for
+    # #has_many <tt>:through</tt>, where the default strategy is <tt>delete_all</tt> (delete
+    # the join records, without running their callbacks).
+    #
+    # There is also a <tt>clear</tt> method which is the same as <tt>delete_all</tt>, except that
+    # it returns the association rather than the records which have been deleted.
+    #
+    # === What gets deleted?
+    #
+    # There is a potential pitfall here: #has_and_belongs_to_many and #has_many <tt>:through</tt>
+    # associations have records in join tables, as well as the associated records. So when we
+    # call one of these deletion methods, what exactly should be deleted?
+    #
+    # The answer is that it is assumed that deletion on an association is about removing the
+    # <i>link</i> between the owner and the associated object(s), rather than necessarily the
+    # associated objects themselves. So with #has_and_belongs_to_many and #has_many
+    # <tt>:through</tt>, the join records will be deleted, but the associated records won't.
+    #
+    # This makes sense if you think about it: if you were to call <tt>post.tags.delete(Tag.find_by(name: 'food'))</tt>
+    # you would want the 'food' tag to be unlinked from the post, rather than for the tag itself
+    # to be removed from the database.
+    #
+    # However, there are examples where this strategy doesn't make sense. For example, suppose
+    # a person has many projects, and each project has many tasks. If we deleted one of a person's
+    # tasks, we would probably not want the project to be deleted. In this scenario, the delete method
+    # won't actually work: it can only be used if the association on the join model is a
+    # #belongs_to. In other situations you are expected to perform operations directly on
+    # either the associated records or the <tt>:through</tt> association.
+    #
+    # With a regular #has_many there is no distinction between the "associated records"
+    # and the "link", so there is only one choice for what gets deleted.
+    #
+    # With #has_and_belongs_to_many and #has_many <tt>:through</tt>, if you want to delete the
+    # associated records themselves, you can always do something along the lines of
+    # <tt>person.tasks.each(&:destroy)</tt>.
+    #
+    # == Type safety with ActiveRecord::AssociationTypeMismatch
+    #
+    # If you attempt to assign an object to an association that doesn't match the inferred
+    # or specified <tt>:class_name</tt>, you'll get an ActiveRecord::AssociationTypeMismatch.
+    #
+    # == Options
+    #
+    # All of the association macros can be specialized through options. This makes cases
+    # more complex than the simple and guessable ones possible.
+    module ClassMethods
+      # Specifies a one-to-many association. The following methods for retrieval and query of
+      # collections of associated objects will be added:
+      #
+      # +collection+ is a placeholder for the symbol passed as the +name+ argument, so
+      # <tt>has_many :clients</tt> would add among others <tt>clients.empty?</tt>.
+      #
+      # [collection]
+      #   Returns a Relation of all the associated objects.
+      #   An empty Relation is returned if none are found.
+      # [collection<<(object, ...)]
+      #   Adds one or more objects to the collection by setting their foreign keys to the collection's primary key.
+      #   Note that this operation instantly fires update SQL without waiting for the save or update call on the
+      #   parent object, unless the parent object is a new record.
+      #   This will also run validations and callbacks of associated object(s).
+      # [collection.delete(object, ...)]
+      #   Removes one or more objects from the collection by setting their foreign keys to +NULL+.
+      #   Objects will be in addition destroyed if they're associated with <tt>dependent: :destroy</tt>,
+      #   and deleted if they're associated with <tt>dependent: :delete_all</tt>.
+      #
+      #   If the <tt>:through</tt> option is used, then the join records are deleted (rather than
+      #   nullified) by default, but you can specify <tt>dependent: :destroy</tt> or
+      #   <tt>dependent: :nullify</tt> to override this.
+      # [collection.destroy(object, ...)]
+      #   Removes one or more objects from the collection by running <tt>destroy</tt> on
+      #   each record, regardless of any dependent option, ensuring callbacks are run.
+      #
+      #   If the <tt>:through</tt> option is used, then the join records are destroyed
+      #   instead, not the objects themselves.
+      # [collection=objects]
+      #   Replaces the collections content by deleting and adding objects as appropriate. If the <tt>:through</tt>
+      #   option is true callbacks in the join models are triggered except destroy callbacks, since deletion is
+      #   direct by default. You can specify <tt>dependent: :destroy</tt> or
+      #   <tt>dependent: :nullify</tt> to override this.
+      # [collection_singular_ids]
+      #   Returns an array of the associated objects' ids
+      # [collection_singular_ids=ids]
+      #   Replace the collection with the objects identified by the primary keys in +ids+. This
+      #   method loads the models and calls <tt>collection=</tt>. See above.
+      # [collection.clear]
+      #   Removes every object from the collection. This destroys the associated objects if they
+      #   are associated with <tt>dependent: :destroy</tt>, deletes them directly from the
+      #   database if <tt>dependent: :delete_all</tt>, otherwise sets their foreign keys to +NULL+.
+      #   If the <tt>:through</tt> option is true no destroy callbacks are invoked on the join models.
+      #   Join models are directly deleted.
+      # [collection.empty?]
+      #   Returns +true+ if there are no associated objects.
+      # [collection.size]
+      #   Returns the number of associated objects.
+      # [collection.find(...)]
+      #   Finds an associated object according to the same rules as ActiveRecord::FinderMethods#find.
+      # [collection.exists?(...)]
+      #   Checks whether an associated object with the given conditions exists.
+      #   Uses the same rules as ActiveRecord::FinderMethods#exists?.
+      # [collection.build(attributes = {}, ...)]
+      #   Returns one or more new objects of the collection type that have been instantiated
+      #   with +attributes+ and linked to this object through a foreign key, but have not yet
+      #   been saved.
+      # [collection.create(attributes = {})]
+      #   Returns a new object of the collection type that has been instantiated
+      #   with +attributes+, linked to this object through a foreign key, and that has already
+      #   been saved (if it passed the validation). *Note*: This only works if the base model
+      #   already exists in the DB, not if it is a new (unsaved) record!
+      # [collection.create!(attributes = {})]
+      #   Does the same as <tt>collection.create</tt>, but raises ActiveRecord::RecordInvalid
+      #   if the record is invalid.
+      # [collection.reload]
+      #   Returns a Relation of all of the associated objects, forcing a database read.
+      #   An empty Relation is returned if none are found.
+      #
+      # === Example
+      #
+      # A <tt>Firm</tt> class declares <tt>has_many :clients</tt>, which will add:
+      # * <tt>Firm#clients</tt> (similar to <tt>Client.where(firm_id: id)</tt>)
+      # * <tt>Firm#clients<<</tt>
+      # * <tt>Firm#clients.delete</tt>
+      # * <tt>Firm#clients.destroy</tt>
+      # * <tt>Firm#clients=</tt>
+      # * <tt>Firm#client_ids</tt>
+      # * <tt>Firm#client_ids=</tt>
+      # * <tt>Firm#clients.clear</tt>
+      # * <tt>Firm#clients.empty?</tt> (similar to <tt>firm.clients.size == 0</tt>)
+      # * <tt>Firm#clients.size</tt> (similar to <tt>Client.count "firm_id = #{id}"</tt>)
+      # * <tt>Firm#clients.find</tt> (similar to <tt>Client.where(firm_id: id).find(id)</tt>)
+      # * <tt>Firm#clients.exists?(name: 'ACME')</tt> (similar to <tt>Client.exists?(name: 'ACME', firm_id: firm.id)</tt>)
+      # * <tt>Firm#clients.build</tt> (similar to <tt>Client.new(firm_id: id)</tt>)
+      # * <tt>Firm#clients.create</tt> (similar to <tt>c = Client.new(firm_id: id); c.save; c</tt>)
+      # * <tt>Firm#clients.create!</tt> (similar to <tt>c = Client.new(firm_id: id); c.save!</tt>)
+      # * <tt>Firm#clients.reload</tt>
+      # The declaration can also include an +options+ hash to specialize the behavior of the association.
+      #
+      # === Scopes
+      #
+      # You can pass a second argument +scope+ as a callable (i.e. proc or
+      # lambda) to retrieve a specific set of records or customize the generated
+      # query when you access the associated collection.
+      #
+      # Scope examples:
+      #   has_many :comments, -> { where(author_id: 1) }
+      #   has_many :employees, -> { joins(:address) }
+      #   has_many :posts, ->(blog) { where("max_post_length > ?", blog.max_post_length) }
+      #
+      # === Extensions
+      #
+      # The +extension+ argument allows you to pass a block into a has_many
+      # association. This is useful for adding new finders, creators and other
+      # factory-type methods to be used as part of the association.
+      #
+      # Extension examples:
+      #   has_many :employees do
+      #     def find_or_create_by_name(name)
+      #       first_name, last_name = name.split(" ", 2)
+      #       find_or_create_by(first_name: first_name, last_name: last_name)
+      #     end
+      #   end
+      #
+      # === Options
+      # [:class_name]
+      #   Specify the class name of the association. Use it only if that name can't be inferred
+      #   from the association name. So <tt>has_many :products</tt> will by default be linked
+      #   to the +Product+ class, but if the real class name is +SpecialProduct+, you'll have to
+      #   specify it with this option.
+      # [:foreign_key]
+      #   Specify the foreign key used for the association. By default this is guessed to be the name
+      #   of this class in lower-case and "_id" suffixed. So a Person class that makes a #has_many
+      #   association will use "person_id" as the default <tt>:foreign_key</tt>.
+      #
+      #   If you are going to modify the association (rather than just read from it), then it is
+      #   a good idea to set the <tt>:inverse_of</tt> option.
+      # [:foreign_type]
+      #   Specify the column used to store the associated object's type, if this is a polymorphic
+      #   association. By default this is guessed to be the name of the polymorphic association
+      #   specified on "as" option with a "_type" suffix. So a class that defines a
+      #   <tt>has_many :tags, as: :taggable</tt> association will use "taggable_type" as the
+      #   default <tt>:foreign_type</tt>.
+      # [:primary_key]
+      #   Specify the name of the column to use as the primary key for the association. By default this is +id+.
+      # [:dependent]
+      #   Controls what happens to the associated objects when
+      #   their owner is destroyed. Note that these are implemented as
+      #   callbacks, and Rails executes callbacks in order. Therefore, other
+      #   similar callbacks may affect the <tt>:dependent</tt> behavior, and the
+      #   <tt>:dependent</tt> behavior may affect other callbacks.
+      #
+      #   * <tt>:destroy</tt> causes all the associated objects to also be destroyed.
+      #   * <tt>:delete_all</tt> causes all the associated objects to be deleted directly from the database (so callbacks will not be executed).
+      #   * <tt>:nullify</tt> causes the foreign keys to be set to +NULL+. Polymorphic type will also be nullified
+      #     on polymorphic associations. Callbacks are not executed.
+      #   * <tt>:restrict_with_exception</tt> causes an <tt>ActiveRecord::DeleteRestrictionError</tt> exception to be raised if there are any associated records.
+      #   * <tt>:restrict_with_error</tt> causes an error to be added to the owner if there are any associated objects.
+      #
+      #   If using with the <tt>:through</tt> option, the association on the join model must be
+      #   a #belongs_to, and the records which get deleted are the join records, rather than
+      #   the associated records.
+      #
+      #   If using <tt>dependent: :destroy</tt> on a scoped association, only the scoped objects are destroyed.
+      #   For example, if a Post model defines
+      #   <tt>has_many :comments, -> { where published: true }, dependent: :destroy</tt> and <tt>destroy</tt> is
+      #   called on a post, only published comments are destroyed. This means that any unpublished comments in the
+      #   database would still contain a foreign key pointing to the now deleted post.
+      # [:counter_cache]
+      #   This option can be used to configure a custom named <tt>:counter_cache.</tt> You only need this option,
+      #   when you customized the name of your <tt>:counter_cache</tt> on the #belongs_to association.
+      # [:as]
+      #   Specifies a polymorphic interface (See #belongs_to).
+      # [:through]
+      #   Specifies an association through which to perform the query. This can be any other type
+      #   of association, including other <tt>:through</tt> associations. Options for <tt>:class_name</tt>,
+      #   <tt>:primary_key</tt> and <tt>:foreign_key</tt> are ignored, as the association uses the
+      #   source reflection.
+      #
+      #   If the association on the join model is a #belongs_to, the collection can be modified
+      #   and the records on the <tt>:through</tt> model will be automatically created and removed
+      #   as appropriate. Otherwise, the collection is read-only, so you should manipulate the
+      #   <tt>:through</tt> association directly.
+      #
+      #   If you are going to modify the association (rather than just read from it), then it is
+      #   a good idea to set the <tt>:inverse_of</tt> option on the source association on the
+      #   join model. This allows associated records to be built which will automatically create
+      #   the appropriate join model records when they are saved. (See the 'Association Join Models'
+      #   section above.)
+      # [:source]
+      #   Specifies the source association name used by #has_many <tt>:through</tt> queries.
+      #   Only use it if the name cannot be inferred from the association.
+      #   <tt>has_many :subscribers, through: :subscriptions</tt> will look for either <tt>:subscribers</tt> or
+      #   <tt>:subscriber</tt> on Subscription, unless a <tt>:source</tt> is given.
+      # [:source_type]
+      #   Specifies type of the source association used by #has_many <tt>:through</tt> queries where the source
+      #   association is a polymorphic #belongs_to.
+      # [:validate]
+      #   When set to +true+, validates new objects added to association when saving the parent object. +true+ by default.
+      #   If you want to ensure associated objects are revalidated on every update, use +validates_associated+.
+      # [:autosave]
+      #   If true, always save the associated objects or destroy them if marked for destruction,
+      #   when saving the parent object. If false, never save or destroy the associated objects.
+      #   By default, only save associated objects that are new records. This option is implemented as a
+      #   +before_save+ callback. Because callbacks are run in the order they are defined, associated objects
+      #   may need to be explicitly saved in any user-defined +before_save+ callbacks.
+      #
+      #   Note that NestedAttributes::ClassMethods#accepts_nested_attributes_for sets
+      #   <tt>:autosave</tt> to <tt>true</tt>.
+      # [:inverse_of]
+      #   Specifies the name of the #belongs_to association on the associated object
+      #   that is the inverse of this #has_many association.
+      #   See ActiveRecord::Associations::ClassMethods's overview on Bi-directional associations for more detail.
+      # [:extend]
+      #   Specifies a module or array of modules that will be extended into the association object returned.
+      #   Useful for defining methods on associations, especially when they should be shared between multiple
+      #   association objects.
+      #
+      # Option examples:
+      #   has_many :comments, -> { order("posted_on") }
+      #   has_many :comments, -> { includes(:author) }
+      #   has_many :people, -> { where(deleted: false).order("name") }, class_name: "Person"
+      #   has_many :tracks, -> { order("position") }, dependent: :destroy
+      #   has_many :comments, dependent: :nullify
+      #   has_many :tags, as: :taggable
+      #   has_many :reports, -> { readonly }
+      #   has_many :subscribers, through: :subscriptions, source: :user
+      def has_many: (untyped name, ?untyped? scope, **untyped options) { () -> untyped } -> untyped
+
+      # Specifies a one-to-one association with another class. This method should only be used
+      # if the other class contains the foreign key. If the current class contains the foreign key,
+      # then you should use #belongs_to instead. See also ActiveRecord::Associations::ClassMethods's overview
+      # on when to use #has_one and when to use #belongs_to.
+      #
+      # The following methods for retrieval and query of a single associated object will be added:
+      #
+      # +association+ is a placeholder for the symbol passed as the +name+ argument, so
+      # <tt>has_one :manager</tt> would add among others <tt>manager.nil?</tt>.
+      #
+      # [association]
+      #   Returns the associated object. +nil+ is returned if none is found.
+      # [association=(associate)]
+      #   Assigns the associate object, extracts the primary key, sets it as the foreign key,
+      #   and saves the associate object. To avoid database inconsistencies, permanently deletes an existing
+      #   associated object when assigning a new one, even if the new one isn't saved to database.
+      # [build_association(attributes = {})]
+      #   Returns a new object of the associated type that has been instantiated
+      #   with +attributes+ and linked to this object through a foreign key, but has not
+      #   yet been saved.
+      # [create_association(attributes = {})]
+      #   Returns a new object of the associated type that has been instantiated
+      #   with +attributes+, linked to this object through a foreign key, and that
+      #   has already been saved (if it passed the validation).
+      # [create_association!(attributes = {})]
+      #   Does the same as <tt>create_association</tt>, but raises ActiveRecord::RecordInvalid
+      #   if the record is invalid.
+      # [reload_association]
+      #   Returns the associated object, forcing a database read.
+      #
+      # === Example
+      #
+      # An Account class declares <tt>has_one :beneficiary</tt>, which will add:
+      # * <tt>Account#beneficiary</tt> (similar to <tt>Beneficiary.where(account_id: id).first</tt>)
+      # * <tt>Account#beneficiary=(beneficiary)</tt> (similar to <tt>beneficiary.account_id = account.id; beneficiary.save</tt>)
+      # * <tt>Account#build_beneficiary</tt> (similar to <tt>Beneficiary.new(account_id: id)</tt>)
+      # * <tt>Account#create_beneficiary</tt> (similar to <tt>b = Beneficiary.new(account_id: id); b.save; b</tt>)
+      # * <tt>Account#create_beneficiary!</tt> (similar to <tt>b = Beneficiary.new(account_id: id); b.save!; b</tt>)
+      # * <tt>Account#reload_beneficiary</tt>
+      #
+      # === Scopes
+      #
+      # You can pass a second argument +scope+ as a callable (i.e. proc or
+      # lambda) to retrieve a specific record or customize the generated query
+      # when you access the associated object.
+      #
+      # Scope examples:
+      #   has_one :author, -> { where(comment_id: 1) }
+      #   has_one :employer, -> { joins(:company) }
+      #   has_one :latest_post, ->(blog) { where("created_at > ?", blog.enabled_at) }
+      #
+      # === Options
+      #
+      # The declaration can also include an +options+ hash to specialize the behavior of the association.
+      #
+      # Options are:
+      # [:class_name]
+      #   Specify the class name of the association. Use it only if that name can't be inferred
+      #   from the association name. So <tt>has_one :manager</tt> will by default be linked to the Manager class, but
+      #   if the real class name is Person, you'll have to specify it with this option.
+      # [:dependent]
+      #   Controls what happens to the associated object when
+      #   its owner is destroyed:
+      #
+      #   * <tt>:destroy</tt> causes the associated object to also be destroyed
+      #   * <tt>:delete</tt> causes the associated object to be deleted directly from the database (so callbacks will not execute)
+      #   * <tt>:nullify</tt> causes the foreign key to be set to +NULL+. Polymorphic type column is also nullified
+      #     on polymorphic associations. Callbacks are not executed.
+      #   * <tt>:restrict_with_exception</tt> causes an <tt>ActiveRecord::DeleteRestrictionError</tt> exception to be raised if there is an associated record
+      #   * <tt>:restrict_with_error</tt> causes an error to be added to the owner if there is an associated object
+      #
+      #   Note that <tt>:dependent</tt> option is ignored when using <tt>:through</tt> option.
+      # [:foreign_key]
+      #   Specify the foreign key used for the association. By default this is guessed to be the name
+      #   of this class in lower-case and "_id" suffixed. So a Person class that makes a #has_one association
+      #   will use "person_id" as the default <tt>:foreign_key</tt>.
+      #
+      #   If you are going to modify the association (rather than just read from it), then it is
+      #   a good idea to set the <tt>:inverse_of</tt> option.
+      # [:foreign_type]
+      #   Specify the column used to store the associated object's type, if this is a polymorphic
+      #   association. By default this is guessed to be the name of the polymorphic association
+      #   specified on "as" option with a "_type" suffix. So a class that defines a
+      #   <tt>has_one :tag, as: :taggable</tt> association will use "taggable_type" as the
+      #   default <tt>:foreign_type</tt>.
+      # [:primary_key]
+      #   Specify the method that returns the primary key used for the association. By default this is +id+.
+      # [:as]
+      #   Specifies a polymorphic interface (See #belongs_to).
+      # [:through]
+      #   Specifies a Join Model through which to perform the query. Options for <tt>:class_name</tt>,
+      #   <tt>:primary_key</tt>, and <tt>:foreign_key</tt> are ignored, as the association uses the
+      #   source reflection. You can only use a <tt>:through</tt> query through a #has_one
+      #   or #belongs_to association on the join model.
+      #
+      #   If you are going to modify the association (rather than just read from it), then it is
+      #   a good idea to set the <tt>:inverse_of</tt> option.
+      # [:source]
+      #   Specifies the source association name used by #has_one <tt>:through</tt> queries.
+      #   Only use it if the name cannot be inferred from the association.
+      #   <tt>has_one :favorite, through: :favorites</tt> will look for a
+      #   <tt>:favorite</tt> on Favorite, unless a <tt>:source</tt> is given.
+      # [:source_type]
+      #   Specifies type of the source association used by #has_one <tt>:through</tt> queries where the source
+      #   association is a polymorphic #belongs_to.
+      # [:validate]
+      #   When set to +true+, validates new objects added to association when saving the parent object. +false+ by default.
+      #   If you want to ensure associated objects are revalidated on every update, use +validates_associated+.
+      # [:autosave]
+      #   If true, always save the associated object or destroy it if marked for destruction,
+      #   when saving the parent object. If false, never save or destroy the associated object.
+      #   By default, only save the associated object if it's a new record.
+      #
+      #   Note that NestedAttributes::ClassMethods#accepts_nested_attributes_for sets
+      #   <tt>:autosave</tt> to <tt>true</tt>.
+      # [:inverse_of]
+      #   Specifies the name of the #belongs_to association on the associated object
+      #   that is the inverse of this #has_one association.
+      #   See ActiveRecord::Associations::ClassMethods's overview on Bi-directional associations for more detail.
+      # [:required]
+      #   When set to +true+, the association will also have its presence validated.
+      #   This will validate the association itself, not the id. You can use
+      #   +:inverse_of+ to avoid an extra query during validation.
+      #
+      # Option examples:
+      #   has_one :credit_card, dependent: :destroy  # destroys the associated credit card
+      #   has_one :credit_card, dependent: :nullify  # updates the associated records foreign
+      #                                                 # key value to NULL rather than destroying it
+      #   has_one :last_comment, -> { order('posted_on') }, class_name: "Comment"
+      #   has_one :project_manager, -> { where(role: 'project_manager') }, class_name: "Person"
+      #   has_one :attachment, as: :attachable
+      #   has_one :boss, -> { readonly }
+      #   has_one :club, through: :membership
+      #   has_one :primary_address, -> { where(primary: true) }, through: :addressables, source: :addressable
+      #   has_one :credit_card, required: true
+      def has_one: (untyped name, ?untyped? scope, **untyped options) -> untyped
+
+      # Specifies a one-to-one association with another class. This method should only be used
+      # if this class contains the foreign key. If the other class contains the foreign key,
+      # then you should use #has_one instead. See also ActiveRecord::Associations::ClassMethods's overview
+      # on when to use #has_one and when to use #belongs_to.
+      #
+      # Methods will be added for retrieval and query for a single associated object, for which
+      # this object holds an id:
+      #
+      # +association+ is a placeholder for the symbol passed as the +name+ argument, so
+      # <tt>belongs_to :author</tt> would add among others <tt>author.nil?</tt>.
+      #
+      # [association]
+      #   Returns the associated object. +nil+ is returned if none is found.
+      # [association=(associate)]
+      #   Assigns the associate object, extracts the primary key, and sets it as the foreign key.
+      #   No modification or deletion of existing records takes place.
+      # [build_association(attributes = {})]
+      #   Returns a new object of the associated type that has been instantiated
+      #   with +attributes+ and linked to this object through a foreign key, but has not yet been saved.
+      # [create_association(attributes = {})]
+      #   Returns a new object of the associated type that has been instantiated
+      #   with +attributes+, linked to this object through a foreign key, and that
+      #   has already been saved (if it passed the validation).
+      # [create_association!(attributes = {})]
+      #   Does the same as <tt>create_association</tt>, but raises ActiveRecord::RecordInvalid
+      #   if the record is invalid.
+      # [reload_association]
+      #   Returns the associated object, forcing a database read.
+      #
+      # === Example
+      #
+      # A Post class declares <tt>belongs_to :author</tt>, which will add:
+      # * <tt>Post#author</tt> (similar to <tt>Author.find(author_id)</tt>)
+      # * <tt>Post#author=(author)</tt> (similar to <tt>post.author_id = author.id</tt>)
+      # * <tt>Post#build_author</tt> (similar to <tt>post.author = Author.new</tt>)
+      # * <tt>Post#create_author</tt> (similar to <tt>post.author = Author.new; post.author.save; post.author</tt>)
+      # * <tt>Post#create_author!</tt> (similar to <tt>post.author = Author.new; post.author.save!; post.author</tt>)
+      # * <tt>Post#reload_author</tt>
+      # The declaration can also include an +options+ hash to specialize the behavior of the association.
+      #
+      # === Scopes
+      #
+      # You can pass a second argument +scope+ as a callable (i.e. proc or
+      # lambda) to retrieve a specific record or customize the generated query
+      # when you access the associated object.
+      #
+      # Scope examples:
+      #   belongs_to :firm, -> { where(id: 2) }
+      #   belongs_to :user, -> { joins(:friends) }
+      #   belongs_to :level, ->(game) { where("game_level > ?", game.current_level) }
+      #
+      # === Options
+      #
+      # [:class_name]
+      #   Specify the class name of the association. Use it only if that name can't be inferred
+      #   from the association name. So <tt>belongs_to :author</tt> will by default be linked to the Author class, but
+      #   if the real class name is Person, you'll have to specify it with this option.
+      # [:foreign_key]
+      #   Specify the foreign key used for the association. By default this is guessed to be the name
+      #   of the association with an "_id" suffix. So a class that defines a <tt>belongs_to :person</tt>
+      #   association will use "person_id" as the default <tt>:foreign_key</tt>. Similarly,
+      #   <tt>belongs_to :favorite_person, class_name: "Person"</tt> will use a foreign key
+      #   of "favorite_person_id".
+      #
+      #   If you are going to modify the association (rather than just read from it), then it is
+      #   a good idea to set the <tt>:inverse_of</tt> option.
+      # [:foreign_type]
+      #   Specify the column used to store the associated object's type, if this is a polymorphic
+      #   association. By default this is guessed to be the name of the association with a "_type"
+      #   suffix. So a class that defines a <tt>belongs_to :taggable, polymorphic: true</tt>
+      #   association will use "taggable_type" as the default <tt>:foreign_type</tt>.
+      # [:primary_key]
+      #   Specify the method that returns the primary key of associated object used for the association.
+      #   By default this is +id+.
+      # [:dependent]
+      #   If set to <tt>:destroy</tt>, the associated object is destroyed when this object is. If set to
+      #   <tt>:delete</tt>, the associated object is deleted *without* calling its destroy method.
+      #   This option should not be specified when #belongs_to is used in conjunction with
+      #   a #has_many relationship on another class because of the potential to leave
+      #   orphaned records behind.
+      # [:counter_cache]
+      #   Caches the number of belonging objects on the associate class through the use of CounterCache::ClassMethods#increment_counter
+      #   and CounterCache::ClassMethods#decrement_counter. The counter cache is incremented when an object of this
+      #   class is created and decremented when it's destroyed. This requires that a column
+      #   named <tt>#{table_name}_count</tt> (such as +comments_count+ for a belonging Comment class)
+      #   is used on the associate class (such as a Post class) - that is the migration for
+      #   <tt>#{table_name}_count</tt> is created on the associate class (such that <tt>Post.comments_count</tt> will
+      #   return the count cached, see note below). You can also specify a custom counter
+      #   cache column by providing a column name instead of a +true+/+false+ value to this
+      #   option (e.g., <tt>counter_cache: :my_custom_counter</tt>.)
+      #   Note: Specifying a counter cache will add it to that model's list of readonly attributes
+      #   using +attr_readonly+.
+      # [:polymorphic]
+      #   Specify this association is a polymorphic association by passing +true+.
+      #   Note: If you've enabled the counter cache, then you may want to add the counter cache attribute
+      #   to the +attr_readonly+ list in the associated classes (e.g. <tt>class Post; attr_readonly :comments_count; end</tt>).
+      # [:validate]
+      #   When set to +true+, validates new objects added to association when saving the parent object. +false+ by default.
+      #   If you want to ensure associated objects are revalidated on every update, use +validates_associated+.
+      # [:autosave]
+      #   If true, always save the associated object or destroy it if marked for destruction, when
+      #   saving the parent object.
+      #   If false, never save or destroy the associated object.
+      #   By default, only save the associated object if it's a new record.
+      #
+      #   Note that NestedAttributes::ClassMethods#accepts_nested_attributes_for
+      #   sets <tt>:autosave</tt> to <tt>true</tt>.
+      # [:touch]
+      #   If true, the associated object will be touched (the updated_at/on attributes set to current time)
+      #   when this record is either saved or destroyed. If you specify a symbol, that attribute
+      #   will be updated with the current time in addition to the updated_at/on attribute.
+      #   Please note that with touching no validation is performed and only the +after_touch+,
+      #   +after_commit+ and +after_rollback+ callbacks are executed.
+      # [:inverse_of]
+      #   Specifies the name of the #has_one or #has_many association on the associated
+      #   object that is the inverse of this #belongs_to association.
+      #   See ActiveRecord::Associations::ClassMethods's overview on Bi-directional associations for more detail.
+      # [:optional]
+      #   When set to +true+, the association will not have its presence validated.
+      # [:required]
+      #   When set to +true+, the association will also have its presence validated.
+      #   This will validate the association itself, not the id. You can use
+      #   +:inverse_of+ to avoid an extra query during validation.
+      #   NOTE: <tt>required</tt> is set to <tt>true</tt> by default and is deprecated. If
+      #   you don't want to have association presence validated, use <tt>optional: true</tt>.
+      # [:default]
+      #   Provide a callable (i.e. proc or lambda) to specify that the association should
+      #   be initialized with a particular record before validation.
+      #
+      # Option examples:
+      #   belongs_to :firm, foreign_key: "client_of"
+      #   belongs_to :person, primary_key: "name", foreign_key: "person_name"
+      #   belongs_to :author, class_name: "Person", foreign_key: "author_id"
+      #   belongs_to :valid_coupon, ->(o) { where "discounts > ?", o.payments_count },
+      #                             class_name: "Coupon", foreign_key: "coupon_id"
+      #   belongs_to :attachable, polymorphic: true
+      #   belongs_to :project, -> { readonly }
+      #   belongs_to :post, counter_cache: true
+      #   belongs_to :comment, touch: true
+      #   belongs_to :company, touch: :employees_last_updated_at
+      #   belongs_to :user, optional: true
+      #   belongs_to :account, default: -> { company.account }
+      def belongs_to: (untyped name, ?untyped? scope, **untyped options) -> untyped
+
+      # Specifies a many-to-many relationship with another class. This associates two classes via an
+      # intermediate join table. Unless the join table is explicitly specified as an option, it is
+      # guessed using the lexical order of the class names. So a join between Developer and Project
+      # will give the default join table name of "developers_projects" because "D" precedes "P" alphabetically.
+      # Note that this precedence is calculated using the <tt><</tt> operator for String. This
+      # means that if the strings are of different lengths, and the strings are equal when compared
+      # up to the shortest length, then the longer string is considered of higher
+      # lexical precedence than the shorter one. For example, one would expect the tables "paper_boxes" and "papers"
+      # to generate a join table name of "papers_paper_boxes" because of the length of the name "paper_boxes",
+      # but it in fact generates a join table name of "paper_boxes_papers". Be aware of this caveat, and use the
+      # custom <tt>:join_table</tt> option if you need to.
+      # If your tables share a common prefix, it will only appear once at the beginning. For example,
+      # the tables "catalog_categories" and "catalog_products" generate a join table name of "catalog_categories_products".
+      #
+      # The join table should not have a primary key or a model associated with it. You must manually generate the
+      # join table with a migration such as this:
+      #
+      #   class CreateDevelopersProjectsJoinTable < ActiveRecord::Migration[5.0]
+      #     def change
+      #       create_join_table :developers, :projects
+      #     end
+      #   end
+      #
+      # It's also a good idea to add indexes to each of those columns to speed up the joins process.
+      # However, in MySQL it is advised to add a compound index for both of the columns as MySQL only
+      # uses one index per table during the lookup.
+      #
+      # Adds the following methods for retrieval and query:
+      #
+      # +collection+ is a placeholder for the symbol passed as the +name+ argument, so
+      # <tt>has_and_belongs_to_many :categories</tt> would add among others <tt>categories.empty?</tt>.
+      #
+      # [collection]
+      #   Returns a Relation of all the associated objects.
+      #   An empty Relation is returned if none are found.
+      # [collection<<(object, ...)]
+      #   Adds one or more objects to the collection by creating associations in the join table
+      #   (<tt>collection.push</tt> and <tt>collection.concat</tt> are aliases to this method).
+      #   Note that this operation instantly fires update SQL without waiting for the save or update call on the
+      #   parent object, unless the parent object is a new record.
+      # [collection.delete(object, ...)]
+      #   Removes one or more objects from the collection by removing their associations from the join table.
+      #   This does not destroy the objects.
+      # [collection.destroy(object, ...)]
+      #   Removes one or more objects from the collection by running destroy on each association in the join table, overriding any dependent option.
+      #   This does not destroy the objects.
+      # [collection=objects]
+      #   Replaces the collection's content by deleting and adding objects as appropriate.
+      # [collection_singular_ids]
+      #   Returns an array of the associated objects' ids.
+      # [collection_singular_ids=ids]
+      #   Replace the collection by the objects identified by the primary keys in +ids+.
+      # [collection.clear]
+      #   Removes every object from the collection. This does not destroy the objects.
+      # [collection.empty?]
+      #   Returns +true+ if there are no associated objects.
+      # [collection.size]
+      #   Returns the number of associated objects.
+      # [collection.find(id)]
+      #   Finds an associated object responding to the +id+ and that
+      #   meets the condition that it has to be associated with this object.
+      #   Uses the same rules as ActiveRecord::FinderMethods#find.
+      # [collection.exists?(...)]
+      #   Checks whether an associated object with the given conditions exists.
+      #   Uses the same rules as ActiveRecord::FinderMethods#exists?.
+      # [collection.build(attributes = {})]
+      #   Returns a new object of the collection type that has been instantiated
+      #   with +attributes+ and linked to this object through the join table, but has not yet been saved.
+      # [collection.create(attributes = {})]
+      #   Returns a new object of the collection type that has been instantiated
+      #   with +attributes+, linked to this object through the join table, and that has already been
+      #   saved (if it passed the validation).
+      # [collection.reload]
+      #   Returns a Relation of all of the associated objects, forcing a database read.
+      #   An empty Relation is returned if none are found.
+      #
+      # === Example
+      #
+      # A Developer class declares <tt>has_and_belongs_to_many :projects</tt>, which will add:
+      # * <tt>Developer#projects</tt>
+      # * <tt>Developer#projects<<</tt>
+      # * <tt>Developer#projects.delete</tt>
+      # * <tt>Developer#projects.destroy</tt>
+      # * <tt>Developer#projects=</tt>
+      # * <tt>Developer#project_ids</tt>
+      # * <tt>Developer#project_ids=</tt>
+      # * <tt>Developer#projects.clear</tt>
+      # * <tt>Developer#projects.empty?</tt>
+      # * <tt>Developer#projects.size</tt>
+      # * <tt>Developer#projects.find(id)</tt>
+      # * <tt>Developer#projects.exists?(...)</tt>
+      # * <tt>Developer#projects.build</tt> (similar to <tt>Project.new(developer_id: id)</tt>)
+      # * <tt>Developer#projects.create</tt> (similar to <tt>c = Project.new(developer_id: id); c.save; c</tt>)
+      # * <tt>Developer#projects.reload</tt>
+      # The declaration may include an +options+ hash to specialize the behavior of the association.
+      #
+      # === Scopes
+      #
+      # You can pass a second argument +scope+ as a callable (i.e. proc or
+      # lambda) to retrieve a specific set of records or customize the generated
+      # query when you access the associated collection.
+      #
+      # Scope examples:
+      #   has_and_belongs_to_many :projects, -> { includes(:milestones, :manager) }
+      #   has_and_belongs_to_many :categories, ->(post) {
+      #     where("default_category = ?", post.default_category)
+      #   }
+      #
+      # === Extensions
+      #
+      # The +extension+ argument allows you to pass a block into a
+      # has_and_belongs_to_many association. This is useful for adding new
+      # finders, creators and other factory-type methods to be used as part of
+      # the association.
+      #
+      # Extension examples:
+      #   has_and_belongs_to_many :contractors do
+      #     def find_or_create_by_name(name)
+      #       first_name, last_name = name.split(" ", 2)
+      #       find_or_create_by(first_name: first_name, last_name: last_name)
+      #     end
+      #   end
+      #
+      # === Options
+      #
+      # [:class_name]
+      #   Specify the class name of the association. Use it only if that name can't be inferred
+      #   from the association name. So <tt>has_and_belongs_to_many :projects</tt> will by default be linked to the
+      #   Project class, but if the real class name is SuperProject, you'll have to specify it with this option.
+      # [:join_table]
+      #   Specify the name of the join table if the default based on lexical order isn't what you want.
+      #   <b>WARNING:</b> If you're overwriting the table name of either class, the +table_name+ method
+      #   MUST be declared underneath any #has_and_belongs_to_many declaration in order to work.
+      # [:foreign_key]
+      #   Specify the foreign key used for the association. By default this is guessed to be the name
+      #   of this class in lower-case and "_id" suffixed. So a Person class that makes
+      #   a #has_and_belongs_to_many association to Project will use "person_id" as the
+      #   default <tt>:foreign_key</tt>.
+      #
+      #   If you are going to modify the association (rather than just read from it), then it is
+      #   a good idea to set the <tt>:inverse_of</tt> option.
+      # [:association_foreign_key]
+      #   Specify the foreign key used for the association on the receiving side of the association.
+      #   By default this is guessed to be the name of the associated class in lower-case and "_id" suffixed.
+      #   So if a Person class makes a #has_and_belongs_to_many association to Project,
+      #   the association will use "project_id" as the default <tt>:association_foreign_key</tt>.
+      # [:validate]
+      #   When set to +true+, validates new objects added to association when saving the parent object. +true+ by default.
+      #   If you want to ensure associated objects are revalidated on every update, use +validates_associated+.
+      # [:autosave]
+      #   If true, always save the associated objects or destroy them if marked for destruction, when
+      #   saving the parent object.
+      #   If false, never save or destroy the associated objects.
+      #   By default, only save associated objects that are new records.
+      #
+      #   Note that NestedAttributes::ClassMethods#accepts_nested_attributes_for sets
+      #   <tt>:autosave</tt> to <tt>true</tt>.
+      #
+      # Option examples:
+      #   has_and_belongs_to_many :projects
+      #   has_and_belongs_to_many :projects, -> { includes(:milestones, :manager) }
+      #   has_and_belongs_to_many :nations, class_name: "Country"
+      #   has_and_belongs_to_many :categories, join_table: "prods_cats"
+      #   has_and_belongs_to_many :categories, -> { readonly }
+      def has_and_belongs_to_many: (untyped name, ?untyped? scope, **untyped options) { () -> untyped } -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module AttributeAssignment
+    include ActiveModel::AttributeAssignment
+
+    def _assign_attributes: (untyped attributes) -> untyped
+
+    # Assign any deferred nested attributes after the base attributes have been set.
+    def assign_nested_parameter_attributes: (untyped pairs) -> untyped
+
+    # Instantiates objects for all attribute classes that needs more than one constructor parameter. This is done
+    # by calling new on the column type or aggregation type (through composed_of) object with these parameters.
+    # So having the pairs written_on(1) = "2004", written_on(2) = "6", written_on(3) = "24", will instantiate
+    # written_on (a date type) with Date.new("2004", "6", "24"). You can also specify a typecast character in the
+    # parentheses to have the parameters typecasted before they're used in the constructor. Use i for Integer and
+    # f for Float. If all the values for a given attribute are empty, the attribute will be set to +nil+.
+    def assign_multiparameter_attributes: (untyped pairs) -> untyped
+
+    def execute_callstack_for_multiparameter_attributes: (untyped callstack) -> untyped
+
+    def extract_callstack_for_multiparameter_attributes: (untyped pairs) -> untyped
+
+    def type_cast_attribute_value: (untyped multiparameter_name, untyped value) -> untyped
+
+    def find_parameter_position: (untyped multiparameter_name) -> untyped
+  end
+end
+
+module ActiveRecord
+  module AttributeDecorators
+    # :nodoc:
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      # :nodoc:
+      # This method is an internal API used to create class macros such as
+      # +serialize+, and features like time zone aware attributes.
+      #
+      # Used to wrap the type of an attribute in a new type.
+      # When the schema for a model is loaded, attributes with the same name as
+      # +column_name+ will have their type yielded to the given block. The
+      # return value of that block will be used instead.
+      #
+      # Subsequent calls where +column_name+ and +decorator_name+ are the same
+      # will override the previous decorator, not decorate twice. This can be
+      # used to create idempotent class macros like +serialize+
+      def decorate_attribute_type: (untyped column_name, untyped decorator_name) { () -> untyped } -> untyped
+
+      # This method is an internal API used to create higher level features like
+      # time zone aware attributes.
+      #
+      # When the schema for a model is loaded, +matcher+ will be called for each
+      # attribute with its name and type. If the matcher returns a truthy value,
+      # the type will then be yielded to the given block, and the return value
+      # of that block will replace the type.
+      #
+      # Subsequent calls to this method with the same value for +decorator_name+
+      # will replace the previous decorator, not decorate twice. This can be
+      # used to ensure that class macros are idempotent.
+      def decorate_matching_attribute_types: (untyped matcher, untyped decorator_name) { () -> untyped } -> untyped
+
+      def load_schema!: () -> untyped
+    end
+
+    class TypeDecorator
+      def initialize: (?::Hash[untyped, untyped] decorations) -> untyped
+
+      def merge: (*untyped args) -> TypeDecorator
+
+      def apply: (untyped name, untyped `type`) -> untyped
+
+      def decorators_for: (untyped name, untyped `type`) -> untyped
+
+      def matching: (untyped name, untyped `type`) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module AttributeMethods
+    # = Active Record Attribute Methods Before Type Cast
+    #
+    # ActiveRecord::AttributeMethods::BeforeTypeCast provides a way to
+    # read the value of the attributes before typecasting and deserialization.
+    #
+    #   class Task < ActiveRecord::Base
+    #   end
+    #
+    #   task = Task.new(id: '1', completed_on: '2012-10-21')
+    #   task.id           # => 1
+    #   task.completed_on # => Sun, 21 Oct 2012
+    #
+    #   task.attributes_before_type_cast
+    #   # => {"id"=>"1", "completed_on"=>"2012-10-21", ... }
+    #   task.read_attribute_before_type_cast('id')           # => "1"
+    #   task.read_attribute_before_type_cast('completed_on') # => "2012-10-21"
+    #
+    # In addition to #read_attribute_before_type_cast and #attributes_before_type_cast,
+    # it declares a method for all attributes with the <tt>*_before_type_cast</tt>
+    # suffix.
+    #
+    #   task.id_before_type_cast           # => "1"
+    #   task.completed_on_before_type_cast # => "2012-10-21"
+    module BeforeTypeCast
+      extend ActiveSupport::Concern
+
+      # Returns the value of the attribute identified by +attr_name+ before
+      # typecasting and deserialization.
+      #
+      #   class Task < ActiveRecord::Base
+      #   end
+      #
+      #   task = Task.new(id: '1', completed_on: '2012-10-21')
+      #   task.read_attribute('id')                            # => 1
+      #   task.read_attribute_before_type_cast('id')           # => '1'
+      #   task.read_attribute('completed_on')                  # => Sun, 21 Oct 2012
+      #   task.read_attribute_before_type_cast('completed_on') # => "2012-10-21"
+      #   task.read_attribute_before_type_cast(:completed_on)  # => "2012-10-21"
+      def read_attribute_before_type_cast: (untyped attr_name) -> untyped
+
+      # Returns a hash of attributes before typecasting and deserialization.
+      #
+      #   class Task < ActiveRecord::Base
+      #   end
+      #
+      #   task = Task.new(title: nil, is_done: true, completed_on: '2012-10-21')
+      #   task.attributes
+      #   # => {"id"=>nil, "title"=>nil, "is_done"=>true, "completed_on"=>Sun, 21 Oct 2012, "created_at"=>nil, "updated_at"=>nil}
+      #   task.attributes_before_type_cast
+      #   # => {"id"=>nil, "title"=>nil, "is_done"=>true, "completed_on"=>"2012-10-21", "created_at"=>nil, "updated_at"=>nil}
+      def attributes_before_type_cast: () -> untyped
+
+      # Dispatch target for <tt>*_before_type_cast</tt> attribute methods.
+      def attribute_before_type_cast: (untyped attribute_name) -> untyped
+
+      def attribute_came_from_user?: (untyped attribute_name) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module AttributeMethods
+    module Dirty
+      extend ActiveSupport::Concern
+
+      include ActiveModel::Dirty
+
+      # <tt>reload</tt> the record and clears changed attributes.
+      def reload: () -> untyped
+
+      # Did this attribute change when we last saved?
+      #
+      # This method is useful in after callbacks to determine if an attribute
+      # was changed during the save that triggered the callbacks to run. It can
+      # be invoked as +saved_change_to_name?+ instead of
+      # <tt>saved_change_to_attribute?("name")</tt>.
+      #
+      # ==== Options
+      #
+      # +from+ When passed, this method will return false unless the original
+      # value is equal to the given option
+      #
+      # +to+ When passed, this method will return false unless the value was
+      # changed to the given value
+      def saved_change_to_attribute?: (untyped attr_name, **untyped options) -> untyped
+
+      # Returns the change to an attribute during the last save. If the
+      # attribute was changed, the result will be an array containing the
+      # original value and the saved value.
+      #
+      # This method is useful in after callbacks, to see the change in an
+      # attribute during the save that triggered the callbacks to run. It can be
+      # invoked as +saved_change_to_name+ instead of
+      # <tt>saved_change_to_attribute("name")</tt>.
+      def saved_change_to_attribute: (untyped attr_name) -> untyped
+
+      # Returns the original value of an attribute before the last save.
+      #
+      # This method is useful in after callbacks to get the original value of an
+      # attribute before the save that triggered the callbacks to run. It can be
+      # invoked as +name_before_last_save+ instead of
+      # <tt>attribute_before_last_save("name")</tt>.
+      def attribute_before_last_save: (untyped attr_name) -> untyped
+
+      # Did the last call to +save+ have any changes to change?
+      def saved_changes?: () -> untyped
+
+      # Returns a hash containing all the changes that were just saved.
+      def saved_changes: () -> untyped
+
+      # Will this attribute change the next time we save?
+      #
+      # This method is useful in validations and before callbacks to determine
+      # if the next call to +save+ will change a particular attribute. It can be
+      # invoked as +will_save_change_to_name?+ instead of
+      # <tt>will_save_change_to_attribute("name")</tt>.
+      #
+      # ==== Options
+      #
+      # +from+ When passed, this method will return false unless the original
+      # value is equal to the given option
+      #
+      # +to+ When passed, this method will return false unless the value will be
+      # changed to the given value
+      def will_save_change_to_attribute?: (untyped attr_name, **untyped options) -> untyped
+
+      # Returns the change to an attribute that will be persisted during the
+      # next save.
+      #
+      # This method is useful in validations and before callbacks, to see the
+      # change to an attribute that will occur when the record is saved. It can
+      # be invoked as +name_change_to_be_saved+ instead of
+      # <tt>attribute_change_to_be_saved("name")</tt>.
+      #
+      # If the attribute will change, the result will be an array containing the
+      # original value and the new value about to be saved.
+      def attribute_change_to_be_saved: (untyped attr_name) -> untyped
+
+      # Returns the value of an attribute in the database, as opposed to the
+      # in-memory value that will be persisted the next time the record is
+      # saved.
+      #
+      # This method is useful in validations and before callbacks, to see the
+      # original value of an attribute prior to any changes about to be
+      # saved. It can be invoked as +name_in_database+ instead of
+      # <tt>attribute_in_database("name")</tt>.
+      def attribute_in_database: (untyped attr_name) -> untyped
+
+      # Will the next call to +save+ have any changes to persist?
+      def has_changes_to_save?: () -> untyped
+
+      # Returns a hash containing all the changes that will be persisted during
+      # the next save.
+      def changes_to_save: () -> untyped
+
+      # Returns an array of the names of any attributes that will change when
+      # the record is next saved.
+      def changed_attribute_names_to_save: () -> untyped
+
+      # Returns a hash of the attributes that will change when the record is
+      # next saved.
+      #
+      # The hash keys are the attribute names, and the hash values are the
+      # original attribute values in the database (as opposed to the in-memory
+      # values about to be saved).
+      def attributes_in_database: () -> untyped
+
+      def mutations_from_database: () -> untyped
+
+      def mutations_before_last_save: () -> untyped
+
+      def write_attribute_without_type_cast: (untyped attr_name, untyped value) -> untyped
+
+      def _touch_row: (untyped attribute_names, untyped time) -> untyped
+
+      def _update_record: (?untyped attribute_names) -> untyped
+
+      def _create_record: (?untyped attribute_names) -> untyped
+
+      def attribute_names_for_partial_writes: () -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module AttributeMethods
+    module PrimaryKey
+      extend ActiveSupport::Concern
+
+      # Returns this record's primary key value wrapped in an array if one is
+      # available.
+      def to_key: () -> untyped
+
+      # Returns the primary key column's value.
+      def id: () -> untyped
+
+      # Sets the primary key column's value.
+      def id=: (untyped value) -> untyped
+
+      # Queries the primary key column's value.
+      def id?: () -> untyped
+
+      # Returns the primary key column's value before type cast.
+      def id_before_type_cast: () -> untyped
+
+      # Returns the primary key column's previous value.
+      def id_was: () -> untyped
+
+      # Returns the primary key column's value from the database.
+      def id_in_database: () -> untyped
+
+      def attribute_method?: (untyped attr_name) -> untyped
+
+      module ClassMethods
+        ID_ATTRIBUTE_METHODS: untyped
+
+        def instance_method_already_implemented?: (untyped method_name) -> untyped
+
+        def dangerous_attribute_method?: (untyped method_name) -> untyped
+
+        # Defines the primary key field -- can be overridden in subclasses.
+        # Overwriting will negate any effect of the +primary_key_prefix_type+
+        # setting, though.
+        def primary_key: () -> untyped
+
+        # Returns a quoted version of the primary key name, used to construct
+        # SQL statements.
+        def quoted_primary_key: () -> untyped
+
+        def reset_primary_key: () -> untyped
+
+        def get_primary_key: (untyped base_name) -> untyped
+
+        # Sets the name of the primary key column.
+        #
+        #   class Project < ActiveRecord::Base
+        #     self.primary_key = 'sysid'
+        #   end
+        #
+        # You can also define the #primary_key method yourself:
+        #
+        #   class Project < ActiveRecord::Base
+        #     def self.primary_key
+        #       'foo_' + super
+        #     end
+        #   end
+        #
+        #   Project.primary_key # => "foo_id"
+        def primary_key=: (untyped value) -> untyped
+
+        def suppress_composite_primary_key: (untyped pk) -> untyped
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module AttributeMethods
+    module Query
+      extend ActiveSupport::Concern
+
+      def query_attribute: (untyped attr_name) -> (::FalseClass | untyped)
+
+      # Dispatch target for <tt>*?</tt> attribute methods.
+      def attribute?: (untyped attribute_name) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module AttributeMethods
+    module Read
+      extend ActiveSupport::Concern
+
+      module ClassMethods
+        def define_method_attribute: (untyped name) -> untyped
+      end
+
+      # Returns the value of the attribute identified by <tt>attr_name</tt> after
+      # it has been typecast (for example, "2004-12-12" in a date column is cast
+      # to a date object, like Date.new(2004, 12, 12)).
+      def read_attribute: (untyped attr_name) { () -> untyped } -> untyped
+
+      def _read_attribute: (untyped attr_name) { () -> untyped } -> untyped
+
+      alias attribute _read_attribute
+    end
+  end
+end
+
+module ActiveRecord
+  module AttributeMethods
+    module Serialization
+      extend ActiveSupport::Concern
+
+      class ColumnNotSerializableError < StandardError
+        def initialize: (untyped name, untyped `type`) -> untyped
+      end
+
+      module ClassMethods
+        # If you have an attribute that needs to be saved to the database as an
+        # object, and retrieved as the same object, then specify the name of that
+        # attribute using this method and it will be handled automatically. The
+        # serialization is done through YAML. If +class_name+ is specified, the
+        # serialized object must be of that class on assignment and retrieval.
+        # Otherwise SerializationTypeMismatch will be raised.
+        #
+        # Empty objects as <tt>{}</tt>, in the case of +Hash+, or <tt>[]</tt>, in the case of
+        # +Array+, will always be persisted as null.
+        #
+        # Keep in mind that database adapters handle certain serialization tasks
+        # for you. For instance: +json+ and +jsonb+ types in PostgreSQL will be
+        # converted between JSON object/array syntax and Ruby +Hash+ or +Array+
+        # objects transparently. There is no need to use #serialize in this
+        # case.
+        #
+        # For more complex cases, such as conversion to or from your application
+        # domain objects, consider using the ActiveRecord::Attributes API.
+        #
+        # ==== Parameters
+        #
+        # * +attr_name+ - The field name that should be serialized.
+        # * +class_name_or_coder+ - Optional, a coder object, which responds to +.load+ and +.dump+
+        #   or a class name that the object type should be equal to.
+        #
+        # ==== Example
+        #
+        #   # Serialize a preferences attribute.
+        #   class User < ActiveRecord::Base
+        #     serialize :preferences
+        #   end
+        #
+        #   # Serialize preferences using JSON as coder.
+        #   class User < ActiveRecord::Base
+        #     serialize :preferences, JSON
+        #   end
+        #
+        #   # Serialize preferences as Hash using YAML coder.
+        #   class User < ActiveRecord::Base
+        #     serialize :preferences, Hash
+        #   end
+        def serialize: (untyped attr_name, ?untyped class_name_or_coder) -> untyped
+
+        def type_incompatible_with_serialize?: (untyped `type`, untyped class_name) -> untyped
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module AttributeMethods
+    module TimeZoneConversion
+      class TimeZoneConverter
+        # :nodoc:
+        def deserialize: (untyped value) -> untyped
+
+        def cast: (untyped value) -> (nil | untyped)
+
+        def convert_time_to_time_zone: (untyped value) -> (nil | untyped)
+
+        def set_time_zone_without_conversion: (untyped value) -> untyped
+
+        def map_avoiding_infinite_recursion: (untyped value) { (untyped) -> untyped } -> untyped
+      end
+
+      extend ActiveSupport::Concern
+
+      module ClassMethods
+        def inherited: (untyped subclass) -> untyped
+
+        def create_time_zone_conversion_attribute?: (untyped name, untyped cast_type) -> untyped
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module AttributeMethods
+    module Write
+      extend ActiveSupport::Concern
+
+      module ClassMethods
+        def define_method_attribute=: (untyped name) -> untyped
+      end
+
+      # Updates the attribute identified by <tt>attr_name</tt> with the
+      # specified +value+. Empty strings for Integer and Float columns are
+      # turned into +nil+.
+      def write_attribute: (untyped attr_name, untyped value) -> untyped
+
+      def _write_attribute: (untyped attr_name, untyped value) -> untyped
+
+      def write_attribute_without_type_cast: (untyped attr_name, untyped value) -> untyped
+
+      # Dispatch target for <tt>*=</tt> attribute methods.
+      def attribute=: (untyped attribute_name, untyped value) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  # = Active Record Attribute Methods
+  module AttributeMethods
+    extend ActiveSupport::Concern
+
+    include ActiveModel::AttributeMethods
+
+    include Read
+
+    include Write
+
+    include BeforeTypeCast
+
+    include Query
+
+    include PrimaryKey
+
+    include TimeZoneConversion
+
+    include Dirty
+
+    include Serialization
+
+    RESTRICTED_CLASS_METHODS: ::Array[untyped]
+
+    class GeneratedAttributeMethods < Module
+      # nodoc:
+      include Mutex_m
+    end
+
+    module ClassMethods
+      def inherited: (untyped child_class) -> untyped
+
+      def initialize_generated_modules: () -> untyped
+
+      def define_attribute_methods: () -> (::FalseClass | untyped)
+
+      def undefine_attribute_methods: () -> untyped
+
+      # Raises an ActiveRecord::DangerousAttributeError exception when an
+      # \Active \Record method is defined in the model, otherwise +false+.
+      #
+      #   class Person < ActiveRecord::Base
+      #     def save
+      #       'already defined by Active Record'
+      #     end
+      #   end
+      #
+      #   Person.instance_method_already_implemented?(:save)
+      #   # => ActiveRecord::DangerousAttributeError: save is defined by Active Record. Check to make sure that you don't have an attribute or method with the same name.
+      #
+      #   Person.instance_method_already_implemented?(:name)
+      #   # => false
+      def instance_method_already_implemented?: (untyped method_name) -> untyped
+
+      def dangerous_attribute_method?: (untyped name) -> untyped
+
+      def method_defined_within?: (untyped name, untyped klass, ?untyped superklass) -> untyped
+
+      # A class method is 'dangerous' if it is already (re)defined by Active Record, but
+      # not by any ancestors. (So 'puts' is not dangerous but 'new' is.)
+      def dangerous_class_method?: (untyped method_name) -> untyped
+
+      def class_method_defined_within?: (untyped name, untyped klass, ?untyped superklass) -> untyped
+
+      # Returns +true+ if +attribute+ is an attribute method and table exists,
+      # +false+ otherwise.
+      #
+      #   class Person < ActiveRecord::Base
+      #   end
+      #
+      #   Person.attribute_method?('name')   # => true
+      #   Person.attribute_method?(:age=)    # => true
+      #   Person.attribute_method?(:nothing) # => false
+      def attribute_method?: (untyped attribute) -> untyped
+
+      # Returns an array of column names as strings if it's not an abstract class and
+      # table exists. Otherwise it returns an empty array.
+      #
+      #   class Person < ActiveRecord::Base
+      #   end
+      #
+      #   Person.attribute_names
+      #   # => ["id", "created_at", "updated_at", "name", "age"]
+      def attribute_names: () -> untyped
+
+      # Returns true if the given attribute exists, otherwise false.
+      #
+      #   class Person < ActiveRecord::Base
+      #   end
+      #
+      #   Person.has_attribute?('name')   # => true
+      #   Person.has_attribute?(:age)     # => true
+      #   Person.has_attribute?(:nothing) # => false
+      def has_attribute?: (untyped attr_name) -> untyped
+
+      # Returns the column object for the named attribute.
+      # Returns a +ActiveRecord::ConnectionAdapters::NullColumn+ if the
+      # named attribute does not exist.
+      #
+      #   class Person < ActiveRecord::Base
+      #   end
+      #
+      #   person = Person.new
+      #   person.column_for_attribute(:name) # the result depends on the ConnectionAdapter
+      #   # => #<ActiveRecord::ConnectionAdapters::Column:0x007ff4ab083980 @name="name", @sql_type="varchar(255)", @null=true, ...>
+      #
+      #   person.column_for_attribute(:nothing)
+      #   # => #<ActiveRecord::ConnectionAdapters::NullColumn:0xXXX @name=nil, @sql_type=nil, @cast_type=#<Type::Value>, ...>
+      def column_for_attribute: (untyped name) -> untyped
+    end
+
+    # A Person object with a name attribute can ask <tt>person.respond_to?(:name)</tt>,
+    # <tt>person.respond_to?(:name=)</tt>, and <tt>person.respond_to?(:name?)</tt>
+    # which will all return +true+. It also defines the attribute methods if they have
+    # not been generated.
+    #
+    #   class Person < ActiveRecord::Base
+    #   end
+    #
+    #   person = Person.new
+    #   person.respond_to?(:name)    # => true
+    #   person.respond_to?(:name=)   # => true
+    #   person.respond_to?(:name?)   # => true
+    #   person.respond_to?('age')    # => true
+    #   person.respond_to?('age=')   # => true
+    #   person.respond_to?('age?')   # => true
+    #   person.respond_to?(:nothing) # => false
+    def respond_to?: (untyped name, ?bool include_private) -> (::FalseClass | untyped | ::TrueClass)
+
+    # Returns +true+ if the given attribute is in the attributes hash, otherwise +false+.
+    #
+    #   class Person < ActiveRecord::Base
+    #   end
+    #
+    #   person = Person.new
+    #   person.has_attribute?(:name)    # => true
+    #   person.has_attribute?('age')    # => true
+    #   person.has_attribute?(:nothing) # => false
+    def has_attribute?: (untyped attr_name) -> untyped
+
+    # Returns an array of names for the attributes available on this object.
+    #
+    #   class Person < ActiveRecord::Base
+    #   end
+    #
+    #   person = Person.new
+    #   person.attribute_names
+    #   # => ["id", "created_at", "updated_at", "name", "age"]
+    def attribute_names: () -> untyped
+
+    # Returns a hash of all the attributes with their names as keys and the values of the attributes as values.
+    #
+    #   class Person < ActiveRecord::Base
+    #   end
+    #
+    #   person = Person.create(name: 'Francesco', age: 22)
+    #   person.attributes
+    #   # => {"id"=>3, "created_at"=>Sun, 21 Oct 2012 04:53:04, "updated_at"=>Sun, 21 Oct 2012 04:53:04, "name"=>"Francesco", "age"=>22}
+    def attributes: () -> untyped
+
+    # Returns an <tt>#inspect</tt>-like string for the value of the
+    # attribute +attr_name+. String attributes are truncated up to 50
+    # characters, Date and Time attributes are returned in the
+    # <tt>:db</tt> format. Other attributes return the value of
+    # <tt>#inspect</tt> without modification.
+    #
+    #   person = Person.create!(name: 'David Heinemeier Hansson ' * 3)
+    #
+    #   person.attribute_for_inspect(:name)
+    #   # => "\"David Heinemeier Hansson David Heinemeier Hansson ...\""
+    #
+    #   person.attribute_for_inspect(:created_at)
+    #   # => "\"2012-10-22 00:15:07\""
+    #
+    #   person.attribute_for_inspect(:tag_ids)
+    #   # => "[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]"
+    def attribute_for_inspect: (untyped attr_name) -> untyped
+
+    # Returns +true+ if the specified +attribute+ has been set by the user or by a
+    # database load and is neither +nil+ nor <tt>empty?</tt> (the latter only applies
+    # to objects that respond to <tt>empty?</tt>, most notably Strings). Otherwise, +false+.
+    # Note that it always returns +true+ with boolean attributes.
+    #
+    #   class Task < ActiveRecord::Base
+    #   end
+    #
+    #   task = Task.new(title: '', is_done: false)
+    #   task.attribute_present?(:title)   # => false
+    #   task.attribute_present?(:is_done) # => true
+    #   task.title = 'Buy milk'
+    #   task.is_done = true
+    #   task.attribute_present?(:title)   # => true
+    #   task.attribute_present?(:is_done) # => true
+    def attribute_present?: (untyped attribute) -> untyped
+
+    # Returns the value of the attribute identified by <tt>attr_name</tt> after it has been typecast (for example,
+    # "2004-12-12" in a date column is cast to a date object, like Date.new(2004, 12, 12)). It raises
+    # <tt>ActiveModel::MissingAttributeError</tt> if the identified attribute is missing.
+    #
+    # Note: +:id+ is always present.
+    #
+    #   class Person < ActiveRecord::Base
+    #     belongs_to :organization
+    #   end
+    #
+    #   person = Person.new(name: 'Francesco', age: '22')
+    #   person[:name] # => "Francesco"
+    #   person[:age]  # => 22
+    #
+    #   person = Person.select('id').first
+    #   person[:name]            # => ActiveModel::MissingAttributeError: missing attribute: name
+    #   person[:organization_id] # => ActiveModel::MissingAttributeError: missing attribute: organization_id
+    def []: (untyped attr_name) -> untyped
+
+    # Updates the attribute identified by <tt>attr_name</tt> with the specified +value+.
+    # (Alias for the protected #write_attribute method).
+    #
+    #   class Person < ActiveRecord::Base
+    #   end
+    #
+    #   person = Person.new
+    #   person[:age] = '22'
+    #   person[:age] # => 22
+    #   person[:age].class # => Integer
+    def []=: (untyped attr_name, untyped value) -> untyped
+
+    # Returns the name of all database fields which have been read from this
+    # model. This can be useful in development mode to determine which fields
+    # need to be selected. For performance critical pages, selecting only the
+    # required fields can be an easy performance win (assuming you aren't using
+    # all of the fields on the model).
+    #
+    # For example:
+    #
+    #   class PostsController < ActionController::Base
+    #     after_action :print_accessed_fields, only: :index
+    #
+    #     def index
+    #       @posts = Post.all
+    #     end
+    #
+    #     private
+    #
+    #     def print_accessed_fields
+    #       p @posts.first.accessed_fields
+    #     end
+    #   end
+    #
+    # Which allows you to quickly change your code to:
+    #
+    #   class PostsController < ActionController::Base
+    #     def index
+    #       @posts = Post.select(:id, :title, :author_id, :updated_at)
+    #     end
+    #   end
+    def accessed_fields: () -> untyped
+
+    def attribute_method?: (untyped attr_name) -> untyped
+
+    def attributes_with_values: (untyped attribute_names) -> untyped
+
+    # Filters the primary keys and readonly attributes from the attribute names.
+    def attributes_for_update: (untyped attribute_names) -> untyped
+
+    # Filters out the primary keys, from the attribute names, when the primary
+    # key is to be generated (e.g. the id attribute has no value).
+    def attributes_for_create: (untyped attribute_names) -> untyped
+
+    def format_for_inspect: (untyped value) -> untyped
+
+    def readonly_attribute?: (untyped name) -> untyped
+
+    def pk_attribute?: (untyped name) -> untyped
+  end
+end
+
+module ActiveRecord
+  # See ActiveRecord::Attributes::ClassMethods for documentation
+  module Attributes
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      # Defines an attribute with a type on this model. It will override the
+      # type of existing attributes if needed. This allows control over how
+      # values are converted to and from SQL when assigned to a model. It also
+      # changes the behavior of values passed to
+      # {ActiveRecord::Base.where}[rdoc-ref:QueryMethods#where]. This will let you use
+      # your domain objects across much of Active Record, without having to
+      # rely on implementation details or monkey patching.
+      #
+      # +name+ The name of the methods to define attribute methods for, and the
+      # column which this will persist to.
+      #
+      # +cast_type+ A symbol such as +:string+ or +:integer+, or a type object
+      # to be used for this attribute. See the examples below for more
+      # information about providing custom type objects.
+      #
+      # ==== Options
+      #
+      # The following options are accepted:
+      #
+      # +default+ The default value to use when no value is provided. If this option
+      # is not passed, the previous default value (if any) will be used.
+      # Otherwise, the default will be +nil+.
+      #
+      # +array+ (PostgreSQL only) specifies that the type should be an array (see the
+      # examples below).
+      #
+      # +range+ (PostgreSQL only) specifies that the type should be a range (see the
+      # examples below).
+      #
+      # When using a symbol for +cast_type+, extra options are forwarded to the
+      # constructor of the type object.
+      #
+      # ==== Examples
+      #
+      # The type detected by Active Record can be overridden.
+      #
+      #   # db/schema.rb
+      #   create_table :store_listings, force: true do |t|
+      #     t.decimal :price_in_cents
+      #   end
+      #
+      #   # app/models/store_listing.rb
+      #   class StoreListing < ActiveRecord::Base
+      #   end
+      #
+      #   store_listing = StoreListing.new(price_in_cents: '10.1')
+      #
+      #   # before
+      #   store_listing.price_in_cents # => BigDecimal(10.1)
+      #
+      #   class StoreListing < ActiveRecord::Base
+      #     attribute :price_in_cents, :integer
+      #   end
+      #
+      #   # after
+      #   store_listing.price_in_cents # => 10
+      #
+      # A default can also be provided.
+      #
+      #   # db/schema.rb
+      #   create_table :store_listings, force: true do |t|
+      #     t.string :my_string, default: "original default"
+      #   end
+      #
+      #   StoreListing.new.my_string # => "original default"
+      #
+      #   # app/models/store_listing.rb
+      #   class StoreListing < ActiveRecord::Base
+      #     attribute :my_string, :string, default: "new default"
+      #   end
+      #
+      #   StoreListing.new.my_string # => "new default"
+      #
+      #   class Product < ActiveRecord::Base
+      #     attribute :my_default_proc, :datetime, default: -> { Time.now }
+      #   end
+      #
+      #   Product.new.my_default_proc # => 2015-05-30 11:04:48 -0600
+      #   sleep 1
+      #   Product.new.my_default_proc # => 2015-05-30 11:04:49 -0600
+      #
+      # \Attributes do not need to be backed by a database column.
+      #
+      #   # app/models/my_model.rb
+      #   class MyModel < ActiveRecord::Base
+      #     attribute :my_string, :string
+      #     attribute :my_int_array, :integer, array: true
+      #     attribute :my_float_range, :float, range: true
+      #   end
+      #
+      #   model = MyModel.new(
+      #     my_string: "string",
+      #     my_int_array: ["1", "2", "3"],
+      #     my_float_range: "[1,3.5]",
+      #   )
+      #   model.attributes
+      #   # =>
+      #     {
+      #       my_string: "string",
+      #       my_int_array: [1, 2, 3],
+      #       my_float_range: 1.0..3.5
+      #     }
+      #
+      # Passing options to the type constructor
+      #
+      #   # app/models/my_model.rb
+      #   class MyModel < ActiveRecord::Base
+      #     attribute :small_int, :integer, limit: 2
+      #   end
+      #
+      #   MyModel.create(small_int: 65537)
+      #   # => Error: 65537 is out of range for the limit of two bytes
+      #
+      # ==== Creating Custom Types
+      #
+      # Users may also define their own custom types, as long as they respond
+      # to the methods defined on the value type. The method +deserialize+ or
+      # +cast+ will be called on your type object, with raw input from the
+      # database or from your controllers. See ActiveModel::Type::Value for the
+      # expected API. It is recommended that your type objects inherit from an
+      # existing type, or from ActiveRecord::Type::Value
+      #
+      #   class MoneyType < ActiveRecord::Type::Integer
+      #     def cast(value)
+      #       if !value.kind_of?(Numeric) && value.include?('$')
+      #         price_in_dollars = value.gsub(/\$/, '').to_f
+      #         super(price_in_dollars * 100)
+      #       else
+      #         super
+      #       end
+      #     end
+      #   end
+      #
+      #   # config/initializers/types.rb
+      #   ActiveRecord::Type.register(:money, MoneyType)
+      #
+      #   # app/models/store_listing.rb
+      #   class StoreListing < ActiveRecord::Base
+      #     attribute :price_in_cents, :money
+      #   end
+      #
+      #   store_listing = StoreListing.new(price_in_cents: '$10.00')
+      #   store_listing.price_in_cents # => 1000
+      #
+      # For more details on creating custom types, see the documentation for
+      # ActiveModel::Type::Value. For more details on registering your types
+      # to be referenced by a symbol, see ActiveRecord::Type.register. You can
+      # also pass a type object directly, in place of a symbol.
+      #
+      # ==== \Querying
+      #
+      # When {ActiveRecord::Base.where}[rdoc-ref:QueryMethods#where] is called, it will
+      # use the type defined by the model class to convert the value to SQL,
+      # calling +serialize+ on your type object. For example:
+      #
+      #   class Money < Struct.new(:amount, :currency)
+      #   end
+      #
+      #   class MoneyType < ActiveModel::Type::Value
+      #     def initialize(currency_converter:)
+      #       @currency_converter = currency_converter
+      #     end
+      #
+      #     # value will be the result of +deserialize+ or
+      #     # +cast+. Assumed to be an instance of +Money+ in
+      #     # this case.
+      #     def serialize(value)
+      #       value_in_bitcoins = @currency_converter.convert_to_bitcoins(value)
+      #       value_in_bitcoins.amount
+      #     end
+      #   end
+      #
+      #   # config/initializers/types.rb
+      #   ActiveRecord::Type.register(:money, MoneyType)
+      #
+      #   # app/models/product.rb
+      #   class Product < ActiveRecord::Base
+      #     currency_converter = ConversionRatesFromTheInternet.new
+      #     attribute :price_in_bitcoins, :money, currency_converter: currency_converter
+      #   end
+      #
+      #   Product.where(price_in_bitcoins: Money.new(5, "USD"))
+      #   # => SELECT * FROM products WHERE price_in_bitcoins = 0.02230
+      #
+      #   Product.where(price_in_bitcoins: Money.new(5, "GBP"))
+      #   # => SELECT * FROM products WHERE price_in_bitcoins = 0.03412
+      #
+      # ==== Dirty Tracking
+      #
+      # The type of an attribute is given the opportunity to change how dirty
+      # tracking is performed. The methods +changed?+ and +changed_in_place?+
+      # will be called from ActiveModel::Dirty. See the documentation for those
+      # methods in ActiveModel::Type::Value for more details.
+      def attribute: (untyped name, ?untyped cast_type, **untyped options) -> untyped
+
+      # This is the low level API which sits beneath +attribute+. It only
+      # accepts type objects, and will do its work immediately instead of
+      # waiting for the schema to load. Automatic schema detection and
+      # ClassMethods#attribute both call this under the hood. While this method
+      # is provided so it can be used by plugin authors, application code
+      # should probably use ClassMethods#attribute.
+      #
+      # +name+ The name of the attribute being defined. Expected to be a +String+.
+      #
+      # +cast_type+ The type object to use for this attribute.
+      #
+      # +default+ The default value to use when no value is provided. If this option
+      # is not passed, the previous default value (if any) will be used.
+      # Otherwise, the default will be +nil+. A proc can also be passed, and
+      # will be called once each time a new value is needed.
+      #
+      # +user_provided_default+ Whether the default value should be cast using
+      # +cast+ or +deserialize+.
+      def define_attribute: (untyped name, untyped cast_type, ?user_provided_default: bool user_provided_default, ?default: untyped default) -> untyped
+
+      def load_schema!: () -> untyped
+
+      NO_DEFAULT_PROVIDED: untyped
+
+      def define_default_attribute: (untyped name, untyped value, untyped `type`, from_user: untyped from_user) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  # = Active Record Autosave Association
+  #
+  # AutosaveAssociation is a module that takes care of automatically saving
+  # associated records when their parent is saved. In addition to saving, it
+  # also destroys any associated records that were marked for destruction.
+  # (See #mark_for_destruction and #marked_for_destruction?).
+  #
+  # Saving of the parent, its associations, and the destruction of marked
+  # associations, all happen inside a transaction. This should never leave the
+  # database in an inconsistent state.
+  #
+  # If validations for any of the associations fail, their error messages will
+  # be applied to the parent.
+  #
+  # Note that it also means that associations marked for destruction won't
+  # be destroyed directly. They will however still be marked for destruction.
+  #
+  # Note that <tt>autosave: false</tt> is not same as not declaring <tt>:autosave</tt>.
+  # When the <tt>:autosave</tt> option is not present then new association records are
+  # saved but the updated association records are not saved.
+  #
+  # == Validation
+  #
+  # Child records are validated unless <tt>:validate</tt> is +false+.
+  #
+  # == Callbacks
+  #
+  # Association with autosave option defines several callbacks on your
+  # model (before_save, after_create, after_update). Please note that
+  # callbacks are executed in the order they were defined in
+  # model. You should avoid modifying the association content, before
+  # autosave callbacks are executed. Placing your callbacks after
+  # associations is usually a good practice.
+  #
+  # === One-to-one Example
+  #
+  #   class Post < ActiveRecord::Base
+  #     has_one :author, autosave: true
+  #   end
+  #
+  # Saving changes to the parent and its associated model can now be performed
+  # automatically _and_ atomically:
+  #
+  #   post = Post.find(1)
+  #   post.title       # => "The current global position of migrating ducks"
+  #   post.author.name # => "alloy"
+  #
+  #   post.title = "On the migration of ducks"
+  #   post.author.name = "Eloy Duran"
+  #
+  #   post.save
+  #   post.reload
+  #   post.title       # => "On the migration of ducks"
+  #   post.author.name # => "Eloy Duran"
+  #
+  # Destroying an associated model, as part of the parent's save action, is as
+  # simple as marking it for destruction:
+  #
+  #   post.author.mark_for_destruction
+  #   post.author.marked_for_destruction? # => true
+  #
+  # Note that the model is _not_ yet removed from the database:
+  #
+  #   id = post.author.id
+  #   Author.find_by(id: id).nil? # => false
+  #
+  #   post.save
+  #   post.reload.author # => nil
+  #
+  # Now it _is_ removed from the database:
+  #
+  #   Author.find_by(id: id).nil? # => true
+  #
+  # === One-to-many Example
+  #
+  # When <tt>:autosave</tt> is not declared new children are saved when their parent is saved:
+  #
+  #   class Post < ActiveRecord::Base
+  #     has_many :comments # :autosave option is not declared
+  #   end
+  #
+  #   post = Post.new(title: 'ruby rocks')
+  #   post.comments.build(body: 'hello world')
+  #   post.save # => saves both post and comment
+  #
+  #   post = Post.create(title: 'ruby rocks')
+  #   post.comments.build(body: 'hello world')
+  #   post.save # => saves both post and comment
+  #
+  #   post = Post.create(title: 'ruby rocks')
+  #   post.comments.create(body: 'hello world')
+  #   post.save # => saves both post and comment
+  #
+  # When <tt>:autosave</tt> is true all children are saved, no matter whether they
+  # are new records or not:
+  #
+  #   class Post < ActiveRecord::Base
+  #     has_many :comments, autosave: true
+  #   end
+  #
+  #   post = Post.create(title: 'ruby rocks')
+  #   post.comments.create(body: 'hello world')
+  #   post.comments[0].body = 'hi everyone'
+  #   post.comments.build(body: "good morning.")
+  #   post.title += "!"
+  #   post.save # => saves both post and comments.
+  #
+  # Destroying one of the associated models as part of the parent's save action
+  # is as simple as marking it for destruction:
+  #
+  #   post.comments # => [#<Comment id: 1, ...>, #<Comment id: 2, ...]>
+  #   post.comments[1].mark_for_destruction
+  #   post.comments[1].marked_for_destruction? # => true
+  #   post.comments.length # => 2
+  #
+  # Note that the model is _not_ yet removed from the database:
+  #
+  #   id = post.comments.last.id
+  #   Comment.find_by(id: id).nil? # => false
+  #
+  #   post.save
+  #   post.reload.comments.length # => 1
+  #
+  # Now it _is_ removed from the database:
+  #
+  #   Comment.find_by(id: id).nil? # => true
+  module AutosaveAssociation
+    extend ActiveSupport::Concern
+
+    module AssociationBuilderExtension
+      # nodoc:
+      def self.build: (untyped model, untyped reflection) -> untyped
+
+      def self.valid_options: () -> ::Array[:autosave]
+    end
+
+    module ClassMethods
+      def define_non_cyclic_method: (untyped name) { () -> untyped } -> (nil | untyped)
+
+      # Adds validation and save callbacks for the association as specified by
+      # the +reflection+.
+      #
+      # For performance reasons, we don't check whether to validate at runtime.
+      # However the validation and callback methods are lazy and those methods
+      # get created when they are invoked for the very first time. However,
+      # this can change, for instance, when using nested attributes, which is
+      # called _after_ the association has been defined. Since we don't want
+      # the callbacks to get defined multiple times, there are guards that
+      # check if the save or validation methods have already been defined
+      # before actually defining them.
+      def add_autosave_association_callbacks: (untyped reflection) -> untyped
+
+      def define_autosave_validation_callbacks: (untyped reflection) -> untyped
+    end
+
+    # Reloads the attributes of the object as usual and clears <tt>marked_for_destruction</tt> flag.
+    def reload: (?untyped? options) -> untyped
+
+    # Marks this record to be destroyed as part of the parent's save transaction.
+    # This does _not_ actually destroy the record instantly, rather child record will be destroyed
+    # when <tt>parent.save</tt> is called.
+    #
+    # Only useful if the <tt>:autosave</tt> option on the parent is enabled for this associated model.
+    def mark_for_destruction: () -> untyped
+
+    # Returns whether or not this record will be destroyed as part of the parent's save transaction.
+    #
+    # Only useful if the <tt>:autosave</tt> option on the parent is enabled for this associated model.
+    def marked_for_destruction?: () -> untyped
+
+    # Records the association that is being destroyed and destroying this
+    # record in the process.
+    def destroyed_by_association=: (untyped reflection) -> untyped
+
+    # Returns the association for the parent being destroyed.
+    #
+    # Used to avoid updating the counter cache unnecessarily.
+    def destroyed_by_association: () -> untyped
+
+    # Returns whether or not this record has been changed in any way (including whether
+    # any of its nested autosave associations are likewise changed)
+    def changed_for_autosave?: () -> untyped
+
+    # Returns the record for an association collection that should be validated
+    # or saved. If +autosave+ is +false+ only new records will be returned,
+    # unless the parent is/was a new record itself.
+    def associated_records_to_validate_or_save: (untyped association, untyped new_record, untyped autosave) -> untyped
+
+    # go through nested autosave associations that are loaded in memory (without loading
+    # any new ones), and return true if is changed for autosave
+    def nested_records_changed_for_autosave?: () -> (::FalseClass | untyped)
+
+    # Validate the association if <tt>:validate</tt> or <tt>:autosave</tt> is
+    # turned on for the association.
+    def validate_single_association: (untyped reflection) -> untyped
+
+    # Validate the associated records if <tt>:validate</tt> or
+    # <tt>:autosave</tt> is turned on for the association specified by
+    # +reflection+.
+    def validate_collection_association: (untyped reflection) -> untyped
+
+    # Returns whether or not the association is valid and applies any errors to
+    # the parent, <tt>self</tt>, if it wasn't. Skips any <tt>:autosave</tt>
+    # enabled records if they're marked_for_destruction? or destroyed.
+    def association_valid?: (untyped reflection, untyped record, ?untyped? index) -> (::TrueClass | untyped)
+
+    def normalize_reflection_attribute: (untyped indexed_attribute, untyped reflection, untyped index, untyped attribute) -> untyped
+
+    # Is used as a before_save callback to check while saving a collection
+    # association whether or not the parent was a new record before saving.
+    def before_save_collection_association: () -> untyped
+
+    def after_save_collection_association: () -> untyped
+
+    # Saves any new associated records, or all loaded autosave associations if
+    # <tt>:autosave</tt> is enabled on the association.
+    #
+    # In addition, it destroys all children that were marked for destruction
+    # with #mark_for_destruction.
+    #
+    # This all happens inside a transaction, _if_ the Transactions module is included into
+    # ActiveRecord::Base after the AutosaveAssociation module, which it does by default.
+    def save_collection_association: (untyped reflection) -> untyped
+
+    # Saves the associated record if it's new or <tt>:autosave</tt> is enabled
+    # on the association.
+    #
+    # In addition, it will destroy the association if it was marked for
+    # destruction with #mark_for_destruction.
+    #
+    # This all happens inside a transaction, _if_ the Transactions module is included into
+    # ActiveRecord::Base after the AutosaveAssociation module, which it does by default.
+    def save_has_one_association: (untyped reflection) -> untyped
+
+    # If the record is new or it has changed, returns true.
+    def record_changed?: (untyped reflection, untyped record, untyped key) -> untyped
+
+    def association_foreign_key_changed?: (untyped reflection, untyped record, untyped key) -> (::FalseClass | untyped)
+
+    # Saves the associated record if it's new or <tt>:autosave</tt> is enabled.
+    #
+    # In addition, it will destroy the association if it was marked for destruction.
+    def save_belongs_to_association: (untyped reflection) -> (nil | untyped)
+
+    def custom_validation_context?: () -> untyped
+
+    def _ensure_no_duplicate_errors: () -> untyped
+  end
+end
+
+module ActiveRecord
+  # nodoc:
+  # = Active Record
+  #
+  # Active Record objects don't specify their attributes directly, but rather infer them from
+  # the table definition with which they're linked. Adding, removing, and changing attributes
+  # and their type is done directly in the database. Any change is instantly reflected in the
+  # Active Record objects. The mapping that binds a given Active Record class to a certain
+  # database table will happen automatically in most common cases, but can be overwritten for the uncommon ones.
+  #
+  # See the mapping rules in table_name and the full example in link:files/activerecord/README_rdoc.html for more insight.
+  #
+  # == Creation
+  #
+  # Active Records accept constructor parameters either in a hash or as a block. The hash
+  # method is especially useful when you're receiving the data from somewhere else, like an
+  # HTTP request. It works like this:
+  #
+  #   user = User.new(name: "David", occupation: "Code Artist")
+  #   user.name # => "David"
+  #
+  # You can also use block initialization:
+  #
+  #   user = User.new do |u|
+  #     u.name = "David"
+  #     u.occupation = "Code Artist"
+  #   end
+  #
+  # And of course you can just create a bare object and specify the attributes after the fact:
+  #
+  #   user = User.new
+  #   user.name = "David"
+  #   user.occupation = "Code Artist"
+  #
+  # == Conditions
+  #
+  # Conditions can either be specified as a string, array, or hash representing the WHERE-part of an SQL statement.
+  # The array form is to be used when the condition input is tainted and requires sanitization. The string form can
+  # be used for statements that don't involve tainted data. The hash form works much like the array form, except
+  # only equality and range is possible. Examples:
+  #
+  #   class User < ActiveRecord::Base
+  #     def self.authenticate_unsafely(user_name, password)
+  #       where("user_name = '#{user_name}' AND password = '#{password}'").first
+  #     end
+  #
+  #     def self.authenticate_safely(user_name, password)
+  #       where("user_name = ? AND password = ?", user_name, password).first
+  #     end
+  #
+  #     def self.authenticate_safely_simply(user_name, password)
+  #       where(user_name: user_name, password: password).first
+  #     end
+  #   end
+  #
+  # The <tt>authenticate_unsafely</tt> method inserts the parameters directly into the query
+  # and is thus susceptible to SQL-injection attacks if the <tt>user_name</tt> and +password+
+  # parameters come directly from an HTTP request. The <tt>authenticate_safely</tt> and
+  # <tt>authenticate_safely_simply</tt> both will sanitize the <tt>user_name</tt> and +password+
+  # before inserting them in the query, which will ensure that an attacker can't escape the
+  # query and fake the login (or worse).
+  #
+  # When using multiple parameters in the conditions, it can easily become hard to read exactly
+  # what the fourth or fifth question mark is supposed to represent. In those cases, you can
+  # resort to named bind variables instead. That's done by replacing the question marks with
+  # symbols and supplying a hash with values for the matching symbol keys:
+  #
+  #   Company.where(
+  #     "id = :id AND name = :name AND division = :division AND created_at > :accounting_date",
+  #     { id: 3, name: "37signals", division: "First", accounting_date: '2005-01-01' }
+  #   ).first
+  #
+  # Similarly, a simple hash without a statement will generate conditions based on equality with the SQL AND
+  # operator. For instance:
+  #
+  #   Student.where(first_name: "Harvey", status: 1)
+  #   Student.where(params[:student])
+  #
+  # A range may be used in the hash to use the SQL BETWEEN operator:
+  #
+  #   Student.where(grade: 9..12)
+  #
+  # An array may be used in the hash to use the SQL IN operator:
+  #
+  #   Student.where(grade: [9,11,12])
+  #
+  # When joining tables, nested hashes or keys written in the form 'table_name.column_name'
+  # can be used to qualify the table name of a particular condition. For instance:
+  #
+  #   Student.joins(:schools).where(schools: { category: 'public' })
+  #   Student.joins(:schools).where('schools.category' => 'public' )
+  #
+  # == Overwriting default accessors
+  #
+  # All column values are automatically available through basic accessors on the Active Record
+  # object, but sometimes you want to specialize this behavior. This can be done by overwriting
+  # the default accessors (using the same name as the attribute) and calling
+  # +super+ to actually change things.
+  #
+  #   class Song < ActiveRecord::Base
+  #     # Uses an integer of seconds to hold the length of the song
+  #
+  #     def length=(minutes)
+  #       super(minutes.to_i * 60)
+  #     end
+  #
+  #     def length
+  #       super / 60
+  #     end
+  #   end
+  #
+  # == Attribute query methods
+  #
+  # In addition to the basic accessors, query methods are also automatically available on the Active Record object.
+  # Query methods allow you to test whether an attribute value is present.
+  # Additionally, when dealing with numeric values, a query method will return false if the value is zero.
+  #
+  # For example, an Active Record User with the <tt>name</tt> attribute has a <tt>name?</tt> method that you can call
+  # to determine whether the user has a name:
+  #
+  #   user = User.new(name: "David")
+  #   user.name? # => true
+  #
+  #   anonymous = User.new(name: "")
+  #   anonymous.name? # => false
+  #
+  # == Accessing attributes before they have been typecasted
+  #
+  # Sometimes you want to be able to read the raw attribute data without having the column-determined
+  # typecast run its course first. That can be done by using the <tt><attribute>_before_type_cast</tt>
+  # accessors that all attributes have. For example, if your Account model has a <tt>balance</tt> attribute,
+  # you can call <tt>account.balance_before_type_cast</tt> or <tt>account.id_before_type_cast</tt>.
+  #
+  # This is especially useful in validation situations where the user might supply a string for an
+  # integer field and you want to display the original string back in an error message. Accessing the
+  # attribute normally would typecast the string to 0, which isn't what you want.
+  #
+  # == Dynamic attribute-based finders
+  #
+  # Dynamic attribute-based finders are a mildly deprecated way of getting (and/or creating) objects
+  # by simple queries without turning to SQL. They work by appending the name of an attribute
+  # to <tt>find_by_</tt> like <tt>Person.find_by_user_name</tt>.
+  # Instead of writing <tt>Person.find_by(user_name: user_name)</tt>, you can use
+  # <tt>Person.find_by_user_name(user_name)</tt>.
+  #
+  # It's possible to add an exclamation point (!) on the end of the dynamic finders to get them to raise an
+  # ActiveRecord::RecordNotFound error if they do not return any records,
+  # like <tt>Person.find_by_last_name!</tt>.
+  #
+  # It's also possible to use multiple attributes in the same <tt>find_by_</tt> by separating them with
+  # "_and_".
+  #
+  #  Person.find_by(user_name: user_name, password: password)
+  #  Person.find_by_user_name_and_password(user_name, password) # with dynamic finder
+  #
+  # It's even possible to call these dynamic finder methods on relations and named scopes.
+  #
+  #   Payment.order("created_on").find_by_amount(50)
+  #
+  # == Saving arrays, hashes, and other non-mappable objects in text columns
+  #
+  # Active Record can serialize any object in text columns using YAML. To do so, you must
+  # specify this with a call to the class method
+  # {serialize}[rdoc-ref:AttributeMethods::Serialization::ClassMethods#serialize].
+  # This makes it possible to store arrays, hashes, and other non-mappable objects without doing
+  # any additional work.
+  #
+  #   class User < ActiveRecord::Base
+  #     serialize :preferences
+  #   end
+  #
+  #   user = User.create(preferences: { "background" => "black", "display" => large })
+  #   User.find(user.id).preferences # => { "background" => "black", "display" => large }
+  #
+  # You can also specify a class option as the second parameter that'll raise an exception
+  # if a serialized object is retrieved as a descendant of a class not in the hierarchy.
+  #
+  #   class User < ActiveRecord::Base
+  #     serialize :preferences, Hash
+  #   end
+  #
+  #   user = User.create(preferences: %w( one two three ))
+  #   User.find(user.id).preferences    # raises SerializationTypeMismatch
+  #
+  # When you specify a class option, the default value for that attribute will be a new
+  # instance of that class.
+  #
+  #   class User < ActiveRecord::Base
+  #     serialize :preferences, OpenStruct
+  #   end
+  #
+  #   user = User.new
+  #   user.preferences.theme_color = "red"
+  #
+  #
+  # == Single table inheritance
+  #
+  # Active Record allows inheritance by storing the name of the class in a
+  # column that is named "type" by default. See ActiveRecord::Inheritance for
+  # more details.
+  #
+  # == Connection to multiple databases in different models
+  #
+  # Connections are usually created through
+  # {ActiveRecord::Base.establish_connection}[rdoc-ref:ConnectionHandling#establish_connection] and retrieved
+  # by ActiveRecord::Base.connection. All classes inheriting from ActiveRecord::Base will use this
+  # connection. But you can also set a class-specific connection. For example, if Course is an
+  # ActiveRecord::Base, but resides in a different database, you can just say <tt>Course.establish_connection</tt>
+  # and Course and all of its subclasses will use this connection instead.
+  #
+  # This feature is implemented by keeping a connection pool in ActiveRecord::Base that is
+  # a hash indexed by the class. If a connection is requested, the
+  # {ActiveRecord::Base.retrieve_connection}[rdoc-ref:ConnectionHandling#retrieve_connection] method
+  # will go up the class-hierarchy until a connection is found in the connection pool.
+  #
+  # == Exceptions
+  #
+  # * ActiveRecordError - Generic error class and superclass of all other errors raised by Active Record.
+  # * AdapterNotSpecified - The configuration hash used in
+  #   {ActiveRecord::Base.establish_connection}[rdoc-ref:ConnectionHandling#establish_connection]
+  #   didn't include an <tt>:adapter</tt> key.
+  # * AdapterNotFound - The <tt>:adapter</tt> key used in
+  #   {ActiveRecord::Base.establish_connection}[rdoc-ref:ConnectionHandling#establish_connection]
+  #   specified a non-existent adapter
+  #   (or a bad spelling of an existing one).
+  # * AssociationTypeMismatch - The object assigned to the association wasn't of the type
+  #   specified in the association definition.
+  # * AttributeAssignmentError - An error occurred while doing a mass assignment through the
+  #   {ActiveRecord::Base#attributes=}[rdoc-ref:AttributeAssignment#attributes=] method.
+  #   You can inspect the +attribute+ property of the exception object to determine which attribute
+  #   triggered the error.
+  # * ConnectionNotEstablished - No connection has been established.
+  #   Use {ActiveRecord::Base.establish_connection}[rdoc-ref:ConnectionHandling#establish_connection] before querying.
+  # * MultiparameterAssignmentErrors - Collection of errors that occurred during a mass assignment using the
+  #   {ActiveRecord::Base#attributes=}[rdoc-ref:AttributeAssignment#attributes=] method.
+  #   The +errors+ property of this exception contains an array of
+  #   AttributeAssignmentError
+  #   objects that should be inspected to determine which attributes triggered the errors.
+  # * RecordInvalid - raised by {ActiveRecord::Base#save!}[rdoc-ref:Persistence#save!] and
+  #   {ActiveRecord::Base.create!}[rdoc-ref:Persistence::ClassMethods#create!]
+  #   when the record is invalid.
+  # * RecordNotFound - No record responded to the {ActiveRecord::Base.find}[rdoc-ref:FinderMethods#find] method.
+  #   Either the row with the given ID doesn't exist or the row didn't meet the additional restrictions.
+  #   Some {ActiveRecord::Base.find}[rdoc-ref:FinderMethods#find] calls do not raise this exception to signal
+  #   nothing was found, please check its documentation for further details.
+  # * SerializationTypeMismatch - The serialized object wasn't of the class specified as the second parameter.
+  # * StatementInvalid - The database server rejected the SQL statement. The precise error is added in the message.
+  #
+  # *Note*: The attributes listed are class-level attributes (accessible from both the class and instance level).
+  # So it's possible to assign a logger to the class through <tt>Base.logger=</tt> which will then be used by all
+  # instances in the current object space.
+  class Base
+    extend ActiveModel::Naming
+
+    extend ActiveSupport::Benchmarkable
+
+    extend ActiveSupport::DescendantsTracker
+
+    extend ConnectionHandling
+
+    extend QueryCache::ClassMethods
+
+    extend Querying
+
+    extend Translation
+
+    extend DynamicMatchers
+
+    extend Explain
+
+    extend Enum
+
+    extend Delegation::DelegateCache
+
+    extend Aggregations::ClassMethods
+
+    include Core
+
+    include Persistence
+
+    include ReadonlyAttributes
+
+    include ModelSchema
+
+    include Inheritance
+
+    include Scoping
+
+    include Sanitization
+
+    include AttributeAssignment
+
+    include ActiveModel::Conversion
+
+    include Integration
+
+    include Validations
+
+    include CounterCache
+
+    include Attributes
+
+    include AttributeDecorators
+
+    include Locking::Optimistic
+
+    include Locking::Pessimistic
+
+    include DefineCallbacks
+
+    include AttributeMethods
+
+    include Callbacks
+
+    include Timestamp
+
+    include Associations
+
+    include ActiveModel::SecurePassword
+
+    include AutosaveAssociation
+
+    include NestedAttributes
+
+    include Transactions
+
+    include TouchLater
+
+    include NoTouching
+
+    include Reflection
+
+    include Serialization
+
+    include Store
+
+    include SecureToken
+
+    include Suppressor
+  end
+end
+
+module ActiveRecord
+  # = Active Record \Callbacks
+  #
+  # \Callbacks are hooks into the life cycle of an Active Record object that allow you to trigger logic
+  # before or after an alteration of the object state. This can be used to make sure that associated and
+  # dependent objects are deleted when {ActiveRecord::Base#destroy}[rdoc-ref:Persistence#destroy] is called (by overwriting +before_destroy+) or
+  # to massage attributes before they're validated (by overwriting +before_validation+).
+  # As an example of the callbacks initiated, consider the {ActiveRecord::Base#save}[rdoc-ref:Persistence#save] call for a new record:
+  #
+  # * (-) <tt>save</tt>
+  # * (-) <tt>valid</tt>
+  # * (1) <tt>before_validation</tt>
+  # * (-) <tt>validate</tt>
+  # * (2) <tt>after_validation</tt>
+  # * (3) <tt>before_save</tt>
+  # * (4) <tt>before_create</tt>
+  # * (-) <tt>create</tt>
+  # * (5) <tt>after_create</tt>
+  # * (6) <tt>after_save</tt>
+  # * (7) <tt>after_commit</tt>
+  #
+  # Also, an <tt>after_rollback</tt> callback can be configured to be triggered whenever a rollback is issued.
+  # Check out ActiveRecord::Transactions for more details about <tt>after_commit</tt> and
+  # <tt>after_rollback</tt>.
+  #
+  # Additionally, an <tt>after_touch</tt> callback is triggered whenever an
+  # object is touched.
+  #
+  # Lastly an <tt>after_find</tt> and <tt>after_initialize</tt> callback is triggered for each object that
+  # is found and instantiated by a finder, with <tt>after_initialize</tt> being triggered after new objects
+  # are instantiated as well.
+  #
+  # There are nineteen callbacks in total, which give you immense power to react and prepare for each state in the
+  # Active Record life cycle. The sequence for calling {ActiveRecord::Base#save}[rdoc-ref:Persistence#save] for an existing record is similar,
+  # except that each <tt>_create</tt> callback is replaced by the corresponding <tt>_update</tt> callback.
+  #
+  # Examples:
+  #   class CreditCard < ActiveRecord::Base
+  #     # Strip everything but digits, so the user can specify "555 234 34" or
+  #     # "5552-3434" and both will mean "55523434"
+  #     before_validation(on: :create) do
+  #       self.number = number.gsub(/[^0-9]/, "") if attribute_present?("number")
+  #     end
+  #   end
+  #
+  #   class Subscription < ActiveRecord::Base
+  #     before_create :record_signup
+  #
+  #     private
+  #       def record_signup
+  #         self.signed_up_on = Date.today
+  #       end
+  #   end
+  #
+  #   class Firm < ActiveRecord::Base
+  #     # Disables access to the system, for associated clients and people when the firm is destroyed
+  #     before_destroy { |record| Person.where(firm_id: record.id).update_all(access: 'disabled')   }
+  #     before_destroy { |record| Client.where(client_of: record.id).update_all(access: 'disabled') }
+  #   end
+  #
+  # == Inheritable callback queues
+  #
+  # Besides the overwritable callback methods, it's also possible to register callbacks through the
+  # use of the callback macros. Their main advantage is that the macros add behavior into a callback
+  # queue that is kept intact down through an inheritance hierarchy.
+  #
+  #   class Topic < ActiveRecord::Base
+  #     before_destroy :destroy_author
+  #   end
+  #
+  #   class Reply < Topic
+  #     before_destroy :destroy_readers
+  #   end
+  #
+  # Now, when <tt>Topic#destroy</tt> is run only +destroy_author+ is called. When <tt>Reply#destroy</tt> is
+  # run, both +destroy_author+ and +destroy_readers+ are called.
+  #
+  # *IMPORTANT:* In order for inheritance to work for the callback queues, you must specify the
+  # callbacks before specifying the associations. Otherwise, you might trigger the loading of a
+  # child before the parent has registered the callbacks and they won't be inherited.
+  #
+  # == Types of callbacks
+  #
+  # There are four types of callbacks accepted by the callback macros: Method references (symbol), callback objects,
+  # inline methods (using a proc). Method references and callback objects
+  # are the recommended approaches, inline methods using a proc are sometimes appropriate (such as for
+  # creating mix-ins).
+  #
+  # The method reference callbacks work by specifying a protected or private method available in the object, like this:
+  #
+  #   class Topic < ActiveRecord::Base
+  #     before_destroy :delete_parents
+  #
+  #     private
+  #       def delete_parents
+  #         self.class.delete_by(parent_id: id)
+  #       end
+  #   end
+  #
+  # The callback objects have methods named after the callback called with the record as the only parameter, such as:
+  #
+  #   class BankAccount < ActiveRecord::Base
+  #     before_save      EncryptionWrapper.new
+  #     after_save       EncryptionWrapper.new
+  #     after_initialize EncryptionWrapper.new
+  #   end
+  #
+  #   class EncryptionWrapper
+  #     def before_save(record)
+  #       record.credit_card_number = encrypt(record.credit_card_number)
+  #     end
+  #
+  #     def after_save(record)
+  #       record.credit_card_number = decrypt(record.credit_card_number)
+  #     end
+  #
+  #     alias_method :after_initialize, :after_save
+  #
+  #     private
+  #       def encrypt(value)
+  #         # Secrecy is committed
+  #       end
+  #
+  #       def decrypt(value)
+  #         # Secrecy is unveiled
+  #       end
+  #   end
+  #
+  # So you specify the object you want to be messaged on a given callback. When that callback is triggered, the object has
+  # a method by the name of the callback messaged. You can make these callbacks more flexible by passing in other
+  # initialization data such as the name of the attribute to work with:
+  #
+  #   class BankAccount < ActiveRecord::Base
+  #     before_save      EncryptionWrapper.new("credit_card_number")
+  #     after_save       EncryptionWrapper.new("credit_card_number")
+  #     after_initialize EncryptionWrapper.new("credit_card_number")
+  #   end
+  #
+  #   class EncryptionWrapper
+  #     def initialize(attribute)
+  #       @attribute = attribute
+  #     end
+  #
+  #     def before_save(record)
+  #       record.send("#{@attribute}=", encrypt(record.send("#{@attribute}")))
+  #     end
+  #
+  #     def after_save(record)
+  #       record.send("#{@attribute}=", decrypt(record.send("#{@attribute}")))
+  #     end
+  #
+  #     alias_method :after_initialize, :after_save
+  #
+  #     private
+  #       def encrypt(value)
+  #         # Secrecy is committed
+  #       end
+  #
+  #       def decrypt(value)
+  #         # Secrecy is unveiled
+  #       end
+  #   end
+  #
+  # == <tt>before_validation*</tt> returning statements
+  #
+  # If the +before_validation+ callback throws +:abort+, the process will be
+  # aborted and {ActiveRecord::Base#save}[rdoc-ref:Persistence#save] will return +false+.
+  # If {ActiveRecord::Base#save!}[rdoc-ref:Persistence#save!] is called it will raise an ActiveRecord::RecordInvalid exception.
+  # Nothing will be appended to the errors object.
+  #
+  # == Canceling callbacks
+  #
+  # If a <tt>before_*</tt> callback throws +:abort+, all the later callbacks and
+  # the associated action are cancelled.
+  # Callbacks are generally run in the order they are defined, with the exception of callbacks defined as
+  # methods on the model, which are called last.
+  #
+  # == Ordering callbacks
+  #
+  # Sometimes the code needs that the callbacks execute in a specific order. For example, a +before_destroy+
+  # callback (+log_children+ in this case) should be executed before the children get destroyed by the
+  # <tt>dependent: :destroy</tt> option.
+  #
+  # Let's look at the code below:
+  #
+  #   class Topic < ActiveRecord::Base
+  #     has_many :children, dependent: :destroy
+  #
+  #     before_destroy :log_children
+  #
+  #     private
+  #       def log_children
+  #         # Child processing
+  #       end
+  #   end
+  #
+  # In this case, the problem is that when the +before_destroy+ callback is executed, the children are not available
+  # because the {ActiveRecord::Base#destroy}[rdoc-ref:Persistence#destroy] callback gets executed first.
+  # You can use the +prepend+ option on the +before_destroy+ callback to avoid this.
+  #
+  #   class Topic < ActiveRecord::Base
+  #     has_many :children, dependent: :destroy
+  #
+  #     before_destroy :log_children, prepend: true
+  #
+  #     private
+  #       def log_children
+  #         # Child processing
+  #       end
+  #   end
+  #
+  # This way, the +before_destroy+ gets executed before the <tt>dependent: :destroy</tt> is called, and the data is still available.
+  #
+  # Also, there are cases when you want several callbacks of the same type to
+  # be executed in order.
+  #
+  # For example:
+  #
+  #   class Topic < ActiveRecord::Base
+  #     has_many :children
+  #
+  #     after_save :log_children
+  #     after_save :do_something_else
+  #
+  #     private
+  #
+  #     def log_children
+  #       # Child processing
+  #     end
+  #
+  #     def do_something_else
+  #       # Something else
+  #     end
+  #   end
+  #
+  # In this case the +log_children+ gets executed before +do_something_else+.
+  # The same applies to all non-transactional callbacks.
+  #
+  # In case there are multiple transactional callbacks as seen below, the order
+  # is reversed.
+  #
+  # For example:
+  #
+  #   class Topic < ActiveRecord::Base
+  #     has_many :children
+  #
+  #     after_commit :log_children
+  #     after_commit :do_something_else
+  #
+  #     private
+  #
+  #     def log_children
+  #       # Child processing
+  #     end
+  #
+  #     def do_something_else
+  #       # Something else
+  #     end
+  #   end
+  #
+  # In this case the +do_something_else+ gets executed before +log_children+.
+  #
+  # == \Transactions
+  #
+  # The entire callback chain of a {#save}[rdoc-ref:Persistence#save], {#save!}[rdoc-ref:Persistence#save!],
+  # or {#destroy}[rdoc-ref:Persistence#destroy] call runs within a transaction. That includes <tt>after_*</tt> hooks.
+  # If everything goes fine a COMMIT is executed once the chain has been completed.
+  #
+  # If a <tt>before_*</tt> callback cancels the action a ROLLBACK is issued. You
+  # can also trigger a ROLLBACK raising an exception in any of the callbacks,
+  # including <tt>after_*</tt> hooks. Note, however, that in that case the client
+  # needs to be aware of it because an ordinary {#save}[rdoc-ref:Persistence#save] will raise such exception
+  # instead of quietly returning +false+.
+  #
+  # == Debugging callbacks
+  #
+  # The callback chain is accessible via the <tt>_*_callbacks</tt> method on an object. Active Model \Callbacks support
+  # <tt>:before</tt>, <tt>:after</tt> and <tt>:around</tt> as values for the <tt>kind</tt> property. The <tt>kind</tt> property
+  # defines what part of the chain the callback runs in.
+  #
+  # To find all callbacks in the before_save callback chain:
+  #
+  #   Topic._save_callbacks.select { |cb| cb.kind.eql?(:before) }
+  #
+  # Returns an array of callback objects that form the before_save chain.
+  #
+  # To further check if the before_save chain contains a proc defined as <tt>rest_when_dead</tt> use the <tt>filter</tt> property of the callback object:
+  #
+  #   Topic._save_callbacks.select { |cb| cb.kind.eql?(:before) }.collect(&:filter).include?(:rest_when_dead)
+  #
+  # Returns true or false depending on whether the proc is contained in the before_save callback chain on a Topic model.
+  #
+  module Callbacks
+    extend ActiveSupport::Concern
+
+    CALLBACKS: ::Array[untyped]
+
+    def destroy: () -> untyped
+
+    def touch: () -> untyped
+
+    def increment!: (untyped attribute, ?::Integer by, ?touch: untyped? touch) -> untyped
+
+    def create_or_update: () -> untyped
+
+    def _create_record: () -> untyped
+
+    def _update_record: () -> untyped
+  end
+end
+
+module ActiveRecord
+  module Coders
+    class JSON
+      # :nodoc:
+      # :nodoc:
+      def self.dump: (untyped obj) -> untyped
+
+      def self.load: (untyped json) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module Coders
+    class YAMLColumn
+      # :nodoc:
+      # :nodoc:
+      attr_accessor object_class: untyped
+
+      def initialize: (untyped attr_name, ?untyped object_class) -> untyped
+
+      def dump: (untyped obj) -> (nil | untyped)
+
+      def load: (untyped yaml) -> untyped
+
+      def assert_valid_value: (untyped obj, action: untyped action) -> untyped
+
+      def check_arity_of_constructor: () -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  # Raised when a connection could not be obtained within the connection
+  # acquisition timeout period: because max connections in pool
+  # are in use.
+  class ConnectionTimeoutError < ConnectionNotEstablished
+  end
+
+  # Raised when a pool was unable to get ahold of all its connections
+  # to perform a "group" action such as
+  # {ActiveRecord::Base.connection_pool.disconnect!}[rdoc-ref:ConnectionAdapters::ConnectionPool#disconnect!]
+  # or {ActiveRecord::Base.clear_reloadable_connections!}[rdoc-ref:ConnectionAdapters::ConnectionHandler#clear_reloadable_connections!].
+  class ExclusiveConnectionTimeoutError < ConnectionTimeoutError
+  end
+
+  module ConnectionAdapters
+    module AbstractPool
+      # :nodoc:
+      def get_schema_cache: (untyped connection) -> untyped
+
+      def set_schema_cache: (untyped cache) -> untyped
+    end
+
+    class NullPool
+      # :nodoc:
+      include ConnectionAdapters::AbstractPool
+
+      def initialize: () -> untyped
+    end
+
+    # Connection pool base class for managing Active Record database
+    # connections.
+    #
+    # == Introduction
+    #
+    # A connection pool synchronizes thread access to a limited number of
+    # database connections. The basic idea is that each thread checks out a
+    # database connection from the pool, uses that connection, and checks the
+    # connection back in. ConnectionPool is completely thread-safe, and will
+    # ensure that a connection cannot be used by two threads at the same time,
+    # as long as ConnectionPool's contract is correctly followed. It will also
+    # handle cases in which there are more threads than connections: if all
+    # connections have been checked out, and a thread tries to checkout a
+    # connection anyway, then ConnectionPool will wait until some other thread
+    # has checked in a connection.
+    #
+    # == Obtaining (checking out) a connection
+    #
+    # Connections can be obtained and used from a connection pool in several
+    # ways:
+    #
+    # 1. Simply use {ActiveRecord::Base.connection}[rdoc-ref:ConnectionHandling.connection]
+    #    as with Active Record 2.1 and
+    #    earlier (pre-connection-pooling). Eventually, when you're done with
+    #    the connection(s) and wish it to be returned to the pool, you call
+    #    {ActiveRecord::Base.clear_active_connections!}[rdoc-ref:ConnectionAdapters::ConnectionHandler#clear_active_connections!].
+    #    This will be the default behavior for Active Record when used in conjunction with
+    #    Action Pack's request handling cycle.
+    # 2. Manually check out a connection from the pool with
+    #    {ActiveRecord::Base.connection_pool.checkout}[rdoc-ref:#checkout]. You are responsible for
+    #    returning this connection to the pool when finished by calling
+    #    {ActiveRecord::Base.connection_pool.checkin(connection)}[rdoc-ref:#checkin].
+    # 3. Use {ActiveRecord::Base.connection_pool.with_connection(&block)}[rdoc-ref:#with_connection], which
+    #    obtains a connection, yields it as the sole argument to the block,
+    #    and returns it to the pool after the block completes.
+    #
+    # Connections in the pool are actually AbstractAdapter objects (or objects
+    # compatible with AbstractAdapter's interface).
+    #
+    # == Options
+    #
+    # There are several connection-pooling-related options that you can add to
+    # your database connection configuration:
+    #
+    # * +pool+: maximum number of connections the pool may manage (default 5).
+    # * +idle_timeout+: number of seconds that a connection will be kept
+    #   unused in the pool before it is automatically disconnected (default
+    #   300 seconds). Set this to zero to keep connections forever.
+    # * +checkout_timeout+: number of seconds to wait for a connection to
+    #   become available before giving up and raising a timeout error (default
+    #   5 seconds).
+    #
+    # -
+    # Synchronization policy:
+    # * all public methods can be called outside +synchronize+
+    # * access to these instance variables needs to be in +synchronize+:
+    #   * @connections
+    #   * @now_connecting
+    # * private methods that require being called in a +synchronize+ blocks
+    #   are now explicitly documented
+    class ConnectionPool
+      # Threadsafe, fair, LIFO queue.  Meant to be used by ConnectionPool
+      # with which it shares a Monitor.
+      class Queue
+        def initialize: (?untyped lock) -> untyped
+
+        # Test if any threads are currently waiting on the queue.
+        def any_waiting?: () -> untyped
+
+        # Returns the number of threads currently waiting on this
+        # queue.
+        def num_waiting: () -> untyped
+
+        # Add +element+ to the queue.  Never blocks.
+        def add: (untyped element) -> untyped
+
+        # If +element+ is in the queue, remove and return it, or +nil+.
+        def delete: (untyped element) -> untyped
+
+        # Remove all elements from the queue.
+        def clear: () -> untyped
+
+        # Remove the head of the queue.
+        #
+        # If +timeout+ is not given, remove and return the head the
+        # queue if the number of available elements is strictly
+        # greater than the number of threads currently waiting (that
+        # is, don't jump ahead in line).  Otherwise, return +nil+.
+        #
+        # If +timeout+ is given, block if there is no element
+        # available, waiting up to +timeout+ seconds for an element to
+        # become available.
+        #
+        # Raises:
+        # - ActiveRecord::ConnectionTimeoutError if +timeout+ is given and no element
+        # becomes available within +timeout+ seconds,
+        def poll: (?untyped? timeout) -> untyped
+
+        def internal_poll: (untyped timeout) -> untyped
+
+        def synchronize: () { () -> untyped } -> untyped
+
+        # Test if the queue currently contains any elements.
+        def any?: () -> untyped
+
+        # A thread can remove an element from the queue without
+        # waiting if and only if the number of currently available
+        # connections is strictly greater than the number of waiting
+        # threads.
+        def can_remove_no_wait?: () -> untyped
+
+        # Removes and returns the head of the queue if possible, or +nil+.
+        def remove: () -> untyped
+
+        # Remove and return the head the queue if the number of
+        # available elements is strictly greater than the number of
+        # threads currently waiting.  Otherwise, return +nil+.
+        def no_wait_poll: () -> untyped
+
+        # Waits on the queue up to +timeout+ seconds, then removes and
+        # returns the head of the queue.
+        def wait_poll: (untyped timeout) -> untyped
+      end
+
+      module BiasableQueue
+        class BiasedConditionVariable
+          # Adds the ability to turn a basic fair FIFO queue into one
+          # biased to some thread.
+          # :nodoc:
+          # :nodoc:
+          # semantics of condition variables guarantee that +broadcast+, +broadcast_on_biased+,
+          # +signal+ and +wait+ methods are only called while holding a lock
+          def initialize: (untyped lock, untyped other_cond, untyped preferred_thread) -> untyped
+
+          def broadcast: () -> untyped
+
+          def broadcast_on_biased: () -> untyped
+
+          def signal: () -> untyped
+
+          def wait: (untyped timeout) -> untyped
+        end
+
+        def with_a_bias_for: (untyped thread) { () -> untyped } -> untyped
+      end
+
+      class ConnectionLeasingQueue < Queue
+        # Connections must be leased while holding the main pool mutex. This is
+        # an internal subclass that also +.leases+ returned connections while
+        # still in queue's critical section (queue synchronizes with the same
+        # <tt>@lock</tt> as the main pool) so that a returned connection is already
+        # leased and there is no need to re-enter synchronized block.
+        # :nodoc:
+        include BiasableQueue
+
+        def internal_poll: (untyped timeout) -> untyped
+      end
+
+      # Every +frequency+ seconds, the reaper will call +reap+ and +flush+ on
+      # +pool+. A reaper instantiated with a zero frequency will never reap
+      # the connection pool.
+      #
+      # Configure the frequency by setting +reaping_frequency+ in your database
+      # yaml file (default 60 seconds).
+      class Reaper
+        attr_reader pool: untyped
+
+        attr_reader frequency: untyped
+
+        def initialize: (untyped pool, untyped frequency) -> untyped
+
+        def self.register_pool: (untyped pool, untyped frequency) -> untyped
+
+        def self.spawn_thread: (untyped frequency) -> untyped
+
+        def run: () -> (nil | untyped)
+      end
+
+      include MonitorMixin
+
+      include QueryCache::ConnectionPoolConfiguration
+
+      include ConnectionAdapters::AbstractPool
+
+      attr_accessor automatic_reconnect: untyped
+
+      attr_accessor checkout_timeout: untyped
+
+      attr_accessor schema_cache: untyped
+
+      attr_reader spec: untyped
+
+      attr_reader size: untyped
+
+      attr_reader reaper: untyped
+
+      # Creates a new ConnectionPool object. +spec+ is a ConnectionSpecification
+      # object which describes database connection information (e.g. adapter,
+      # host name, username, password, etc), as well as the maximum size for
+      # this ConnectionPool.
+      #
+      # The default ConnectionPool maximum size is 5.
+      def initialize: (untyped spec) -> untyped
+
+      def lock_thread=: (untyped lock_thread) -> untyped
+
+      # Retrieve the connection associated with the current thread, or call
+      # #checkout to obtain one if necessary.
+      #
+      # #connection can be called any number of times; the connection is
+      # held in a cache keyed by a thread.
+      def connection: () -> untyped
+
+      # Returns true if there is an open connection being used for the current thread.
+      #
+      # This method only works for connections that have been obtained through
+      # #connection or #with_connection methods. Connections obtained through
+      # #checkout will not be detected by #active_connection?
+      def active_connection?: () -> untyped
+
+      # Signal that the thread is finished with the current connection.
+      # #release_connection releases the connection-thread association
+      # and returns the connection to the pool.
+      #
+      # This method only works for connections that have been obtained through
+      # #connection or #with_connection methods, connections obtained through
+      # #checkout will not be automatically released.
+      def release_connection: (?untyped owner_thread) -> untyped
+
+      # If a connection obtained through #connection or #with_connection methods
+      # already exists yield it to the block. If no such connection
+      # exists checkout a connection, yield it to the block, and checkin the
+      # connection when finished.
+      def with_connection: () { (untyped) -> untyped } -> untyped
+
+      # Returns true if a connection has already been opened.
+      def connected?: () -> untyped
+
+      # Returns an array containing the connections currently in the pool.
+      # Access to the array does not require synchronization on the pool because
+      # the array is newly created and not retained by the pool.
+      #
+      # However; this method bypasses the ConnectionPool's thread-safe connection
+      # access pattern. A returned connection may be owned by another thread,
+      # unowned, or by happen-stance owned by the calling thread.
+      #
+      # Calling methods on a connection without ownership is subject to the
+      # thread-safety guarantees of the underlying method. Many of the methods
+      # on connection adapter classes are inherently multi-thread unsafe.
+      def connections: () -> untyped
+
+      # Disconnects all connections in the pool, and clears the pool.
+      #
+      # Raises:
+      # - ActiveRecord::ExclusiveConnectionTimeoutError if unable to gain ownership of all
+      #   connections in the pool within a timeout interval (default duration is
+      #   <tt>spec.config[:checkout_timeout] * 2</tt> seconds).
+      def disconnect: (?bool raise_on_acquisition_timeout) -> untyped
+
+      # Disconnects all connections in the pool, and clears the pool.
+      #
+      # The pool first tries to gain ownership of all connections. If unable to
+      # do so within a timeout interval (default duration is
+      # <tt>spec.config[:checkout_timeout] * 2</tt> seconds), then the pool is forcefully
+      # disconnected without any regard for other connection owning threads.
+      def disconnect!: () -> untyped
+
+      def discard!: () -> untyped
+
+      # Clears the cache which maps classes and re-connects connections that
+      # require reloading.
+      #
+      # Raises:
+      # - ActiveRecord::ExclusiveConnectionTimeoutError if unable to gain ownership of all
+      #   connections in the pool within a timeout interval (default duration is
+      #   <tt>spec.config[:checkout_timeout] * 2</tt> seconds).
+      def clear_reloadable_connections: (?bool raise_on_acquisition_timeout) -> untyped
+
+      # Clears the cache which maps classes and re-connects connections that
+      # require reloading.
+      #
+      # The pool first tries to gain ownership of all connections. If unable to
+      # do so within a timeout interval (default duration is
+      # <tt>spec.config[:checkout_timeout] * 2</tt> seconds), then the pool forcefully
+      # clears the cache and reloads connections without any regard for other
+      # connection owning threads.
+      def clear_reloadable_connections!: () -> untyped
+
+      # Check-out a database connection from the pool, indicating that you want
+      # to use it. You should call #checkin when you no longer need this.
+      #
+      # This is done by either returning and leasing existing connection, or by
+      # creating a new connection and leasing it.
+      #
+      # If all connections are leased and the pool is at capacity (meaning the
+      # number of currently leased connections is greater than or equal to the
+      # size limit set), an ActiveRecord::ConnectionTimeoutError exception will be raised.
+      #
+      # Returns: an AbstractAdapter object.
+      #
+      # Raises:
+      # - ActiveRecord::ConnectionTimeoutError no connection can be obtained from the pool.
+      def checkout: (?untyped checkout_timeout) -> untyped
+
+      # Check-in a database connection back into the pool, indicating that you
+      # no longer need this connection.
+      #
+      # +conn+: an AbstractAdapter object, which was obtained by earlier by
+      # calling #checkout on this pool.
+      def checkin: (untyped conn) -> untyped
+
+      # Remove a connection from the connection pool. The connection will
+      # remain open and active but will no longer be managed by this pool.
+      def remove: (untyped conn) -> untyped
+
+      # Recover lost connections for the pool. A lost connection can occur if
+      # a programmer forgets to checkin a connection at the end of a thread
+      # or a thread dies unexpectedly.
+      def reap: () -> (nil | untyped)
+
+      # Disconnect all connections that have been idle for at least
+      # +minimum_idle+ seconds. Connections currently checked out, or that were
+      # checked in less than +minimum_idle+ seconds ago, are unaffected.
+      def flush: (?untyped minimum_idle) -> (nil | untyped)
+
+      # Disconnect all currently idle connections. Connections currently checked
+      # out are unaffected.
+      def flush!: () -> untyped
+
+      def num_waiting_in_queue: () -> untyped
+
+      # Return connection pool's usage statistic
+      # Example:
+      #
+      #    ActiveRecord::Base.connection_pool.stat # => { size: 15, connections: 1, busy: 1, dead: 0, idle: 0, waiting: 0, checkout_timeout: 5 }
+      def stat: () -> untyped
+
+      # -
+      # this is unfortunately not concurrent
+      def bulk_make_new_connections: (untyped num_new_conns_needed) -> untyped
+
+      # -
+      # From the discussion on GitHub:
+      #  https://github.com/rails/rails/pull/14938#commitcomment-6601951
+      # This hook-in method allows for easier monkey-patching fixes needed by
+      # JRuby users that use Fibers.
+      def connection_cache_key: (untyped thread) -> untyped
+
+      def current_thread: () -> untyped
+
+      # Take control of all existing connections so a "group" action such as
+      # reload/disconnect can be performed safely. It is no longer enough to
+      # wrap it in +synchronize+ because some pool's actions are allowed
+      # to be performed outside of the main +synchronize+ block.
+      def with_exclusively_acquired_all_connections: (?bool raise_on_acquisition_timeout) { () -> untyped } -> untyped
+
+      def attempt_to_checkout_all_existing_connections: (?bool raise_on_acquisition_timeout) -> untyped
+
+      # -
+      # Must be called in a synchronize block.
+      def checkout_for_exclusive_access: (untyped checkout_timeout) -> untyped
+
+      def with_new_connections_blocked: () { () -> untyped } -> untyped
+
+      # Acquire a connection by one of 1) immediately removing one
+      # from the queue of available connections, 2) creating a new
+      # connection if the pool is not at capacity, 3) waiting on the
+      # queue for a connection to become available.
+      #
+      # Raises:
+      # - ActiveRecord::ConnectionTimeoutError if a connection could not be acquired
+      #
+      # -
+      # Implementation detail: the connection returned by +acquire_connection+
+      # will already be "+connection.lease+ -ed" to the current thread.
+      def acquire_connection: (untyped checkout_timeout) -> untyped
+
+      # -
+      # if owner_thread param is omitted, this must be called in synchronize block
+      def remove_connection_from_thread_cache: (untyped conn, ?untyped owner_thread) -> untyped
+
+      alias release remove_connection_from_thread_cache
+
+      def new_connection: () -> untyped
+
+      # If the pool is not at a <tt>@size</tt> limit, establish new connection. Connecting
+      # to the DB is done outside main synchronized section.
+      # -
+      # Implementation constraint: a newly established connection returned by this
+      # method must be in the +.leased+ state.
+      def try_to_checkout_new_connection: () -> untyped
+
+      def adopt_connection: (untyped conn) -> untyped
+
+      def checkout_new_connection: () -> untyped
+
+      def checkout_and_verify: (untyped c) -> untyped
+    end
+
+    # ConnectionHandler is a collection of ConnectionPool objects. It is used
+    # for keeping separate connection pools that connect to different databases.
+    #
+    # For example, suppose that you have 5 models, with the following hierarchy:
+    #
+    #   class Author < ActiveRecord::Base
+    #   end
+    #
+    #   class BankAccount < ActiveRecord::Base
+    #   end
+    #
+    #   class Book < ActiveRecord::Base
+    #     establish_connection :library_db
+    #   end
+    #
+    #   class ScaryBook < Book
+    #   end
+    #
+    #   class GoodBook < Book
+    #   end
+    #
+    # And a database.yml that looked like this:
+    #
+    #   development:
+    #     database: my_application
+    #     host: localhost
+    #
+    #   library_db:
+    #     database: library
+    #     host: some.library.org
+    #
+    # Your primary database in the development environment is "my_application"
+    # but the Book model connects to a separate database called "library_db"
+    # (this can even be a database on a different machine).
+    #
+    # Book, ScaryBook and GoodBook will all use the same connection pool to
+    # "library_db" while Author, BankAccount, and any other models you create
+    # will use the default connection pool to "my_application".
+    #
+    # The various connection pools are managed by a single instance of
+    # ConnectionHandler accessible via ActiveRecord::Base.connection_handler.
+    # All Active Record models use this handler to determine the connection pool that they
+    # should use.
+    #
+    # The ConnectionHandler class is not coupled with the Active models, as it has no knowledge
+    # about the model. The model needs to pass a specification name to the handler,
+    # in order to look up the correct connection pool.
+    class ConnectionHandler
+      def self.create_owner_to_pool: () -> untyped
+
+      def self.unowned_pool_finalizer: (untyped pid_map) -> untyped
+
+      def self.discard_unowned_pools: (untyped pid_map) -> untyped
+
+      def initialize: () -> untyped
+
+      def prevent_writes: () -> untyped
+
+      def prevent_writes=: (untyped prevent_writes) -> untyped
+
+      # Prevent writing to the database regardless of role.
+      #
+      # In some cases you may want to prevent writes to the database
+      # even if you are on a database that can write. `while_preventing_writes`
+      # will prevent writes to the database for the duration of the block.
+      def while_preventing_writes: (?bool enabled) { () -> untyped } -> untyped
+
+      def connection_pool_list: () -> untyped
+
+      alias connection_pools connection_pool_list
+
+      def establish_connection: (untyped config) -> untyped
+
+      # Returns true if there are any active connections among the connection
+      # pools that the ConnectionHandler is managing.
+      def active_connections?: () -> untyped
+
+      # Returns any connections in use by the current thread back to the pool,
+      # and also returns connections to the pool cached by threads that are no
+      # longer alive.
+      def clear_active_connections!: () -> untyped
+
+      # Clears the cache which maps classes.
+      #
+      # See ConnectionPool#clear_reloadable_connections! for details.
+      def clear_reloadable_connections!: () -> untyped
+
+      def clear_all_connections!: () -> untyped
+
+      # Disconnects all currently idle connections.
+      #
+      # See ConnectionPool#flush! for details.
+      def flush_idle_connections!: () -> untyped
+
+      def retrieve_connection: (untyped spec_name) -> untyped
+
+      # Returns true if a connection that's accessible to this class has
+      # already been opened.
+      def connected?: (untyped spec_name) -> untyped
+
+      # Remove the connection for this class. This will close the active
+      # connection and the defined connection (if they exist). The result
+      # can be used as an argument for #establish_connection, for easily
+      # re-establishing the connection.
+      def remove_connection: (untyped spec_name) -> untyped
+
+      # Retrieving the connection pool happens a lot, so we cache it in @owner_to_pool.
+      # This makes retrieving the connection pool O(1) once the process is warm.
+      # When a connection is established or removed, we invalidate the cache.
+      def retrieve_connection_pool: (untyped spec_name) -> untyped
+
+      def owner_to_pool: () -> untyped
+
+      def pool_from_any_process_for: (untyped spec_name) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    # :nodoc:
+    module DatabaseLimits
+      def max_identifier_length: () -> 64
+
+      # Returns the maximum length of a table alias.
+      def table_alias_length: () -> untyped
+
+      # Returns the maximum length of a column name.
+      def column_name_length: () -> untyped
+
+      # Returns the maximum length of a table name.
+      def table_name_length: () -> untyped
+
+      # Returns the maximum allowed length for an index name. This
+      # limit is enforced by \Rails and is less than or equal to
+      # #index_name_length. The gap between
+      # #index_name_length is to allow internal \Rails
+      # operations to use prefixes in temporary operations.
+      def allowed_index_name_length: () -> untyped
+
+      # Returns the maximum length of an index name.
+      def index_name_length: () -> untyped
+
+      # Returns the maximum number of columns per table.
+      def columns_per_table: () -> 1024
+
+      # Returns the maximum number of indexes per table.
+      def indexes_per_table: () -> 16
+
+      # Returns the maximum number of columns in a multicolumn index.
+      def columns_per_multicolumn_index: () -> 16
+
+      # Returns the maximum number of elements in an IN (x,y,z) clause.
+      # +nil+ means no limit.
+      def in_clause_length: () -> nil
+
+      # Returns the maximum length of an SQL query.
+      def sql_query_length: () -> 1048575
+
+      # Returns maximum number of joins in a single query.
+      def joins_per_query: () -> 256
+
+      def bind_params_length: () -> 65535
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    # :nodoc:
+    module DatabaseStatements
+      def initialize: () -> untyped
+
+      # Converts an arel AST to SQL
+      def to_sql: (untyped arel_or_sql_string, ?untyped binds) -> untyped
+
+      def to_sql_and_binds: (untyped arel_or_sql_string, ?untyped binds) -> untyped
+
+      def cacheable_query: (untyped klass, untyped arel) -> ::Array[untyped]
+
+      # Returns an ActiveRecord::Result instance.
+      def select_all: (untyped arel, ?untyped? name, ?untyped binds, ?preparable: untyped? preparable) -> untyped
+
+      # Returns a record hash with the column names as keys and column values
+      # as values.
+      def select_one: (untyped arel, ?untyped? name, ?untyped binds) -> untyped
+
+      # Returns a single value from a record
+      def select_value: (untyped arel, ?untyped? name, ?untyped binds) -> untyped
+
+      # Returns an array of the values of the first column in a select:
+      #   select_values("SELECT id FROM companies LIMIT 3") => [1,2,3]
+      def select_values: (untyped arel, ?untyped? name, ?untyped binds) -> untyped
+
+      # Returns an array of arrays containing the field values.
+      # Order is the same as that returned by +columns+.
+      def select_rows: (untyped arel, ?untyped? name, ?untyped binds) -> untyped
+
+      def query_value: (untyped sql, ?untyped? name) -> untyped
+
+      def query_values: (untyped sql, ?untyped? name) -> untyped
+
+      def query: (untyped sql, ?untyped? name) -> untyped
+
+      # Determines whether the SQL statement is a write query.
+      def write_query?: (untyped sql) -> untyped
+
+      # Executes the SQL statement in the context of this connection and returns
+      # the raw result from the connection adapter.
+      # Note: depending on your database connector, the result returned by this
+      # method may be manually memory managed. Consider using the exec_query
+      # wrapper instead.
+      def execute: (untyped sql, ?untyped? name) -> untyped
+
+      # Executes +sql+ statement in the context of this connection using
+      # +binds+ as the bind substitutes. +name+ is logged along with
+      # the executed +sql+ statement.
+      def exec_query: (untyped sql, ?::String name, ?untyped binds, ?prepare: bool prepare) -> untyped
+
+      # Executes insert +sql+ statement in the context of this connection using
+      # +binds+ as the bind substitutes. +name+ is logged along with
+      # the executed +sql+ statement.
+      def exec_insert: (untyped sql, ?untyped? name, ?untyped binds, ?untyped? pk, ?untyped? sequence_name) -> untyped
+
+      # Executes delete +sql+ statement in the context of this connection using
+      # +binds+ as the bind substitutes. +name+ is logged along with
+      # the executed +sql+ statement.
+      def exec_delete: (untyped sql, ?untyped? name, ?untyped binds) -> untyped
+
+      # Executes update +sql+ statement in the context of this connection using
+      # +binds+ as the bind substitutes. +name+ is logged along with
+      # the executed +sql+ statement.
+      def exec_update: (untyped sql, ?untyped? name, ?untyped binds) -> untyped
+
+      def exec_insert_all: (untyped sql, untyped name) -> untyped
+
+      # Executes an INSERT query and returns the new record's ID
+      #
+      # +id_value+ will be returned unless the value is +nil+, in
+      # which case the database will attempt to calculate the last inserted
+      # id and return that value.
+      #
+      # If the next id was calculated in advance (as in Oracle), it should be
+      # passed in as +id_value+.
+      def insert: (untyped arel, ?untyped? name, ?untyped? pk, ?untyped? id_value, ?untyped? sequence_name, ?untyped binds) -> untyped
+
+      alias create insert
+
+      # Executes the update statement and returns the number of rows affected.
+      def update: (untyped arel, ?untyped? name, ?untyped binds) -> untyped
+
+      # Executes the delete statement and returns the number of rows affected.
+      def delete: (untyped arel, ?untyped? name, ?untyped binds) -> untyped
+
+      # Executes the truncate statement.
+      def truncate: (untyped table_name, ?untyped? name) -> untyped
+
+      def truncate_tables: (*untyped table_names) -> (nil | untyped)
+
+      # Runs the given block in a database transaction, and returns the result
+      # of the block.
+      #
+      # == Nested transactions support
+      #
+      # Most databases don't support true nested transactions. At the time of
+      # writing, the only database that supports true nested transactions that
+      # we're aware of, is MS-SQL.
+      #
+      # In order to get around this problem, #transaction will emulate the effect
+      # of nested transactions, by using savepoints:
+      # https://dev.mysql.com/doc/refman/5.7/en/savepoint.html
+      # Savepoints are supported by MySQL and PostgreSQL. SQLite3 version >= '3.6.8'
+      # supports savepoints.
+      #
+      # It is safe to call this method if a database transaction is already open,
+      # i.e. if #transaction is called within another #transaction block. In case
+      # of a nested call, #transaction will behave as follows:
+      #
+      # - The block will be run without doing anything. All database statements
+      #   that happen within the block are effectively appended to the already
+      #   open database transaction.
+      # - However, if +:requires_new+ is set, the block will be wrapped in a
+      #   database savepoint acting as a sub-transaction.
+      #
+      # === Caveats
+      #
+      # MySQL doesn't support DDL transactions. If you perform a DDL operation,
+      # then any created savepoints will be automatically released. For example,
+      # if you've created a savepoint, then you execute a CREATE TABLE statement,
+      # then the savepoint that was created will be automatically released.
+      #
+      # This means that, on MySQL, you shouldn't execute DDL operations inside
+      # a #transaction call that you know might create a savepoint. Otherwise,
+      # #transaction will raise exceptions when it tries to release the
+      # already-automatically-released savepoints:
+      #
+      #   Model.connection.transaction do  # BEGIN
+      #     Model.connection.transaction(requires_new: true) do  # CREATE SAVEPOINT active_record_1
+      #       Model.connection.create_table(...)
+      #       # active_record_1 now automatically released
+      #     end  # RELEASE SAVEPOINT active_record_1  <--- BOOM! database error!
+      #   end
+      #
+      # == Transaction isolation
+      #
+      # If your database supports setting the isolation level for a transaction, you can set
+      # it like so:
+      #
+      #   Post.transaction(isolation: :serializable) do
+      #     # ...
+      #   end
+      #
+      # Valid isolation levels are:
+      #
+      # * <tt>:read_uncommitted</tt>
+      # * <tt>:read_committed</tt>
+      # * <tt>:repeatable_read</tt>
+      # * <tt>:serializable</tt>
+      #
+      # You should consult the documentation for your database to understand the
+      # semantics of these different levels:
+      #
+      # * https://www.postgresql.org/docs/current/static/transaction-iso.html
+      # * https://dev.mysql.com/doc/refman/5.7/en/set-transaction.html
+      #
+      # An ActiveRecord::TransactionIsolationError will be raised if:
+      #
+      # * The adapter does not support setting the isolation level
+      # * You are joining an existing open transaction
+      # * You are creating a nested (savepoint) transaction
+      #
+      # The mysql2 and postgresql adapters support setting the transaction
+      # isolation level.
+      def transaction: (?joinable: bool joinable, ?isolation: untyped? isolation, ?requires_new: untyped? requires_new) { () -> untyped } -> untyped
+
+      attr_reader transaction_manager: untyped
+
+      def transaction_open?: () -> untyped
+
+      def reset_transaction: () -> untyped
+
+      # Register a record with the current transaction so that its after_commit and after_rollback callbacks
+      # can be called.
+      def add_transaction_record: (untyped record) -> untyped
+
+      def transaction_state: () -> untyped
+
+      # Begins the transaction (and turns off auto-committing).
+      def begin_db_transaction: () -> nil
+
+      def transaction_isolation_levels: () -> { read_uncommitted: "READ UNCOMMITTED", read_committed: "READ COMMITTED", repeatable_read: "REPEATABLE READ", serializable: "SERIALIZABLE" }
+
+      # Begins the transaction with the isolation level set. Raises an error by
+      # default; adapters that support setting the isolation level should implement
+      # this method.
+      def begin_isolated_db_transaction: (untyped isolation) -> untyped
+
+      # Commits the transaction (and turns on auto-committing).
+      def commit_db_transaction: () -> nil
+
+      # Rolls back the transaction (and turns on auto-committing). Must be
+      # done if the transaction block raises an exception or returns false.
+      def rollback_db_transaction: () -> untyped
+
+      def exec_rollback_db_transaction: () -> nil
+
+      def rollback_to_savepoint: (?untyped? name) -> untyped
+
+      def default_sequence_name: (untyped table, untyped column) -> nil
+
+      # Set the sequence to the max value of the table's column.
+      def reset_sequence!: (untyped table, untyped column, ?untyped? sequence) -> nil
+
+      # Inserts the given fixture into the table. Overridden in adapters that require
+      # something beyond a simple insert (eg. Oracle).
+      # Most of adapters should implement `insert_fixtures_set` that leverages bulk SQL insert.
+      # We keep this method to provide fallback
+      # for databases like sqlite that do not support bulk inserts.
+      def insert_fixture: (untyped fixture, untyped table_name) -> untyped
+
+      def insert_fixtures_set: (untyped fixture_set, ?untyped tables_to_delete) -> untyped
+
+      def empty_insert_statement_value: (?untyped? primary_key) -> "DEFAULT VALUES"
+
+      # Sanitizes the given LIMIT parameter in order to prevent SQL injection.
+      #
+      # The +limit+ may be anything that can evaluate to a string via #to_s. It
+      # should look like an integer, or an Arel SQL literal.
+      #
+      # Returns Integer and Arel::Nodes::SqlLiteral limits as is.
+      def sanitize_limit: (untyped limit) -> untyped
+
+      def with_yaml_fallback: (untyped value) -> untyped
+
+      def execute_batch: (untyped statements, ?untyped? name) -> untyped
+
+      DEFAULT_INSERT_VALUE: untyped
+
+      def default_insert_value: (untyped column) -> untyped
+
+      def build_fixture_sql: (untyped fixtures, untyped table_name) -> untyped
+
+      def build_fixture_statements: (untyped fixture_set) -> untyped
+
+      def build_truncate_statement: (untyped table_name) -> ::String
+
+      def build_truncate_statements: (untyped table_names) -> untyped
+
+      def with_multi_statements: () { () -> untyped } -> untyped
+
+      def combine_multi_statements: (untyped total_sql) -> untyped
+
+      # Returns an ActiveRecord::Result instance.
+      def select: (untyped sql, ?untyped? name, ?untyped binds) -> untyped
+
+      def select_prepared: (untyped sql, ?untyped? name, ?untyped binds) -> untyped
+
+      def sql_for_insert: (untyped sql, untyped pk, untyped binds) -> ::Array[untyped]
+
+      def last_inserted_id: (untyped result) -> untyped
+
+      def single_value_from_rows: (untyped rows) -> untyped
+
+      def arel_from_relation: (untyped relation) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    # :nodoc:
+    module QueryCache
+      def self.included: (untyped base) -> untyped
+
+      def self.dirties_query_cache: (untyped base, *untyped method_names) -> untyped
+
+      module ConnectionPoolConfiguration
+        def initialize: () -> untyped
+
+        def enable_query_cache!: () -> untyped
+
+        def disable_query_cache!: () -> untyped
+
+        def query_cache_enabled: () -> untyped
+      end
+
+      attr_reader query_cache: untyped
+
+      attr_reader query_cache_enabled: untyped
+
+      def initialize: () -> untyped
+
+      # Enable the query cache within the block.
+      def cache: () { () -> untyped } -> untyped
+
+      def enable_query_cache!: () -> untyped
+
+      def disable_query_cache!: () -> untyped
+
+      # Disable the query cache within the block.
+      def uncached: () { () -> untyped } -> untyped
+
+      # Clears the query cache.
+      #
+      # One reason you may wish to call this method explicitly is between queries
+      # that ask the database to randomize results. Otherwise the cache would see
+      # the same SQL query and repeatedly return the same result each time, silently
+      # undermining the randomness you were expecting.
+      def clear_query_cache: () -> untyped
+
+      def select_all: (untyped arel, ?untyped? name, ?untyped binds, ?preparable: untyped? preparable) -> untyped
+
+      def cache_sql: (untyped sql, untyped name, untyped binds) { () -> untyped } -> untyped
+
+      # Database adapters can override this method to
+      # provide custom cache information.
+      def cache_notification_info: (untyped sql, untyped name, untyped binds) -> { sql: untyped, binds: untyped, type_casted_binds: untyped, name: untyped, connection_id: untyped, connection: untyped, cached: ::TrueClass }
+
+      # If arel is locked this is a SELECT ... FOR UPDATE or somesuch. Such
+      # queries should not be cached.
+      def locked?: (untyped arel) -> untyped
+
+      def configure_query_cache!: () -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    # :nodoc:
+    module Quoting
+      # Quotes the column value to help prevent
+      # {SQL injection attacks}[https://en.wikipedia.org/wiki/SQL_injection].
+      def quote: (untyped value) -> untyped
+
+      # Cast a +value+ to a type that the database understands. For example,
+      # SQLite does not understand dates, so this method will convert a Date
+      # to a String.
+      def type_cast: (untyped value, ?untyped? column) -> untyped
+
+      def type_cast_from_column: (untyped column, untyped value) -> untyped
+
+      def lookup_cast_type_from_column: (untyped column) -> untyped
+
+      # Quotes a string, escaping any ' (single quote) and \ (backslash)
+      # characters.
+      def quote_string: (untyped s) -> untyped
+
+      # Quotes the column name. Defaults to no quoting.
+      def quote_column_name: (untyped column_name) -> untyped
+
+      # Quotes the table name. Defaults to column name quoting.
+      def quote_table_name: (untyped table_name) -> untyped
+
+      # Override to return the quoted table name for assignment. Defaults to
+      # table quoting.
+      #
+      # This works for mysql2 where table.column can be used to
+      # resolve ambiguity.
+      #
+      # We override this in the sqlite3 and postgresql adapters to use only
+      # the column name (as per syntax requirements).
+      def quote_table_name_for_assignment: (untyped table, untyped attr) -> untyped
+
+      def quote_default_expression: (untyped value, untyped column) -> untyped
+
+      def quoted_true: () -> "TRUE"
+
+      def unquoted_true: () -> ::TrueClass
+
+      def quoted_false: () -> "FALSE"
+
+      def unquoted_false: () -> ::FalseClass
+
+      # Quote date/time values for use in SQL input. Includes microseconds
+      # if the value is a Time responding to usec.
+      def quoted_date: (untyped value) -> untyped
+
+      def quoted_time: (untyped value) -> untyped
+
+      def quoted_binary: (untyped value) -> ::String
+
+      def sanitize_as_sql_comment: (untyped value) -> untyped
+
+      def column_name_matcher: () -> untyped
+
+      def column_name_with_order_matcher: () -> untyped
+
+      # Regexp for column names (with or without a table name prefix).
+      # Matches the following:
+      #
+      #   "#{table_name}.#{column_name}"
+      #   "#{column_name}"
+      COLUMN_NAME: untyped
+
+      # Regexp for column names with order (with or without a table name prefix,
+      # with or without various order modifiers). Matches the following:
+      #
+      #   "#{table_name}.#{column_name}"
+      #   "#{table_name}.#{column_name} #{direction}"
+      #   "#{table_name}.#{column_name} #{direction} NULLS FIRST"
+      #   "#{table_name}.#{column_name} NULLS LAST"
+      #   "#{column_name}"
+      #   "#{column_name} #{direction}"
+      #   "#{column_name} #{direction} NULLS FIRST"
+      #   "#{column_name} NULLS LAST"
+      COLUMN_NAME_WITH_ORDER: untyped
+
+      def type_casted_binds: (untyped binds) -> untyped
+
+      def lookup_cast_type: (untyped sql_type) -> untyped
+
+      def id_value_for_database: (untyped value) -> untyped
+
+      def _quote: (untyped value) -> untyped
+
+      def _type_cast: (untyped value) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    module Savepoints
+      def current_savepoint_name: () -> untyped
+
+      def create_savepoint: (?untyped name) -> untyped
+
+      def exec_rollback_to_savepoint: (?untyped name) -> untyped
+
+      def release_savepoint: (?untyped name) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    class AbstractAdapter
+      class SchemaCreation
+        # :nodoc:
+        def initialize: (untyped conn) -> untyped
+
+        def accept: (untyped o) -> untyped
+
+        def visit_AlterTable: (untyped o) -> untyped
+
+        def visit_ColumnDefinition: (untyped o) -> untyped
+
+        def visit_AddColumnDefinition: (untyped o) -> untyped
+
+        def visit_TableDefinition: (untyped o) -> untyped
+
+        def visit_PrimaryKeyDefinition: (untyped o) -> ::String
+
+        def visit_ForeignKeyDefinition: (untyped o) -> untyped
+
+        def visit_AddForeignKey: (untyped o) -> ::String
+
+        def visit_DropForeignKey: (untyped name) -> ::String
+
+        def table_options: (untyped o) -> untyped
+
+        def add_table_options!: (untyped create_sql, untyped options) -> untyped
+
+        def column_options: (untyped o) -> untyped
+
+        def add_column_options!: (untyped sql, untyped options) -> untyped
+
+        def to_sql: (untyped sql) -> untyped
+
+        # Returns any SQL string to go between CREATE and TABLE. May be nil.
+        def table_modifier_in_create: (untyped o) -> untyped
+
+        def foreign_key_in_create: (untyped from_table, untyped to_table, untyped options) -> untyped
+
+        def action_sql: (untyped action, untyped dependency) -> untyped
+      end
+    end
+
+    SchemaCreation: untyped
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    class IndexDefinition
+      # nodoc:
+      # Abstract representation of an index definition on a table. Instances of
+      # this type are typically created and returned by methods in database
+      # adapters. e.g. ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#indexes
+      # :nodoc:
+      attr_reader table: untyped
+
+      # nodoc:
+      # Abstract representation of an index definition on a table. Instances of
+      # this type are typically created and returned by methods in database
+      # adapters. e.g. ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#indexes
+      # :nodoc:
+      attr_reader name: untyped
+
+      # nodoc:
+      # Abstract representation of an index definition on a table. Instances of
+      # this type are typically created and returned by methods in database
+      # adapters. e.g. ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#indexes
+      # :nodoc:
+      attr_reader unique: untyped
+
+      # nodoc:
+      # Abstract representation of an index definition on a table. Instances of
+      # this type are typically created and returned by methods in database
+      # adapters. e.g. ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#indexes
+      # :nodoc:
+      attr_reader columns: untyped
+
+      # nodoc:
+      # Abstract representation of an index definition on a table. Instances of
+      # this type are typically created and returned by methods in database
+      # adapters. e.g. ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#indexes
+      # :nodoc:
+      attr_reader lengths: untyped
+
+      # nodoc:
+      # Abstract representation of an index definition on a table. Instances of
+      # this type are typically created and returned by methods in database
+      # adapters. e.g. ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#indexes
+      # :nodoc:
+      attr_reader orders: untyped
+
+      # nodoc:
+      # Abstract representation of an index definition on a table. Instances of
+      # this type are typically created and returned by methods in database
+      # adapters. e.g. ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#indexes
+      # :nodoc:
+      attr_reader opclasses: untyped
+
+      # nodoc:
+      # Abstract representation of an index definition on a table. Instances of
+      # this type are typically created and returned by methods in database
+      # adapters. e.g. ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#indexes
+      # :nodoc:
+      attr_reader where: untyped
+
+      # nodoc:
+      # Abstract representation of an index definition on a table. Instances of
+      # this type are typically created and returned by methods in database
+      # adapters. e.g. ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#indexes
+      # :nodoc:
+      attr_reader type: untyped
+
+      # nodoc:
+      # Abstract representation of an index definition on a table. Instances of
+      # this type are typically created and returned by methods in database
+      # adapters. e.g. ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#indexes
+      # :nodoc:
+      attr_reader using: untyped
+
+      # nodoc:
+      # Abstract representation of an index definition on a table. Instances of
+      # this type are typically created and returned by methods in database
+      # adapters. e.g. ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#indexes
+      # :nodoc:
+      attr_reader comment: untyped
+
+      def initialize: (untyped table, untyped name, ?bool unique, ?untyped columns, ?comment: untyped? comment, ?using: untyped? using, ?type: untyped? `type`, ?where: untyped? where, ?opclasses: ::Hash[untyped, untyped] opclasses, ?orders: ::Hash[untyped, untyped] orders, ?lengths: ::Hash[untyped, untyped] lengths) -> untyped
+
+      def concise_options: (untyped options) -> untyped
+    end
+
+    class ColumnDefinition[T] < ::Struct[T]
+      attr_accessor name(): untyped
+
+      attr_accessor type(): untyped
+
+      attr_accessor options(): untyped
+
+      attr_accessor sql_type(): untyped
+
+      # Abstract representation of a column definition. Instances of this type
+      # are typically created by methods in TableDefinition, and added to the
+      # +columns+ attribute of said TableDefinition object, in order to be used
+      # for generating a number of table creation or table changing SQL statements.
+      # :nodoc:
+      def primary_key?: () -> untyped
+    end
+
+    class AddColumnDefinition[T] < ::Struct[T]
+      attr_accessor column(): untyped
+    end
+
+    class ChangeColumnDefinition[T] < ::Struct[T]
+      attr_accessor column(): untyped
+
+      attr_accessor name(): untyped
+    end
+
+    class PrimaryKeyDefinition[T] < ::Struct[T]
+      attr_accessor name(): untyped
+    end
+
+    class ForeignKeyDefinition[T] < ::Struct[T]
+      attr_accessor from_table(): untyped
+
+      attr_accessor to_table(): untyped
+
+      attr_accessor options(): untyped
+
+      # nodoc:
+      def name: () -> untyped
+
+      def column: () -> untyped
+
+      def primary_key: () -> untyped
+
+      def on_delete: () -> untyped
+
+      def on_update: () -> untyped
+
+      def custom_primary_key?: () -> untyped
+
+      def validate?: () -> untyped
+
+      alias validated? validate?
+
+      def export_name_on_schema_dump?: () -> untyped
+
+      def defined_for?: (?to_table: untyped? to_table, **untyped options) -> untyped
+
+      def default_primary_key: () -> "id"
+    end
+
+    class ReferenceDefinition
+      # :nodoc:
+      def initialize: (untyped name, ?type: ::Symbol `type`, ?foreign_key: bool foreign_key, ?index: bool index, ?polymorphic: bool polymorphic, **untyped options) -> untyped
+
+      def add_to: (untyped table) -> untyped
+
+      attr_reader name: untyped
+
+      attr_reader polymorphic: untyped
+
+      attr_reader index: untyped
+
+      attr_reader foreign_key: untyped
+
+      attr_reader type: untyped
+
+      attr_reader options: untyped
+
+      def as_options: (untyped value) -> untyped
+
+      def polymorphic_options: () -> untyped
+
+      def index_options: () -> untyped
+
+      def foreign_key_options: () -> untyped
+
+      def columns: () -> untyped
+
+      def column_name: () -> ::String
+
+      def column_names: () -> untyped
+
+      def foreign_table_name: () -> untyped
+    end
+
+    module ColumnMethods
+      extend ActiveSupport::Concern
+
+      # Appends a primary key definition to the table definition.
+      # Can be called multiple times, but this is probably not a good idea.
+      def primary_key: (untyped name, ?::Symbol `type`, **untyped options) -> untyped
+
+      module ClassMethods
+        def define_column_methods: (*untyped column_types) -> untyped
+      end
+    end
+
+    # Represents the schema of an SQL table in an abstract way. This class
+    # provides methods for manipulating the schema representation.
+    #
+    # Inside migration files, the +t+ object in {create_table}[rdoc-ref:SchemaStatements#create_table]
+    # is actually of this type:
+    #
+    #   class SomeMigration < ActiveRecord::Migration[5.0]
+    #     def up
+    #       create_table :foo do |t|
+    #         puts t.class  # => "ActiveRecord::ConnectionAdapters::TableDefinition"
+    #       end
+    #     end
+    #
+    #     def down
+    #       ...
+    #     end
+    #   end
+    #
+    class TableDefinition
+      include ColumnMethods
+
+      attr_reader name: untyped
+
+      attr_reader temporary: untyped
+
+      attr_reader if_not_exists: untyped
+
+      attr_reader options: untyped
+
+      attr_reader as: untyped
+
+      attr_reader comment: untyped
+
+      attr_reader indexes: untyped
+
+      attr_reader foreign_keys: untyped
+
+      def initialize: (untyped conn, untyped name, ?comment: untyped? comment, ?as: untyped? as, ?options: untyped? options, ?if_not_exists: bool if_not_exists, ?temporary: bool temporary) -> untyped
+
+      def primary_keys: (?untyped? name) -> untyped
+
+      # Returns an array of ColumnDefinition objects for the columns of the table.
+      def columns: () -> untyped
+
+      # Returns a ColumnDefinition for the column with name +name+.
+      def []: (untyped name) -> untyped
+
+      # Instantiates a new column for the table.
+      # See {connection.add_column}[rdoc-ref:ConnectionAdapters::SchemaStatements#add_column]
+      # for available options.
+      #
+      # Additional options are:
+      # * <tt>:index</tt> -
+      #   Create an index for the column. Can be either <tt>true</tt> or an options hash.
+      #
+      # This method returns <tt>self</tt>.
+      #
+      # == Examples
+      #
+      #  # Assuming +td+ is an instance of TableDefinition
+      #  td.column(:granted, :boolean, index: true)
+      #
+      # == Short-hand examples
+      #
+      # Instead of calling #column directly, you can also work with the short-hand definitions for the default types.
+      # They use the type as the method name instead of as a parameter and allow for multiple columns to be defined
+      # in a single statement.
+      #
+      # What can be written like this with the regular calls to column:
+      #
+      #   create_table :products do |t|
+      #     t.column :shop_id,     :integer
+      #     t.column :creator_id,  :integer
+      #     t.column :item_number, :string
+      #     t.column :name,        :string, default: "Untitled"
+      #     t.column :value,       :string, default: "Untitled"
+      #     t.column :created_at,  :datetime
+      #     t.column :updated_at,  :datetime
+      #   end
+      #   add_index :products, :item_number
+      #
+      # can also be written as follows using the short-hand:
+      #
+      #   create_table :products do |t|
+      #     t.integer :shop_id, :creator_id
+      #     t.string  :item_number, index: true
+      #     t.string  :name, :value, default: "Untitled"
+      #     t.timestamps null: false
+      #   end
+      #
+      # There's a short-hand method for each of the type values declared at the top. And then there's
+      # TableDefinition#timestamps that'll add +created_at+ and +updated_at+ as datetimes.
+      #
+      # TableDefinition#references will add an appropriately-named _id column, plus a corresponding _type
+      # column if the <tt>:polymorphic</tt> option is supplied. If <tt>:polymorphic</tt> is a hash of
+      # options, these will be used when creating the <tt>_type</tt> column. The <tt>:index</tt> option
+      # will also create an index, similar to calling {add_index}[rdoc-ref:ConnectionAdapters::SchemaStatements#add_index].
+      # So what can be written like this:
+      #
+      #   create_table :taggings do |t|
+      #     t.integer :tag_id, :tagger_id, :taggable_id
+      #     t.string  :tagger_type
+      #     t.string  :taggable_type, default: 'Photo'
+      #   end
+      #   add_index :taggings, :tag_id, name: 'index_taggings_on_tag_id'
+      #   add_index :taggings, [:tagger_id, :tagger_type]
+      #
+      # Can also be written as follows using references:
+      #
+      #   create_table :taggings do |t|
+      #     t.references :tag, index: { name: 'index_taggings_on_tag_id' }
+      #     t.references :tagger, polymorphic: true
+      #     t.references :taggable, polymorphic: { default: 'Photo' }, index: false
+      #   end
+      def column: (untyped name, untyped `type`, **untyped options) -> untyped
+
+      # remove the column +name+ from the table.
+      #   remove_column(:account_id)
+      def remove_column: (untyped name) -> untyped
+
+      # Adds index options to the indexes hash, keyed by column name
+      # This is primarily used to track indexes that need to be created after the table
+      #
+      #   index(:account_id, name: 'index_projects_on_account_id')
+      def index: (untyped column_name, ?::Hash[untyped, untyped] options) -> untyped
+
+      def foreign_key: (untyped table_name, **untyped options) -> untyped
+
+      # Appends <tt>:datetime</tt> columns <tt>:created_at</tt> and
+      # <tt>:updated_at</tt> to the table. See {connection.add_timestamps}[rdoc-ref:SchemaStatements#add_timestamps]
+      #
+      #   t.timestamps null: false
+      def timestamps: (**untyped options) -> untyped
+
+      # Adds a reference.
+      #
+      #  t.references(:user)
+      #  t.belongs_to(:supplier, foreign_key: true)
+      #  t.belongs_to(:supplier, foreign_key: true, type: :integer)
+      #
+      # See {connection.add_reference}[rdoc-ref:SchemaStatements#add_reference] for details of the options you can use.
+      def references: (*untyped args, **untyped options) -> untyped
+
+      alias belongs_to references
+
+      def new_column_definition: (untyped name, untyped `type`, **untyped options) -> untyped
+
+      def create_column_definition: (untyped name, untyped `type`, untyped options) -> ColumnDefinition[untyped]
+
+      def aliased_types: (untyped name, untyped fallback) -> untyped
+
+      def integer_like_primary_key?: (untyped `type`, untyped options) -> untyped
+
+      def integer_like_primary_key_type: (untyped `type`, untyped options) -> untyped
+    end
+
+    class AlterTable
+      # :nodoc:
+      attr_reader adds: untyped
+
+      attr_reader foreign_key_adds: untyped
+
+      attr_reader foreign_key_drops: untyped
+
+      def initialize: (untyped td) -> untyped
+
+      def name: () -> untyped
+
+      def add_foreign_key: (untyped to_table, untyped options) -> untyped
+
+      def drop_foreign_key: (untyped name) -> untyped
+
+      def add_column: (untyped name, untyped `type`, **untyped options) -> untyped
+    end
+
+    # Represents an SQL table in an abstract way for updating a table.
+    # Also see TableDefinition and {connection.create_table}[rdoc-ref:SchemaStatements#create_table]
+    #
+    # Available transformations are:
+    #
+    #   change_table :table do |t|
+    #     t.primary_key
+    #     t.column
+    #     t.index
+    #     t.rename_index
+    #     t.timestamps
+    #     t.change
+    #     t.change_default
+    #     t.rename
+    #     t.references
+    #     t.belongs_to
+    #     t.string
+    #     t.text
+    #     t.integer
+    #     t.bigint
+    #     t.float
+    #     t.decimal
+    #     t.numeric
+    #     t.datetime
+    #     t.timestamp
+    #     t.time
+    #     t.date
+    #     t.binary
+    #     t.boolean
+    #     t.foreign_key
+    #     t.json
+    #     t.virtual
+    #     t.remove
+    #     t.remove_foreign_key
+    #     t.remove_references
+    #     t.remove_belongs_to
+    #     t.remove_index
+    #     t.remove_timestamps
+    #   end
+    #
+    class Table
+      include ColumnMethods
+
+      attr_reader name: untyped
+
+      def initialize: (untyped table_name, untyped base) -> untyped
+
+      # Adds a new column to the named table.
+      #
+      #  t.column(:name, :string)
+      #
+      # See TableDefinition#column for details of the options you can use.
+      def column: (untyped column_name, untyped `type`, **untyped options) -> untyped
+
+      # Checks to see if a column exists.
+      #
+      #  t.string(:name) unless t.column_exists?(:name, :string)
+      #
+      # See {connection.column_exists?}[rdoc-ref:SchemaStatements#column_exists?]
+      def column_exists?: (untyped column_name, ?untyped? `type`, **untyped options) -> untyped
+
+      # Adds a new index to the table. +column_name+ can be a single Symbol, or
+      # an Array of Symbols.
+      #
+      #  t.index(:name)
+      #  t.index([:branch_id, :party_id], unique: true)
+      #  t.index([:branch_id, :party_id], unique: true, name: 'by_branch_party')
+      #
+      # See {connection.add_index}[rdoc-ref:SchemaStatements#add_index] for details of the options you can use.
+      def index: (untyped column_name, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Checks to see if an index exists.
+      #
+      #  unless t.index_exists?(:branch_id)
+      #    t.index(:branch_id)
+      #  end
+      #
+      # See {connection.index_exists?}[rdoc-ref:SchemaStatements#index_exists?]
+      def index_exists?: (untyped column_name, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Renames the given index on the table.
+      #
+      #  t.rename_index(:user_id, :account_id)
+      #
+      # See {connection.rename_index}[rdoc-ref:SchemaStatements#rename_index]
+      def rename_index: (untyped index_name, untyped new_index_name) -> untyped
+
+      # Adds timestamps (+created_at+ and +updated_at+) columns to the table.
+      #
+      #  t.timestamps(null: false)
+      #
+      # See {connection.add_timestamps}[rdoc-ref:SchemaStatements#add_timestamps]
+      def timestamps: (**untyped options) -> untyped
+
+      # Changes the column's definition according to the new options.
+      #
+      #  t.change(:name, :string, limit: 80)
+      #  t.change(:description, :text)
+      #
+      # See TableDefinition#column for details of the options you can use.
+      def change: (untyped column_name, untyped `type`, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Sets a new default value for a column.
+      #
+      #  t.change_default(:qualification, 'new')
+      #  t.change_default(:authorized, 1)
+      #  t.change_default(:status, from: nil, to: "draft")
+      #
+      # See {connection.change_column_default}[rdoc-ref:SchemaStatements#change_column_default]
+      def change_default: (untyped column_name, untyped default_or_changes) -> untyped
+
+      # Removes the column(s) from the table definition.
+      #
+      #  t.remove(:qualification)
+      #  t.remove(:qualification, :experience)
+      #
+      # See {connection.remove_columns}[rdoc-ref:SchemaStatements#remove_columns]
+      def remove: (*untyped column_names) -> untyped
+
+      # Removes the given index from the table.
+      #
+      #   t.remove_index(:branch_id)
+      #   t.remove_index(column: [:branch_id, :party_id])
+      #   t.remove_index(name: :by_branch_party)
+      #
+      # See {connection.remove_index}[rdoc-ref:SchemaStatements#remove_index]
+      def remove_index: (?::Hash[untyped, untyped] options) -> untyped
+
+      # Removes the timestamp columns (+created_at+ and +updated_at+) from the table.
+      #
+      #  t.remove_timestamps
+      #
+      # See {connection.remove_timestamps}[rdoc-ref:SchemaStatements#remove_timestamps]
+      def remove_timestamps: (**untyped options) -> untyped
+
+      # Renames a column.
+      #
+      #  t.rename(:description, :name)
+      #
+      # See {connection.rename_column}[rdoc-ref:SchemaStatements#rename_column]
+      def rename: (untyped column_name, untyped new_column_name) -> untyped
+
+      # Adds a reference.
+      #
+      #  t.references(:user)
+      #  t.belongs_to(:supplier, foreign_key: true)
+      #
+      # See {connection.add_reference}[rdoc-ref:SchemaStatements#add_reference] for details of the options you can use.
+      def references: (*untyped args, **untyped options) -> untyped
+
+      alias belongs_to references
+
+      # Removes a reference. Optionally removes a +type+ column.
+      #
+      #  t.remove_references(:user)
+      #  t.remove_belongs_to(:supplier, polymorphic: true)
+      #
+      # See {connection.remove_reference}[rdoc-ref:SchemaStatements#remove_reference]
+      def remove_references: (*untyped args, **untyped options) -> untyped
+
+      alias remove_belongs_to remove_references
+
+      # Adds a foreign key to the table using a supplied table name.
+      #
+      #  t.foreign_key(:authors)
+      #  t.foreign_key(:authors, column: :author_id, primary_key: "id")
+      #
+      # See {connection.add_foreign_key}[rdoc-ref:SchemaStatements#add_foreign_key]
+      def foreign_key: (*untyped args, **untyped options) -> untyped
+
+      # Removes the given foreign key from the table.
+      #
+      #  t.remove_foreign_key(:authors)
+      #  t.remove_foreign_key(column: :author_id)
+      #
+      # See {connection.remove_foreign_key}[rdoc-ref:SchemaStatements#remove_foreign_key]
+      def remove_foreign_key: (*untyped args, **untyped options) -> untyped
+
+      # Checks to see if a foreign key exists.
+      #
+      #  t.foreign_key(:authors) unless t.foreign_key_exists?(:authors)
+      #
+      # See {connection.foreign_key_exists?}[rdoc-ref:SchemaStatements#foreign_key_exists?]
+      def foreign_key_exists?: (*untyped args, **untyped options) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    class SchemaDumper < ActiveRecord::SchemaDumper
+      # :nodoc:
+      # :nodoc:
+      def self.create: (untyped connection, untyped options) -> untyped
+
+      def column_spec: (untyped column) -> ::Array[untyped]
+
+      def column_spec_for_primary_key: (untyped column) -> (::Hash[untyped, untyped] | untyped)
+
+      def prepare_column_options: (untyped column) -> untyped
+
+      def default_primary_key?: (untyped column) -> untyped
+
+      def explicit_primary_key_default?: (untyped column) -> ::FalseClass
+
+      def schema_type_with_virtual: (untyped column) -> untyped
+
+      def schema_type: (untyped column) -> untyped
+
+      def schema_limit: (untyped column) -> untyped
+
+      def schema_precision: (untyped column) -> untyped
+
+      def schema_scale: (untyped column) -> untyped
+
+      def schema_default: (untyped column) -> (nil | untyped)
+
+      def schema_expression: (untyped column) -> untyped
+
+      def schema_collation: (untyped column) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    # :nodoc:
+    module SchemaStatements
+      include ActiveRecord::Migration::JoinTable
+
+      # Returns a hash of mappings from the abstract data types to the native
+      # database types. See TableDefinition#column for details on the recognized
+      # abstract data types.
+      def native_database_types: () -> ::Hash[untyped, untyped]
+
+      def table_options: (untyped table_name) -> nil
+
+      # Returns the table comment that's stored in database metadata.
+      def table_comment: (untyped table_name) -> nil
+
+      # Truncates a table alias according to the limits of the current adapter.
+      def table_alias_for: (untyped table_name) -> untyped
+
+      # Returns the relation names useable to back Active Record models.
+      # For most adapters this means all #tables and #views.
+      def data_sources: () -> untyped
+
+      # Checks to see if the data source +name+ exists on the database.
+      #
+      #   data_source_exists?(:ebooks)
+      #
+      def data_source_exists?: (untyped name) -> untyped
+
+      # Returns an array of table names defined in the database.
+      def tables: () -> untyped
+
+      # Checks to see if the table +table_name+ exists on the database.
+      #
+      #   table_exists?(:developers)
+      #
+      def table_exists?: (untyped table_name) -> untyped
+
+      # Returns an array of view names defined in the database.
+      def views: () -> untyped
+
+      # Checks to see if the view +view_name+ exists on the database.
+      #
+      #   view_exists?(:ebooks)
+      #
+      def view_exists?: (untyped view_name) -> untyped
+
+      # Returns an array of indexes for the given table.
+      def indexes: (untyped table_name) -> untyped
+
+      # Checks to see if an index exists on a table for a given index definition.
+      #
+      #   # Check an index exists
+      #   index_exists?(:suppliers, :company_id)
+      #
+      #   # Check an index on multiple columns exists
+      #   index_exists?(:suppliers, [:company_id, :company_type])
+      #
+      #   # Check a unique index exists
+      #   index_exists?(:suppliers, :company_id, unique: true)
+      #
+      #   # Check an index with a custom name exists
+      #   index_exists?(:suppliers, :company_id, name: "idx_company_id")
+      #
+      def index_exists?: (untyped table_name, untyped column_name, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Returns an array of +Column+ objects for the table specified by +table_name+.
+      def columns: (untyped table_name) -> untyped
+
+      # Checks to see if a column exists in a given table.
+      #
+      #   # Check a column exists
+      #   column_exists?(:suppliers, :name)
+      #
+      #   # Check a column exists of a particular type
+      #   column_exists?(:suppliers, :name, :string)
+      #
+      #   # Check a column exists with a specific definition
+      #   column_exists?(:suppliers, :name, :string, limit: 100)
+      #   column_exists?(:suppliers, :name, :string, default: 'default')
+      #   column_exists?(:suppliers, :name, :string, null: false)
+      #   column_exists?(:suppliers, :tax, :decimal, precision: 8, scale: 2)
+      #
+      def column_exists?: (untyped table_name, untyped column_name, ?untyped? `type`, **untyped options) -> untyped
+
+      # Returns just a table's primary key
+      def primary_key: (untyped table_name) -> untyped
+
+      # Creates a new table with the name +table_name+. +table_name+ may either
+      # be a String or a Symbol.
+      #
+      # There are two ways to work with #create_table. You can use the block
+      # form or the regular form, like this:
+      #
+      # === Block form
+      #
+      #   # create_table() passes a TableDefinition object to the block.
+      #   # This form will not only create the table, but also columns for the
+      #   # table.
+      #
+      #   create_table(:suppliers) do |t|
+      #     t.column :name, :string, limit: 60
+      #     # Other fields here
+      #   end
+      #
+      # === Block form, with shorthand
+      #
+      #   # You can also use the column types as method calls, rather than calling the column method.
+      #   create_table(:suppliers) do |t|
+      #     t.string :name, limit: 60
+      #     # Other fields here
+      #   end
+      #
+      # === Regular form
+      #
+      #   # Creates a table called 'suppliers' with no columns.
+      #   create_table(:suppliers)
+      #   # Add a column to 'suppliers'.
+      #   add_column(:suppliers, :name, :string, {limit: 60})
+      #
+      # The +options+ hash can include the following keys:
+      # [<tt>:id</tt>]
+      #   Whether to automatically add a primary key column. Defaults to true.
+      #   Join tables for {ActiveRecord::Base.has_and_belongs_to_many}[rdoc-ref:Associations::ClassMethods#has_and_belongs_to_many] should set it to false.
+      #
+      #   A Symbol can be used to specify the type of the generated primary key column.
+      # [<tt>:primary_key</tt>]
+      #   The name of the primary key, if one is to be added automatically.
+      #   Defaults to +id+. If <tt>:id</tt> is false, then this option is ignored.
+      #
+      #   If an array is passed, a composite primary key will be created.
+      #
+      #   Note that Active Record models will automatically detect their
+      #   primary key. This can be avoided by using
+      #   {self.primary_key=}[rdoc-ref:AttributeMethods::PrimaryKey::ClassMethods#primary_key=] on the model
+      #   to define the key explicitly.
+      #
+      # [<tt>:options</tt>]
+      #   Any extra options you want appended to the table definition.
+      # [<tt>:temporary</tt>]
+      #   Make a temporary table.
+      # [<tt>:force</tt>]
+      #   Set to true to drop the table before creating it.
+      #   Set to +:cascade+ to drop dependent objects as well.
+      #   Defaults to false.
+      # [<tt>:if_not_exists</tt>]
+      #   Set to true to avoid raising an error when the table already exists.
+      #   Defaults to false.
+      # [<tt>:as</tt>]
+      #   SQL to use to generate the table. When this option is used, the block is
+      #   ignored, as are the <tt>:id</tt> and <tt>:primary_key</tt> options.
+      #
+      # ====== Add a backend specific option to the generated SQL (MySQL)
+      #
+      #   create_table(:suppliers, options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8mb4')
+      #
+      # generates:
+      #
+      #   CREATE TABLE suppliers (
+      #     id bigint auto_increment PRIMARY KEY
+      #   ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+      #
+      # ====== Rename the primary key column
+      #
+      #   create_table(:objects, primary_key: 'guid') do |t|
+      #     t.column :name, :string, limit: 80
+      #   end
+      #
+      # generates:
+      #
+      #   CREATE TABLE objects (
+      #     guid bigint auto_increment PRIMARY KEY,
+      #     name varchar(80)
+      #   )
+      #
+      # ====== Change the primary key column type
+      #
+      #   create_table(:tags, id: :string) do |t|
+      #     t.column :label, :string
+      #   end
+      #
+      # generates:
+      #
+      #   CREATE TABLE tags (
+      #     id varchar PRIMARY KEY,
+      #     label varchar
+      #   )
+      #
+      # ====== Create a composite primary key
+      #
+      #   create_table(:orders, primary_key: [:product_id, :client_id]) do |t|
+      #     t.belongs_to :product
+      #     t.belongs_to :client
+      #   end
+      #
+      # generates:
+      #
+      #   CREATE TABLE order (
+      #       product_id bigint NOT NULL,
+      #       client_id bigint NOT NULL
+      #   );
+      #
+      #   ALTER TABLE ONLY "orders"
+      #     ADD CONSTRAINT orders_pkey PRIMARY KEY (product_id, client_id);
+      #
+      # ====== Do not add a primary key column
+      #
+      #   create_table(:categories_suppliers, id: false) do |t|
+      #     t.column :category_id, :bigint
+      #     t.column :supplier_id, :bigint
+      #   end
+      #
+      # generates:
+      #
+      #   CREATE TABLE categories_suppliers (
+      #     category_id bigint,
+      #     supplier_id bigint
+      #   )
+      #
+      # ====== Create a temporary table based on a query
+      #
+      #   create_table(:long_query, temporary: true,
+      #     as: "SELECT * FROM orders INNER JOIN line_items ON order_id=orders.id")
+      #
+      # generates:
+      #
+      #   CREATE TEMPORARY TABLE long_query AS
+      #     SELECT * FROM orders INNER JOIN line_items ON order_id=orders.id
+      #
+      # See also TableDefinition#column for details on how to create columns.
+      def create_table: (untyped table_name, **untyped options) { (untyped) -> untyped } -> untyped
+
+      # Creates a new join table with the name created using the lexical order of the first two
+      # arguments. These arguments can be a String or a Symbol.
+      #
+      #   # Creates a table called 'assemblies_parts' with no id.
+      #   create_join_table(:assemblies, :parts)
+      #
+      # You can pass an +options+ hash which can include the following keys:
+      # [<tt>:table_name</tt>]
+      #   Sets the table name, overriding the default.
+      # [<tt>:column_options</tt>]
+      #   Any extra options you want appended to the columns definition.
+      # [<tt>:options</tt>]
+      #   Any extra options you want appended to the table definition.
+      # [<tt>:temporary</tt>]
+      #   Make a temporary table.
+      # [<tt>:force</tt>]
+      #   Set to true to drop the table before creating it.
+      #   Defaults to false.
+      #
+      # Note that #create_join_table does not create any indices by default; you can use
+      # its block form to do so yourself:
+      #
+      #   create_join_table :products, :categories do |t|
+      #     t.index :product_id
+      #     t.index :category_id
+      #   end
+      #
+      # ====== Add a backend specific option to the generated SQL (MySQL)
+      #
+      #   create_join_table(:assemblies, :parts, options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8')
+      #
+      # generates:
+      #
+      #   CREATE TABLE assemblies_parts (
+      #     assembly_id bigint NOT NULL,
+      #     part_id bigint NOT NULL,
+      #   ) ENGINE=InnoDB DEFAULT CHARSET=utf8
+      #
+      def create_join_table: (untyped table_1, untyped table_2, ?column_options: ::Hash[untyped, untyped] column_options, **untyped options) { (untyped) -> untyped } -> untyped
+
+      # Drops the join table specified by the given arguments.
+      # See #create_join_table for details.
+      #
+      # Although this command ignores the block if one is given, it can be helpful
+      # to provide one in a migration's +change+ method so it can be reverted.
+      # In that case, the block will be used by #create_join_table.
+      def drop_join_table: (untyped table_1, untyped table_2, **untyped options) -> untyped
+
+      # A block for changing columns in +table+.
+      #
+      #   # change_table() yields a Table instance
+      #   change_table(:suppliers) do |t|
+      #     t.column :name, :string, limit: 60
+      #     # Other column alterations here
+      #   end
+      #
+      # The +options+ hash can include the following keys:
+      # [<tt>:bulk</tt>]
+      #   Set this to true to make this a bulk alter query, such as
+      #
+      #     ALTER TABLE `users` ADD COLUMN age INT, ADD COLUMN birthdate DATETIME ...
+      #
+      #   Defaults to false.
+      #
+      #   Only supported on the MySQL and PostgreSQL adapter, ignored elsewhere.
+      #
+      # ====== Add a column
+      #
+      #   change_table(:suppliers) do |t|
+      #     t.column :name, :string, limit: 60
+      #   end
+      #
+      # ====== Add 2 integer columns
+      #
+      #   change_table(:suppliers) do |t|
+      #     t.integer :width, :height, null: false, default: 0
+      #   end
+      #
+      # ====== Add created_at/updated_at columns
+      #
+      #   change_table(:suppliers) do |t|
+      #     t.timestamps
+      #   end
+      #
+      # ====== Add a foreign key column
+      #
+      #   change_table(:suppliers) do |t|
+      #     t.references :company
+      #   end
+      #
+      # Creates a <tt>company_id(bigint)</tt> column.
+      #
+      # ====== Add a polymorphic foreign key column
+      #
+      #  change_table(:suppliers) do |t|
+      #    t.belongs_to :company, polymorphic: true
+      #  end
+      #
+      # Creates <tt>company_type(varchar)</tt> and <tt>company_id(bigint)</tt> columns.
+      #
+      # ====== Remove a column
+      #
+      #  change_table(:suppliers) do |t|
+      #    t.remove :company
+      #  end
+      #
+      # ====== Remove several columns
+      #
+      #  change_table(:suppliers) do |t|
+      #    t.remove :company_id
+      #    t.remove :width, :height
+      #  end
+      #
+      # ====== Remove an index
+      #
+      #  change_table(:suppliers) do |t|
+      #    t.remove_index :company_id
+      #  end
+      #
+      # See also Table for details on all of the various column transformations.
+      def change_table: (untyped table_name, **untyped options) { (untyped) -> untyped } -> untyped
+
+      # Renames a table.
+      #
+      #   rename_table('octopuses', 'octopi')
+      #
+      def rename_table: (untyped table_name, untyped new_name) -> untyped
+
+      # Drops a table from the database.
+      #
+      # [<tt>:force</tt>]
+      #   Set to +:cascade+ to drop dependent objects as well.
+      #   Defaults to false.
+      # [<tt>:if_exists</tt>]
+      #   Set to +true+ to only drop the table if it exists.
+      #   Defaults to false.
+      #
+      # Although this command ignores most +options+ and the block if one is given,
+      # it can be helpful to provide these in a migration's +change+ method so it can be reverted.
+      # In that case, +options+ and the block will be used by #create_table.
+      def drop_table: (untyped table_name, **untyped options) -> untyped
+
+      # Add a new +type+ column named +column_name+ to +table_name+.
+      #
+      # The +type+ parameter is normally one of the migrations native types,
+      # which is one of the following:
+      # <tt>:primary_key</tt>, <tt>:string</tt>, <tt>:text</tt>,
+      # <tt>:integer</tt>, <tt>:bigint</tt>, <tt>:float</tt>, <tt>:decimal</tt>, <tt>:numeric</tt>,
+      # <tt>:datetime</tt>, <tt>:time</tt>, <tt>:date</tt>,
+      # <tt>:binary</tt>, <tt>:boolean</tt>.
+      #
+      # You may use a type not in this list as long as it is supported by your
+      # database (for example, "polygon" in MySQL), but this will not be database
+      # agnostic and should usually be avoided.
+      #
+      # Available options are (none of these exists by default):
+      # * <tt>:limit</tt> -
+      #   Requests a maximum column length. This is the number of characters for a <tt>:string</tt> column
+      #   and number of bytes for <tt>:text</tt>, <tt>:binary</tt>, and <tt>:integer</tt> columns.
+      #   This option is ignored by some backends.
+      # * <tt>:default</tt> -
+      #   The column's default value. Use +nil+ for +NULL+.
+      # * <tt>:null</tt> -
+      #   Allows or disallows +NULL+ values in the column.
+      # * <tt>:precision</tt> -
+      #   Specifies the precision for the <tt>:decimal</tt>, <tt>:numeric</tt>,
+      #   <tt>:datetime</tt>, and <tt>:time</tt> columns.
+      # * <tt>:scale</tt> -
+      #   Specifies the scale for the <tt>:decimal</tt> and <tt>:numeric</tt> columns.
+      # * <tt>:collation</tt> -
+      #   Specifies the collation for a <tt>:string</tt> or <tt>:text</tt> column. If not specified, the
+      #   column will have the same collation as the table.
+      # * <tt>:comment</tt> -
+      #   Specifies the comment for the column. This option is ignored by some backends.
+      #
+      # Note: The precision is the total number of significant digits,
+      # and the scale is the number of digits that can be stored following
+      # the decimal point. For example, the number 123.45 has a precision of 5
+      # and a scale of 2. A decimal with a precision of 5 and a scale of 2 can
+      # range from -999.99 to 999.99.
+      #
+      # Please be aware of different RDBMS implementations behavior with
+      # <tt>:decimal</tt> columns:
+      # * The SQL standard says the default scale should be 0, <tt>:scale</tt> <=
+      #   <tt>:precision</tt>, and makes no comments about the requirements of
+      #   <tt>:precision</tt>.
+      # * MySQL: <tt>:precision</tt> [1..63], <tt>:scale</tt> [0..30].
+      #   Default is (10,0).
+      # * PostgreSQL: <tt>:precision</tt> [1..infinity],
+      #   <tt>:scale</tt> [0..infinity]. No default.
+      # * SQLite3: No restrictions on <tt>:precision</tt> and <tt>:scale</tt>,
+      #   but the maximum supported <tt>:precision</tt> is 16. No default.
+      # * Oracle: <tt>:precision</tt> [1..38], <tt>:scale</tt> [-84..127].
+      #   Default is (38,0).
+      # * DB2: <tt>:precision</tt> [1..63], <tt>:scale</tt> [0..62].
+      #   Default unknown.
+      # * SqlServer: <tt>:precision</tt> [1..38], <tt>:scale</tt> [0..38].
+      #   Default (38,0).
+      #
+      # == Examples
+      #
+      #  add_column(:users, :picture, :binary, limit: 2.megabytes)
+      #  # ALTER TABLE "users" ADD "picture" blob(2097152)
+      #
+      #  add_column(:articles, :status, :string, limit: 20, default: 'draft', null: false)
+      #  # ALTER TABLE "articles" ADD "status" varchar(20) DEFAULT 'draft' NOT NULL
+      #
+      #  add_column(:answers, :bill_gates_money, :decimal, precision: 15, scale: 2)
+      #  # ALTER TABLE "answers" ADD "bill_gates_money" decimal(15,2)
+      #
+      #  add_column(:measurements, :sensor_reading, :decimal, precision: 30, scale: 20)
+      #  # ALTER TABLE "measurements" ADD "sensor_reading" decimal(30,20)
+      #
+      #  # While :scale defaults to zero on most databases, it
+      #  # probably wouldn't hurt to include it.
+      #  add_column(:measurements, :huge_integer, :decimal, precision: 30)
+      #  # ALTER TABLE "measurements" ADD "huge_integer" decimal(30)
+      #
+      #  # Defines a column that stores an array of a type.
+      #  add_column(:users, :skills, :text, array: true)
+      #  # ALTER TABLE "users" ADD "skills" text[]
+      #
+      #  # Defines a column with a database-specific type.
+      #  add_column(:shapes, :triangle, 'polygon')
+      #  # ALTER TABLE "shapes" ADD "triangle" polygon
+      def add_column: (untyped table_name, untyped column_name, untyped `type`, **untyped options) -> untyped
+
+      # Removes the given columns from the table definition.
+      #
+      #   remove_columns(:suppliers, :qualification, :experience)
+      #
+      def remove_columns: (untyped table_name, *untyped column_names) -> untyped
+
+      # Removes the column from the table definition.
+      #
+      #   remove_column(:suppliers, :qualification)
+      #
+      # The +type+ and +options+ parameters will be ignored if present. It can be helpful
+      # to provide these in a migration's +change+ method so it can be reverted.
+      # In that case, +type+ and +options+ will be used by #add_column.
+      # Indexes on the column are automatically removed.
+      def remove_column: (untyped table_name, untyped column_name, ?untyped? `type`, **untyped options) -> untyped
+
+      # Changes the column's definition according to the new options.
+      # See TableDefinition#column for details of the options you can use.
+      #
+      #   change_column(:suppliers, :name, :string, limit: 80)
+      #   change_column(:accounts, :description, :text)
+      #
+      def change_column: (untyped table_name, untyped column_name, untyped `type`, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Sets a new default value for a column:
+      #
+      #   change_column_default(:suppliers, :qualification, 'new')
+      #   change_column_default(:accounts, :authorized, 1)
+      #
+      # Setting the default to +nil+ effectively drops the default:
+      #
+      #   change_column_default(:users, :email, nil)
+      #
+      # Passing a hash containing +:from+ and +:to+ will make this change
+      # reversible in migration:
+      #
+      #   change_column_default(:posts, :state, from: nil, to: "draft")
+      #
+      def change_column_default: (untyped table_name, untyped column_name, untyped default_or_changes) -> untyped
+
+      # Sets or removes a <tt>NOT NULL</tt> constraint on a column. The +null+ flag
+      # indicates whether the value can be +NULL+. For example
+      #
+      #   change_column_null(:users, :nickname, false)
+      #
+      # says nicknames cannot be +NULL+ (adds the constraint), whereas
+      #
+      #   change_column_null(:users, :nickname, true)
+      #
+      # allows them to be +NULL+ (drops the constraint).
+      #
+      # The method accepts an optional fourth argument to replace existing
+      # <tt>NULL</tt>s with some other value. Use that one when enabling the
+      # constraint if needed, since otherwise those rows would not be valid.
+      #
+      # Please note the fourth argument does not set a column's default.
+      def change_column_null: (untyped table_name, untyped column_name, untyped null, ?untyped? default) -> untyped
+
+      # Renames a column.
+      #
+      #   rename_column(:suppliers, :description, :name)
+      #
+      def rename_column: (untyped table_name, untyped column_name, untyped new_column_name) -> untyped
+
+      # Adds a new index to the table. +column_name+ can be a single Symbol, or
+      # an Array of Symbols.
+      #
+      # The index will be named after the table and the column name(s), unless
+      # you pass <tt>:name</tt> as an option.
+      #
+      # ====== Creating a simple index
+      #
+      #   add_index(:suppliers, :name)
+      #
+      # generates:
+      #
+      #   CREATE INDEX suppliers_name_index ON suppliers(name)
+      #
+      # ====== Creating a unique index
+      #
+      #   add_index(:accounts, [:branch_id, :party_id], unique: true)
+      #
+      # generates:
+      #
+      #   CREATE UNIQUE INDEX accounts_branch_id_party_id_index ON accounts(branch_id, party_id)
+      #
+      # ====== Creating a named index
+      #
+      #   add_index(:accounts, [:branch_id, :party_id], unique: true, name: 'by_branch_party')
+      #
+      # generates:
+      #
+      #  CREATE UNIQUE INDEX by_branch_party ON accounts(branch_id, party_id)
+      #
+      # ====== Creating an index with specific key length
+      #
+      #   add_index(:accounts, :name, name: 'by_name', length: 10)
+      #
+      # generates:
+      #
+      #   CREATE INDEX by_name ON accounts(name(10))
+      #
+      # ====== Creating an index with specific key lengths for multiple keys
+      #
+      #   add_index(:accounts, [:name, :surname], name: 'by_name_surname', length: {name: 10, surname: 15})
+      #
+      # generates:
+      #
+      #   CREATE INDEX by_name_surname ON accounts(name(10), surname(15))
+      #
+      # Note: SQLite doesn't support index length.
+      #
+      # ====== Creating an index with a sort order (desc or asc, asc is the default)
+      #
+      #   add_index(:accounts, [:branch_id, :party_id, :surname], order: {branch_id: :desc, party_id: :asc})
+      #
+      # generates:
+      #
+      #   CREATE INDEX by_branch_desc_party ON accounts(branch_id DESC, party_id ASC, surname)
+      #
+      # Note: MySQL only supports index order from 8.0.1 onwards (earlier versions accepted the syntax but ignored it).
+      #
+      # ====== Creating a partial index
+      #
+      #   add_index(:accounts, [:branch_id, :party_id], unique: true, where: "active")
+      #
+      # generates:
+      #
+      #   CREATE UNIQUE INDEX index_accounts_on_branch_id_and_party_id ON accounts(branch_id, party_id) WHERE active
+      #
+      # Note: Partial indexes are only supported for PostgreSQL and SQLite 3.8.0+.
+      #
+      # ====== Creating an index with a specific method
+      #
+      #   add_index(:developers, :name, using: 'btree')
+      #
+      # generates:
+      #
+      #   CREATE INDEX index_developers_on_name ON developers USING btree (name) -- PostgreSQL
+      #   CREATE INDEX index_developers_on_name USING btree ON developers (name) -- MySQL
+      #
+      # Note: only supported by PostgreSQL and MySQL
+      #
+      # ====== Creating an index with a specific operator class
+      #
+      #   add_index(:developers, :name, using: 'gist', opclass: :gist_trgm_ops)
+      #   # CREATE INDEX developers_on_name ON developers USING gist (name gist_trgm_ops) -- PostgreSQL
+      #
+      #   add_index(:developers, [:name, :city], using: 'gist', opclass: { city: :gist_trgm_ops })
+      #   # CREATE INDEX developers_on_name_and_city ON developers USING gist (name, city gist_trgm_ops) -- PostgreSQL
+      #
+      #   add_index(:developers, [:name, :city], using: 'gist', opclass: :gist_trgm_ops)
+      #   # CREATE INDEX developers_on_name_and_city ON developers USING gist (name gist_trgm_ops, city gist_trgm_ops) -- PostgreSQL
+      #
+      # Note: only supported by PostgreSQL
+      #
+      # ====== Creating an index with a specific type
+      #
+      #   add_index(:developers, :name, type: :fulltext)
+      #
+      # generates:
+      #
+      #   CREATE FULLTEXT INDEX index_developers_on_name ON developers (name) -- MySQL
+      #
+      # Note: only supported by MySQL.
+      #
+      # ====== Creating an index with a specific algorithm
+      #
+      #  add_index(:developers, :name, algorithm: :concurrently)
+      #  # CREATE INDEX CONCURRENTLY developers_on_name on developers (name)
+      #
+      # Note: only supported by PostgreSQL.
+      #
+      # Concurrently adding an index is not supported in a transaction.
+      #
+      # For more information see the {"Transactional Migrations" section}[rdoc-ref:Migration].
+      def add_index: (untyped table_name, untyped column_name, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Removes the given index from the table.
+      #
+      # Removes the index on +branch_id+ in the +accounts+ table if exactly one such index exists.
+      #
+      #   remove_index :accounts, :branch_id
+      #
+      # Removes the index on +branch_id+ in the +accounts+ table if exactly one such index exists.
+      #
+      #   remove_index :accounts, column: :branch_id
+      #
+      # Removes the index on +branch_id+ and +party_id+ in the +accounts+ table if exactly one such index exists.
+      #
+      #   remove_index :accounts, column: [:branch_id, :party_id]
+      #
+      # Removes the index named +by_branch_party+ in the +accounts+ table.
+      #
+      #   remove_index :accounts, name: :by_branch_party
+      #
+      # Removes the index named +by_branch_party+ in the +accounts+ table +concurrently+.
+      #
+      #   remove_index :accounts, name: :by_branch_party, algorithm: :concurrently
+      #
+      # Note: only supported by PostgreSQL.
+      #
+      # Concurrently removing an index is not supported in a transaction.
+      #
+      # For more information see the {"Transactional Migrations" section}[rdoc-ref:Migration].
+      def remove_index: (untyped table_name, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Renames an index.
+      #
+      # Rename the +index_people_on_last_name+ index to +index_users_on_last_name+:
+      #
+      #   rename_index :people, 'index_people_on_last_name', 'index_users_on_last_name'
+      #
+      def rename_index: (untyped table_name, untyped old_name, untyped new_name) -> (nil | untyped)
+
+      def index_name: (untyped table_name, untyped options) -> untyped
+
+      # Verifies the existence of an index with a given name.
+      def index_name_exists?: (untyped table_name, untyped index_name) -> untyped
+
+      # Adds a reference. The reference column is a bigint by default,
+      # the <tt>:type</tt> option can be used to specify a different type.
+      # Optionally adds a +_type+ column, if <tt>:polymorphic</tt> option is provided.
+      # #add_reference and #add_belongs_to are acceptable.
+      #
+      # The +options+ hash can include the following keys:
+      # [<tt>:type</tt>]
+      #   The reference column type. Defaults to +:bigint+.
+      # [<tt>:index</tt>]
+      #   Add an appropriate index. Defaults to true.
+      #   See #add_index for usage of this option.
+      # [<tt>:foreign_key</tt>]
+      #   Add an appropriate foreign key constraint. Defaults to false.
+      # [<tt>:polymorphic</tt>]
+      #   Whether an additional +_type+ column should be added. Defaults to false.
+      # [<tt>:null</tt>]
+      #   Whether the column allows nulls. Defaults to true.
+      #
+      # ====== Create a user_id bigint column without an index
+      #
+      #   add_reference(:products, :user, index: false)
+      #
+      # ====== Create a user_id string column
+      #
+      #   add_reference(:products, :user, type: :string)
+      #
+      # ====== Create supplier_id, supplier_type columns
+      #
+      #   add_reference(:products, :supplier, polymorphic: true)
+      #
+      # ====== Create a supplier_id column with a unique index
+      #
+      #   add_reference(:products, :supplier, index: { unique: true })
+      #
+      # ====== Create a supplier_id column with a named index
+      #
+      #   add_reference(:products, :supplier, index: { name: "my_supplier_index" })
+      #
+      # ====== Create a supplier_id column and appropriate foreign key
+      #
+      #   add_reference(:products, :supplier, foreign_key: true)
+      #
+      # ====== Create a supplier_id column and a foreign key to the firms table
+      #
+      #   add_reference(:products, :supplier, foreign_key: {to_table: :firms})
+      #
+      def add_reference: (untyped table_name, untyped ref_name, **untyped options) -> untyped
+
+      alias add_belongs_to add_reference
+
+      # Removes the reference(s). Also removes a +type+ column if one exists.
+      # #remove_reference and #remove_belongs_to are acceptable.
+      #
+      # ====== Remove the reference
+      #
+      #   remove_reference(:products, :user, index: false)
+      #
+      # ====== Remove polymorphic reference
+      #
+      #   remove_reference(:products, :supplier, polymorphic: true)
+      #
+      # ====== Remove the reference with a foreign key
+      #
+      #   remove_reference(:products, :user, foreign_key: true)
+      #
+      def remove_reference: (untyped table_name, untyped ref_name, ?polymorphic: bool polymorphic, ?foreign_key: bool foreign_key, **untyped options) -> untyped
+
+      alias remove_belongs_to remove_reference
+
+      # Returns an array of foreign keys for the given table.
+      # The foreign keys are represented as ForeignKeyDefinition objects.
+      def foreign_keys: (untyped table_name) -> untyped
+
+      # Adds a new foreign key. +from_table+ is the table with the key column,
+      # +to_table+ contains the referenced primary key.
+      #
+      # The foreign key will be named after the following pattern: <tt>fk_rails_<identifier></tt>.
+      # +identifier+ is a 10 character long string which is deterministically generated from the
+      # +from_table+ and +column+. A custom name can be specified with the <tt>:name</tt> option.
+      #
+      # ====== Creating a simple foreign key
+      #
+      #   add_foreign_key :articles, :authors
+      #
+      # generates:
+      #
+      #   ALTER TABLE "articles" ADD CONSTRAINT fk_rails_e74ce85cbc FOREIGN KEY ("author_id") REFERENCES "authors" ("id")
+      #
+      # ====== Creating a foreign key on a specific column
+      #
+      #   add_foreign_key :articles, :users, column: :author_id, primary_key: "lng_id"
+      #
+      # generates:
+      #
+      #   ALTER TABLE "articles" ADD CONSTRAINT fk_rails_58ca3d3a82 FOREIGN KEY ("author_id") REFERENCES "users" ("lng_id")
+      #
+      # ====== Creating a cascading foreign key
+      #
+      #   add_foreign_key :articles, :authors, on_delete: :cascade
+      #
+      # generates:
+      #
+      #   ALTER TABLE "articles" ADD CONSTRAINT fk_rails_e74ce85cbc FOREIGN KEY ("author_id") REFERENCES "authors" ("id") ON DELETE CASCADE
+      #
+      # The +options+ hash can include the following keys:
+      # [<tt>:column</tt>]
+      #   The foreign key column name on +from_table+. Defaults to <tt>to_table.singularize + "_id"</tt>
+      # [<tt>:primary_key</tt>]
+      #   The primary key column name on +to_table+. Defaults to +id+.
+      # [<tt>:name</tt>]
+      #   The constraint name. Defaults to <tt>fk_rails_<identifier></tt>.
+      # [<tt>:on_delete</tt>]
+      #   Action that happens <tt>ON DELETE</tt>. Valid values are +:nullify+, +:cascade+ and +:restrict+
+      # [<tt>:on_update</tt>]
+      #   Action that happens <tt>ON UPDATE</tt>. Valid values are +:nullify+, +:cascade+ and +:restrict+
+      # [<tt>:validate</tt>]
+      #   (PostgreSQL only) Specify whether or not the constraint should be validated. Defaults to +true+.
+      def add_foreign_key: (untyped from_table, untyped to_table, **untyped options) -> (nil | untyped)
+
+      # Removes the given foreign key from the table. Any option parameters provided
+      # will be used to re-add the foreign key in case of a migration rollback.
+      # It is recommended that you provide any options used when creating the foreign
+      # key so that the migration can be reverted properly.
+      #
+      # Removes the foreign key on +accounts.branch_id+.
+      #
+      #   remove_foreign_key :accounts, :branches
+      #
+      # Removes the foreign key on +accounts.owner_id+.
+      #
+      #   remove_foreign_key :accounts, column: :owner_id
+      #
+      # Removes the foreign key on +accounts.owner_id+.
+      #
+      #   remove_foreign_key :accounts, to_table: :owners
+      #
+      # Removes the foreign key named +special_fk_name+ on the +accounts+ table.
+      #
+      #   remove_foreign_key :accounts, name: :special_fk_name
+      #
+      # The +options+ hash accepts the same keys as SchemaStatements#add_foreign_key
+      # with an addition of
+      # [<tt>:to_table</tt>]
+      #   The name of the table that contains the referenced primary key.
+      def remove_foreign_key: (untyped from_table, ?untyped? to_table, **untyped options) -> (nil | untyped)
+
+      # Checks to see if a foreign key exists on a table for a given foreign key definition.
+      #
+      #   # Checks to see if a foreign key exists.
+      #   foreign_key_exists?(:accounts, :branches)
+      #
+      #   # Checks to see if a foreign key on a specified column exists.
+      #   foreign_key_exists?(:accounts, column: :owner_id)
+      #
+      #   # Checks to see if a foreign key with a custom name exists.
+      #   foreign_key_exists?(:accounts, name: "special_fk_name")
+      #
+      def foreign_key_exists?: (untyped from_table, ?untyped? to_table, **untyped options) -> untyped
+
+      def foreign_key_column_for: (untyped table_name) -> ::String
+
+      def foreign_key_options: (untyped from_table, untyped to_table, untyped options) -> untyped
+
+      def dump_schema_information: () -> untyped
+
+      def internal_string_options_for_primary_key: () -> { primary_key: ::TrueClass }
+
+      def assume_migrated_upto_version: (untyped version, ?untyped? migrations_paths) -> untyped
+
+      def type_to_sql: (untyped `type`, ?scale: untyped? scale, ?precision: untyped? precision, ?limit: untyped? limit) -> untyped
+
+      def columns_for_distinct: (untyped columns, untyped orders) -> untyped
+
+      # Adds timestamps (+created_at+ and +updated_at+) columns to +table_name+.
+      # Additional options (like +:null+) are forwarded to #add_column.
+      #
+      #   add_timestamps(:suppliers, null: true)
+      #
+      def add_timestamps: (untyped table_name, **untyped options) -> untyped
+
+      # Removes the timestamp columns (+created_at+ and +updated_at+) from the table definition.
+      #
+      #  remove_timestamps(:suppliers)
+      #
+      def remove_timestamps: (untyped table_name, **untyped options) -> untyped
+
+      def update_table_definition: (untyped table_name, untyped base) -> Table
+
+      def add_index_options: (untyped table_name, untyped column_name, ?comment: untyped? comment, **untyped options) -> ::Array[untyped]
+
+      def options_include_default?: (untyped options) -> untyped
+
+      # Changes the comment for a table or removes it if +nil+.
+      #
+      # Passing a hash containing +:from+ and +:to+ will make this change
+      # reversible in migration:
+      #
+      #   change_table_comment(:posts, from: "old_comment", to: "new_comment")
+      def change_table_comment: (untyped table_name, untyped comment_or_changes) -> untyped
+
+      # Changes the comment for a column or removes it if +nil+.
+      #
+      # Passing a hash containing +:from+ and +:to+ will make this change
+      # reversible in migration:
+      #
+      #   change_column_comment(:posts, :state, from: "old_comment", to: "new_comment")
+      def change_column_comment: (untyped table_name, untyped column_name, untyped comment_or_changes) -> untyped
+
+      def create_schema_dumper: (untyped options) -> untyped
+
+      def column_options_keys: () -> ::Array[:limit | :precision | :scale | :default | :null | :collation | :comment]
+
+      def add_index_sort_order: (untyped quoted_columns, **untyped options) -> untyped
+
+      def options_for_index_columns: (untyped options) -> untyped
+
+      # Overridden by the MySQL adapter for supporting index lengths and by
+      # the PostgreSQL adapter for supporting operator classes.
+      def add_options_for_index_columns: (untyped quoted_columns, **untyped options) -> untyped
+
+      def quoted_columns_for_index: (untyped column_names, **untyped options) -> (::Array[untyped] | untyped)
+
+      def index_name_for_remove: (untyped table_name, ?::Hash[untyped, untyped] options) -> untyped
+
+      def rename_table_indexes: (untyped table_name, untyped new_name) -> untyped
+
+      def rename_column_indexes: (untyped table_name, untyped column_name, untyped new_column_name) -> untyped
+
+      def schema_creation: () -> untyped
+
+      def create_table_definition: (*untyped args, **untyped options) -> TableDefinition
+
+      def create_alter_table: (untyped name) -> AlterTable
+
+      def fetch_type_metadata: (untyped sql_type) -> SqlTypeMetadata
+
+      def index_column_names: (untyped column_names) -> untyped
+
+      def index_name_options: (untyped column_names) -> { column: untyped }
+
+      def strip_table_name_prefix_and_suffix: (untyped table_name) -> untyped
+
+      def foreign_key_name: (untyped table_name, untyped options) -> untyped
+
+      def foreign_key_for: (untyped from_table, **untyped options) -> (nil | untyped)
+
+      def foreign_key_for!: (untyped from_table, ?to_table: untyped? to_table, **untyped options) -> untyped
+
+      def extract_foreign_key_action: (untyped specifier) -> untyped
+
+      def validate_index_length!: (untyped table_name, untyped new_name, ?bool internal) -> untyped
+
+      def extract_new_default_value: (untyped default_or_changes) -> untyped
+
+      alias extract_new_comment_value extract_new_default_value
+
+      def can_remove_index_by_name?: (untyped options) -> untyped
+
+      def bulk_change_table: (untyped table_name, untyped operations) -> untyped
+
+      def add_column_for_alter: (untyped table_name, untyped column_name, untyped `type`, **untyped options) -> untyped
+
+      def remove_column_for_alter: (untyped table_name, untyped column_name, ?untyped? `type`, **untyped options) -> ::String
+
+      def remove_columns_for_alter: (untyped table_name, *untyped column_names, **untyped options) -> untyped
+
+      def add_timestamps_for_alter: (untyped table_name, **untyped options) -> ::Array[untyped]
+
+      def remove_timestamps_for_alter: (untyped table_name, **untyped options) -> untyped
+
+      def insert_versions_sql: (untyped versions) -> untyped
+
+      def data_source_sql: (?untyped? name, ?type: untyped? `type`) -> untyped
+
+      def quoted_scope: (?untyped? name, ?type: untyped? `type`) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    class TransactionState
+      def initialize: (?untyped? state) -> untyped
+
+      def add_child: (untyped state) -> untyped
+
+      def finalized?: () -> untyped
+
+      def committed?: () -> untyped
+
+      def fully_committed?: () -> untyped
+
+      def rolledback?: () -> untyped
+
+      def fully_rolledback?: () -> untyped
+
+      def fully_completed?: () -> untyped
+
+      def completed?: () -> untyped
+
+      def rollback!: () -> untyped
+
+      def full_rollback!: () -> untyped
+
+      def commit!: () -> untyped
+
+      def full_commit!: () -> untyped
+
+      def nullify!: () -> untyped
+    end
+
+    class NullTransaction
+      # nodoc:
+      def initialize: () -> nil
+
+      def state: () -> nil
+
+      def closed?: () -> ::TrueClass
+
+      def open?: () -> ::FalseClass
+
+      def joinable?: () -> ::FalseClass
+
+      def add_record: (untyped record) -> nil
+    end
+
+    class Transaction
+      # nodoc:
+      attr_reader connection: untyped
+
+      # nodoc:
+      attr_reader state: untyped
+
+      # nodoc:
+      attr_reader records: untyped
+
+      # nodoc:
+      attr_reader savepoint_name: untyped
+
+      # nodoc:
+      attr_reader isolation_level: untyped
+
+      def initialize: (untyped connection, untyped options, ?run_commit_callbacks: bool run_commit_callbacks) -> untyped
+
+      def add_record: (untyped record) -> untyped
+
+      def materialize!: () -> untyped
+
+      def materialized?: () -> untyped
+
+      def rollback_records: () -> untyped
+
+      def before_commit_records: () -> untyped
+
+      def commit_records: () -> untyped
+
+      def full_rollback?: () -> ::TrueClass
+
+      def joinable?: () -> untyped
+
+      def closed?: () -> ::FalseClass
+
+      def open?: () -> untyped
+    end
+
+    class SavepointTransaction < Transaction
+      def initialize: (untyped connection, untyped savepoint_name, untyped parent_transaction, *untyped args, **untyped options) -> untyped
+
+      def materialize!: () -> untyped
+
+      def rollback: () -> untyped
+
+      def commit: () -> untyped
+
+      def full_rollback?: () -> ::FalseClass
+    end
+
+    class RealTransaction < Transaction
+      def materialize!: () -> untyped
+
+      def rollback: () -> untyped
+
+      def commit: () -> untyped
+    end
+
+    class TransactionManager
+      # nodoc:
+      def initialize: (untyped connection) -> untyped
+
+      def begin_transaction: (?::Hash[untyped, untyped] options) -> untyped
+
+      def disable_lazy_transactions!: () -> untyped
+
+      def enable_lazy_transactions!: () -> untyped
+
+      def lazy_transactions_enabled?: () -> untyped
+
+      def materialize_transactions: () -> (nil | untyped)
+
+      def commit_transaction: () -> untyped
+
+      def rollback_transaction: (?untyped? transaction) -> untyped
+
+      def within_new_transaction: (?::Hash[untyped, untyped] options) { () -> untyped } -> untyped
+
+      def open_transactions: () -> untyped
+
+      def current_transaction: () -> untyped
+
+      NULL_TRANSACTION: untyped
+
+      # Deallocate invalidated prepared statements outside of the transaction
+      def after_failure_actions: (untyped transaction, untyped error) -> (nil | untyped)
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    # :nodoc:
+    extend ActiveSupport::Autoload
+
+    # Active Record supports multiple database systems. AbstractAdapter and
+    # related classes form the abstraction layer which makes this possible.
+    # An AbstractAdapter represents a connection to a database, and provides an
+    # abstract interface for database-specific functionality such as establishing
+    # a connection, escaping values, building the right SQL fragments for +:offset+
+    # and +:limit+ options, etc.
+    #
+    # All the concrete database adapters follow the interface laid down in this class.
+    # {ActiveRecord::Base.connection}[rdoc-ref:ConnectionHandling#connection] returns an AbstractAdapter object, which
+    # you can use.
+    #
+    # Most of the methods in the adapter are useful during migrations. Most
+    # notably, the instance methods provided by SchemaStatements are very useful.
+    class AbstractAdapter
+      ADAPTER_NAME: ::String
+
+      include ActiveSupport::Callbacks
+
+      include Quoting
+
+      include DatabaseStatements
+
+      include SchemaStatements
+
+      include DatabaseLimits
+
+      include QueryCache
+
+      include Savepoints
+
+      SIMPLE_INT: untyped
+
+      COMMENT_REGEX: untyped
+
+      attr_accessor pool: untyped
+
+      attr_reader visitor: untyped
+
+      attr_reader owner: untyped
+
+      attr_reader logger: untyped
+
+      attr_reader lock: untyped
+
+      alias in_use? owner
+
+      def self.type_cast_config_to_integer: (untyped config) -> untyped
+
+      def self.type_cast_config_to_boolean: (untyped config) -> untyped
+
+      def self.build_read_query_regexp: (*untyped parts) -> ::Regexp
+
+      def self.quoted_column_names: () -> untyped
+
+      def self.quoted_table_names: () -> untyped
+
+      def initialize: (untyped connection, ?untyped? logger, ?::Hash[untyped, untyped] config) -> untyped
+
+      def replica?: () -> untyped
+
+      # Determines whether writes are currently being prevents.
+      #
+      # Returns true if the connection is a replica, or if +prevent_writes+
+      # is set to true.
+      def preventing_writes?: () -> untyped
+
+      def migrations_paths: () -> untyped
+
+      def migration_context: () -> MigrationContext
+
+      def schema_migration: () -> untyped
+
+      def prepared_statements: () -> untyped
+
+      def prepared_statements_disabled_cache: () -> untyped
+
+      class Version
+        include Comparable
+
+        attr_reader full_version_string: untyped
+
+        def initialize: (untyped version_string, ?untyped? full_version_string) -> untyped
+
+        def <=>: (untyped version_string) -> untyped
+
+        def to_s: () -> untyped
+      end
+
+      def valid_type?: (untyped `type`) -> untyped
+
+      # this method must only be called while holding connection pool's mutex
+      def lease: () -> untyped
+
+      def schema_cache: () -> untyped
+
+      def schema_cache=: (untyped cache) -> untyped
+
+      # this method must only be called while holding connection pool's mutex
+      def expire: () -> untyped
+
+      def steal!: () -> untyped
+
+      def seconds_idle: () -> (0 | untyped)
+
+      def unprepared_statement: () { () -> untyped } -> untyped
+
+      # Returns the human-readable name of the adapter. Use mixed case - one
+      # can always use downcase if needed.
+      def adapter_name: () -> untyped
+
+      # Does the database for this adapter exist?
+      def self.database_exists?: (untyped config) -> untyped
+
+      # Does this adapter support DDL rollbacks in transactions? That is, would
+      # CREATE TABLE or ALTER TABLE get rolled back by a transaction?
+      def supports_ddl_transactions?: () -> ::FalseClass
+
+      def supports_bulk_alter?: () -> ::FalseClass
+
+      # Does this adapter support savepoints?
+      def supports_savepoints?: () -> ::FalseClass
+
+      # Does this adapter support application-enforced advisory locking?
+      def supports_advisory_locks?: () -> ::FalseClass
+
+      # Should primary key values be selected from their corresponding
+      # sequence before the insert statement? If true, next_sequence_value
+      # is called before each insert to set the record's primary key.
+      def prefetch_primary_key?: (?untyped? table_name) -> ::FalseClass
+
+      def supports_partitioned_indexes?: () -> ::FalseClass
+
+      # Does this adapter support index sort order?
+      def supports_index_sort_order?: () -> ::FalseClass
+
+      # Does this adapter support partial indices?
+      def supports_partial_index?: () -> ::FalseClass
+
+      # Does this adapter support expression indices?
+      def supports_expression_index?: () -> ::FalseClass
+
+      # Does this adapter support explain?
+      def supports_explain?: () -> ::FalseClass
+
+      # Does this adapter support setting the isolation level for a transaction?
+      def supports_transaction_isolation?: () -> ::FalseClass
+
+      # Does this adapter support database extensions?
+      def supports_extensions?: () -> ::FalseClass
+
+      # Does this adapter support creating indexes in the same statement as
+      # creating the table?
+      def supports_indexes_in_create?: () -> ::FalseClass
+
+      # Does this adapter support creating foreign key constraints?
+      def supports_foreign_keys?: () -> ::FalseClass
+
+      # Does this adapter support creating invalid constraints?
+      def supports_validate_constraints?: () -> ::FalseClass
+
+      # Does this adapter support creating foreign key constraints
+      # in the same statement as creating the table?
+      def supports_foreign_keys_in_create?: () -> untyped
+
+      # Does this adapter support views?
+      def supports_views?: () -> ::FalseClass
+
+      # Does this adapter support materialized views?
+      def supports_materialized_views?: () -> ::FalseClass
+
+      # Does this adapter support datetime with precision?
+      def supports_datetime_with_precision?: () -> ::FalseClass
+
+      # Does this adapter support json data type?
+      def supports_json?: () -> ::FalseClass
+
+      # Does this adapter support metadata comments on database objects (tables, columns, indexes)?
+      def supports_comments?: () -> ::FalseClass
+
+      # Can comments for tables, columns, and indexes be specified in create/alter table statements?
+      def supports_comments_in_create?: () -> ::FalseClass
+
+      # Does this adapter support multi-value insert?
+      def supports_multi_insert?: () -> ::TrueClass
+
+      # Does this adapter support virtual columns?
+      def supports_virtual_columns?: () -> ::FalseClass
+
+      # Does this adapter support foreign/external tables?
+      def supports_foreign_tables?: () -> ::FalseClass
+
+      # Does this adapter support optimizer hints?
+      def supports_optimizer_hints?: () -> ::FalseClass
+
+      def supports_common_table_expressions?: () -> ::FalseClass
+
+      def supports_lazy_transactions?: () -> ::FalseClass
+
+      def supports_insert_returning?: () -> ::FalseClass
+
+      def supports_insert_on_duplicate_skip?: () -> ::FalseClass
+
+      def supports_insert_on_duplicate_update?: () -> ::FalseClass
+
+      def supports_insert_conflict_target?: () -> ::FalseClass
+
+      # This is meant to be implemented by the adapters that support extensions
+      def disable_extension: (untyped name) -> nil
+
+      # This is meant to be implemented by the adapters that support extensions
+      def enable_extension: (untyped name) -> nil
+
+      def advisory_locks_enabled?: () -> untyped
+
+      def get_advisory_lock: (untyped lock_id) -> nil
+
+      def release_advisory_lock: (untyped lock_id) -> nil
+
+      # A list of extensions, to be filled in by adapters that support them.
+      def extensions: () -> ::Array[untyped]
+
+      # A list of index algorithms, to be filled by adapters that support them.
+      def index_algorithms: () -> ::Hash[untyped, untyped]
+
+      # Override to turn off referential integrity while executing <tt>&block</tt>.
+      def disable_referential_integrity: () { () -> untyped } -> untyped
+
+      # Checks whether the connection to the database is still active. This includes
+      # checking whether the database is actually capable of responding, i.e. whether
+      # the connection isn't stale.
+      def active?: () -> nil
+
+      # Disconnects from the database if already connected, and establishes a
+      # new connection with the database. Implementors should call super if they
+      # override the default implementation.
+      def reconnect!: () -> untyped
+
+      # Disconnects from the database if already connected. Otherwise, this
+      # method does nothing.
+      def disconnect!: () -> untyped
+
+      # Immediately forget this connection ever existed. Unlike disconnect!,
+      # this will not communicate with the server.
+      #
+      # After calling this method, the behavior of all other methods becomes
+      # undefined. This is called internally just before a forked process gets
+      # rid of a connection that belonged to its parent.
+      def discard!: () -> untyped
+
+      # Reset the state of this connection, directing the DBMS to clear
+      # transactions and other connection-related server-side state. Usually a
+      # database-dependent operation.
+      #
+      # The default implementation does nothing; the implementation should be
+      # overridden by concrete adapters.
+      def reset!: () -> nil
+
+      # Clear any caching the database adapter may be doing.
+      def clear_cache!: () -> untyped
+
+      # Returns true if its required to reload the connection between requests for development mode.
+      def requires_reloading?: () -> ::FalseClass
+
+      # Checks whether the connection to the database is still active (i.e. not stale).
+      # This is done under the hood by calling #active?. If the connection
+      # is no longer active, then this method will reconnect to the database.
+      def verify!: () -> untyped
+
+      # Provides access to the underlying database driver for this adapter. For
+      # example, this method returns a Mysql2::Client object in case of Mysql2Adapter,
+      # and a PG::Connection object in case of PostgreSQLAdapter.
+      #
+      # This is useful for when you need to call a proprietary method such as
+      # PostgreSQL's lo_* methods.
+      def raw_connection: () -> untyped
+
+      def default_uniqueness_comparison: (untyped attribute, untyped value, untyped klass) -> untyped
+
+      def case_sensitive_comparison: (untyped attribute, untyped value) -> untyped
+
+      def case_insensitive_comparison: (untyped attribute, untyped value) -> untyped
+
+      def can_perform_case_insensitive_comparison_for?: (untyped column) -> ::TrueClass
+
+      # Check the connection back in to the connection pool
+      def close: () -> untyped
+
+      def column_name_for_operation: (untyped operation, untyped node) -> untyped
+
+      def default_index_type?: (untyped index) -> untyped
+
+      def build_insert_sql: (untyped insert) -> ::String
+
+      def get_database_version: () -> nil
+
+      def database_version: () -> untyped
+
+      def check_version: () -> nil
+
+      def type_map: () -> untyped
+
+      def initialize_type_map: (?untyped m) -> untyped
+
+      def reload_type_map: () -> untyped
+
+      def register_class_with_limit: (untyped mapping, untyped key, untyped klass) -> untyped
+
+      def register_class_with_precision: (untyped mapping, untyped key, untyped klass) -> untyped
+
+      def extract_scale: (untyped sql_type) -> untyped
+
+      def extract_precision: (untyped sql_type) -> untyped
+
+      def extract_limit: (untyped sql_type) -> untyped
+
+      def translate_exception_class: (untyped e, untyped sql, untyped binds) -> untyped
+
+      def log: (untyped sql, ?::String name, ?untyped binds, ?untyped type_casted_binds, ?untyped? statement_name) { () -> untyped } -> untyped
+
+      def translate_exception: (untyped exception, binds: untyped binds, sql: untyped sql, message: untyped message) -> untyped
+
+      def without_prepared_statement?: (untyped binds) -> untyped
+
+      def column_for: (untyped table_name, untyped column_name) -> untyped
+
+      def column_for_attribute: (untyped attribute) -> untyped
+
+      def collector: () -> untyped
+
+      def arel_visitor: () -> Arel::Visitors::ToSql
+
+      def build_statement_pool: () -> nil
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    class AbstractMysqlAdapter < AbstractAdapter
+      include MySQL::Quoting
+
+      include MySQL::SchemaStatements
+
+      NATIVE_DATABASE_TYPES: ::Hash[untyped, untyped]
+
+      class StatementPool < ConnectionAdapters::StatementPool
+        def dealloc: (untyped stmt) -> untyped
+      end
+
+      def initialize: (untyped connection, untyped logger, untyped connection_options, untyped config) -> untyped
+
+      def get_database_version: () -> AbstractAdapter::Version
+
+      def mariadb?: () -> untyped
+
+      def supports_bulk_alter?: () -> ::TrueClass
+
+      def supports_index_sort_order?: () -> untyped
+
+      def supports_expression_index?: () -> untyped
+
+      def supports_transaction_isolation?: () -> ::TrueClass
+
+      def supports_explain?: () -> ::TrueClass
+
+      def supports_indexes_in_create?: () -> ::TrueClass
+
+      def supports_foreign_keys?: () -> ::TrueClass
+
+      def supports_views?: () -> ::TrueClass
+
+      def supports_datetime_with_precision?: () -> untyped
+
+      def supports_virtual_columns?: () -> untyped
+
+      # See https://dev.mysql.com/doc/refman/8.0/en/optimizer-hints.html for more details.
+      def supports_optimizer_hints?: () -> untyped
+
+      def supports_common_table_expressions?: () -> untyped
+
+      def supports_advisory_locks?: () -> ::TrueClass
+
+      def supports_insert_on_duplicate_skip?: () -> ::TrueClass
+
+      def supports_insert_on_duplicate_update?: () -> ::TrueClass
+
+      def get_advisory_lock: (untyped lock_name, ?::Integer timeout) -> untyped
+
+      def release_advisory_lock: (untyped lock_name) -> untyped
+
+      def native_database_types: () -> untyped
+
+      def index_algorithms: () -> { default: untyped, copy: untyped, inplace: untyped }
+
+      def each_hash: (untyped result) -> untyped
+
+      def error_number: (untyped exception) -> untyped
+
+      def disable_referential_integrity: () { () -> untyped } -> untyped
+
+      def clear_cache!: () -> untyped
+
+      def explain: (untyped arel, ?untyped binds) -> untyped
+
+      # Executes the SQL statement in the context of this connection.
+      def execute: (untyped sql, ?untyped? name) -> untyped
+
+      def execute_and_free: (untyped sql, ?untyped? name) { (untyped) -> untyped } -> untyped
+
+      def begin_db_transaction: () -> untyped
+
+      def begin_isolated_db_transaction: (untyped isolation) -> untyped
+
+      def commit_db_transaction: () -> untyped
+
+      def exec_rollback_db_transaction: () -> untyped
+
+      def empty_insert_statement_value: (?untyped? primary_key) -> "VALUES ()"
+
+      # Drops the database specified on the +name+ attribute
+      # and creates it again using the provided +options+.
+      def recreate_database: (untyped name, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Create a new MySQL database with optional <tt>:charset</tt> and <tt>:collation</tt>.
+      # Charset defaults to utf8mb4.
+      #
+      # Example:
+      #   create_database 'charset_test', charset: 'latin1', collation: 'latin1_bin'
+      #   create_database 'matt_development'
+      #   create_database 'matt_development', charset: :big5
+      def create_database: (untyped name, ?::Hash[untyped, untyped] options) -> untyped
+
+      def drop_database: (untyped name) -> untyped
+
+      def current_database: () -> untyped
+
+      # Returns the database character set.
+      def charset: () -> untyped
+
+      # Returns the database collation strategy.
+      def collation: () -> untyped
+
+      def table_comment: (untyped table_name) -> untyped
+
+      def change_table_comment: (untyped table_name, untyped comment_or_changes) -> untyped
+
+      # Renames a table.
+      #
+      # Example:
+      #   rename_table('octopuses', 'octopi')
+      def rename_table: (untyped table_name, untyped new_name) -> untyped
+
+      # Drops a table from the database.
+      #
+      # [<tt>:force</tt>]
+      #   Set to +:cascade+ to drop dependent objects as well.
+      #   Defaults to false.
+      # [<tt>:if_exists</tt>]
+      #   Set to +true+ to only drop the table if it exists.
+      #   Defaults to false.
+      # [<tt>:temporary</tt>]
+      #   Set to +true+ to drop temporary table.
+      #   Defaults to false.
+      #
+      # Although this command ignores most +options+ and the block if one is given,
+      # it can be helpful to provide these in a migration's +change+ method so it can be reverted.
+      # In that case, +options+ and the block will be used by create_table.
+      def drop_table: (untyped table_name, ?::Hash[untyped, untyped] options) -> untyped
+
+      def rename_index: (untyped table_name, untyped old_name, untyped new_name) -> untyped
+
+      def change_column_default: (untyped table_name, untyped column_name, untyped default_or_changes) -> untyped
+
+      def change_column_null: (untyped table_name, untyped column_name, untyped null, ?untyped? default) -> untyped
+
+      def change_column_comment: (untyped table_name, untyped column_name, untyped comment_or_changes) -> untyped
+
+      def change_column: (untyped table_name, untyped column_name, untyped `type`, ?::Hash[untyped, untyped] options) -> untyped
+
+      def rename_column: (untyped table_name, untyped column_name, untyped new_column_name) -> untyped
+
+      def add_index: (untyped table_name, untyped column_name, ?::Hash[untyped, untyped] options) -> untyped
+
+      def add_sql_comment!: (untyped sql, untyped comment) -> untyped
+
+      def foreign_keys: (untyped table_name) -> untyped
+
+      def table_options: (untyped table_name) -> untyped
+
+      # SHOW VARIABLES LIKE 'name'
+      def show_variable: (untyped name) -> untyped
+
+      def primary_keys: (untyped table_name) -> untyped
+
+      def default_uniqueness_comparison: (untyped attribute, untyped value, untyped klass) -> untyped
+
+      def case_sensitive_comparison: (untyped attribute, untyped value) -> untyped
+
+      def can_perform_case_insensitive_comparison_for?: (untyped column) -> untyped
+
+      def columns_for_distinct: (untyped columns, untyped orders) -> untyped
+
+      def strict_mode?: () -> untyped
+
+      def default_index_type?: (untyped index) -> untyped
+
+      def build_insert_sql: (untyped insert) -> untyped
+
+      def check_version: () -> untyped
+
+      def initialize_type_map: (?untyped m) -> untyped
+
+      def register_integer_type: (untyped mapping, untyped key, **untyped options) -> untyped
+
+      def extract_precision: (untyped sql_type) -> untyped
+
+      # See https://dev.mysql.com/doc/refman/5.7/en/error-messages-server.html
+      ER_FILSORT_ABORT: ::Integer
+
+      ER_DUP_ENTRY: ::Integer
+
+      ER_NOT_NULL_VIOLATION: ::Integer
+
+      ER_NO_REFERENCED_ROW: ::Integer
+
+      ER_ROW_IS_REFERENCED: ::Integer
+
+      ER_DO_NOT_HAVE_DEFAULT: ::Integer
+
+      ER_ROW_IS_REFERENCED_2: ::Integer
+
+      ER_NO_REFERENCED_ROW_2: ::Integer
+
+      ER_DATA_TOO_LONG: ::Integer
+
+      ER_OUT_OF_RANGE: ::Integer
+
+      ER_LOCK_DEADLOCK: ::Integer
+
+      ER_CANNOT_ADD_FOREIGN: ::Integer
+
+      ER_CANNOT_CREATE_TABLE: ::Integer
+
+      ER_LOCK_WAIT_TIMEOUT: ::Integer
+
+      ER_QUERY_INTERRUPTED: ::Integer
+
+      ER_QUERY_TIMEOUT: ::Integer
+
+      ER_FK_INCOMPATIBLE_COLUMNS: ::Integer
+
+      def translate_exception: (untyped exception, binds: untyped binds, sql: untyped sql, message: untyped message) -> untyped
+
+      def change_column_for_alter: (untyped table_name, untyped column_name, untyped `type`, ?::Hash[untyped, untyped] options) -> untyped
+
+      def rename_column_for_alter: (untyped table_name, untyped column_name, untyped new_column_name) -> untyped
+
+      def add_index_for_alter: (untyped table_name, untyped column_name, ?::Hash[untyped, untyped] options) -> ::String
+
+      def remove_index_for_alter: (untyped table_name, ?::Hash[untyped, untyped] options) -> ::String
+
+      def supports_rename_index?: () -> untyped
+
+      def configure_connection: () -> untyped
+
+      def column_definitions: (untyped table_name) -> untyped
+
+      def create_table_info: (untyped table_name) -> untyped
+
+      def arel_visitor: () -> Arel::Visitors::MySQL
+
+      def build_statement_pool: () -> StatementPool
+
+      def mismatched_foreign_key: (untyped message, binds: untyped binds, sql: untyped sql) -> MismatchedForeignKey
+
+      def version_string: (untyped full_version_string) -> untyped
+
+      class MysqlString < ActiveModel::Type::String
+        # :nodoc:
+        def serialize: (untyped value) -> untyped
+
+        def cast_value: (untyped value) -> untyped
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  # :stopdoc:
+  module ConnectionAdapters
+    # An abstract definition of a column in a table.
+    class Column
+      attr_reader name: untyped
+
+      attr_reader default: untyped
+
+      attr_reader sql_type_metadata: untyped
+
+      attr_reader null: untyped
+
+      attr_reader default_function: untyped
+
+      attr_reader collation: untyped
+
+      attr_reader comment: untyped
+
+      # Instantiates a new column in the table.
+      #
+      # +name+ is the column's name, such as <tt>supplier_id</tt> in <tt>supplier_id bigint</tt>.
+      # +default+ is the type-casted default value, such as +new+ in <tt>sales_stage varchar(20) default 'new'</tt>.
+      # +sql_type_metadata+ is various information about the type of the column
+      # +null+ determines if this column allows +NULL+ values.
+      def initialize: (untyped name, untyped default, ?untyped? sql_type_metadata, ?bool null, ?untyped? default_function, ?comment: untyped? comment, ?collation: untyped? collation) -> untyped
+
+      def has_default?: () -> untyped
+
+      def bigint?: () -> untyped
+
+      # Returns the human name of the column name.
+      #
+      # ===== Examples
+      #  Column.new('sales_stage', ...).human_name # => 'Sales stage'
+      def human_name: () -> untyped
+
+      def init_with: (untyped coder) -> untyped
+
+      def encode_with: (untyped coder) -> untyped
+
+      def ==: (untyped other) -> untyped
+
+      alias eql? ==
+
+      def hash: () -> untyped
+    end
+
+    class NullColumn < Column
+      def initialize: (untyped name) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    class ConnectionSpecification
+      # nodoc:
+      attr_reader name: untyped
+
+      # nodoc:
+      attr_reader config: untyped
+
+      # nodoc:
+      attr_reader adapter_method: untyped
+
+      def initialize: (untyped name, untyped config, untyped adapter_method) -> untyped
+
+      def initialize_dup: (untyped original) -> untyped
+
+      def to_hash: () -> untyped
+
+      class ConnectionUrlResolver
+        # Expands a connection string into a hash.
+        # :nodoc:
+        # == Example
+        #
+        #   url = "postgresql://foo:bar@localhost:9000/foo_test?pool=5&timeout=3000"
+        #   ConnectionUrlResolver.new(url).to_hash
+        #   # => {
+        #     "adapter"  => "postgresql",
+        #     "host"     => "localhost",
+        #     "port"     => 9000,
+        #     "database" => "foo_test",
+        #     "username" => "foo",
+        #     "password" => "bar",
+        #     "pool"     => "5",
+        #     "timeout"  => "3000"
+        #   }
+        def initialize: (untyped url) -> untyped
+
+        # Converts the given URL to a full connection hash.
+        def to_hash: () -> untyped
+
+        attr_reader uri: untyped
+
+        def uri_parser: () -> untyped
+
+        # Converts the query parameters of the URI into a hash.
+        #
+        #   "localhost?pool=5&reaping_frequency=2"
+        #   # => { "pool" => "5", "reaping_frequency" => "2" }
+        #
+        # returns empty hash if no query present.
+        #
+        #   "localhost"
+        #   # => {}
+        def query_hash: () -> untyped
+
+        def raw_config: () -> untyped
+
+        # Returns name of the database.
+        def database_from_path: () -> untyped
+      end
+
+      class Resolver
+        #
+        # Builds a ConnectionSpecification from user input.
+        # :nodoc:
+        attr_reader configurations: untyped
+
+        # Accepts a list of db config objects.
+        def initialize: (untyped configurations) -> untyped
+
+        # Returns a hash with database connection information.
+        #
+        # == Examples
+        #
+        # Full hash Configuration.
+        #
+        #   configurations = { "production" => { "host" => "localhost", "database" => "foo", "adapter" => "sqlite3" } }
+        #   Resolver.new(configurations).resolve(:production)
+        #   # => { "host" => "localhost", "database" => "foo", "adapter" => "sqlite3"}
+        #
+        # Initialized with URL configuration strings.
+        #
+        #   configurations = { "production" => "postgresql://localhost/foo" }
+        #   Resolver.new(configurations).resolve(:production)
+        #   # => { "host" => "localhost", "database" => "foo", "adapter" => "postgresql" }
+        #
+        def resolve: (untyped config_or_env, ?untyped? pool_name) -> untyped
+
+        # Returns an instance of ConnectionSpecification for a given adapter.
+        # Accepts a hash one layer deep that contains all connection information.
+        #
+        # == Example
+        #
+        #   config = { "production" => { "host" => "localhost", "database" => "foo", "adapter" => "sqlite3" } }
+        #   spec = Resolver.new(config).spec(:production)
+        #   spec.adapter_method
+        #   # => "sqlite3_connection"
+        #   spec.config
+        #   # => { "host" => "localhost", "database" => "foo", "adapter" => "sqlite3" }
+        #
+        def spec: (untyped config) -> ConnectionSpecification
+
+        # Returns fully resolved connection, accepts hash, string or symbol.
+        # Always returns a hash.
+        #
+        # == Examples
+        #
+        # Symbol representing current environment.
+        #
+        #   Resolver.new("production" => {}).resolve_connection(:production)
+        #   # => {}
+        #
+        # One layer deep hash of connection values.
+        #
+        #   Resolver.new({}).resolve_connection("adapter" => "sqlite3")
+        #   # => { "adapter" => "sqlite3" }
+        #
+        # Connection URL.
+        #
+        #   Resolver.new({}).resolve_connection("postgresql://localhost/foo")
+        #   # => { "host" => "localhost", "database" => "foo", "adapter" => "postgresql" }
+        #
+        def resolve_connection: (untyped config_or_env, ?untyped? pool_name) -> untyped
+
+        # Takes the environment such as +:production+ or +:development+ and a
+        # pool name the corresponds to the name given by the connection pool
+        # to the connection. That pool name is merged into the hash with the
+        # name key.
+        #
+        # This requires that the @configurations was initialized with a key that
+        # matches.
+        #
+        #   configurations = #<ActiveRecord::DatabaseConfigurations:0x00007fd9fdace3e0
+        #     @configurations=[
+        #       #<ActiveRecord::DatabaseConfigurations::HashConfig:0x00007fd9fdace250
+        #         @env_name="production", @spec_name="primary", @config={"database"=>"my_db"}>
+        #       ]>
+        #
+        #   Resolver.new(configurations).resolve_symbol_connection(:production, "primary")
+        #   # => { "database" => "my_db" }
+        def resolve_symbol_connection: (untyped env_name, untyped pool_name) -> untyped
+
+        def build_configuration_sentence: () -> untyped
+
+        # Accepts a hash. Expands the "url" key that contains a
+        # URL database connection to a full connection
+        # hash and merges with the rest of the hash.
+        # Connection details inside of the "url" key win any merge conflicts
+        def resolve_hash_connection: (untyped spec) -> untyped
+
+        # Takes a connection URL.
+        #
+        #   Resolver.new({}).resolve_url_connection("postgresql://localhost/foo")
+        #   # => { "host" => "localhost", "database" => "foo", "adapter" => "postgresql" }
+        #
+        def resolve_url_connection: (untyped url) -> untyped
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    module DetermineIfPreparableVisitor
+      attr_accessor preparable: untyped
+
+      def accept: (untyped object, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_In: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_NotIn: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_SqlLiteral: (untyped o, untyped collector) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    module MySQL
+      class Column < ConnectionAdapters::Column
+        def unsigned?: () -> untyped
+
+        def case_sensitive?: () -> untyped
+
+        def auto_increment?: () -> untyped
+
+        def virtual?: () -> untyped
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    module MySQL
+      module DatabaseStatements
+        def select_all: () -> untyped
+
+        def query: (untyped sql, ?untyped? name) -> untyped
+
+        READ_QUERY: untyped
+
+        def write_query?: (untyped sql) -> untyped
+
+        # Executes the SQL statement in the context of this connection.
+        def execute: (untyped sql, ?untyped? name) -> untyped
+
+        def exec_query: (untyped sql, ?::String name, ?untyped binds, ?prepare: bool prepare) -> untyped
+
+        def exec_delete: (untyped sql, ?untyped? name, ?untyped binds) -> untyped
+
+        alias exec_update exec_delete
+
+        def execute_batch: (untyped statements, ?untyped? name) -> untyped
+
+        def default_insert_value: (untyped column) -> untyped
+
+        def last_inserted_id: (untyped result) -> untyped
+
+        def supports_set_server_option?: () -> untyped
+
+        def multi_statements_enabled?: (untyped flags) -> untyped
+
+        def with_multi_statements: () { () -> untyped } -> untyped
+
+        def combine_multi_statements: (untyped total_sql) -> untyped
+
+        def max_allowed_packet_reached?: (untyped current_packet, untyped previous_packet) -> untyped
+
+        def max_allowed_packet: () -> untyped
+
+        def exec_stmt_and_free: (untyped sql, untyped name, untyped binds, ?cache_stmt: bool cache_stmt) { (untyped, untyped) -> untyped } -> untyped
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    module MySQL
+      class ExplainPrettyPrinter
+        # :nodoc:
+        # Pretty prints the result of an EXPLAIN in a way that resembles the output of the
+        # MySQL shell:
+        #
+        #   +----+-------------+-------+-------+---------------+---------+---------+-------+------+-------------+
+        #   | id | select_type | table | type  | possible_keys | key     | key_len | ref   | rows | Extra       |
+        #   +----+-------------+-------+-------+---------------+---------+---------+-------+------+-------------+
+        #   |  1 | SIMPLE      | users | const | PRIMARY       | PRIMARY | 4       | const |    1 |             |
+        #   |  1 | SIMPLE      | posts | ALL   | NULL          | NULL    | NULL    | NULL  |    1 | Using where |
+        #   +----+-------------+-------+-------+---------------+---------+---------+-------+------+-------------+
+        #   2 rows in set (0.00 sec)
+        #
+        # This is an exercise in Ruby hyperrealism :).
+        def pp: (untyped result, untyped elapsed) -> untyped
+
+        def compute_column_widths: (untyped result) -> untyped
+
+        def build_separator: (untyped widths) -> untyped
+
+        def build_cells: (untyped items, untyped widths) -> untyped
+
+        def build_footer: (untyped nrows, untyped elapsed) -> untyped
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    module MySQL
+      module Quoting
+        # :nodoc:
+        def quote_column_name: (untyped name) -> untyped
+
+        def quote_table_name: (untyped name) -> untyped
+
+        def unquoted_true: () -> 1
+
+        def unquoted_false: () -> 0
+
+        def quoted_date: (untyped value) -> untyped
+
+        def quoted_binary: (untyped value) -> ::String
+
+        def column_name_matcher: () -> untyped
+
+        def column_name_with_order_matcher: () -> untyped
+
+        COLUMN_NAME: untyped
+
+        COLUMN_NAME_WITH_ORDER: untyped
+
+        def _type_cast: (untyped value) -> untyped
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    module MySQL
+      class SchemaCreation < AbstractAdapter::SchemaCreation
+        def visit_DropForeignKey: (untyped name) -> ::String
+
+        def visit_AddColumnDefinition: (untyped o) -> untyped
+
+        def visit_ChangeColumnDefinition: (untyped o) -> untyped
+
+        def add_table_options!: (untyped create_sql, untyped options) -> untyped
+
+        def add_column_options!: (untyped sql, untyped options) -> untyped
+
+        def add_column_position!: (untyped sql, untyped options) -> untyped
+
+        def index_in_create: (untyped table_name, untyped column_name, untyped options) -> untyped
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    module MySQL
+      module ColumnMethods
+        extend ActiveSupport::Concern
+      end
+
+      class TableDefinition < ActiveRecord::ConnectionAdapters::TableDefinition
+        include ColumnMethods
+
+        def new_column_definition: (untyped name, untyped `type`, **untyped options) -> untyped
+
+        def aliased_types: (untyped name, untyped fallback) -> untyped
+
+        def integer_like_primary_key_type: (untyped `type`, untyped options) -> untyped
+      end
+
+      class Table < ActiveRecord::ConnectionAdapters::Table
+        include ColumnMethods
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    module MySQL
+      class SchemaDumper < ConnectionAdapters::SchemaDumper
+        def prepare_column_options: (untyped column) -> untyped
+
+        def column_spec_for_primary_key: (untyped column) -> untyped
+
+        def default_primary_key?: (untyped column) -> untyped
+
+        def explicit_primary_key_default?: (untyped column) -> untyped
+
+        def schema_type: (untyped column) -> untyped
+
+        def schema_limit: (untyped column) -> untyped
+
+        def schema_precision: (untyped column) -> untyped
+
+        def schema_collation: (untyped column) -> untyped
+
+        def extract_expression_for_virtual_column: (untyped column) -> untyped
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    module MySQL
+      module SchemaStatements
+        # :nodoc:
+        # Returns an array of indexes for the given table.
+        def indexes: (untyped table_name) -> untyped
+
+        def remove_column: (untyped table_name, untyped column_name, ?untyped? `type`, **untyped options) -> untyped
+
+        def create_table: (untyped table_name, ?options: untyped options) -> untyped
+
+        def internal_string_options_for_primary_key: () -> untyped
+
+        def update_table_definition: (untyped table_name, untyped base) -> MySQL::Table
+
+        def create_schema_dumper: (untyped options) -> untyped
+
+        # Maps logical Rails types to MySQL-specific data types.
+        def type_to_sql: (untyped `type`, ?unsigned: untyped? unsigned, ?size: untyped size, ?scale: untyped? scale, ?precision: untyped? precision, ?limit: untyped? limit) -> untyped
+
+        def table_alias_length: () -> 256
+
+        CHARSETS_OF_4BYTES_MAXLEN: ::Array[untyped]
+
+        def row_format_dynamic_by_default?: () -> untyped
+
+        def default_row_format: () -> (nil | untyped)
+
+        def schema_creation: () -> MySQL::SchemaCreation
+
+        def create_table_definition: (*untyped args, **untyped options) -> MySQL::TableDefinition
+
+        def new_column_from_field: (untyped table_name, untyped field) -> MySQL::Column
+
+        def fetch_type_metadata: (untyped sql_type, ?::String extra) -> MySQL::TypeMetadata
+
+        def extract_foreign_key_action: (untyped specifier) -> untyped
+
+        def add_index_length: (untyped quoted_columns, **untyped options) -> untyped
+
+        def add_options_for_index_columns: (untyped quoted_columns, **untyped options) -> untyped
+
+        def data_source_sql: (?untyped? name, ?type: untyped? `type`) -> untyped
+
+        def quoted_scope: (?untyped? name, ?type: untyped? `type`) -> untyped
+
+        def extract_schema_qualified_name: (untyped string) -> ::Array[untyped]
+
+        def type_with_size_to_sql: (untyped `type`, untyped size) -> untyped
+
+        def limit_to_size: (untyped limit, untyped `type`) -> untyped
+
+        def integer_to_sql: (untyped limit) -> untyped
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    module MySQL
+      class TypeMetadata
+        # Note: It inherits unnamed class, but omitted
+        attr_reader extra: untyped
+
+        def initialize: (untyped type_metadata, ?extra: ::String extra) -> untyped
+
+        def ==: (untyped other) -> untyped
+
+        alias eql? ==
+
+        def hash: () -> untyped
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionHandling
+    # :nodoc:
+    ER_BAD_DB_ERROR: ::Integer
+
+    # Establishes a connection to the database that's used by all Active Record objects.
+    def mysql2_connection: (untyped config) -> untyped
+  end
+
+  module ConnectionAdapters
+    class Mysql2Adapter < AbstractMysqlAdapter
+      ADAPTER_NAME: ::String
+
+      include MySQL::DatabaseStatements
+
+      def initialize: (untyped connection, untyped logger, untyped connection_options, untyped config) -> untyped
+
+      def self.database_exists?: (untyped config) -> untyped
+
+      def supports_json?: () -> untyped
+
+      def supports_comments?: () -> ::TrueClass
+
+      def supports_comments_in_create?: () -> ::TrueClass
+
+      def supports_savepoints?: () -> ::TrueClass
+
+      def supports_lazy_transactions?: () -> ::TrueClass
+
+      def each_hash: (untyped result) { (untyped) -> untyped } -> untyped
+
+      def error_number: (untyped exception) -> untyped
+
+      def quote_string: (untyped string) -> untyped
+
+      def active?: () -> untyped
+
+      def reconnect!: () -> untyped
+
+      alias reset! reconnect!
+
+      # Disconnects from the database if already connected.
+      # Otherwise, this method does nothing.
+      def disconnect!: () -> untyped
+
+      def discard!: () -> untyped
+
+      def connect: () -> untyped
+
+      def configure_connection: () -> untyped
+
+      def full_version: () -> untyped
+
+      def get_full_version: () -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      class Column < ConnectionAdapters::Column
+        def initialize: (?serial: untyped? serial) -> untyped
+
+        def serial?: () -> untyped
+
+        def array: () -> untyped
+
+        alias array? array
+
+        def sql_type: () -> untyped
+      end
+    end
+
+    PostgreSQLColumn: untyped
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      module DatabaseStatements
+        def explain: (untyped arel, ?untyped binds) -> untyped
+
+        MONEY_COLUMN_TYPE_OID: ::Integer
+
+        BYTEA_COLUMN_TYPE_OID: ::Integer
+
+        def result_as_array: (untyped res) -> untyped
+
+        def query: (untyped sql, ?untyped? name) -> untyped
+
+        READ_QUERY: untyped
+
+        def write_query?: (untyped sql) -> untyped
+
+        # Executes an SQL statement, returning a PG::Result object on success
+        # or raising a PG::Error exception otherwise.
+        # Note: the PG::Result object is manually memory managed; if you don't
+        # need it specifically, you may want consider the <tt>exec_query</tt> wrapper.
+        def execute: (untyped sql, ?untyped? name) -> untyped
+
+        def exec_query: (untyped sql, ?::String name, ?untyped binds, ?prepare: bool prepare) -> untyped
+
+        def exec_delete: (untyped sql, ?untyped? name, ?untyped binds) -> untyped
+
+        alias exec_update exec_delete
+
+        def sql_for_insert: (untyped sql, untyped pk, untyped binds) -> untyped
+
+        def exec_insert: (untyped sql, ?untyped? name, ?untyped binds, ?untyped? pk, ?untyped? sequence_name) -> untyped
+
+        # Begins a transaction.
+        def begin_db_transaction: () -> untyped
+
+        def begin_isolated_db_transaction: (untyped isolation) -> untyped
+
+        # Commits a transaction.
+        def commit_db_transaction: () -> untyped
+
+        # Aborts a transaction.
+        def exec_rollback_db_transaction: () -> untyped
+
+        def execute_batch: (untyped statements, ?untyped? name) -> untyped
+
+        def build_truncate_statements: (untyped table_names) -> ::Array[::String]
+
+        # Returns the current ID of a table's sequence.
+        def last_insert_id_result: (untyped sequence_name) -> untyped
+
+        def suppress_composite_primary_key: (untyped pk) -> untyped
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      class ExplainPrettyPrinter
+        # :nodoc:
+        # Pretty prints the result of an EXPLAIN in a way that resembles the output of the
+        # PostgreSQL shell:
+        #
+        #                                     QUERY PLAN
+        #   ------------------------------------------------------------------------------
+        #    Nested Loop Left Join  (cost=0.00..37.24 rows=8 width=0)
+        #      Join Filter: (posts.user_id = users.id)
+        #      ->  Index Scan using users_pkey on users  (cost=0.00..8.27 rows=1 width=4)
+        #            Index Cond: (id = 1)
+        #      ->  Seq Scan on posts  (cost=0.00..28.88 rows=8 width=4)
+        #            Filter: (posts.user_id = 1)
+        #   (6 rows)
+        #
+        def pp: (untyped result) -> untyped
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      module OID
+        class Array[unchecked out Elem] < ActiveModel::Type::Value
+          # :nodoc:
+          # :nodoc:
+          include ActiveModel::Type::Helpers::Mutable
+
+          class Data[T] < ::Struct[T]
+            attr_accessor encoder(): untyped
+
+            attr_accessor values(): untyped
+          end
+
+          attr_reader subtype: untyped
+
+          attr_reader delimiter: untyped
+
+          def initialize: (untyped subtype, ?::String delimiter) -> untyped
+
+          def deserialize: (untyped value) -> untyped
+
+          def cast: (untyped value) -> untyped
+
+          def serialize: (untyped value) -> untyped
+
+          def ==: (untyped other) -> untyped
+
+          def type_cast_for_schema: (untyped value) -> untyped
+
+          def map: (untyped value) { () -> untyped } -> untyped
+
+          def changed_in_place?: (untyped raw_old_value, untyped new_value) -> untyped
+
+          def force_equality?: (untyped value) -> untyped
+
+          def type_cast_array: (untyped value, untyped method) -> untyped
+        end
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      module OID
+        class Bit < ActiveModel::Type::Value
+          # :nodoc:
+          # :nodoc:
+          def `type`: () -> :bit
+
+          def cast_value: (untyped value) -> untyped
+
+          def serialize: (untyped value) -> untyped
+
+          class Data
+            def initialize: (untyped value) -> untyped
+
+            def to_s: () -> untyped
+
+            def binary?: () -> untyped
+
+            def hex?: () -> untyped
+
+            attr_reader value: untyped
+          end
+        end
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      module OID
+        class BitVarying < OID::Bit
+          # :nodoc:
+          # :nodoc:
+          def `type`: () -> :bit_varying
+        end
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      module OID
+        class Bytea < ActiveModel::Type::Binary
+          # :nodoc:
+          # :nodoc:
+          def deserialize: (untyped value) -> (nil | untyped)
+        end
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      module OID
+        class Cidr < ActiveModel::Type::Value
+          # :nodoc:
+          # :nodoc:
+          def `type`: () -> :cidr
+
+          def type_cast_for_schema: (untyped value) -> untyped
+
+          def serialize: (untyped value) -> untyped
+
+          def cast_value: (untyped value) -> untyped
+        end
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      module OID
+        class Date < Type::Date
+          # :nodoc:
+          # :nodoc:
+          def cast_value: (untyped value) -> untyped
+        end
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      module OID
+        class DateTime < Type::DateTime
+          # :nodoc:
+          # :nodoc:
+          def cast_value: (untyped value) -> untyped
+        end
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      module OID
+        class Decimal < ActiveModel::Type::Decimal
+          # :nodoc:
+          # :nodoc:
+          def infinity: (?::Hash[untyped, untyped] options) -> untyped
+        end
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      module OID
+        class Enum < ActiveModel::Type::Value
+          # :nodoc:
+          # :nodoc:
+          def `type`: () -> :enum
+
+          def cast_value: (untyped value) -> untyped
+        end
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      module OID
+        class Hstore < ActiveModel::Type::Value
+          # :nodoc:
+          # :nodoc:
+          include ActiveModel::Type::Helpers::Mutable
+
+          def `type`: () -> :hstore
+
+          def deserialize: (untyped value) -> untyped
+
+          def serialize: (untyped value) -> untyped
+
+          def accessor: () -> untyped
+
+          # Will compare the Hash equivalents of +raw_old_value+ and +new_value+.
+          # By comparing hashes, this avoids an edge case where the order of
+          # the keys change between the two hashes, and they would not be marked
+          # as equal.
+          def changed_in_place?: (untyped raw_old_value, untyped new_value) -> untyped
+
+          HstorePair: untyped
+
+          def escape_hstore: (untyped value) -> untyped
+        end
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      module OID
+        class Inet < Cidr
+          # :nodoc:
+          # :nodoc:
+          def `type`: () -> :inet
+        end
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      module OID
+        class Jsonb < Type::Json
+          # :nodoc:
+          # :nodoc:
+          def `type`: () -> :jsonb
+        end
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      module OID
+        class LegacyPoint < ActiveModel::Type::Value
+          # :nodoc:
+          # :nodoc:
+          include ActiveModel::Type::Helpers::Mutable
+
+          def `type`: () -> :point
+
+          def cast: (untyped value) -> untyped
+
+          def serialize: (untyped value) -> untyped
+
+          def number_for_point: (untyped number) -> untyped
+        end
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      module OID
+        class Money < ActiveModel::Type::Decimal
+          # :nodoc:
+          # :nodoc:
+          def `type`: () -> :money
+
+          def scale: () -> 2
+
+          def cast_value: (untyped value) -> untyped
+        end
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      module OID
+        class Oid < Type::UnsignedInteger
+          # :nodoc:
+          # :nodoc:
+          def `type`: () -> :oid
+        end
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  class Point[T] < ::Struct[T]
+    attr_accessor x(): untyped
+
+    attr_accessor y(): untyped
+  end
+
+  module ConnectionAdapters
+    module PostgreSQL
+      module OID
+        class Point < ActiveModel::Type::Value
+          # :nodoc:
+          # :nodoc:
+          include ActiveModel::Type::Helpers::Mutable
+
+          def `type`: () -> :point
+
+          def cast: (untyped value) -> untyped
+
+          def serialize: (untyped value) -> untyped
+
+          def type_cast_for_schema: (untyped value) -> untyped
+
+          def number_for_point: (untyped number) -> untyped
+
+          def build_point: (untyped x, untyped y) -> ActiveRecord::Point[untyped]
+        end
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      module OID
+        class Range[out Elem] < ActiveModel::Type::Value
+          # :nodoc:
+          # :nodoc:
+          attr_reader subtype: untyped
+
+          # :nodoc:
+          # :nodoc:
+          attr_reader type: untyped
+
+          def initialize: (untyped subtype, ?::Symbol `type`) -> untyped
+
+          def type_cast_for_schema: (untyped value) -> untyped
+
+          def cast_value: (untyped value) -> (nil | untyped)
+
+          def serialize: (untyped value) -> untyped
+
+          def ==: (untyped other) -> untyped
+
+          def map: (untyped value) { (untyped) -> untyped } -> untyped
+
+          def force_equality?: (untyped value) -> untyped
+
+          def type_cast_single: (untyped value) -> untyped
+
+          def type_cast_single_for_database: (untyped value) -> untyped
+
+          def extract_bounds: (untyped value) -> { from: untyped, to: untyped, exclude_start: untyped, :exclude_end => untyped }
+
+          def infinity: (?negative: bool negative) -> untyped
+
+          def infinity?: (untyped value) -> untyped
+        end
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      module OID
+        class SpecializedString < ActiveModel::Type::String
+          # :nodoc:
+          # :nodoc:
+          attr_reader type: untyped
+
+          def initialize: (untyped `type`, **untyped options) -> untyped
+        end
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      module OID
+        class TypeMapInitializer
+          # :nodoc:
+          # This class uses the data from PostgreSQL pg_type table to build
+          # the OID -> Type mapping.
+          #   - OID is an integer representing the type.
+          #   - Type is an OID::Type object.
+          # This class has side effects on the +store+ passed during initialization.
+          # :nodoc:
+          def initialize: (untyped store) -> untyped
+
+          def run: (untyped records) -> untyped
+
+          def query_conditions_for_initial_load: () -> untyped
+
+          def register_mapped_type: (untyped row) -> untyped
+
+          def register_enum_type: (untyped row) -> untyped
+
+          def register_array_type: (untyped row) -> untyped
+
+          def register_range_type: (untyped row) -> untyped
+
+          def register_domain_type: (untyped row) -> untyped
+
+          def register_composite_type: (untyped row) -> untyped
+
+          def register: (untyped oid, ?untyped? oid_type) { () -> untyped } -> untyped
+
+          def alias_type: (untyped oid, untyped target) -> untyped
+
+          def register_with_subtype: (untyped oid, untyped target_oid) { (untyped) -> untyped } -> untyped
+
+          def assert_valid_registration: (untyped oid, untyped oid_type) -> untyped
+        end
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      module OID
+        class Uuid < ActiveModel::Type::Value
+          # :nodoc:
+          # :nodoc:
+          ACCEPTABLE_UUID: untyped
+
+          alias serialize deserialize
+
+          def `type`: () -> :uuid
+
+          def cast_value: (untyped value) -> untyped
+        end
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      module OID
+        class Vector < ActiveModel::Type::Value
+          # :nodoc:
+          # :nodoc:
+          attr_reader delim: untyped
+
+          # :nodoc:
+          # :nodoc:
+          attr_reader subtype: untyped
+
+          # +delim+ corresponds to the `typdelim` column in the pg_types
+          # table.  +subtype+ is derived from the `typelem` column in the
+          # pg_types table.
+          def initialize: (untyped delim, untyped subtype) -> untyped
+
+          # FIXME: this should probably split on +delim+ and use +subtype+
+          # to cast the values.  Unfortunately, the current Rails behavior
+          # is to just return the string.
+          def cast: (untyped value) -> untyped
+        end
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      module OID
+        class Xml < ActiveModel::Type::String
+          # :nodoc:
+          # :nodoc:
+          def `type`: () -> :xml
+
+          def serialize: (untyped value) -> (nil | Data)
+
+          class Data
+            # :nodoc:
+            def initialize: (untyped value) -> untyped
+
+            def to_s: () -> untyped
+          end
+        end
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      module OID
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      module Quoting
+        # Escapes binary strings for bytea input to the database.
+        def escape_bytea: (untyped value) -> untyped
+
+        # Unescapes bytea output from a database to the binary string it represents.
+        # NOTE: This is NOT an inverse of escape_bytea! This is only to be used
+        # on escaped binary output from database drive.
+        def unescape_bytea: (untyped value) -> untyped
+
+        def quote_string: (untyped s) -> untyped
+
+        def quote_table_name: (untyped name) -> untyped
+
+        # Quotes schema names for use in SQL queries.
+        def quote_schema_name: (untyped name) -> untyped
+
+        def quote_table_name_for_assignment: (untyped table, untyped attr) -> untyped
+
+        def quote_column_name: (untyped name) -> untyped
+
+        def quoted_date: (untyped value) -> untyped
+
+        def quoted_binary: (untyped value) -> ::String
+
+        def quote_default_expression: (untyped value, untyped column) -> untyped
+
+        def lookup_cast_type_from_column: (untyped column) -> untyped
+
+        def column_name_matcher: () -> untyped
+
+        def column_name_with_order_matcher: () -> untyped
+
+        COLUMN_NAME: untyped
+
+        COLUMN_NAME_WITH_ORDER: untyped
+
+        def lookup_cast_type: (untyped sql_type) -> untyped
+
+        def _quote: (untyped value) -> untyped
+
+        def _type_cast: (untyped value) -> untyped
+
+        def encode_array: (untyped array_data) -> untyped
+
+        def encode_range: (untyped range) -> ::String
+
+        def determine_encoding_of_strings_in_array: (untyped value) -> untyped
+
+        def type_cast_array: (untyped values) -> untyped
+
+        def type_cast_range_value: (untyped value) -> untyped
+
+        def infinity?: (untyped value) -> untyped
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      module ReferentialIntegrity
+        def disable_referential_integrity: () { () -> untyped } -> untyped
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      class SchemaCreation < AbstractAdapter::SchemaCreation
+        def visit_AlterTable: (untyped o) -> untyped
+
+        def visit_AddForeignKey: (untyped o) -> untyped
+
+        def visit_ValidateConstraint: (untyped name) -> ::String
+
+        def visit_ChangeColumnDefinition: (untyped o) -> untyped
+
+        def add_column_options!: (untyped sql, untyped options) -> untyped
+
+        # Returns any SQL string to go between CREATE and TABLE. May be nil.
+        def table_modifier_in_create: (untyped o) -> untyped
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      module ColumnMethods
+        extend ActiveSupport::Concern
+
+        # Defines the primary key field.
+        # Use of the native PostgreSQL UUID type is supported, and can be used
+        # by defining your tables as such:
+        #
+        #   create_table :stuffs, id: :uuid do |t|
+        #     t.string :content
+        #     t.timestamps
+        #   end
+        #
+        # By default, this will use the <tt>gen_random_uuid()</tt> function from the
+        # +pgcrypto+ extension. As that extension is only available in
+        # PostgreSQL 9.4+, for earlier versions an explicit default can be set
+        # to use <tt>uuid_generate_v4()</tt> from the +uuid-ossp+ extension instead:
+        #
+        #   create_table :stuffs, id: false do |t|
+        #     t.primary_key :id, :uuid, default: "uuid_generate_v4()"
+        #     t.uuid :foo_id
+        #     t.timestamps
+        #   end
+        #
+        # To enable the appropriate extension, which is a requirement, use
+        # the +enable_extension+ method in your migrations.
+        #
+        # To use a UUID primary key without any of the extensions, set the
+        # +:default+ option to +nil+:
+        #
+        #   create_table :stuffs, id: false do |t|
+        #     t.primary_key :id, :uuid, default: nil
+        #     t.uuid :foo_id
+        #     t.timestamps
+        #   end
+        #
+        # You may also pass a custom stored procedure that returns a UUID or use a
+        # different UUID generation function from another library.
+        #
+        # Note that setting the UUID primary key default value to +nil+ will
+        # require you to assure that you always provide a UUID value before saving
+        # a record (as primary keys cannot be +nil+). This might be done via the
+        # +SecureRandom.uuid+ method and a +before_save+ callback, for instance.
+        def primary_key: (untyped name, ?::Symbol `type`, **untyped options) -> untyped
+      end
+
+      class TableDefinition < ActiveRecord::ConnectionAdapters::TableDefinition
+        include ColumnMethods
+
+        attr_reader unlogged: untyped
+
+        def initialize: () -> untyped
+
+        def integer_like_primary_key_type: (untyped `type`, untyped options) -> untyped
+      end
+
+      class Table < ActiveRecord::ConnectionAdapters::Table
+        include ColumnMethods
+      end
+
+      class AlterTable < ActiveRecord::ConnectionAdapters::AlterTable
+        attr_reader constraint_validations: untyped
+
+        def initialize: (untyped td) -> untyped
+
+        def validate_constraint: (untyped name) -> untyped
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      class SchemaDumper < ConnectionAdapters::SchemaDumper
+        def extensions: (untyped stream) -> untyped
+
+        def prepare_column_options: (untyped column) -> untyped
+
+        def default_primary_key?: (untyped column) -> untyped
+
+        def explicit_primary_key_default?: (untyped column) -> untyped
+
+        def schema_type: (untyped column) -> untyped
+
+        def schema_expression: (untyped column) -> untyped
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      module SchemaStatements
+        def recreate_database: (untyped name, ?::Hash[untyped, untyped] options) -> untyped
+
+        # Create a new PostgreSQL database. Options include <tt>:owner</tt>, <tt>:template</tt>,
+        # <tt>:encoding</tt> (defaults to utf8), <tt>:collation</tt>, <tt>:ctype</tt>,
+        # <tt>:tablespace</tt>, and <tt>:connection_limit</tt> (note that MySQL uses
+        # <tt>:charset</tt> while PostgreSQL uses <tt>:encoding</tt>).
+        #
+        # Example:
+        #   create_database config[:database], config
+        #   create_database 'foo_development', encoding: 'unicode'
+        def create_database: (untyped name, ?::Hash[untyped, untyped] options) -> untyped
+
+        def drop_database: (untyped name) -> untyped
+
+        def drop_table: (untyped table_name, ?::Hash[untyped, untyped] options) -> untyped
+
+        # Returns true if schema exists.
+        def schema_exists?: (untyped name) -> untyped
+
+        # Verifies existence of an index with a given name.
+        def index_name_exists?: (untyped table_name, untyped index_name) -> untyped
+
+        def indexes: (untyped table_name) -> untyped
+
+        def table_options: (untyped table_name) -> untyped
+
+        def table_comment: (untyped table_name) -> untyped
+
+        # Returns the current database name.
+        def current_database: () -> untyped
+
+        # Returns the current schema name.
+        def current_schema: () -> untyped
+
+        # Returns the current database encoding format.
+        def encoding: () -> untyped
+
+        # Returns the current database collation.
+        def collation: () -> untyped
+
+        # Returns the current database ctype.
+        def ctype: () -> untyped
+
+        # Returns an array of schema names.
+        def schema_names: () -> untyped
+
+        # Creates a schema for the given schema name.
+        def create_schema: (untyped schema_name) -> untyped
+
+        # Drops the schema for the given schema name.
+        def drop_schema: (untyped schema_name, ?::Hash[untyped, untyped] options) -> untyped
+
+        # Sets the schema search path to a string of comma-separated schema names.
+        # Names beginning with $ have to be quoted (e.g. $user => '$user').
+        # See: https://www.postgresql.org/docs/current/static/ddl-schemas.html
+        #
+        # This should be not be called manually but set in database.yml.
+        def schema_search_path=: (untyped schema_csv) -> untyped
+
+        # Returns the active schema search path.
+        def schema_search_path: () -> untyped
+
+        # Returns the current client message level.
+        def client_min_messages: () -> untyped
+
+        # Set the client message level.
+        def client_min_messages=: (untyped level) -> untyped
+
+        def default_sequence_name: (untyped table_name, ?::String pk) -> untyped
+
+        def serial_sequence: (untyped table, untyped column) -> untyped
+
+        def set_pk_sequence!: (untyped table, untyped value) -> untyped
+
+        def reset_pk_sequence!: (untyped table, ?untyped? pk, ?untyped? sequence) -> untyped
+
+        def pk_and_sequence_for: (untyped table) -> untyped
+
+        def primary_keys: (untyped table_name) -> untyped
+
+        # Renames a table.
+        # Also renames a table's primary key sequence if the sequence name exists and
+        # matches the Active Record default.
+        #
+        # Example:
+        #   rename_table('octopuses', 'octopi')
+        def rename_table: (untyped table_name, untyped new_name) -> untyped
+
+        def add_column: (untyped table_name, untyped column_name, untyped `type`, **untyped options) -> untyped
+
+        def change_column: (untyped table_name, untyped column_name, untyped `type`, ?::Hash[untyped, untyped] options) -> untyped
+
+        def change_column_default: (untyped table_name, untyped column_name, untyped default_or_changes) -> untyped
+
+        def change_column_null: (untyped table_name, untyped column_name, untyped null, ?untyped? default) -> untyped
+
+        def change_column_comment: (untyped table_name, untyped column_name, untyped comment_or_changes) -> untyped
+
+        def change_table_comment: (untyped table_name, untyped comment_or_changes) -> untyped
+
+        def rename_column: (untyped table_name, untyped column_name, untyped new_column_name) -> untyped
+
+        def add_index: (untyped table_name, untyped column_name, ?::Hash[untyped, untyped] options) -> untyped
+
+        def remove_index: (untyped table_name, ?::Hash[untyped, untyped] options) -> untyped
+
+        # Renames an index of a table. Raises error if length of new
+        # index name is greater than allowed limit.
+        def rename_index: (untyped table_name, untyped old_name, untyped new_name) -> untyped
+
+        def foreign_keys: (untyped table_name) -> untyped
+
+        def foreign_tables: () -> untyped
+
+        def foreign_table_exists?: (untyped table_name) -> untyped
+
+        def type_to_sql: (untyped `type`, ?array: untyped? array, ?scale: untyped? scale, ?precision: untyped? precision, ?limit: untyped? limit) -> untyped
+
+        def columns_for_distinct: (untyped columns, untyped orders) -> untyped
+
+        def update_table_definition: (untyped table_name, untyped base) -> PostgreSQL::Table
+
+        def create_schema_dumper: (untyped options) -> untyped
+
+        # Validates the given constraint.
+        #
+        # Validates the constraint named +constraint_name+ on +accounts+.
+        #
+        #   validate_constraint :accounts, :constraint_name
+        def validate_constraint: (untyped table_name, untyped constraint_name) -> (nil | untyped)
+
+        # Validates the given foreign key.
+        #
+        # Validates the foreign key on +accounts.branch_id+.
+        #
+        #   validate_foreign_key :accounts, :branches
+        #
+        # Validates the foreign key on +accounts.owner_id+.
+        #
+        #   validate_foreign_key :accounts, column: :owner_id
+        #
+        # Validates the foreign key named +special_fk_name+ on the +accounts+ table.
+        #
+        #   validate_foreign_key :accounts, name: :special_fk_name
+        #
+        # The +options+ hash accepts the same keys as SchemaStatements#add_foreign_key.
+        def validate_foreign_key: (untyped from_table, ?untyped? to_table, **untyped options) -> (nil | untyped)
+
+        def schema_creation: () -> PostgreSQL::SchemaCreation
+
+        def create_table_definition: (*untyped args, **untyped options) -> PostgreSQL::TableDefinition
+
+        def create_alter_table: (untyped name) -> PostgreSQL::AlterTable
+
+        def new_column_from_field: (untyped table_name, untyped field) -> PostgreSQL::Column
+
+        def fetch_type_metadata: (untyped column_name, untyped sql_type, untyped oid, untyped fmod) -> PostgreSQL::TypeMetadata
+
+        def sequence_name_from_parts: (untyped table_name, untyped column_name, untyped suffix) -> ::String
+
+        def extract_foreign_key_action: (untyped specifier) -> untyped
+
+        def add_column_for_alter: (untyped table_name, untyped column_name, untyped `type`, **untyped options) -> (untyped | ::Array[untyped])
+
+        def change_column_for_alter: (untyped table_name, untyped column_name, untyped `type`, ?::Hash[untyped, untyped] options) -> untyped
+
+        def change_column_default_for_alter: (untyped table_name, untyped column_name, untyped default_or_changes) -> (nil | untyped)
+
+        def change_column_null_for_alter: (untyped table_name, untyped column_name, untyped null, ?untyped? default) -> ::String
+
+        def add_index_opclass: (untyped quoted_columns, **untyped options) -> untyped
+
+        def add_options_for_index_columns: (untyped quoted_columns, **untyped options) -> untyped
+
+        def data_source_sql: (?untyped? name, ?type: untyped? `type`) -> untyped
+
+        def quoted_scope: (?untyped? name, ?type: untyped? `type`) -> untyped
+
+        def extract_schema_qualified_name: (untyped string) -> ::Array[untyped]
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  # :stopdoc:
+  module ConnectionAdapters
+    module PostgreSQL
+      class TypeMetadata
+        # Note: It inherits unnamed class, but omitted
+        attr_reader oid: untyped
+
+        attr_reader fmod: untyped
+
+        def initialize: (untyped type_metadata, ?fmod: untyped? fmod, ?oid: untyped? oid) -> untyped
+
+        def ==: (untyped other) -> untyped
+
+        alias eql? ==
+
+        def hash: () -> untyped
+      end
+    end
+
+    PostgreSQLTypeMetadata: untyped
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      class Name
+        # Value Object to hold a schema qualified name.
+        # This is usually the name of a PostgreSQL relation but it can also represent
+        # schema qualified type names. +schema+ and +identifier+ are unquoted to prevent
+        # double quoting.
+        # :nodoc:
+        SEPARATOR: ::String
+
+        attr_reader schema: untyped
+
+        attr_reader identifier: untyped
+
+        def initialize: (untyped schema, untyped identifier) -> untyped
+
+        def to_s: () -> untyped
+
+        def quoted: () -> untyped
+
+        def ==: (untyped o) -> untyped
+
+        alias eql? ==
+
+        def hash: () -> untyped
+
+        def parts: () -> untyped
+
+        def unquote: (untyped part) -> untyped
+      end
+
+      module Utils
+        # Returns an instance of <tt>ActiveRecord::ConnectionAdapters::PostgreSQL::Name</tt>
+        # extracted from +string+.
+        # +schema+ is +nil+ if not specified in +string+.
+        # +schema+ and +identifier+ exclude surrounding quotes (regardless of whether provided in +string+)
+        # +string+ supports the range of schema/table references understood by PostgreSQL, for example:
+        #
+        # * <tt>table_name</tt>
+        # * <tt>"table.name"</tt>
+        # * <tt>schema_name.table_name</tt>
+        # * <tt>schema_name."table.name"</tt>
+        # * <tt>"schema_name".table_name</tt>
+        # * <tt>"schema.name"."table name"</tt>
+        def extract_schema_qualified_name: (untyped string) -> PostgreSQL::Name
+      end
+    end
+  end
+end
+
+class ::PG::Connection
+  alias exec_params async_exec
+end
+
+module ActiveRecord
+  module ConnectionHandling
+    # :nodoc:
+    # Establishes a connection to the database that's used by all Active Record objects
+    def postgresql_connection: (untyped config) -> untyped
+  end
+
+  module ConnectionAdapters
+    # The PostgreSQL adapter works with the native C (https://bitbucket.org/ged/ruby-pg) driver.
+    #
+    # Options:
+    #
+    # * <tt>:host</tt> - Defaults to a Unix-domain socket in /tmp. On machines without Unix-domain sockets,
+    #   the default is to connect to localhost.
+    # * <tt>:port</tt> - Defaults to 5432.
+    # * <tt>:username</tt> - Defaults to be the same as the operating system name of the user running the application.
+    # * <tt>:password</tt> - Password to be used if the server demands password authentication.
+    # * <tt>:database</tt> - Defaults to be the same as the user name.
+    # * <tt>:schema_search_path</tt> - An optional schema search path for the connection given
+    #   as a string of comma-separated schema names. This is backward-compatible with the <tt>:schema_order</tt> option.
+    # * <tt>:encoding</tt> - An optional client encoding that is used in a <tt>SET client_encoding TO
+    #   <encoding></tt> call on the connection.
+    # * <tt>:min_messages</tt> - An optional client min messages that is used in a
+    #   <tt>SET client_min_messages TO <min_messages></tt> call on the connection.
+    # * <tt>:variables</tt> - An optional hash of additional parameters that
+    #   will be used in <tt>SET SESSION key = val</tt> calls on the connection.
+    # * <tt>:insert_returning</tt> - An optional boolean to control the use of <tt>RETURNING</tt> for <tt>INSERT</tt> statements
+    #   defaults to true.
+    #
+    # Any further options are used as connection parameters to libpq. See
+    # https://www.postgresql.org/docs/current/static/libpq-connect.html for the
+    # list of parameters.
+    #
+    # In addition, default connection parameters of libpq can be set per environment variables.
+    # See https://www.postgresql.org/docs/current/static/libpq-envars.html .
+    class PostgreSQLAdapter < AbstractAdapter
+      ADAPTER_NAME: ::String
+
+      NATIVE_DATABASE_TYPES: ::Hash[untyped, untyped]
+
+      OID: untyped
+
+      include PostgreSQL::Quoting
+
+      include PostgreSQL::ReferentialIntegrity
+
+      include PostgreSQL::SchemaStatements
+
+      include PostgreSQL::DatabaseStatements
+
+      def supports_bulk_alter?: () -> ::TrueClass
+
+      def supports_index_sort_order?: () -> ::TrueClass
+
+      def supports_partitioned_indexes?: () -> untyped
+
+      def supports_partial_index?: () -> ::TrueClass
+
+      def supports_expression_index?: () -> ::TrueClass
+
+      def supports_transaction_isolation?: () -> ::TrueClass
+
+      def supports_foreign_keys?: () -> ::TrueClass
+
+      def supports_validate_constraints?: () -> ::TrueClass
+
+      def supports_views?: () -> ::TrueClass
+
+      def supports_datetime_with_precision?: () -> ::TrueClass
+
+      def supports_json?: () -> ::TrueClass
+
+      def supports_comments?: () -> ::TrueClass
+
+      def supports_savepoints?: () -> ::TrueClass
+
+      def supports_insert_returning?: () -> ::TrueClass
+
+      def supports_insert_on_conflict?: () -> untyped
+
+      alias supports_insert_on_duplicate_skip? supports_insert_on_conflict?
+
+      alias supports_insert_on_duplicate_update? supports_insert_on_conflict?
+
+      alias supports_insert_conflict_target? supports_insert_on_conflict?
+
+      def index_algorithms: () -> { concurrently: "CONCURRENTLY" }
+
+      class StatementPool < ConnectionAdapters::StatementPool
+        # :nodoc:
+        def initialize: (untyped connection, untyped max) -> untyped
+
+        def next_key: () -> ::String
+
+        def []=: (untyped sql, untyped key) -> untyped
+
+        def dealloc: (untyped key) -> untyped
+
+        def connection_active?: () -> untyped
+      end
+
+      # Initializes and connects a PostgreSQL adapter.
+      def initialize: (untyped connection, untyped logger, untyped connection_parameters, untyped config) -> untyped
+
+      def self.database_exists?: (untyped config) -> untyped
+
+      # Is this connection alive and ready for queries?
+      def active?: () -> untyped
+
+      # Close then reopen the connection.
+      def reconnect!: () -> untyped
+
+      def reset!: () -> untyped
+
+      # Disconnects from the database if already connected. Otherwise, this
+      # method does nothing.
+      def disconnect!: () -> untyped
+
+      def discard!: () -> untyped
+
+      def native_database_types: () -> untyped
+
+      def set_standard_conforming_strings: () -> untyped
+
+      def supports_ddl_transactions?: () -> ::TrueClass
+
+      def supports_advisory_locks?: () -> ::TrueClass
+
+      def supports_explain?: () -> ::TrueClass
+
+      def supports_extensions?: () -> ::TrueClass
+
+      def supports_ranges?: () -> ::TrueClass
+
+      def supports_materialized_views?: () -> ::TrueClass
+
+      def supports_foreign_tables?: () -> ::TrueClass
+
+      def supports_pgcrypto_uuid?: () -> untyped
+
+      def supports_optimizer_hints?: () -> untyped
+
+      def supports_common_table_expressions?: () -> ::TrueClass
+
+      def supports_lazy_transactions?: () -> ::TrueClass
+
+      def get_advisory_lock: (untyped lock_id) -> untyped
+
+      def release_advisory_lock: (untyped lock_id) -> untyped
+
+      def enable_extension: (untyped name) -> untyped
+
+      def disable_extension: (untyped name) -> untyped
+
+      def extension_available?: (untyped name) -> untyped
+
+      def extension_enabled?: (untyped name) -> untyped
+
+      def extensions: () -> untyped
+
+      # Returns the configured supported identifier length supported by PostgreSQL
+      def max_identifier_length: () -> untyped
+
+      # Set the authorized user for this session
+      def session_auth=: (untyped user) -> untyped
+
+      def use_insert_returning?: () -> untyped
+
+      def column_name_for_operation: (untyped operation, untyped node) -> untyped
+
+      OPERATION_ALIASES: ::Hash[untyped, untyped]
+
+      def get_database_version: () -> untyped
+
+      alias postgresql_version database_version
+
+      def default_index_type?: (untyped index) -> untyped
+
+      def build_insert_sql: (untyped insert) -> untyped
+
+      def check_version: () -> untyped
+
+      # See https://www.postgresql.org/docs/current/static/errcodes-appendix.html
+      VALUE_LIMIT_VIOLATION: ::String
+
+      NUMERIC_VALUE_OUT_OF_RANGE: ::String
+
+      NOT_NULL_VIOLATION: ::String
+
+      FOREIGN_KEY_VIOLATION: ::String
+
+      UNIQUE_VIOLATION: ::String
+
+      SERIALIZATION_FAILURE: ::String
+
+      DEADLOCK_DETECTED: ::String
+
+      LOCK_NOT_AVAILABLE: ::String
+
+      QUERY_CANCELED: ::String
+
+      def translate_exception: (untyped exception, binds: untyped binds, sql: untyped sql, message: untyped message) -> untyped
+
+      def get_oid_type: (untyped oid, untyped fmod, untyped column_name, ?::String sql_type) -> untyped
+
+      def initialize_type_map: (?untyped m) -> untyped
+
+      # Extracts the value from a PostgreSQL column default definition.
+      def extract_value_from_default: (untyped default) -> untyped
+
+      def extract_default_function: (untyped default_value, untyped default) -> untyped
+
+      def has_default_function?: (untyped default_value, untyped default) -> untyped
+
+      def load_additional_types: (?untyped? oids) -> untyped
+
+      FEATURE_NOT_SUPPORTED: ::String
+
+      def execute_and_clear: (untyped sql, untyped name, untyped binds, ?prepare: bool prepare) { (untyped) -> untyped } -> untyped
+
+      def exec_no_cache: (untyped sql, untyped name, untyped binds) -> untyped
+
+      def exec_cache: (untyped sql, untyped name, untyped binds) -> untyped
+
+      # Annoyingly, the code for prepared statements whose return value may
+      # have changed is FEATURE_NOT_SUPPORTED.
+      #
+      # This covers various different error types so we need to do additional
+      # work to classify the exception definitively as a
+      # ActiveRecord::PreparedStatementCacheExpired
+      #
+      # Check here for more details:
+      # https://git.postgresql.org/gitweb/?p=postgresql.git;a=blob;f=src/backend/utils/cache/plancache.c#l573
+      CACHED_PLAN_HEURISTIC: ::String
+
+      def is_cached_plan_failure?: (untyped e) -> untyped
+
+      def in_transaction?: () -> untyped
+
+      # Returns the statement identifier for the client side cache
+      # of statements
+      def sql_key: (untyped sql) -> ::String
+
+      # Prepare the statement if it hasn't been prepared, return
+      # the statement key.
+      def prepare_statement: (untyped sql, untyped binds) -> untyped
+
+      # Connects to a PostgreSQL server and sets up the adapter depending on the
+      # connected server's characteristics.
+      def connect: () -> untyped
+
+      # Configures the encoding, verbosity, schema search path, and time zone of the connection.
+      # This is called by #connect and should not be called manually.
+      def configure_connection: () -> untyped
+
+      # Returns the list of a table's column names, data types, and default values.
+      #
+      # The underlying query is roughly:
+      #  SELECT column.name, column.type, default.value, column.comment
+      #    FROM column LEFT JOIN default
+      #      ON column.table_id = default.table_id
+      #     AND column.num = default.column_num
+      #   WHERE column.table_id = get_table_id('table_name')
+      #     AND column.num > 0
+      #     AND NOT column.is_dropped
+      #   ORDER BY column.num
+      #
+      # If the table name is not prefixed with a schema, the database will
+      # take the first match from the schema search path.
+      #
+      # Query implementation notes:
+      #  - format_type includes the column size constraint, e.g. varchar(50)
+      #  - ::regclass is a function that gives the id for a table name
+      def column_definitions: (untyped table_name) -> untyped
+
+      def extract_table_ref_from_insert_sql: (untyped sql) -> untyped
+
+      def arel_visitor: () -> Arel::Visitors::PostgreSQL
+
+      def build_statement_pool: () -> StatementPool
+
+      def can_perform_case_insensitive_comparison_for?: (untyped column) -> untyped
+
+      def add_pg_encoders: () -> untyped
+
+      def update_typemap_for_default_timezone: () -> untyped
+
+      def add_pg_decoders: () -> untyped
+
+      def construct_coder: (untyped row, untyped coder_class) -> (nil | untyped)
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    class SchemaCache
+      attr_reader version: untyped
+
+      attr_accessor connection: untyped
+
+      def initialize: (untyped conn) -> untyped
+
+      def initialize_dup: (untyped other) -> untyped
+
+      def encode_with: (untyped coder) -> untyped
+
+      def init_with: (untyped coder) -> untyped
+
+      def primary_keys: (untyped table_name) -> untyped
+
+      # A cached lookup for table existence.
+      def data_source_exists?: (untyped name) -> untyped
+
+      # Add internal cache for table with +table_name+.
+      def add: (untyped table_name) -> untyped
+
+      def data_sources: (untyped name) -> untyped
+
+      # Get the columns for a table
+      def columns: (untyped table_name) -> untyped
+
+      # Get the columns for a table as a hash, key is the column name
+      # value is the column object.
+      def columns_hash: (untyped table_name) -> untyped
+
+      # Checks whether the columns hash is already cached for a table.
+      def columns_hash?: (untyped table_name) -> untyped
+
+      def indexes: (untyped table_name) -> untyped
+
+      def database_version: () -> untyped
+
+      # Clears out internal caches
+      def clear!: () -> untyped
+
+      def size: () -> untyped
+
+      # Clear out internal caches for the data source +name+.
+      def clear_data_source_cache!: (untyped name) -> untyped
+
+      def marshal_dump: () -> ::Array[untyped]
+
+      def marshal_load: (untyped array) -> untyped
+
+      def prepare_data_sources: () -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  # :stopdoc:
+  module ConnectionAdapters
+    class SqlTypeMetadata
+      attr_reader sql_type: untyped
+
+      attr_reader type: untyped
+
+      attr_reader limit: untyped
+
+      attr_reader precision: untyped
+
+      attr_reader scale: untyped
+
+      def initialize: (?scale: untyped? scale, ?precision: untyped? precision, ?limit: untyped? limit, ?type: untyped? `type`, ?sql_type: untyped? sql_type) -> untyped
+
+      def ==: (untyped other) -> untyped
+
+      alias eql? ==
+
+      def hash: () -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    module SQLite3
+      module DatabaseStatements
+        READ_QUERY: untyped
+
+        def write_query?: (untyped sql) -> untyped
+
+        def execute: (untyped sql, ?untyped? name) -> untyped
+
+        def exec_query: (untyped sql, ?untyped? name, ?untyped binds, ?prepare: bool prepare) -> untyped
+
+        def exec_delete: (untyped sql, ?::String name, ?untyped binds) -> untyped
+
+        alias exec_update exec_delete
+
+        def begin_db_transaction: () -> untyped
+
+        def commit_db_transaction: () -> untyped
+
+        def exec_rollback_db_transaction: () -> untyped
+
+        def execute_batch: (untyped statements, ?untyped? name) -> untyped
+
+        def last_inserted_id: (untyped result) -> untyped
+
+        def build_fixture_statements: (untyped fixture_set) -> untyped
+
+        def build_truncate_statement: (untyped table_name) -> ::String
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    module SQLite3
+      class ExplainPrettyPrinter
+        # :nodoc:
+        # Pretty prints the result of an EXPLAIN QUERY PLAN in a way that resembles
+        # the output of the SQLite shell:
+        #
+        #   0|0|0|SEARCH TABLE users USING INTEGER PRIMARY KEY (rowid=?) (~1 rows)
+        #   0|1|1|SCAN TABLE posts (~100000 rows)
+        #
+        def pp: (untyped result) -> untyped
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    module SQLite3
+      module Quoting
+        # :nodoc:
+        def quote_string: (untyped s) -> untyped
+
+        def quote_table_name_for_assignment: (untyped table, untyped attr) -> untyped
+
+        def quote_table_name: (untyped name) -> untyped
+
+        def quote_column_name: (untyped name) -> untyped
+
+        def quoted_time: (untyped value) -> untyped
+
+        def quoted_binary: (untyped value) -> ::String
+
+        def quoted_true: () -> "1"
+
+        def unquoted_true: () -> 1
+
+        def quoted_false: () -> "0"
+
+        def unquoted_false: () -> 0
+
+        def column_name_matcher: () -> untyped
+
+        def column_name_with_order_matcher: () -> untyped
+
+        COLUMN_NAME: untyped
+
+        COLUMN_NAME_WITH_ORDER: untyped
+
+        def _type_cast: (untyped value) -> untyped
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    module SQLite3
+      class SchemaCreation < AbstractAdapter::SchemaCreation
+        def add_column_options!: (untyped sql, untyped options) -> untyped
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    module SQLite3
+      class TableDefinition < ActiveRecord::ConnectionAdapters::TableDefinition
+        def references: (*untyped args, **untyped options) -> untyped
+
+        alias belongs_to references
+
+        def integer_like_primary_key_type: (untyped `type`, untyped options) -> :primary_key
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    module SQLite3
+      class SchemaDumper < ConnectionAdapters::SchemaDumper
+        def default_primary_key?: (untyped column) -> untyped
+
+        def explicit_primary_key_default?: (untyped column) -> untyped
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    module SQLite3
+      module SchemaStatements
+        # :nodoc:
+        # Returns an array of indexes for the given table.
+        def indexes: (untyped table_name) -> untyped
+
+        def add_foreign_key: (untyped from_table, untyped to_table, **untyped options) -> untyped
+
+        def remove_foreign_key: (untyped from_table, ?untyped? to_table, **untyped options) -> untyped
+
+        def create_schema_dumper: (untyped options) -> untyped
+
+        def schema_creation: () -> SQLite3::SchemaCreation
+
+        def create_table_definition: (*untyped args, **untyped options) -> SQLite3::TableDefinition
+
+        def new_column_from_field: (untyped table_name, untyped field) -> Column
+
+        def data_source_sql: (?untyped? name, ?type: untyped? `type`) -> untyped
+
+        def quoted_scope: (?untyped? name, ?type: untyped? `type`) -> untyped
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionHandling
+    # :nodoc:
+    def sqlite3_connection: (untyped config) -> untyped
+  end
+
+  module ConnectionAdapters
+    # nodoc:
+    # The SQLite3 adapter works SQLite 3.6.16 or newer
+    # with the sqlite3-ruby drivers (available as gem from https://rubygems.org/gems/sqlite3).
+    #
+    # Options:
+    #
+    # * <tt>:database</tt> - Path to the database file.
+    class SQLite3Adapter < AbstractAdapter
+      ADAPTER_NAME: ::String
+
+      include SQLite3::Quoting
+
+      include SQLite3::SchemaStatements
+
+      include SQLite3::DatabaseStatements
+
+      NATIVE_DATABASE_TYPES: ::Hash[untyped, untyped]
+
+      def self.represent_boolean_as_integer=: (untyped value) -> untyped
+
+      class StatementPool < ConnectionAdapters::StatementPool
+        def dealloc: (untyped stmt) -> untyped
+      end
+
+      def initialize: (untyped connection, untyped logger, untyped connection_options, untyped config) -> untyped
+
+      def self.database_exists?: (untyped config) -> untyped
+
+      def supports_ddl_transactions?: () -> ::TrueClass
+
+      def supports_savepoints?: () -> ::TrueClass
+
+      def supports_partial_index?: () -> ::TrueClass
+
+      def supports_expression_index?: () -> untyped
+
+      def requires_reloading?: () -> ::TrueClass
+
+      def supports_foreign_keys?: () -> ::TrueClass
+
+      def supports_views?: () -> ::TrueClass
+
+      def supports_datetime_with_precision?: () -> ::TrueClass
+
+      def supports_json?: () -> ::TrueClass
+
+      def supports_common_table_expressions?: () -> untyped
+
+      def supports_insert_on_conflict?: () -> untyped
+
+      alias supports_insert_on_duplicate_skip? supports_insert_on_conflict?
+
+      alias supports_insert_on_duplicate_update? supports_insert_on_conflict?
+
+      alias supports_insert_conflict_target? supports_insert_on_conflict?
+
+      def active?: () -> untyped
+
+      def reconnect!: () -> untyped
+
+      # Disconnects from the database if already connected. Otherwise, this
+      # method does nothing.
+      def disconnect!: () -> untyped
+
+      def supports_index_sort_order?: () -> ::TrueClass
+
+      # Returns 62. SQLite supports index names up to 64
+      # characters. The rest is used by Rails internally to perform
+      # temporary rename operations
+      def allowed_index_name_length: () -> untyped
+
+      def native_database_types: () -> untyped
+
+      # Returns the current database encoding format as a string, eg: 'UTF-8'
+      def encoding: () -> untyped
+
+      def supports_explain?: () -> ::TrueClass
+
+      def supports_lazy_transactions?: () -> ::TrueClass
+
+      def disable_referential_integrity: () { () -> untyped } -> untyped
+
+      # -
+      # DATABASE STATEMENTS ======================================
+      # +
+      def explain: (untyped arel, ?untyped binds) -> untyped
+
+      def primary_keys: (untyped table_name) -> untyped
+
+      def remove_index: (untyped table_name, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Renames a table.
+      #
+      # Example:
+      #   rename_table('octopuses', 'octopi')
+      def rename_table: (untyped table_name, untyped new_name) -> untyped
+
+      def add_column: (untyped table_name, untyped column_name, untyped `type`, **untyped options) -> untyped
+
+      def remove_column: (untyped table_name, untyped column_name, ?untyped? `type`, **untyped options) -> untyped
+
+      def change_column_default: (untyped table_name, untyped column_name, untyped default_or_changes) -> untyped
+
+      def change_column_null: (untyped table_name, untyped column_name, untyped null, ?untyped? default) -> untyped
+
+      def change_column: (untyped table_name, untyped column_name, untyped `type`, ?::Hash[untyped, untyped] options) -> untyped
+
+      def rename_column: (untyped table_name, untyped column_name, untyped new_column_name) -> untyped
+
+      def add_reference: (untyped table_name, untyped ref_name, **untyped options) -> untyped
+
+      alias add_belongs_to add_reference
+
+      def foreign_keys: (untyped table_name) -> untyped
+
+      def build_insert_sql: (untyped insert) -> untyped
+
+      def get_database_version: () -> AbstractAdapter::Version
+
+      def check_version: () -> untyped
+
+      # See https://www.sqlite.org/limits.html,
+      # the default value is 999 when not configured.
+      def bind_params_length: () -> 999
+
+      def initialize_type_map: (?untyped m) -> untyped
+
+      def table_structure: (untyped table_name) -> untyped
+
+      alias column_definitions table_structure
+
+      # See: https://www.sqlite.org/lang_altertable.html
+      # SQLite has an additional restriction on the ALTER TABLE statement
+      def invalid_alter_table_type?: (untyped `type`, untyped options) -> untyped
+
+      def alter_table: (untyped table_name, ?untyped foreign_keys, **untyped options) { (untyped) -> untyped } -> untyped
+
+      def move_table: (untyped from, untyped to, ?::Hash[untyped, untyped] options) { () -> untyped } -> untyped
+
+      def copy_table: (untyped from, untyped to, ?::Hash[untyped, untyped] options) { (untyped) -> untyped } -> untyped
+
+      def copy_table_indexes: (untyped from, untyped to, ?::Hash[untyped, untyped] rename) -> untyped
+
+      def copy_table_contents: (untyped from, untyped to, untyped columns, ?::Hash[untyped, untyped] rename) -> untyped
+
+      def translate_exception: (untyped exception, binds: untyped binds, sql: untyped sql, message: untyped message) -> untyped
+
+      COLLATE_REGEX: untyped
+
+      def table_structure_with_collation: (untyped table_name, untyped basic_structure) -> untyped
+
+      def arel_visitor: () -> Arel::Visitors::SQLite
+
+      def build_statement_pool: () -> StatementPool
+
+      def connect: () -> untyped
+
+      def configure_connection: () -> untyped
+
+      class SQLite3Integer < ActiveModel::Type::Integer
+        def _limit: () -> untyped
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    class StatementPool
+      # :nodoc:
+      include Enumerable[untyped]
+
+      DEFAULT_STATEMENT_LIMIT: ::Integer
+
+      def initialize: (?untyped? statement_limit) -> untyped
+
+      def each: () { () -> untyped } -> untyped
+
+      def key?: (untyped key) -> untyped
+
+      def []: (untyped key) -> untyped
+
+      def length: () -> untyped
+
+      def []=: (untyped sql, untyped stmt) -> untyped
+
+      def clear: () -> untyped
+
+      def delete: (untyped key) -> untyped
+
+      def cache: () -> untyped
+
+      def dealloc: (untyped stmt) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module ConnectionHandling
+    RAILS_ENV: untyped
+
+    DEFAULT_ENV: untyped
+
+    # Establishes the connection to the database. Accepts a hash as input where
+    # the <tt>:adapter</tt> key must be specified with the name of a database adapter (in lower-case)
+    # example for regular databases (MySQL, PostgreSQL, etc):
+    #
+    #   ActiveRecord::Base.establish_connection(
+    #     adapter:  "mysql2",
+    #     host:     "localhost",
+    #     username: "myuser",
+    #     password: "mypass",
+    #     database: "somedatabase"
+    #   )
+    #
+    # Example for SQLite database:
+    #
+    #   ActiveRecord::Base.establish_connection(
+    #     adapter:  "sqlite3",
+    #     database: "path/to/dbfile"
+    #   )
+    #
+    # Also accepts keys as strings (for parsing from YAML for example):
+    #
+    #   ActiveRecord::Base.establish_connection(
+    #     "adapter"  => "sqlite3",
+    #     "database" => "path/to/dbfile"
+    #   )
+    #
+    # Or a URL:
+    #
+    #   ActiveRecord::Base.establish_connection(
+    #     "postgres://myuser:mypass@localhost/somedatabase"
+    #   )
+    #
+    # In case {ActiveRecord::Base.configurations}[rdoc-ref:Core.configurations]
+    # is set (Rails automatically loads the contents of config/database.yml into it),
+    # a symbol can also be given as argument, representing a key in the
+    # configuration hash:
+    #
+    #   ActiveRecord::Base.establish_connection(:production)
+    #
+    # The exceptions AdapterNotSpecified, AdapterNotFound and +ArgumentError+
+    # may be returned on an error.
+    def establish_connection: (?untyped? config_or_env) -> untyped
+
+    # Connects a model to the databases specified. The +database+ keyword
+    # takes a hash consisting of a +role+ and a +database_key+.
+    #
+    # This will create a connection handler for switching between connections,
+    # look up the config hash using the +database_key+ and finally
+    # establishes a connection to that config.
+    #
+    #   class AnimalsModel < ApplicationRecord
+    #     self.abstract_class = true
+    #
+    #     connects_to database: { writing: :primary, reading: :primary_replica }
+    #   end
+    #
+    # Returns an array of established connections.
+    def connects_to: (?database: ::Hash[untyped, untyped] database) -> untyped
+
+    # Connects to a database or role (ex writing, reading, or another
+    # custom role) for the duration of the block.
+    #
+    # If a role is passed, Active Record will look up the connection
+    # based on the requested role:
+    #
+    #   ActiveRecord::Base.connected_to(role: :writing) do
+    #     Dog.create! # creates dog using dog writing connection
+    #   end
+    #
+    #   ActiveRecord::Base.connected_to(role: :reading) do
+    #     Dog.create! # throws exception because we're on a replica
+    #   end
+    #
+    #   ActiveRecord::Base.connected_to(role: :unknown_role) do
+    #     # raises exception due to non-existent role
+    #   end
+    #
+    # The `database` kwarg is deprecated in 6.1 and will be removed in 6.2
+    #
+    # It is not recommended for use as it re-establishes a connection every
+    # time it is called.
+    def connected_to: (?prevent_writes: bool prevent_writes, ?role: untyped? role, ?database: untyped? database) { () -> untyped } -> untyped
+
+    # Returns true if role is the current connected role.
+    #
+    #   ActiveRecord::Base.connected_to(role: :writing) do
+    #     ActiveRecord::Base.connected_to?(role: :writing) #=> true
+    #     ActiveRecord::Base.connected_to?(role: :reading) #=> false
+    #   end
+    def connected_to?: (role: untyped role) -> untyped
+
+    # Returns the symbol representing the current connected role.
+    #
+    #   ActiveRecord::Base.connected_to(role: :writing) do
+    #     ActiveRecord::Base.current_role #=> :writing
+    #   end
+    #
+    #   ActiveRecord::Base.connected_to(role: :reading) do
+    #     ActiveRecord::Base.current_role #=> :reading
+    #   end
+    def current_role: () -> untyped
+
+    def lookup_connection_handler: (untyped handler_key) -> untyped
+
+    def with_handler: (untyped handler_key) { () -> untyped } -> untyped
+
+    def resolve_config_for_connection: (untyped config_or_env) -> untyped
+
+    # Clears the query cache for all connections associated with the current thread.
+    def clear_query_caches_for_current_thread: () -> untyped
+
+    # Returns the connection currently associated with the class. This can
+    # also be used to "borrow" the connection to do database work unrelated
+    # to any of the specific Active Records.
+    def connection: () -> untyped
+
+    attr_writer connection_specification_name: untyped
+
+    # Return the specification name from the current class or its parent.
+    def connection_specification_name: () -> untyped
+
+    def primary_class?: () -> untyped
+
+    # Returns the configuration of the associated connection as a hash:
+    #
+    #  ActiveRecord::Base.connection_config
+    #  # => {pool: 5, timeout: 5000, database: "db/development.sqlite3", adapter: "sqlite3"}
+    #
+    # Please use only for reading.
+    def connection_config: () -> untyped
+
+    def connection_pool: () -> untyped
+
+    def retrieve_connection: () -> untyped
+
+    # Returns +true+ if Active Record is connected.
+    def connected?: () -> untyped
+
+    def remove_connection: (?untyped? name) -> untyped
+
+    def clear_cache!: () -> untyped
+
+    def swap_connection_handler: (untyped handler) { () -> untyped } -> untyped
+  end
+end
+
+module ActiveRecord
+  module Core
+    extend ActiveSupport::Concern
+
+    #
+    # Contains the database configuration - as is typically stored in config/database.yml -
+    # as an ActiveRecord::DatabaseConfigurations object.
+    #
+    # For example, the following database.yml...
+    #
+    #   development:
+    #     adapter: sqlite3
+    #     database: db/development.sqlite3
+    #
+    #   production:
+    #     adapter: sqlite3
+    #     database: db/production.sqlite3
+    #
+    # ...would result in ActiveRecord::Base.configurations to look like this:
+    #
+    #   #<ActiveRecord::DatabaseConfigurations:0x00007fd1acbdf800 @configurations=[
+    #     #<ActiveRecord::DatabaseConfigurations::HashConfig:0x00007fd1acbded10 @env_name="development",
+    #       @spec_name="primary", @config={"adapter"=>"sqlite3", "database"=>"db/development.sqlite3"}>,
+    #     #<ActiveRecord::DatabaseConfigurations::HashConfig:0x00007fd1acbdea90 @env_name="production",
+    #       @spec_name="primary", @config={"adapter"=>"mysql2", "database"=>"db/production.sqlite3"}>
+    #   ]>
+    def self.configurations=: (untyped config) -> untyped
+
+    # Returns fully resolved ActiveRecord::DatabaseConfigurations object
+    def self.configurations: () -> untyped
+
+    def self.connection_handler: () -> untyped
+
+    def self.connection_handler=: (untyped handler) -> untyped
+
+    module ClassMethods
+      def initialize_find_by_cache: () -> untyped
+
+      def inherited: (untyped child_class) -> untyped
+
+      def find: (*untyped ids) -> untyped
+
+      def find_by: (*untyped args) -> untyped
+
+      def find_by!: (*untyped args) -> untyped
+
+      def initialize_generated_modules: () -> untyped
+
+      def generated_association_methods: () -> untyped
+
+      # Returns columns which shouldn't be exposed while calling +#inspect+.
+      def filter_attributes: () -> untyped
+
+      # Specifies columns which shouldn't be exposed while calling +#inspect+.
+      attr_writer filter_attributes: untyped
+
+      def inspect: () -> untyped
+
+      def ===: (untyped object) -> untyped
+
+      def arel_table: () -> untyped
+
+      def arel_attribute: (untyped name, ?untyped table) -> untyped
+
+      def predicate_builder: () -> untyped
+
+      def type_caster: () -> TypeCaster::Map
+
+      def _internal?: () -> ::FalseClass
+
+      def cached_find_by_statement: (untyped key) { () -> untyped } -> untyped
+
+      def relation: () -> untyped
+
+      def table_metadata: () -> TableMetadata
+    end
+
+    # New objects can be instantiated as either empty (pass no construction parameter) or pre-set with
+    # attributes but not yet saved (pass a hash with key names matching the associated table column names).
+    # In both instances, valid attribute keys are determined by the column names of the associated table --
+    # hence you can't have attributes that aren't part of the table columns.
+    #
+    # ==== Example:
+    #   # Instantiates a single new object
+    #   User.new(first_name: 'Jamie')
+    def initialize: (?untyped? attributes) { (untyped) -> untyped } -> untyped
+
+    # Initialize an empty model object from +coder+. +coder+ should be
+    # the result of previously encoding an Active Record model, using
+    # #encode_with.
+    #
+    #   class Post < ActiveRecord::Base
+    #   end
+    #
+    #   old_post = Post.new(title: "hello world")
+    #   coder = {}
+    #   old_post.encode_with(coder)
+    #
+    #   post = Post.allocate
+    #   post.init_with(coder)
+    #   post.title # => 'hello world'
+    def init_with: (untyped coder) { () -> untyped } -> untyped
+
+    def init_with_attributes: (untyped attributes, ?bool new_record) { (untyped) -> untyped } -> untyped
+
+    def initialize_dup: (untyped other) -> untyped
+
+    # Populate +coder+ with attributes about this record that should be
+    # serialized. The structure of +coder+ defined in this method is
+    # guaranteed to match the structure of +coder+ passed to the #init_with
+    # method.
+    #
+    # Example:
+    #
+    #   class Post < ActiveRecord::Base
+    #   end
+    #   coder = {}
+    #   Post.new.encode_with(coder)
+    #   coder # => {"attributes" => {"id" => nil, ... }}
+    def encode_with: (untyped coder) -> untyped
+
+    # Returns true if +comparison_object+ is the same exact object, or +comparison_object+
+    # is of the same type and +self+ has an ID and it is equal to +comparison_object.id+.
+    #
+    # Note that new records are different from any other record by definition, unless the
+    # other record is the receiver itself. Besides, if you fetch existing records with
+    # +select+ and leave the ID out, you're on your own, this predicate will return false.
+    #
+    # Note also that destroying a record preserves its ID in the model instance, so deleted
+    # models are still comparable.
+    def ==: (untyped comparison_object) -> untyped
+
+    alias eql? ==
+
+    # Delegates to id in order to allow two records of the same type and id to work with something like:
+    #   [ Person.find(1), Person.find(2), Person.find(3) ] & [ Person.find(1), Person.find(4) ] # => [ Person.find(1) ]
+    def hash: () -> untyped
+
+    # Clone and freeze the attributes hash such that associations are still
+    # accessible, even on destroyed records, but cloned models will not be
+    # frozen.
+    def freeze: () -> untyped
+
+    # Returns +true+ if the attributes hash has been frozen.
+    def frozen?: () -> untyped
+
+    # Allows sort on objects
+    def <=>: (untyped other_object) -> untyped
+
+    def present?: () -> ::TrueClass
+
+    def blank?: () -> ::FalseClass
+
+    # Returns +true+ if the record is read only. Records loaded through joins with piggy-back
+    # attributes will be marked as read only since they cannot be saved.
+    def readonly?: () -> untyped
+
+    # Marks this record as read only.
+    def readonly!: () -> untyped
+
+    def connection_handler: () -> untyped
+
+    # Returns the contents of the record as a nicely formatted string.
+    def inspect: () -> ::String
+
+    # Takes a PP and prettily prints this record to it, allowing you to get a nice result from <tt>pp record</tt>
+    # when pp is required.
+    def pretty_print: (untyped pp) -> untyped
+
+    # Returns a hash of the given methods with their names as keys and returned values as values.
+    def slice: (*untyped methods) -> untyped
+
+    # +Array#flatten+ will call +#to_ary+ (recursively) on each of the elements of
+    # the array, and then rescues from the possible +NoMethodError+. If those elements are
+    # +ActiveRecord::Base+'s, then this triggers the various +method_missing+'s that we have,
+    # which significantly impacts upon performance.
+    #
+    # So we can avoid the +method_missing+ hit by explicitly defining +#to_ary+ as +nil+ here.
+    #
+    # See also https://tenderlovemaking.com/2011/06/28/til-its-ok-to-return-nil-from-to_ary.html
+    def to_ary: () -> nil
+
+    def init_internals: () -> untyped
+
+    def initialize_internals_callback: () -> nil
+
+    def custom_inspect_method_defined?: () -> untyped
+
+    class InspectionMask
+      # Note: It inherits unnamed class, but omitted
+      def pretty_print: (untyped pp) -> untyped
+    end
+
+    def inspection_filter: () -> untyped
+  end
+end
+
+module ActiveRecord
+  # = Active Record Counter Cache
+  module CounterCache
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      # Resets one or more counter caches to their correct value using an SQL
+      # count query. This is useful when adding new counter caches, or if the
+      # counter has been corrupted or modified directly by SQL.
+      #
+      # ==== Parameters
+      #
+      # * +id+ - The id of the object you wish to reset a counter on.
+      # * +counters+ - One or more association counters to reset. Association name or counter name can be given.
+      # * <tt>:touch</tt> - Touch timestamp columns when updating.
+      #   Pass +true+ to touch +updated_at+ and/or +updated_on+. Pass a symbol to
+      #   touch that column or an array of symbols to touch just those ones.
+      #
+      # ==== Examples
+      #
+      #   # For the Post with id #1, reset the comments_count
+      #   Post.reset_counters(1, :comments)
+      #
+      #   # Like above, but also touch the +updated_at+ and/or +updated_on+
+      #   # attributes.
+      #   Post.reset_counters(1, :comments, touch: true)
+      def reset_counters: (untyped id, *untyped counters, ?touch: untyped? touch) -> ::TrueClass
+
+      # A generic "counter updater" implementation, intended primarily to be
+      # used by #increment_counter and #decrement_counter, but which may also
+      # be useful on its own. It simply does a direct SQL update for the record
+      # with the given ID, altering the given hash of counters by the amount
+      # given by the corresponding value:
+      #
+      # ==== Parameters
+      #
+      # * +id+ - The id of the object you wish to update a counter on or an array of ids.
+      # * +counters+ - A Hash containing the names of the fields
+      #   to update as keys and the amount to update the field by as values.
+      # * <tt>:touch</tt> option - Touch timestamp columns when updating.
+      #   If attribute names are passed, they are updated along with updated_at/on
+      #   attributes.
+      #
+      # ==== Examples
+      #
+      #   # For the Post with id of 5, decrement the comment_count by 1, and
+      #   # increment the action_count by 1
+      #   Post.update_counters 5, comment_count: -1, action_count: 1
+      #   # Executes the following SQL:
+      #   # UPDATE posts
+      #   #    SET comment_count = COALESCE(comment_count, 0) - 1,
+      #   #        action_count = COALESCE(action_count, 0) + 1
+      #   #  WHERE id = 5
+      #
+      #   # For the Posts with id of 10 and 15, increment the comment_count by 1
+      #   Post.update_counters [10, 15], comment_count: 1
+      #   # Executes the following SQL:
+      #   # UPDATE posts
+      #   #    SET comment_count = COALESCE(comment_count, 0) + 1
+      #   #  WHERE id IN (10, 15)
+      #
+      #   # For the Posts with id of 10 and 15, increment the comment_count by 1
+      #   # and update the updated_at value for each counter.
+      #   Post.update_counters [10, 15], comment_count: 1, touch: true
+      #   # Executes the following SQL:
+      #   # UPDATE posts
+      #   #    SET comment_count = COALESCE(comment_count, 0) + 1,
+      #   #    `updated_at` = '2016-10-13T09:59:23-05:00'
+      #   #  WHERE id IN (10, 15)
+      def update_counters: (untyped id, untyped counters) -> untyped
+
+      # Increment a numeric field by one, via a direct SQL update.
+      #
+      # This method is used primarily for maintaining counter_cache columns that are
+      # used to store aggregate values. For example, a +DiscussionBoard+ may cache
+      # posts_count and comments_count to avoid running an SQL query to calculate the
+      # number of posts and comments there are, each time it is displayed.
+      #
+      # ==== Parameters
+      #
+      # * +counter_name+ - The name of the field that should be incremented.
+      # * +id+ - The id of the object that should be incremented or an array of ids.
+      # * <tt>:touch</tt> - Touch timestamp columns when updating.
+      #   Pass +true+ to touch +updated_at+ and/or +updated_on+. Pass a symbol to
+      #   touch that column or an array of symbols to touch just those ones.
+      #
+      # ==== Examples
+      #
+      #   # Increment the posts_count column for the record with an id of 5
+      #   DiscussionBoard.increment_counter(:posts_count, 5)
+      #
+      #   # Increment the posts_count column for the record with an id of 5
+      #   # and update the updated_at value.
+      #   DiscussionBoard.increment_counter(:posts_count, 5, touch: true)
+      def increment_counter: (untyped counter_name, untyped id, ?touch: untyped? touch) -> untyped
+
+      # Decrement a numeric field by one, via a direct SQL update.
+      #
+      # This works the same as #increment_counter but reduces the column value by
+      # 1 instead of increasing it.
+      #
+      # ==== Parameters
+      #
+      # * +counter_name+ - The name of the field that should be decremented.
+      # * +id+ - The id of the object that should be decremented or an array of ids.
+      # * <tt>:touch</tt> - Touch timestamp columns when updating.
+      #   Pass +true+ to touch +updated_at+ and/or +updated_on+. Pass a symbol to
+      #   touch that column or an array of symbols to touch just those ones.
+      #
+      # ==== Examples
+      #
+      #   # Decrement the posts_count column for the record with an id of 5
+      #   DiscussionBoard.decrement_counter(:posts_count, 5)
+      #
+      #   # Decrement the posts_count column for the record with an id of 5
+      #   # and update the updated_at value.
+      #   DiscussionBoard.decrement_counter(:posts_count, 5, touch: true)
+      def decrement_counter: (untyped counter_name, untyped id, ?touch: untyped? touch) -> untyped
+    end
+
+    def _create_record: (?untyped attribute_names) -> untyped
+
+    def destroy_row: () -> untyped
+
+    def each_counter_cached_associations: () { (untyped) -> untyped } -> untyped
+  end
+end
+
+module ActiveRecord
+  class DatabaseConfigurations
+    class DatabaseConfig
+      # ActiveRecord::Base.configurations will return either a HashConfig or
+      # UrlConfig respectively. It will never return a DatabaseConfig object,
+      # as this is the parent class for the types of database configuration objects.
+      # :nodoc:
+      attr_reader env_name: untyped
+
+      # ActiveRecord::Base.configurations will return either a HashConfig or
+      # UrlConfig respectively. It will never return a DatabaseConfig object,
+      # as this is the parent class for the types of database configuration objects.
+      # :nodoc:
+      attr_reader spec_name: untyped
+
+      def initialize: (untyped env_name, untyped spec_name) -> untyped
+
+      def replica?: () -> untyped
+
+      def migrations_paths: () -> untyped
+
+      def url_config?: () -> ::FalseClass
+
+      def to_legacy_hash: () -> ::Hash[untyped, untyped]
+
+      def for_current_env?: () -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  class DatabaseConfigurations
+    # A HashConfig object is created for each database configuration entry that
+    # is created from a hash.
+    #
+    # A hash config:
+    #
+    #   { "development" => { "database" => "db_name" } }
+    #
+    # Becomes:
+    #
+    #   #<ActiveRecord::DatabaseConfigurations::HashConfig:0x00007fd1acbded10
+    #     @env_name="development", @spec_name="primary", @config={"database"=>"db_name"}>
+    #
+    # ==== Options
+    #
+    # * <tt>:env_name</tt> - The Rails environment, i.e. "development".
+    # * <tt>:spec_name</tt> - The specification name. In a standard two-tier
+    #   database configuration this will default to "primary". In a multiple
+    #   database three-tier database configuration this corresponds to the name
+    #   used in the second tier, for example "primary_readonly".
+    # * <tt>:config</tt> - The config hash. This is the hash that contains the
+    #   database adapter, name, and other important information for database
+    #   connections.
+    class HashConfig < DatabaseConfig
+      attr_reader config: untyped
+
+      def initialize: (untyped env_name, untyped spec_name, untyped config) -> untyped
+
+      # Determines whether a database configuration is for a replica / readonly
+      # connection. If the +replica+ key is present in the config, +replica?+ will
+      # return +true+.
+      def replica?: () -> untyped
+
+      # The migrations paths for a database configuration. If the
+      # +migrations_paths+ key is present in the config, +migrations_paths+
+      # will return its value.
+      def migrations_paths: () -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  class DatabaseConfigurations
+    # A UrlConfig object is created for each database configuration
+    # entry that is created from a URL. This can either be a URL string
+    # or a hash with a URL in place of the config hash.
+    #
+    # A URL config:
+    #
+    #   postgres://localhost/foo
+    #
+    # Becomes:
+    #
+    #   #<ActiveRecord::DatabaseConfigurations::UrlConfig:0x00007fdc3238f340
+    #     @env_name="default_env", @spec_name="primary",
+    #     @config={"adapter"=>"postgresql", "database"=>"foo", "host"=>"localhost"},
+    #     @url="postgres://localhost/foo">
+    #
+    # ==== Options
+    #
+    # * <tt>:env_name</tt> - The Rails environment, ie "development".
+    # * <tt>:spec_name</tt> - The specification name. In a standard two-tier
+    #   database configuration this will default to "primary". In a multiple
+    #   database three-tier database configuration this corresponds to the name
+    #   used in the second tier, for example "primary_readonly".
+    # * <tt>:url</tt> - The database URL.
+    # * <tt>:config</tt> - The config hash. This is the hash that contains the
+    #   database adapter, name, and other important information for database
+    #   connections.
+    class UrlConfig < DatabaseConfig
+      attr_reader url: untyped
+
+      attr_reader config: untyped
+
+      def initialize: (untyped env_name, untyped spec_name, untyped url, ?::Hash[untyped, untyped] config) -> untyped
+
+      def url_config?: () -> ::TrueClass
+
+      # Determines whether a database configuration is for a replica / readonly
+      # connection. If the +replica+ key is present in the config, +replica?+ will
+      # return +true+.
+      def replica?: () -> untyped
+
+      # The migrations paths for a database configuration. If the
+      # +migrations_paths+ key is present in the config, +migrations_paths+
+      # will return its value.
+      def migrations_paths: () -> untyped
+
+      def build_url_hash: (untyped url) -> untyped
+
+      def build_config: (untyped original_config, untyped url) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  # ActiveRecord::DatabaseConfigurations returns an array of DatabaseConfig
+  # objects (either a HashConfig or UrlConfig) that are constructed from the
+  # application's database configuration hash or URL string.
+  class DatabaseConfigurations
+    class InvalidConfigurationError < StandardError
+    end
+
+    attr_reader configurations: untyped
+
+    def initialize: (?::Hash[untyped, untyped] configurations) -> untyped
+
+    # Collects the configs for the environment and optionally the specification
+    # name passed in. To include replica configurations pass <tt>include_replicas: true</tt>.
+    #
+    # If a spec name is provided a single DatabaseConfig object will be
+    # returned, otherwise an array of DatabaseConfig objects will be
+    # returned that corresponds with the environment and type requested.
+    #
+    # ==== Options
+    #
+    # * <tt>env_name:</tt> The environment name. Defaults to +nil+ which will collect
+    #   configs for all environments.
+    # * <tt>spec_name:</tt> The specification name (i.e. primary, animals, etc.). Defaults
+    #   to +nil+.
+    # * <tt>include_replicas:</tt> Determines whether to include replicas in
+    #   the returned list. Most of the time we're only iterating over the write
+    #   connection (i.e. migrations don't need to run for the write and read connection).
+    #   Defaults to +false+.
+    def configs_for: (?include_replicas: bool include_replicas, ?spec_name: untyped? spec_name, ?env_name: untyped? env_name) -> untyped
+
+    # Returns the config hash that corresponds with the environment
+    #
+    # If the application has multiple databases +default_hash+ will
+    # return the first config hash for the environment.
+    #
+    #   { database: "my_db", adapter: "mysql2" }
+    def default_hash: (?untyped env) -> untyped
+
+    alias [] default_hash
+
+    # Returns a single DatabaseConfig object based on the requested environment.
+    #
+    # If the application has multiple databases +find_db_config+ will return
+    # the first DatabaseConfig for the environment.
+    def find_db_config: (untyped env) -> untyped
+
+    # Returns the DatabaseConfigurations object as a Hash.
+    def to_h: () -> untyped
+
+    # Checks if the application's configurations are empty.
+    #
+    # Aliased to blank?
+    def empty?: () -> untyped
+
+    alias blank? empty?
+
+    def each: () { (untyped) -> untyped } -> untyped
+
+    def first: () -> ::Array[untyped]
+
+    def env_with_configs: (?untyped? env) -> untyped
+
+    def build_configs: (untyped configs) -> untyped
+
+    def walk_configs: (untyped env_name, untyped config) -> untyped
+
+    def build_db_config_from_raw_config: (untyped env_name, untyped spec_name, untyped config) -> untyped
+
+    def build_db_config_from_string: (untyped env_name, untyped spec_name, untyped config) -> untyped
+
+    def build_db_config_from_hash: (untyped env_name, untyped spec_name, untyped config) -> untyped
+
+    def merge_db_environment_variables: (untyped current_env, untyped configs) -> untyped
+
+    def environment_url_config: (untyped env, untyped spec_name, untyped config) -> (nil | ActiveRecord::DatabaseConfigurations::UrlConfig)
+
+    def environment_value_for: (untyped spec_name) -> untyped
+
+    def method_missing: (untyped method, *untyped args) { () -> untyped } -> untyped
+
+    def throw_setter_deprecation: (untyped method) -> untyped
+
+    def throw_getter_deprecation: (untyped method) -> untyped
+  end
+end
+
+module ActiveRecord
+  # This module exists because ActiveRecord::AttributeMethods::Dirty needs to
+  # define callbacks, but continue to have its version of +save+ be the super
+  # method of ActiveRecord::Callbacks. This will be removed when the removal
+  # of deprecated code removes this need.
+  module DefineCallbacks
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      # :nodoc:
+      include ActiveModel::Callbacks
+    end
+
+    include ActiveModel::Validations::Callbacks
+  end
+end
+
+module ActiveRecord
+  module DynamicMatchers
+    def respond_to_missing?: (untyped name, untyped _) -> untyped
+
+    def method_missing: (untyped name, *untyped arguments) { () -> untyped } -> untyped
+
+    class Method
+      attr_reader matchers: untyped
+
+      def self.match: (untyped model, untyped name) -> untyped
+
+      def self.pattern: () -> untyped
+
+      def self.prefix: () -> untyped
+
+      def self.suffix: () -> ::String
+
+      attr_reader model: untyped
+
+      attr_reader name: untyped
+
+      attr_reader attribute_names: untyped
+
+      def initialize: (untyped model, untyped method_name) -> untyped
+
+      def valid?: () -> untyped
+
+      def define: () -> untyped
+
+      def body: () -> ::String
+
+      # The parameters in the signature may have reserved Ruby words, in order
+      # to prevent errors, we start each param name with `_`.
+      def signature: () -> untyped
+
+      # Given that the parameters starts with `_`, the finder needs to use the
+      # same parameter name.
+      def attributes_hash: () -> untyped
+
+      def finder: () -> untyped
+    end
+
+    class FindBy < Method
+      def self.prefix: () -> "find_by"
+
+      def finder: () -> "find_by"
+    end
+
+    class FindByBang < Method
+      def self.prefix: () -> "find_by"
+
+      def self.suffix: () -> "!"
+
+      def finder: () -> "find_by!"
+    end
+  end
+end
+
+module ActiveRecord
+  module Enum
+    def self.extended: (untyped base) -> untyped
+
+    def inherited: (untyped base) -> untyped
+
+    class EnumType < ActiveModel::Type::Value
+      def initialize: (untyped name, untyped mapping, untyped subtype) -> untyped
+
+      def cast: (untyped value) -> (nil | untyped)
+
+      def deserialize: (untyped value) -> (nil | untyped)
+
+      def serialize: (untyped value) -> untyped
+
+      def assert_valid_value: (untyped value) -> untyped
+
+      attr_reader name: untyped
+
+      attr_reader mapping: untyped
+
+      attr_reader subtype: untyped
+    end
+
+    def enum: (untyped definitions) -> untyped
+
+    def _enum_methods_module: () -> untyped
+
+    def assert_valid_enum_definition_values: (untyped values) -> untyped
+
+    ENUM_CONFLICT_MESSAGE: ::String
+
+    def detect_enum_conflict!: (untyped enum_name, untyped method_name, ?bool klass_method) -> untyped
+
+    def raise_conflict_error: (untyped enum_name, untyped method_name, ?source: ::String source, ?type: ::String `type`) -> untyped
+
+    def detect_negative_condition!: (untyped method_name) -> untyped
+  end
+end
+
+module ActiveRecord
+  # = Active Record Errors
+  #
+  # Generic Active Record exception class.
+  class ActiveRecordError < StandardError
+  end
+
+  # Raised when the single-table inheritance mechanism fails to locate the subclass
+  # (for example due to improper usage of column that
+  # {ActiveRecord::Base.inheritance_column}[rdoc-ref:ModelSchema::ClassMethods#inheritance_column]
+  # points to).
+  class SubclassNotFound < ActiveRecordError
+  end
+
+  # Raised when an object assigned to an association has an incorrect type.
+  #
+  #   class Ticket < ActiveRecord::Base
+  #     has_many :patches
+  #   end
+  #
+  #   class Patch < ActiveRecord::Base
+  #     belongs_to :ticket
+  #   end
+  #
+  #   # Comments are not patches, this assignment raises AssociationTypeMismatch.
+  #   @ticket.patches << Comment.new(content: "Please attach tests to your patch.")
+  class AssociationTypeMismatch < ActiveRecordError
+  end
+
+  # Raised when unserialized object's type mismatches one specified for serializable field.
+  class SerializationTypeMismatch < ActiveRecordError
+  end
+
+  # Raised when adapter not specified on connection (or configuration file
+  # +config/database.yml+ misses adapter field).
+  class AdapterNotSpecified < ActiveRecordError
+  end
+
+  # Raised when Active Record cannot find database adapter specified in
+  # +config/database.yml+ or programmatically.
+  class AdapterNotFound < ActiveRecordError
+  end
+
+  # Raised when connection to the database could not been established (for example when
+  # {ActiveRecord::Base.connection=}[rdoc-ref:ConnectionHandling#connection]
+  # is given a +nil+ object).
+  class ConnectionNotEstablished < ActiveRecordError
+  end
+
+  # Raised when a write to the database is attempted on a read only connection.
+  class ReadOnlyError < ActiveRecordError
+  end
+
+  # Raised when Active Record cannot find a record by given id or set of ids.
+  class RecordNotFound < ActiveRecordError
+    attr_reader model: untyped
+
+    attr_reader primary_key: untyped
+
+    attr_reader id: untyped
+
+    def initialize: (?untyped? message, ?untyped? model, ?untyped? primary_key, ?untyped? id) -> untyped
+  end
+
+  # Raised by {ActiveRecord::Base#save!}[rdoc-ref:Persistence#save!] and
+  # {ActiveRecord::Base.create!}[rdoc-ref:Persistence::ClassMethods#create!]
+  # methods when a record is invalid and cannot be saved.
+  class RecordNotSaved < ActiveRecordError
+    attr_reader record: untyped
+
+    def initialize: (?untyped? message, ?untyped? record) -> untyped
+  end
+
+  # Raised by {ActiveRecord::Base#destroy!}[rdoc-ref:Persistence#destroy!]
+  # when a call to {#destroy}[rdoc-ref:Persistence#destroy!]
+  # would return false.
+  #
+  #   begin
+  #     complex_operation_that_internally_calls_destroy!
+  #   rescue ActiveRecord::RecordNotDestroyed => invalid
+  #     puts invalid.record.errors
+  #   end
+  #
+  class RecordNotDestroyed < ActiveRecordError
+    attr_reader record: untyped
+
+    def initialize: (?untyped? message, ?untyped? record) -> untyped
+  end
+
+  # Superclass for all database execution errors.
+  #
+  # Wraps the underlying database error as +cause+.
+  class StatementInvalid < ActiveRecordError
+    def initialize: (?untyped? message, ?binds: untyped? binds, ?sql: untyped? sql) -> untyped
+
+    attr_reader sql: untyped
+
+    attr_reader binds: untyped
+  end
+
+  # Defunct wrapper class kept for compatibility.
+  # StatementInvalid wraps the original exception now.
+  class WrappedDatabaseException < StatementInvalid
+  end
+
+  # Raised when a record cannot be inserted or updated because it would violate a uniqueness constraint.
+  class RecordNotUnique < WrappedDatabaseException
+  end
+
+  # Raised when a record cannot be inserted or updated because it references a non-existent record,
+  # or when a record cannot be deleted because a parent record references it.
+  class InvalidForeignKey < WrappedDatabaseException
+  end
+
+  # Raised when a foreign key constraint cannot be added because the column type does not match the referenced column type.
+  class MismatchedForeignKey < StatementInvalid
+    def initialize: (?primary_key_column: untyped? primary_key_column, ?primary_key: untyped? primary_key, ?target_table: untyped? target_table, ?foreign_key: untyped? foreign_key, ?table: untyped? table, ?binds: untyped? binds, ?sql: untyped? sql, ?message: untyped? message) -> untyped
+  end
+
+  # Raised when a record cannot be inserted or updated because it would violate a not null constraint.
+  class NotNullViolation < StatementInvalid
+  end
+
+  # Raised when a record cannot be inserted or updated because a value too long for a column type.
+  class ValueTooLong < StatementInvalid
+  end
+
+  # Raised when values that executed are out of range.
+  class RangeError < StatementInvalid
+  end
+
+  # Raised when number of bind variables in statement given to +:condition+ key
+  # (for example, when using {ActiveRecord::Base.find}[rdoc-ref:FinderMethods#find] method)
+  # does not match number of expected values supplied.
+  #
+  # For example, when there are two placeholders with only one value supplied:
+  #
+  #   Location.where("lat = ? AND lng = ?", 53.7362)
+  class PreparedStatementInvalid < ActiveRecordError
+  end
+
+  # Raised when a given database does not exist.
+  class NoDatabaseError < StatementInvalid
+  end
+
+  # Raised when PostgreSQL returns 'cached plan must not change result type' and
+  # we cannot retry gracefully (e.g. inside a transaction)
+  class PreparedStatementCacheExpired < StatementInvalid
+  end
+
+  # Raised on attempt to save stale record. Record is stale when it's being saved in another query after
+  # instantiation, for example, when two users edit the same wiki page and one starts editing and saves
+  # the page before the other.
+  #
+  # Read more about optimistic locking in ActiveRecord::Locking module
+  # documentation.
+  class StaleObjectError < ActiveRecordError
+    attr_reader record: untyped
+
+    attr_reader attempted_action: untyped
+
+    def initialize: (?untyped? record, ?untyped? attempted_action) -> untyped
+  end
+
+  # Raised when association is being configured improperly or user tries to use
+  # offset and limit together with
+  # {ActiveRecord::Base.has_many}[rdoc-ref:Associations::ClassMethods#has_many] or
+  # {ActiveRecord::Base.has_and_belongs_to_many}[rdoc-ref:Associations::ClassMethods#has_and_belongs_to_many]
+  # associations.
+  class ConfigurationError < ActiveRecordError
+  end
+
+  # Raised on attempt to update record that is instantiated as read only.
+  class ReadOnlyRecord < ActiveRecordError
+  end
+
+  # {ActiveRecord::Base.transaction}[rdoc-ref:Transactions::ClassMethods#transaction]
+  # uses this exception to distinguish a deliberate rollback from other exceptional situations.
+  # Normally, raising an exception will cause the
+  # {.transaction}[rdoc-ref:Transactions::ClassMethods#transaction] method to rollback
+  # the database transaction *and* pass on the exception. But if you raise an
+  # ActiveRecord::Rollback exception, then the database transaction will be rolled back,
+  # without passing on the exception.
+  #
+  # For example, you could do this in your controller to rollback a transaction:
+  #
+  #   class BooksController < ActionController::Base
+  #     def create
+  #       Book.transaction do
+  #         book = Book.new(params[:book])
+  #         book.save!
+  #         if today_is_friday?
+  #           # The system must fail on Friday so that our support department
+  #           # won't be out of job. We silently rollback this transaction
+  #           # without telling the user.
+  #           raise ActiveRecord::Rollback, "Call tech support!"
+  #         end
+  #       end
+  #       # ActiveRecord::Rollback is the only exception that won't be passed on
+  #       # by ActiveRecord::Base.transaction, so this line will still be reached
+  #       # even on Friday.
+  #       redirect_to root_url
+  #     end
+  #   end
+  class Rollback < ActiveRecordError
+  end
+
+  # Raised when attribute has a name reserved by Active Record (when attribute
+  # has name of one of Active Record instance methods).
+  class DangerousAttributeError < ActiveRecordError
+  end
+
+  # Raised when unknown attributes are supplied via mass assignment.
+  UnknownAttributeError: untyped
+
+  # Raised when an error occurred while doing a mass assignment to an attribute through the
+  # {ActiveRecord::Base#attributes=}[rdoc-ref:AttributeAssignment#attributes=] method.
+  # The exception has an +attribute+ property that is the name of the offending attribute.
+  class AttributeAssignmentError < ActiveRecordError
+    attr_reader exception: untyped
+
+    attr_reader attribute: untyped
+
+    def initialize: (?untyped? message, ?untyped? exception, ?untyped? attribute) -> untyped
+  end
+
+  # Raised when there are multiple errors while doing a mass assignment through the
+  # {ActiveRecord::Base#attributes=}[rdoc-ref:AttributeAssignment#attributes=]
+  # method. The exception has an +errors+ property that contains an array of AttributeAssignmentError
+  # objects, each corresponding to the error while assigning to an attribute.
+  class MultiparameterAssignmentErrors < ActiveRecordError
+    attr_reader errors: untyped
+
+    def initialize: (?untyped? errors) -> untyped
+  end
+
+  # Raised when a primary key is needed, but not specified in the schema or model.
+  class UnknownPrimaryKey < ActiveRecordError
+    attr_reader model: untyped
+
+    def initialize: (?untyped? model, ?untyped? description) -> untyped
+  end
+
+  # Raised when a relation cannot be mutated because it's already loaded.
+  #
+  #   class Task < ActiveRecord::Base
+  #   end
+  #
+  #   relation = Task.all
+  #   relation.loaded? # => true
+  #
+  #   # Methods which try to mutate a loaded relation fail.
+  #   relation.where!(title: 'TODO')  # => ActiveRecord::ImmutableRelation
+  #   relation.limit!(5)              # => ActiveRecord::ImmutableRelation
+  class ImmutableRelation < ActiveRecordError
+  end
+
+  # TransactionIsolationError will be raised under the following conditions:
+  #
+  # * The adapter does not support setting the isolation level
+  # * You are joining an existing open transaction
+  # * You are creating a nested (savepoint) transaction
+  #
+  # The mysql2 and postgresql adapters support setting the transaction isolation level.
+  class TransactionIsolationError < ActiveRecordError
+  end
+
+  # TransactionRollbackError will be raised when a transaction is rolled
+  # back by the database due to a serialization failure or a deadlock.
+  #
+  # See the following:
+  #
+  # * https://www.postgresql.org/docs/current/static/transaction-iso.html
+  # * https://dev.mysql.com/doc/refman/5.7/en/error-messages-server.html#error_er_lock_deadlock
+  class TransactionRollbackError < StatementInvalid
+  end
+
+  # SerializationFailure will be raised when a transaction is rolled
+  # back by the database due to a serialization failure.
+  class SerializationFailure < TransactionRollbackError
+  end
+
+  # Deadlocked will be raised when a transaction is rolled
+  # back by the database when a deadlock is encountered.
+  class Deadlocked < TransactionRollbackError
+  end
+
+  # IrreversibleOrderError is raised when a relation's order is too complex for
+  # +reverse_order+ to automatically reverse.
+  class IrreversibleOrderError < ActiveRecordError
+  end
+
+  # LockWaitTimeout will be raised when lock wait timeout exceeded.
+  class LockWaitTimeout < StatementInvalid
+  end
+
+  # StatementTimeout will be raised when statement timeout exceeded.
+  class StatementTimeout < StatementInvalid
+  end
+
+  # QueryCanceled will be raised when canceling statement due to user request.
+  class QueryCanceled < StatementInvalid
+  end
+
+  # UnknownAttributeReference is raised when an unknown and potentially unsafe
+  # value is passed to a query method when allow_unsafe_raw_sql is set to
+  # :disabled. For example, passing a non column name value to a relation's
+  # #order method might cause this exception.
+  #
+  # When working around this exception, caution should be taken to avoid SQL
+  # injection vulnerabilities when passing user-provided values to query
+  # methods. Known-safe values can be passed to query methods by wrapping them
+  # in Arel.sql.
+  #
+  # For example, with allow_unsafe_raw_sql set to :disabled, the following
+  # code would raise this exception:
+  #
+  #   Post.order("length(title)").first
+  #
+  # The desired result can be accomplished by wrapping the known-safe string
+  # in Arel.sql:
+  #
+  #   Post.order(Arel.sql("length(title)")).first
+  #
+  # Again, such a workaround should *not* be used when passing user-provided
+  # values, such as request parameters or model attributes to query methods.
+  class UnknownAttributeReference < ActiveRecordError
+  end
+end
+
+module ActiveRecord
+  module Explain
+    def collecting_queries_for_explain: () { () -> untyped } -> untyped
+
+    def exec_explain: (untyped queries) -> untyped
+
+    def render_bind: (untyped attr) -> ::Array[untyped]
+  end
+end
+
+module ActiveRecord
+  class ExplainRegistry
+    # This is a thread locals registry for EXPLAIN. For example
+    #
+    #   ActiveRecord::ExplainRegistry.queries
+    #
+    # returns the collected queries local to the current thread.
+    #
+    # See the documentation of ActiveSupport::PerThreadRegistry
+    # for further details.
+    # :nodoc:
+    extend ActiveSupport::PerThreadRegistry
+
+    attr_accessor queries: untyped
+
+    attr_accessor collect: untyped
+
+    def initialize: () -> untyped
+
+    def collect?: () -> untyped
+
+    def reset: () -> untyped
+  end
+end
+
+module ActiveRecord
+  class ExplainSubscriber
+    # :nodoc:
+    def start: (untyped name, untyped id, untyped payload) -> nil
+
+    def finish: (untyped name, untyped id, untyped payload) -> untyped
+
+    # SCHEMA queries cannot be EXPLAINed, also we do not want to run EXPLAIN on
+    # our own EXPLAINs no matter how loopingly beautiful that would be.
+    #
+    # On the other hand, we want to monitor the performance of our real database
+    # queries, not the performance of the access to the query cache.
+    IGNORED_PAYLOADS: ::Array[untyped]
+
+    EXPLAINED_SQLS: untyped
+
+    def ignore_payload?: (untyped payload) -> untyped
+  end
+end
+
+module ActiveRecord
+  class FixtureSet
+    class File
+      # :nodoc:
+      include Enumerable[untyped]
+
+      #
+      # Open a fixture file named +file+.  When called with a block, the block
+      # is called with the filehandle and the filehandle is automatically closed
+      # when the block finishes.
+      def self.open: (untyped file) { (untyped) -> untyped } -> untyped
+
+      def initialize: (untyped file) -> untyped
+
+      def each: () { () -> untyped } -> untyped
+
+      def model_class: () -> untyped
+
+      def rows: () -> untyped
+
+      def config_row: () -> untyped
+
+      def raw_rows: () -> untyped
+
+      def prepare_erb: (untyped content) -> untyped
+
+      def render: (untyped content) -> untyped
+
+      # Validate our unmarshalled data.
+      def validate: (untyped data) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  class FixtureSet
+    class ModelMetadata
+      # :nodoc:
+      def initialize: (untyped model_class) -> untyped
+
+      def primary_key_name: () -> untyped
+
+      def primary_key_type: () -> untyped
+
+      def has_primary_key_column?: () -> untyped
+
+      def timestamp_column_names: () -> untyped
+
+      def inheritance_column_name: () -> untyped
+    end
+  end
+end
+
+class ActiveRecord::FixtureSet::RenderContext
+  # NOTE: This class has to be defined in compact style in
+  # order for rendering context subclassing to work correctly.
+  # :nodoc:
+  def self.create_subclass: () -> untyped
+end
+
+module ActiveRecord
+  class FixtureSet
+    class TableRow
+      class ReflectionProxy
+        # :nodoc:
+        # :nodoc:
+        def initialize: (untyped association) -> untyped
+
+        def join_table: () -> untyped
+
+        def name: () -> untyped
+
+        def primary_key_type: () -> untyped
+      end
+
+      class HasManyThroughProxy < ReflectionProxy
+        # :nodoc:
+        def rhs_key: () -> untyped
+
+        def lhs_key: () -> untyped
+
+        def join_table: () -> untyped
+      end
+
+      def initialize: (untyped fixture, now: untyped now, label: untyped label, table_rows: untyped table_rows) -> untyped
+
+      def to_hash: () -> untyped
+
+      def model_metadata: () -> untyped
+
+      def model_class: () -> untyped
+
+      def fill_row_model_attributes: () -> (nil | untyped)
+
+      def reflection_class: () -> untyped
+
+      def fill_timestamps: () -> untyped
+
+      def interpolate_label: () -> untyped
+
+      def generate_primary_key: () -> untyped
+
+      def resolve_enums: () -> untyped
+
+      def resolve_sti_reflections: () -> untyped
+
+      def add_join_records: (untyped association) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  class FixtureSet
+    class TableRows
+      # :nodoc:
+      def initialize: (untyped table_name, config: untyped config, fixtures: untyped fixtures, model_class: untyped model_class) -> untyped
+
+      attr_reader tables: untyped
+
+      attr_reader model_class: untyped
+
+      def to_hash: () -> untyped
+
+      def model_metadata: () -> untyped
+
+      def build_table_rows_from: (untyped table_name, untyped fixtures, untyped config) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  class FixtureClassNotFound < ActiveRecord::ActiveRecordError
+  end
+
+  # \Fixtures are a way of organizing data that you want to test against; in short, sample data.
+  #
+  # They are stored in YAML files, one file per model, which are placed in the directory
+  # appointed by <tt>ActiveSupport::TestCase.fixture_path=(path)</tt> (this is automatically
+  # configured for Rails, so you can just put your files in <tt><your-rails-app>/test/fixtures/</tt>).
+  # The fixture file ends with the +.yml+ file extension, for example:
+  # <tt><your-rails-app>/test/fixtures/web_sites.yml</tt>).
+  #
+  # The format of a fixture file looks like this:
+  #
+  #   rubyonrails:
+  #     id: 1
+  #     name: Ruby on Rails
+  #     url: http://www.rubyonrails.org
+  #
+  #   google:
+  #     id: 2
+  #     name: Google
+  #     url: http://www.google.com
+  #
+  # This fixture file includes two fixtures. Each YAML fixture (ie. record) is given a name and
+  # is followed by an indented list of key/value pairs in the "key: value" format. Records are
+  # separated by a blank line for your viewing pleasure.
+  #
+  # Note: Fixtures are unordered. If you want ordered fixtures, use the omap YAML type.
+  # See http://yaml.org/type/omap.html
+  # for the specification. You will need ordered fixtures when you have foreign key constraints
+  # on keys in the same table. This is commonly needed for tree structures. Example:
+  #
+  #    --- !omap
+  #    - parent:
+  #        id:         1
+  #        parent_id:  NULL
+  #        title:      Parent
+  #    - child:
+  #        id:         2
+  #        parent_id:  1
+  #        title:      Child
+  #
+  # = Using Fixtures in Test Cases
+  #
+  # Since fixtures are a testing construct, we use them in our unit and functional tests. There
+  # are two ways to use the fixtures, but first let's take a look at a sample unit test:
+  #
+  #   require 'test_helper'
+  #
+  #   class WebSiteTest < ActiveSupport::TestCase
+  #     test "web_site_count" do
+  #       assert_equal 2, WebSite.count
+  #     end
+  #   end
+  #
+  # By default, +test_helper.rb+ will load all of your fixtures into your test
+  # database, so this test will succeed.
+  #
+  # The testing environment will automatically load all the fixtures into the database before each
+  # test. To ensure consistent data, the environment deletes the fixtures before running the load.
+  #
+  # In addition to being available in the database, the fixture's data may also be accessed by
+  # using a special dynamic method, which has the same name as the model.
+  #
+  # Passing in a fixture name to this dynamic method returns the fixture matching this name:
+  #
+  #   test "find one" do
+  #     assert_equal "Ruby on Rails", web_sites(:rubyonrails).name
+  #   end
+  #
+  # Passing in multiple fixture names returns all fixtures matching these names:
+  #
+  #   test "find all by name" do
+  #     assert_equal 2, web_sites(:rubyonrails, :google).length
+  #   end
+  #
+  # Passing in no arguments returns all fixtures:
+  #
+  #   test "find all" do
+  #     assert_equal 2, web_sites.length
+  #   end
+  #
+  # Passing in any fixture name that does not exist will raise <tt>StandardError</tt>:
+  #
+  #   test "find by name that does not exist" do
+  #     assert_raise(StandardError) { web_sites(:reddit) }
+  #   end
+  #
+  # Alternatively, you may enable auto-instantiation of the fixture data. For instance, take the
+  # following tests:
+  #
+  #   test "find_alt_method_1" do
+  #     assert_equal "Ruby on Rails", @web_sites['rubyonrails']['name']
+  #   end
+  #
+  #   test "find_alt_method_2" do
+  #     assert_equal "Ruby on Rails", @rubyonrails.name
+  #   end
+  #
+  # In order to use these methods to access fixtured data within your test cases, you must specify one of the
+  # following in your ActiveSupport::TestCase-derived class:
+  #
+  # - to fully enable instantiated fixtures (enable alternate methods #1 and #2 above)
+  #     self.use_instantiated_fixtures = true
+  #
+  # - create only the hash for the fixtures, do not 'find' each instance (enable alternate method #1 only)
+  #     self.use_instantiated_fixtures = :no_instances
+  #
+  # Using either of these alternate methods incurs a performance hit, as the fixtured data must be fully
+  # traversed in the database to create the fixture hash and/or instance variables. This is expensive for
+  # large sets of fixtured data.
+  #
+  # = Dynamic fixtures with ERB
+  #
+  # Sometimes you don't care about the content of the fixtures as much as you care about the volume.
+  # In these cases, you can mix ERB in with your YAML fixtures to create a bunch of fixtures for load
+  # testing, like:
+  #
+  #   <% 1.upto(1000) do |i| %>
+  #   fix_<%= i %>:
+  #     id: <%= i %>
+  #     name: guy_<%= i %>
+  #   <% end %>
+  #
+  # This will create 1000 very simple fixtures.
+  #
+  # Using ERB, you can also inject dynamic values into your fixtures with inserts like
+  # <tt><%= Date.today.strftime("%Y-%m-%d") %></tt>.
+  # This is however a feature to be used with some caution. The point of fixtures are that they're
+  # stable units of predictable sample data. If you feel that you need to inject dynamic values, then
+  # perhaps you should reexamine whether your application is properly testable. Hence, dynamic values
+  # in fixtures are to be considered a code smell.
+  #
+  # Helper methods defined in a fixture will not be available in other fixtures, to prevent against
+  # unwanted inter-test dependencies. Methods used by multiple fixtures should be defined in a module
+  # that is included in ActiveRecord::FixtureSet.context_class.
+  #
+  # - define a helper method in <tt>test_helper.rb</tt>
+  #     module FixtureFileHelpers
+  #       def file_sha(path)
+  #         Digest::SHA2.hexdigest(File.read(Rails.root.join('test/fixtures', path)))
+  #       end
+  #     end
+  #     ActiveRecord::FixtureSet.context_class.include FixtureFileHelpers
+  #
+  # - use the helper method in a fixture
+  #     photo:
+  #       name: kitten.png
+  #       sha: <%= file_sha 'files/kitten.png' %>
+  #
+  # = Transactional Tests
+  #
+  # Test cases can use begin+rollback to isolate their changes to the database instead of having to
+  # delete+insert for every test case.
+  #
+  #   class FooTest < ActiveSupport::TestCase
+  #     self.use_transactional_tests = true
+  #
+  #     test "godzilla" do
+  #       assert_not_empty Foo.all
+  #       Foo.destroy_all
+  #       assert_empty Foo.all
+  #     end
+  #
+  #     test "godzilla aftermath" do
+  #       assert_not_empty Foo.all
+  #     end
+  #   end
+  #
+  # If you preload your test database with all fixture data (probably by running `rails db:fixtures:load`)
+  # and use transactional tests, then you may omit all fixtures declarations in your test cases since
+  # all the data's already there and every case rolls back its changes.
+  #
+  # In order to use instantiated fixtures with preloaded data, set +self.pre_loaded_fixtures+ to
+  # true. This will provide access to fixture data for every table that has been loaded through
+  # fixtures (depending on the value of +use_instantiated_fixtures+).
+  #
+  # When *not* to use transactional tests:
+  #
+  # 1. You're testing whether a transaction works correctly. Nested transactions don't commit until
+  #    all parent transactions commit, particularly, the fixtures transaction which is begun in setup
+  #    and rolled back in teardown. Thus, you won't be able to verify
+  #    the results of your transaction until Active Record supports nested transactions or savepoints (in progress).
+  # 2. Your database does not support transactions. Every Active Record database supports transactions except MySQL MyISAM.
+  #    Use InnoDB, MaxDB, or NDB instead.
+  #
+  # = Advanced Fixtures
+  #
+  # Fixtures that don't specify an ID get some extra features:
+  #
+  # * Stable, autogenerated IDs
+  # * Label references for associations (belongs_to, has_one, has_many)
+  # * HABTM associations as inline lists
+  #
+  # There are some more advanced features available even if the id is specified:
+  #
+  # * Autofilled timestamp columns
+  # * Fixture label interpolation
+  # * Support for YAML defaults
+  #
+  # == Stable, Autogenerated IDs
+  #
+  # Here, have a monkey fixture:
+  #
+  #   george:
+  #     id: 1
+  #     name: George the Monkey
+  #
+  #   reginald:
+  #     id: 2
+  #     name: Reginald the Pirate
+  #
+  # Each of these fixtures has two unique identifiers: one for the database
+  # and one for the humans. Why don't we generate the primary key instead?
+  # Hashing each fixture's label yields a consistent ID:
+  #
+  #   george: # generated id: 503576764
+  #     name: George the Monkey
+  #
+  #   reginald: # generated id: 324201669
+  #     name: Reginald the Pirate
+  #
+  # Active Record looks at the fixture's model class, discovers the correct
+  # primary key, and generates it right before inserting the fixture
+  # into the database.
+  #
+  # The generated ID for a given label is constant, so we can discover
+  # any fixture's ID without loading anything, as long as we know the label.
+  #
+  # == Label references for associations (belongs_to, has_one, has_many)
+  #
+  # Specifying foreign keys in fixtures can be very fragile, not to
+  # mention difficult to read. Since Active Record can figure out the ID of
+  # any fixture from its label, you can specify FK's by label instead of ID.
+  #
+  # === belongs_to
+  #
+  # Let's break out some more monkeys and pirates.
+  #
+  #   ### in pirates.yml
+  #
+  #   reginald:
+  #     id: 1
+  #     name: Reginald the Pirate
+  #     monkey_id: 1
+  #
+  #   ### in monkeys.yml
+  #
+  #   george:
+  #     id: 1
+  #     name: George the Monkey
+  #     pirate_id: 1
+  #
+  # Add a few more monkeys and pirates and break this into multiple files,
+  # and it gets pretty hard to keep track of what's going on. Let's
+  # use labels instead of IDs:
+  #
+  #   ### in pirates.yml
+  #
+  #   reginald:
+  #     name: Reginald the Pirate
+  #     monkey: george
+  #
+  #   ### in monkeys.yml
+  #
+  #   george:
+  #     name: George the Monkey
+  #     pirate: reginald
+  #
+  # Pow! All is made clear. Active Record reflects on the fixture's model class,
+  # finds all the +belongs_to+ associations, and allows you to specify
+  # a target *label* for the *association* (monkey: george) rather than
+  # a target *id* for the *FK* (<tt>monkey_id: 1</tt>).
+  #
+  # ==== Polymorphic belongs_to
+  #
+  # Supporting polymorphic relationships is a little bit more complicated, since
+  # Active Record needs to know what type your association is pointing at. Something
+  # like this should look familiar:
+  #
+  #   ### in fruit.rb
+  #
+  #   belongs_to :eater, polymorphic: true
+  #
+  #   ### in fruits.yml
+  #
+  #   apple:
+  #     id: 1
+  #     name: apple
+  #     eater_id: 1
+  #     eater_type: Monkey
+  #
+  # Can we do better? You bet!
+  #
+  #   apple:
+  #     eater: george (Monkey)
+  #
+  # Just provide the polymorphic target type and Active Record will take care of the rest.
+  #
+  # === has_and_belongs_to_many
+  #
+  # Time to give our monkey some fruit.
+  #
+  #   ### in monkeys.yml
+  #
+  #   george:
+  #     id: 1
+  #     name: George the Monkey
+  #
+  #   ### in fruits.yml
+  #
+  #   apple:
+  #     id: 1
+  #     name: apple
+  #
+  #   orange:
+  #     id: 2
+  #     name: orange
+  #
+  #   grape:
+  #     id: 3
+  #     name: grape
+  #
+  #   ### in fruits_monkeys.yml
+  #
+  #   apple_george:
+  #     fruit_id: 1
+  #     monkey_id: 1
+  #
+  #   orange_george:
+  #     fruit_id: 2
+  #     monkey_id: 1
+  #
+  #   grape_george:
+  #     fruit_id: 3
+  #     monkey_id: 1
+  #
+  # Let's make the HABTM fixture go away.
+  #
+  #   ### in monkeys.yml
+  #
+  #   george:
+  #     id: 1
+  #     name: George the Monkey
+  #     fruits: apple, orange, grape
+  #
+  #   ### in fruits.yml
+  #
+  #   apple:
+  #     name: apple
+  #
+  #   orange:
+  #     name: orange
+  #
+  #   grape:
+  #     name: grape
+  #
+  # Zap! No more fruits_monkeys.yml file. We've specified the list of fruits
+  # on George's fixture, but we could've just as easily specified a list
+  # of monkeys on each fruit. As with +belongs_to+, Active Record reflects on
+  # the fixture's model class and discovers the +has_and_belongs_to_many+
+  # associations.
+  #
+  # == Autofilled Timestamp Columns
+  #
+  # If your table/model specifies any of Active Record's
+  # standard timestamp columns (+created_at+, +created_on+, +updated_at+, +updated_on+),
+  # they will automatically be set to <tt>Time.now</tt>.
+  #
+  # If you've set specific values, they'll be left alone.
+  #
+  # == Fixture label interpolation
+  #
+  # The label of the current fixture is always available as a column value:
+  #
+  #   geeksomnia:
+  #     name: Geeksomnia's Account
+  #     subdomain: $LABEL
+  #     email: $LABEL@email.com
+  #
+  # Also, sometimes (like when porting older join table fixtures) you'll need
+  # to be able to get a hold of the identifier for a given label. ERB
+  # to the rescue:
+  #
+  #   george_reginald:
+  #     monkey_id: <%= ActiveRecord::FixtureSet.identify(:reginald) %>
+  #     pirate_id: <%= ActiveRecord::FixtureSet.identify(:george) %>
+  #
+  # == Support for YAML defaults
+  #
+  # You can set and reuse defaults in your fixtures YAML file.
+  # This is the same technique used in the +database.yml+ file to specify
+  # defaults:
+  #
+  #   DEFAULTS: &DEFAULTS
+  #     created_on: <%= 3.weeks.ago.to_s(:db) %>
+  #
+  #   first:
+  #     name: Smurf
+  #     <<: *DEFAULTS
+  #
+  #   second:
+  #     name: Fraggle
+  #     <<: *DEFAULTS
+  #
+  # Any fixture labeled "DEFAULTS" is safely ignored.
+  #
+  # == Configure the fixture model class
+  #
+  # It's possible to set the fixture's model class directly in the YAML file.
+  # This is helpful when fixtures are loaded outside tests and
+  # +set_fixture_class+ is not available (e.g.
+  # when running <tt>rails db:fixtures:load</tt>).
+  #
+  #   _fixture:
+  #     model_class: User
+  #   david:
+  #     name: David
+  #
+  # Any fixtures labeled "_fixture" are safely ignored.
+  class FixtureSet
+    MAX_ID: untyped
+
+    class ClassCache
+      def initialize: (untyped class_names, untyped config) -> untyped
+
+      def []: (untyped fs_name) -> untyped
+
+      def insert_class: (untyped class_names, untyped name, untyped klass) -> untyped
+
+      def default_fixture_model: (untyped fs_name, untyped config) -> untyped
+    end
+
+    def self.default_fixture_model_name: (untyped fixture_set_name, ?untyped config) -> untyped
+
+    def self.default_fixture_table_name: (untyped fixture_set_name, ?untyped config) -> untyped
+
+    def self.reset_cache: () -> untyped
+
+    def self.cache_for_connection: (untyped connection) -> untyped
+
+    def self.fixture_is_cached?: (untyped connection, untyped table_name) -> untyped
+
+    def self.cached_fixtures: (untyped connection, ?untyped? keys_to_fetch) -> untyped
+
+    def self.cache_fixtures: (untyped connection, untyped fixtures_map) -> untyped
+
+    def self.instantiate_fixtures: (untyped object, untyped fixture_set, ?bool load_instances) -> (nil | untyped)
+
+    def self.instantiate_all_loaded_fixtures: (untyped object, ?bool load_instances) -> untyped
+
+    def self.create_fixtures: (untyped fixtures_directory, untyped fixture_set_names, ?::Hash[untyped, untyped] class_names, ?untyped config) { () -> untyped } -> untyped
+
+    # Returns a consistent, platform-independent identifier for +label+.
+    # Integer identifiers are values less than 2^30. UUIDs are RFC 4122 version 5 SHA-1 hashes.
+    def self.identify: (untyped label, ?::Symbol column_type) -> untyped
+
+    # Superclass for the evaluation contexts used by ERB fixtures.
+    def self.context_class: () -> untyped
+
+    def self.read_and_insert: (untyped fixtures_directory, untyped fixture_files, untyped class_names, untyped connection) -> untyped
+
+    def self.insert: (untyped fixture_sets, untyped connection) -> untyped
+
+    def self.update_all_loaded_fixtures: (untyped fixtures_map) -> untyped
+
+    attr_reader table_name: untyped
+
+    attr_reader name: untyped
+
+    attr_reader fixtures: untyped
+
+    attr_reader model_class: untyped
+
+    attr_reader config: untyped
+
+    def initialize: (untyped _, untyped name, untyped class_name, untyped path, ?untyped config) -> untyped
+
+    def []: (untyped x) -> untyped
+
+    def []=: (untyped k, untyped v) -> untyped
+
+    def each: () { () -> untyped } -> untyped
+
+    def size: () -> untyped
+
+    # Returns a hash of rows to be inserted. The key is the table, the value is
+    # a list of rows to insert to that table.
+    def table_rows: () -> untyped
+
+    def model_class=: (untyped class_name) -> untyped
+
+    # Loads the fixtures from the YAML file at +path+.
+    # If the file sets the +model_class+ and current instance value is not set,
+    # it uses the file value.
+    def read_fixture_files: (untyped path) -> untyped
+
+    def yaml_file_path: (untyped path) -> ::String
+  end
+
+  class Fixture
+    # nodoc:
+    include Enumerable[untyped]
+
+    class FixtureError < StandardError
+    end
+
+    class FormatError < FixtureError
+    end
+
+    attr_reader model_class: untyped
+
+    attr_reader fixture: untyped
+
+    def initialize: (untyped fixture, untyped model_class) -> untyped
+
+    def class_name: () -> untyped
+
+    def each: () { (untyped) -> untyped } -> untyped
+
+    def []: (untyped key) -> untyped
+
+    alias to_hash fixture
+
+    def find: () -> untyped
+  end
+end
+
+module ActiveRecord
+  # Returns the version of the currently loaded Active Record as a <tt>Gem::Version</tt>
+  def self.gem_version: () -> Gem::Version
+
+  module VERSION
+    MAJOR: ::Integer
+
+    MINOR: ::Integer
+
+    TINY: ::Integer
+
+    PRE: ::String
+
+    STRING: untyped
+  end
+end
+
+module ActiveRecord
+  # == Single table inheritance
+  #
+  # Active Record allows inheritance by storing the name of the class in a column that by
+  # default is named "type" (can be changed by overwriting <tt>Base.inheritance_column</tt>).
+  # This means that an inheritance looking like this:
+  #
+  #   class Company < ActiveRecord::Base; end
+  #   class Firm < Company; end
+  #   class Client < Company; end
+  #   class PriorityClient < Client; end
+  #
+  # When you do <tt>Firm.create(name: "37signals")</tt>, this record will be saved in
+  # the companies table with type = "Firm". You can then fetch this row again using
+  # <tt>Company.where(name: '37signals').first</tt> and it will return a Firm object.
+  #
+  # Be aware that because the type column is an attribute on the record every new
+  # subclass will instantly be marked as dirty and the type column will be included
+  # in the list of changed attributes on the record. This is different from non
+  # Single Table Inheritance(STI) classes:
+  #
+  #   Company.new.changed? # => false
+  #   Firm.new.changed?    # => true
+  #   Firm.new.changes     # => {"type"=>["","Firm"]}
+  #
+  # If you don't have a type column defined in your table, single-table inheritance won't
+  # be triggered. In that case, it'll work just like normal subclasses with no special magic
+  # for differentiating between them or reloading the right type with find.
+  #
+  # Note, all the attributes for all the cases are kept in the same table. Read more:
+  # https://www.martinfowler.com/eaaCatalog/singleTableInheritance.html
+  #
+  module Inheritance
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      # Determines if one of the attributes passed in is the inheritance column,
+      # and if the inheritance column is attr accessible, it initializes an
+      # instance of the given subclass instead of the base class.
+      def new: (?untyped? attributes) { () -> untyped } -> untyped
+
+      # Returns +true+ if this does not need STI type condition. Returns
+      # +false+ if STI type condition needs to be applied.
+      def descends_from_active_record?: () -> untyped
+
+      def finder_needs_type_condition?: () -> untyped
+
+      # Returns the class descending directly from ActiveRecord::Base, or
+      # an abstract class, if any, in the inheritance hierarchy.
+      #
+      # If A extends ActiveRecord::Base, A.base_class will return A. If B descends from A
+      # through some arbitrarily deep hierarchy, B.base_class will return A.
+      #
+      # If B < A and C < B and if A is an abstract_class then both B.base_class
+      # and C.base_class would return B as the answer since A is an abstract_class.
+      def base_class: () -> untyped
+
+      # Returns whether the class is a base class.
+      # See #base_class for more information.
+      def base_class?: () -> untyped
+
+      # Set this to +true+ if this is an abstract class (see
+      # <tt>abstract_class?</tt>).
+      # If you are using inheritance with Active Record and don't want a class
+      # to be considered as part of the STI hierarchy, you must set this to
+      # true.
+      # +ApplicationRecord+, for example, is generated as an abstract class.
+      #
+      # Consider the following default behaviour:
+      #
+      #   Shape = Class.new(ActiveRecord::Base)
+      #   Polygon = Class.new(Shape)
+      #   Square = Class.new(Polygon)
+      #
+      #   Shape.table_name   # => "shapes"
+      #   Polygon.table_name # => "shapes"
+      #   Square.table_name  # => "shapes"
+      #   Shape.create!      # => #<Shape id: 1, type: nil>
+      #   Polygon.create!    # => #<Polygon id: 2, type: "Polygon">
+      #   Square.create!     # => #<Square id: 3, type: "Square">
+      #
+      # However, when using <tt>abstract_class</tt>, +Shape+ is omitted from
+      # the hierarchy:
+      #
+      #   class Shape < ActiveRecord::Base
+      #     self.abstract_class = true
+      #   end
+      #   Polygon = Class.new(Shape)
+      #   Square = Class.new(Polygon)
+      #
+      #   Shape.table_name   # => nil
+      #   Polygon.table_name # => "polygons"
+      #   Square.table_name  # => "polygons"
+      #   Shape.create!      # => NotImplementedError: Shape is an abstract class and cannot be instantiated.
+      #   Polygon.create!    # => #<Polygon id: 1, type: nil>
+      #   Square.create!     # => #<Square id: 2, type: "Square">
+      #
+      # Note that in the above example, to disallow the creation of a plain
+      # +Polygon+, you should use <tt>validates :type, presence: true</tt>,
+      # instead of setting it as an abstract class. This way, +Polygon+ will
+      # stay in the hierarchy, and Active Record will continue to correctly
+      # derive the table name.
+      attr_accessor abstract_class: untyped
+
+      # Returns whether this class is an abstract class or not.
+      def abstract_class?: () -> untyped
+
+      def sti_name: () -> untyped
+
+      def polymorphic_name: () -> untyped
+
+      def inherited: (untyped subclass) -> untyped
+
+      # Returns the class type of the record using the current module as a prefix. So descendants of
+      # MyApp::Business::Account would appear as MyApp::Business::AccountSubclass.
+      def compute_type: (untyped type_name) -> untyped
+
+      # Called by +instantiate+ to decide which class to use for a new
+      # record instance. For single-table inheritance, we check the record
+      # for a +type+ column and return the corresponding class.
+      def discriminate_class_for_record: (untyped record) -> untyped
+
+      def using_single_table_inheritance?: (untyped record) -> untyped
+
+      def find_sti_class: (untyped type_name) -> untyped
+
+      def type_condition: (?untyped table) -> untyped
+
+      # Detect the subclass from the inheritance column of attrs. If the inheritance column value
+      # is not self or a valid subclass, raises ActiveRecord::SubclassNotFound
+      def subclass_from_attributes: (untyped attrs) -> untyped
+    end
+
+    def initialize_dup: (untyped other) -> untyped
+
+    def initialize_internals_callback: () -> untyped
+
+    # Sets the attribute used for single table inheritance to this class name if this is not the
+    # ActiveRecord::Base descendant.
+    # Considering the hierarchy Reply < Message < ActiveRecord::Base, this makes it possible to
+    # do Reply.new without having to set <tt>Reply[Reply.inheritance_column] = "Reply"</tt> yourself.
+    # No such attribute would be set for objects of the Message class in that example.
+    def ensure_proper_type: () -> untyped
+  end
+end
+
+module ActiveRecord
+  class InsertAll
+    # :nodoc:
+    attr_reader model: untyped
+
+    # :nodoc:
+    attr_reader connection: untyped
+
+    # :nodoc:
+    attr_reader inserts: untyped
+
+    # :nodoc:
+    attr_reader keys: untyped
+
+    attr_reader on_duplicate: untyped
+
+    attr_reader returning: untyped
+
+    attr_reader unique_by: untyped
+
+    def initialize: (untyped model, untyped inserts, on_duplicate: untyped on_duplicate, ?unique_by: untyped? unique_by, ?returning: untyped? returning) -> untyped
+
+    def execute: () -> untyped
+
+    def updatable_columns: () -> untyped
+
+    def primary_keys: () -> untyped
+
+    def skip_duplicates?: () -> untyped
+
+    def update_duplicates?: () -> untyped
+
+    def map_key_with_value: () { (untyped, untyped) -> untyped } -> untyped
+
+    def find_unique_index_for: (untyped unique_by) -> untyped
+
+    def unique_indexes: () -> untyped
+
+    def ensure_valid_options_for_connection!: () -> untyped
+
+    def to_sql: () -> untyped
+
+    def readonly_columns: () -> untyped
+
+    def unique_by_columns: () -> untyped
+
+    def verify_attributes: (untyped attributes) -> untyped
+
+    class Builder
+      # :nodoc:
+      attr_reader model: untyped
+
+      def initialize: (untyped insert_all) -> untyped
+
+      def into: () -> ::String
+
+      def values_list: () -> untyped
+
+      def returning: () -> untyped
+
+      def conflict_target: () -> untyped
+
+      def updatable_columns: () -> untyped
+
+      attr_reader connection: untyped
+
+      attr_reader insert_all: untyped
+
+      def columns_list: () -> untyped
+
+      def extract_types_from_columns_on: (untyped table_name, keys: untyped keys) -> untyped
+
+      def format_columns: (untyped columns) -> untyped
+
+      def quote_columns: (untyped columns) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module Integration
+    extend ActiveSupport::Concern
+
+    # Returns a +String+, which Action Pack uses for constructing a URL to this
+    # object. The default implementation returns this record's id as a +String+,
+    # or +nil+ if this record's unsaved.
+    #
+    # For example, suppose that you have a User model, and that you have a
+    # <tt>resources :users</tt> route. Normally, +user_path+ will
+    # construct a path with the user object's 'id' in it:
+    #
+    #   user = User.find_by(name: 'Phusion')
+    #   user_path(user)  # => "/users/1"
+    #
+    # You can override +to_param+ in your model to make +user_path+ construct
+    # a path using the user's name instead of the user's id:
+    #
+    #   class User < ActiveRecord::Base
+    #     def to_param  # overridden
+    #       name
+    #     end
+    #   end
+    #
+    #   user = User.find_by(name: 'Phusion')
+    #   user_path(user)  # => "/users/Phusion"
+    def to_param: () -> untyped
+
+    # Returns a stable cache key that can be used to identify this record.
+    #
+    #   Product.new.cache_key     # => "products/new"
+    #   Product.find(5).cache_key # => "products/5"
+    #
+    # If ActiveRecord::Base.cache_versioning is turned off, as it was in Rails 5.1 and earlier,
+    # the cache key will also include a version.
+    #
+    #   Product.cache_versioning = false
+    #   Product.find(5).cache_key  # => "products/5-20071224150000" (updated_at available)
+    def cache_key: () -> untyped
+
+    # Returns a cache version that can be used together with the cache key to form
+    # a recyclable caching scheme. By default, the #updated_at column is used for the
+    # cache_version, but this method can be overwritten to return something else.
+    #
+    # Note, this method will return nil if ActiveRecord::Base.cache_versioning is set to
+    # +false+ (which it is by default until Rails 6.0).
+    def cache_version: () -> (nil | untyped)
+
+    # Returns a cache key along with the version.
+    def cache_key_with_version: () -> untyped
+
+    module ClassMethods
+      # Defines your model's +to_param+ method to generate "pretty" URLs
+      # using +method_name+, which can be any attribute or method that
+      # responds to +to_s+.
+      #
+      #   class User < ActiveRecord::Base
+      #     to_param :name
+      #   end
+      #
+      #   user = User.find_by(name: 'Fancy Pants')
+      #   user.id         # => 123
+      #   user_path(user) # => "/users/123-fancy-pants"
+      #
+      # Values longer than 20 characters will be truncated. The value
+      # is truncated word by word.
+      #
+      #   user = User.find_by(name: 'David Heinemeier Hansson')
+      #   user.id         # => 125
+      #   user_path(user) # => "/users/125-david-heinemeier"
+      #
+      # Because the generated param begins with the record's +id+, it is
+      # suitable for passing to +find+. In a controller, for example:
+      #
+      #   params[:id]               # => "123-fancy-pants"
+      #   User.find(params[:id]).id # => 123
+      def to_param: (?untyped? method_name) -> untyped
+
+      def collection_cache_key: (?untyped collection, ?::Symbol timestamp_column) -> untyped
+    end
+
+    # Detects if the value before type cast
+    # can be used to generate a cache_version.
+    #
+    # The fast cache version only works with a
+    # string value directly from the database.
+    #
+    # We also must check if the timestamp format has been changed
+    # or if the timezone is not set to UTC then
+    # we cannot apply our transformations correctly.
+    def can_use_fast_cache_version?: (untyped timestamp) -> untyped
+
+    # Converts a raw database string to `:usec`
+    # format.
+    #
+    # Example:
+    #
+    #   timestamp = "2018-10-15 20:02:15.266505"
+    #   raw_timestamp_to_cache_version(timestamp)
+    #   # => "20181015200215266505"
+    #
+    # PostgreSQL truncates trailing zeros,
+    # https://github.com/postgres/postgres/commit/3e1beda2cde3495f41290e1ece5d544525810214
+    # to account for this we pad the output with zeros
+    def raw_timestamp_to_cache_version: (untyped timestamp) -> untyped
+  end
+end
+
+module ActiveRecord
+  class InternalMetadata < ActiveRecord::Base
+    def self._internal?: () -> ::TrueClass
+
+    def self.primary_key: () -> "key"
+
+    def self.table_name: () -> ::String
+
+    def self.[]=: (untyped key, untyped value) -> untyped
+
+    def self.[]: (untyped key) -> untyped
+
+    def self.table_exists?: () -> untyped
+
+    # Creates an internal metadata table with columns +key+ and +value+
+    def self.create_table: () -> untyped
+
+    def self.drop_table: () -> untyped
+  end
+end
+
+module ActiveRecord
+  module LegacyYamlAdapter
+    def self.convert: (untyped klass, untyped coder) -> untyped
+
+    module Rails420
+      def self.convert: (untyped klass, untyped coder) -> untyped
+    end
+
+    module Rails41
+      def self.convert: (untyped klass, untyped coder) -> ::Hash[::String, untyped]
+    end
+  end
+end
+
+module ActiveRecord
+  module Locking
+    # == What is Optimistic Locking
+    #
+    # Optimistic locking allows multiple users to access the same record for edits, and assumes a minimum of
+    # conflicts with the data. It does this by checking whether another process has made changes to a record since
+    # it was opened, an <tt>ActiveRecord::StaleObjectError</tt> exception is thrown if that has occurred
+    # and the update is ignored.
+    #
+    # Check out <tt>ActiveRecord::Locking::Pessimistic</tt> for an alternative.
+    #
+    # == Usage
+    #
+    # Active Record supports optimistic locking if the +lock_version+ field is present. Each update to the
+    # record increments the +lock_version+ column and the locking facilities ensure that records instantiated twice
+    # will let the last one saved raise a +StaleObjectError+ if the first was also updated. Example:
+    #
+    #   p1 = Person.find(1)
+    #   p2 = Person.find(1)
+    #
+    #   p1.first_name = "Michael"
+    #   p1.save
+    #
+    #   p2.first_name = "should fail"
+    #   p2.save # Raises an ActiveRecord::StaleObjectError
+    #
+    # Optimistic locking will also check for stale data when objects are destroyed. Example:
+    #
+    #   p1 = Person.find(1)
+    #   p2 = Person.find(1)
+    #
+    #   p1.first_name = "Michael"
+    #   p1.save
+    #
+    #   p2.destroy # Raises an ActiveRecord::StaleObjectError
+    #
+    # You're then responsible for dealing with the conflict by rescuing the exception and either rolling back, merging,
+    # or otherwise apply the business logic needed to resolve the conflict.
+    #
+    # This locking mechanism will function inside a single Ruby process. To make it work across all
+    # web requests, the recommended approach is to add +lock_version+ as a hidden field to your form.
+    #
+    # This behavior can be turned off by setting <tt>ActiveRecord::Base.lock_optimistically = false</tt>.
+    # To override the name of the +lock_version+ column, set the <tt>locking_column</tt> class attribute:
+    #
+    #   class Person < ActiveRecord::Base
+    #     self.locking_column = :lock_person
+    #   end
+    #
+    module Optimistic
+      extend ActiveSupport::Concern
+
+      def locking_enabled?: () -> untyped
+
+      def _create_record: (?untyped attribute_names) -> untyped
+
+      def _touch_row: (untyped attribute_names, untyped time) -> untyped
+
+      def _update_row: (untyped attribute_names, ?::String attempted_action) -> untyped
+
+      def destroy_row: () -> untyped
+
+      module ClassMethods
+        DEFAULT_LOCKING_COLUMN: ::String
+
+        # Returns true if the +lock_optimistically+ flag is set to true
+        # (which it is, by default) and the table includes the
+        # +locking_column+ column (defaults to +lock_version+).
+        def locking_enabled?: () -> untyped
+
+        # Set the column to use for optimistic locking. Defaults to +lock_version+.
+        def locking_column=: (untyped value) -> untyped
+
+        # The version column used for optimistic locking. Defaults to +lock_version+.
+        def locking_column: () -> untyped
+
+        # Reset the column used for optimistic locking back to the +lock_version+ default.
+        def reset_locking_column: () -> untyped
+
+        # Make sure the lock version column gets updated when counters are
+        # updated.
+        def update_counters: (untyped id, untyped counters) -> untyped
+
+        # We need to apply this decorator here, rather than on module inclusion. The closure
+        # created by the matcher would otherwise evaluate for `ActiveRecord::Base`, not the
+        # sub class being decorated. As such, changes to `lock_optimistically`, or
+        # `locking_column` would not be picked up.
+        def inherited: (untyped subclass) -> untyped
+      end
+    end
+
+    class LockingType
+      # In de/serialize we change `nil` to 0, so that we can allow passing
+      # `nil` values to `lock_version`, and not result in `ActiveRecord::StaleObjectError`
+      # during update record.
+      # :nodoc:
+      def deserialize: (untyped value) -> untyped
+
+      def serialize: (untyped value) -> untyped
+
+      def init_with: (untyped coder) -> untyped
+
+      def encode_with: (untyped coder) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module Locking
+    # Locking::Pessimistic provides support for row-level locking using
+    # SELECT ... FOR UPDATE and other lock types.
+    #
+    # Chain <tt>ActiveRecord::Base#find</tt> to <tt>ActiveRecord::QueryMethods#lock</tt> to obtain an exclusive
+    # lock on the selected rows:
+    #   # select * from accounts where id=1 for update
+    #   Account.lock.find(1)
+    #
+    # Call <tt>lock('some locking clause')</tt> to use a database-specific locking clause
+    # of your own such as 'LOCK IN SHARE MODE' or 'FOR UPDATE NOWAIT'. Example:
+    #
+    #   Account.transaction do
+    #     # select * from accounts where name = 'shugo' limit 1 for update nowait
+    #     shugo = Account.lock("FOR UPDATE NOWAIT").find_by(name: "shugo")
+    #     yuko = Account.lock("FOR UPDATE NOWAIT").find_by(name: "yuko")
+    #     shugo.balance -= 100
+    #     shugo.save!
+    #     yuko.balance += 100
+    #     yuko.save!
+    #   end
+    #
+    # You can also use <tt>ActiveRecord::Base#lock!</tt> method to lock one record by id.
+    # This may be better if you don't need to lock every row. Example:
+    #
+    #   Account.transaction do
+    #     # select * from accounts where ...
+    #     accounts = Account.where(...)
+    #     account1 = accounts.detect { |account| ... }
+    #     account2 = accounts.detect { |account| ... }
+    #     # select * from accounts where id=? for update
+    #     account1.lock!
+    #     account2.lock!
+    #     account1.balance -= 100
+    #     account1.save!
+    #     account2.balance += 100
+    #     account2.save!
+    #   end
+    #
+    # You can start a transaction and acquire the lock in one go by calling
+    # <tt>with_lock</tt> with a block. The block is called from within
+    # a transaction, the object is already locked. Example:
+    #
+    #   account = Account.first
+    #   account.with_lock do
+    #     # This block is called within a transaction,
+    #     # account is already locked.
+    #     account.balance -= 100
+    #     account.save!
+    #   end
+    #
+    # Database-specific information on row locking:
+    #   MySQL: https://dev.mysql.com/doc/refman/5.7/en/innodb-locking-reads.html
+    #   PostgreSQL: https://www.postgresql.org/docs/current/interactive/sql-select.html#SQL-FOR-UPDATE-SHARE
+    module Pessimistic
+      # Obtain a row lock on this record. Reloads the record to obtain the requested
+      # lock. Pass an SQL locking clause to append the end of the SELECT statement
+      # or pass true for "FOR UPDATE" (the default, an exclusive row lock). Returns
+      # the locked record.
+      def lock!: (?bool lock) -> untyped
+
+      # Wraps the passed block in a transaction, locking the object
+      # before yielding. You can pass the SQL locking clause
+      # as argument (see <tt>lock!</tt>).
+      def with_lock: (?bool lock) { () -> untyped } -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  class LogSubscriber < ActiveSupport::LogSubscriber
+    IGNORE_PAYLOAD_NAMES: ::Array[untyped]
+
+    def self.runtime=: (untyped value) -> untyped
+
+    def self.runtime: () -> untyped
+
+    def self.reset_runtime: () -> untyped
+
+    def sql: (untyped event) -> (nil | untyped)
+
+    def type_casted_binds: (untyped casted_binds) -> untyped
+
+    def render_bind: (untyped attr, untyped value) -> ::Array[untyped]
+
+    def colorize_payload_name: (untyped name, untyped payload_name) -> untyped
+
+    def sql_color: (untyped sql) -> untyped
+
+    def logger: () -> untyped
+
+    def debug: (?untyped? progname) { () -> untyped } -> (nil | untyped)
+
+    def log_query_source: () -> untyped
+
+    def extract_query_source_location: (untyped locations) -> untyped
+  end
+end
+
+module ActiveRecord
+  module Middleware
+    class DatabaseSelector
+      class Resolver
+        class Session
+          # The session class is used by the DatabaseSelector::Resolver to save
+          # timestamps of the last write in the session.
+          #
+          # The last_write is used to determine whether it's safe to read
+          # from the replica or the request needs to be sent to the primary.
+          # :nodoc:
+          def self.call: (untyped request) -> untyped
+
+          # Converts time to a timestamp that represents milliseconds since
+          # epoch.
+          def self.convert_time_to_timestamp: (untyped time) -> untyped
+
+          # Converts milliseconds since epoch timestamp into a time object.
+          def self.convert_timestamp_to_time: (untyped timestamp) -> untyped
+
+          def initialize: (untyped session) -> untyped
+
+          attr_reader session: untyped
+
+          def last_write_timestamp: () -> untyped
+
+          def update_last_write_timestamp: () -> untyped
+        end
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module Middleware
+    class DatabaseSelector
+      class Resolver
+        # The Resolver class is used by the DatabaseSelector middleware to
+        # determine which database the request should use.
+        #
+        # To change the behavior of the Resolver class in your application,
+        # create a custom resolver class that inherits from
+        # DatabaseSelector::Resolver and implements the methods that need to
+        # be changed.
+        #
+        # By default the Resolver class will send read traffic to the replica
+        # if it's been 2 seconds since the last write.
+        # :nodoc:
+        SEND_TO_REPLICA_DELAY: untyped
+
+        def self.call: (untyped context, ?::Hash[untyped, untyped] options) -> untyped
+
+        def initialize: (untyped context, ?::Hash[untyped, untyped] options) -> untyped
+
+        attr_reader context: untyped
+
+        attr_reader delay: untyped
+
+        attr_reader instrumenter: untyped
+
+        def read: () { () -> untyped } -> untyped
+
+        def write: () { () -> untyped } -> untyped
+
+        def read_from_primary: () { () -> untyped } -> untyped
+
+        def read_from_replica: () { () -> untyped } -> untyped
+
+        def write_to_primary: () { () -> untyped } -> untyped
+
+        def read_from_primary?: () -> untyped
+
+        def send_to_replica_delay: () -> untyped
+
+        def time_since_last_write_ok?: () -> untyped
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module Middleware
+    # The DatabaseSelector Middleware provides a framework for automatically
+    # swapping from the primary to the replica database connection. Rails
+    # provides a basic framework to determine when to swap and allows for
+    # applications to write custom strategy classes to override the default
+    # behavior.
+    #
+    # The resolver class defines when the application should switch (i.e. read
+    # from the primary if a write occurred less than 2 seconds ago) and a
+    # resolver context class that sets a value that helps the resolver class
+    # decide when to switch.
+    #
+    # Rails default middleware uses the request's session to set a timestamp
+    # that informs the application when to read from a primary or read from a
+    # replica.
+    #
+    # To use the DatabaseSelector in your application with default settings add
+    # the following options to your environment config:
+    #
+    #   config.active_record.database_selector = { delay: 2.seconds }
+    #   config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
+    #   config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+    #
+    # New applications will include these lines commented out in the production.rb.
+    #
+    # The default behavior can be changed by setting the config options to a
+    # custom class:
+    #
+    #   config.active_record.database_selector = { delay: 2.seconds }
+    #   config.active_record.database_resolver = MyResolver
+    #   config.active_record.database_resolver_context = MyResolver::MySession
+    class DatabaseSelector
+      def initialize: (untyped app, ?untyped? resolver_klass, ?untyped? context_klass, ?::Hash[untyped, untyped] options) -> untyped
+
+      attr_reader resolver_klass: untyped
+
+      attr_reader context_klass: untyped
+
+      attr_reader options: untyped
+
+      # Middleware that determines which database connection to use in a multiple
+      # database application.
+      def call: (untyped env) -> untyped
+
+      def select_database: (untyped request) { () -> untyped } -> untyped
+
+      def reading_request?: (untyped request) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  class Migration
+    # <tt>ActiveRecord::Migration::CommandRecorder</tt> records commands done during
+    # a migration and knows how to reverse those commands. The CommandRecorder
+    # knows how to invert the following commands:
+    #
+    # * add_column
+    # * add_foreign_key
+    # * add_index
+    # * add_reference
+    # * add_timestamps
+    # * change_column
+    # * change_column_default (must supply a :from and :to option)
+    # * change_column_null
+    # * change_column_comment (must supply a :from and :to option)
+    # * change_table_comment (must supply a :from and :to option)
+    # * create_join_table
+    # * create_table
+    # * disable_extension
+    # * drop_join_table
+    # * drop_table (must supply a block)
+    # * enable_extension
+    # * remove_column (must supply a type)
+    # * remove_columns (must specify at least one column name or more)
+    # * remove_foreign_key (must supply a second table)
+    # * remove_index
+    # * remove_reference
+    # * remove_timestamps
+    # * rename_column
+    # * rename_index
+    # * rename_table
+    class CommandRecorder
+      ReversibleAndIrreversibleMethods: ::Array[untyped]
+
+      include JoinTable
+
+      attr_accessor commands: untyped
+
+      attr_accessor delegate: untyped
+
+      attr_accessor reverting: untyped
+
+      def initialize: (?untyped? delegate) -> untyped
+
+      # While executing the given block, the recorded will be in reverting mode.
+      # All commands recorded will end up being recorded reverted
+      # and in reverse order.
+      # For example:
+      #
+      #   recorder.revert{ recorder.record(:rename_table, [:old, :new]) }
+      #   # same effect as recorder.record(:rename_table, [:new, :old])
+      def revert: () { () -> untyped } -> untyped
+
+      # Record +command+. +command+ should be a method name and arguments.
+      # For example:
+      #
+      #   recorder.record(:method_name, [:arg1, :arg2])
+      def record: (*untyped command) { () -> untyped } -> untyped
+
+      # Returns the inverse of the given command. For example:
+      #
+      #   recorder.inverse_of(:rename_table, [:old, :new])
+      #   # => [:rename_table, [:new, :old]]
+      #
+      # This method will raise an +IrreversibleMigration+ exception if it cannot
+      # invert the +command+.
+      def inverse_of: (untyped command, untyped args) { () -> untyped } -> untyped
+
+      alias add_belongs_to add_reference
+
+      alias remove_belongs_to remove_reference
+
+      def change_table: (untyped table_name, **untyped options) { (untyped) -> untyped } -> untyped
+
+      def replay: (untyped migration) -> untyped
+
+      module StraightReversions
+      end
+
+      include StraightReversions
+
+      def invert_transaction: (untyped args) { () -> untyped } -> ::Array[:transaction | untyped]
+
+      def invert_drop_table: (untyped args) { () -> untyped } -> untyped
+
+      def invert_rename_table: (untyped args) -> ::Array[:rename_table | untyped]
+
+      def invert_remove_column: (untyped args) -> untyped
+
+      def invert_rename_index: (untyped args) -> ::Array[:rename_index | untyped]
+
+      def invert_rename_column: (untyped args) -> ::Array[:rename_column | untyped]
+
+      def invert_add_index: (untyped args) -> ::Array[:remove_index | ::Array[untyped]]
+
+      def invert_remove_index: (untyped args) -> untyped
+
+      alias invert_add_belongs_to invert_add_reference
+
+      alias invert_remove_belongs_to invert_remove_reference
+
+      def invert_change_column_default: (untyped args) -> ::Array[:change_column_default | ::Array[untyped | { from: untyped, to: untyped }]]
+
+      def invert_change_column_null: (untyped args) -> ::Array[:change_column_null | untyped]
+
+      def invert_remove_foreign_key: (untyped args) -> ::Array[:add_foreign_key | untyped]
+
+      def invert_change_column_comment: (untyped args) -> ::Array[:change_column_comment | ::Array[untyped | { from: untyped, to: untyped }]]
+
+      def invert_change_table_comment: (untyped args) -> ::Array[:change_table_comment | ::Array[untyped | { from: untyped, to: untyped }]]
+
+      def respond_to_missing?: (untyped method, untyped _) -> untyped
+
+      # Forwards any missing method call to the \target.
+      def method_missing: (untyped method, *untyped args) { () -> untyped } -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  class Migration
+    module Compatibility
+      # :nodoc: all
+      def self.find: (untyped version) -> untyped
+
+      # V6_0 and Current are the same object actually. hack for https://github.com/ruby/rbs/issues/345
+      class V6_0 < Current
+      end
+
+      class V5_2 < V6_0
+        module TableDefinition
+          def timestamps: (**untyped options) -> untyped
+        end
+
+        module CommandRecorder
+          def invert_transaction: (untyped args) { () -> untyped } -> ::Array[:transaction | untyped]
+
+          def invert_change_column_comment: (untyped args) -> ::Array[:change_column_comment | ::Array[untyped | { from: untyped, to: untyped }]]
+
+          def invert_change_table_comment: (untyped args) -> ::Array[:change_table_comment | ::Array[untyped | { from: untyped, to: untyped }]]
+        end
+
+        def create_table: (untyped table_name, **untyped options) { (untyped) -> untyped } -> untyped
+
+        def change_table: (untyped table_name, **untyped options) { (untyped) -> untyped } -> untyped
+
+        def create_join_table: (untyped table_1, untyped table_2, **untyped options) { (untyped) -> untyped } -> untyped
+
+        def add_timestamps: (untyped table_name, **untyped options) -> untyped
+
+        def compatible_table_definition: (untyped t) -> untyped
+
+        def command_recorder: () -> untyped
+      end
+
+      class V5_1 < V5_2
+        def change_column: (untyped table_name, untyped column_name, untyped `type`, ?::Hash[untyped, untyped] options) -> untyped
+
+        def create_table: (untyped table_name, **untyped options) -> untyped
+      end
+
+      class V5_0 < V5_1
+        module TableDefinition
+          def primary_key: (untyped name, ?::Symbol `type`, **untyped options) -> untyped
+
+          def references: (*untyped args, **untyped options) -> untyped
+
+          alias belongs_to references
+        end
+
+        def create_table: (untyped table_name, **untyped options) -> untyped
+
+        def create_join_table: (untyped table_1, untyped table_2, ?column_options: ::Hash[untyped, untyped] column_options, **untyped options) -> untyped
+
+        def add_column: (untyped table_name, untyped column_name, untyped `type`, **untyped options) -> untyped
+
+        def add_reference: (untyped table_name, untyped ref_name, **untyped options) -> untyped
+
+        alias add_belongs_to add_reference
+
+        def compatible_table_definition: (untyped t) -> untyped
+      end
+
+      class V4_2 < V5_0
+        module TableDefinition
+          def references: (**untyped options) -> untyped
+
+          alias belongs_to references
+
+          def timestamps: (**untyped options) -> untyped
+        end
+
+        def add_reference: (untyped table_name, untyped ref_name, **untyped options) -> untyped
+
+        alias add_belongs_to add_reference
+
+        def add_timestamps: (untyped table_name, **untyped options) -> untyped
+
+        def index_exists?: (untyped table_name, untyped column_name, ?::Hash[untyped, untyped] options) -> untyped
+
+        def remove_index: (untyped table_name, ?::Hash[untyped, untyped] options) -> untyped
+
+        def compatible_table_definition: (untyped t) -> untyped
+
+        def index_name_for_remove: (untyped table_name, ?::Hash[untyped, untyped] options) -> untyped
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  class Migration
+    module JoinTable
+      def find_join_table_name: (untyped table_1, untyped table_2, ?::Hash[untyped, untyped] options) -> untyped
+
+      def join_table_name: (untyped table_1, untyped table_2) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  class MigrationError < ActiveRecordError
+    # nodoc:
+    def initialize: (?untyped? message) -> untyped
+  end
+
+  # Exception that can be raised to stop migrations from being rolled back.
+  # For example the following migration is not reversible.
+  # Rolling back this migration will raise an ActiveRecord::IrreversibleMigration error.
+  #
+  #   class IrreversibleMigrationExample < ActiveRecord::Migration[5.0]
+  #     def change
+  #       create_table :distributors do |t|
+  #         t.string :zipcode
+  #       end
+  #
+  #       execute <<~SQL
+  #         ALTER TABLE distributors
+  #           ADD CONSTRAINT zipchk
+  #             CHECK (char_length(zipcode) = 5) NO INHERIT;
+  #       SQL
+  #     end
+  #   end
+  #
+  # There are two ways to mitigate this problem.
+  #
+  # 1. Define <tt>#up</tt> and <tt>#down</tt> methods instead of <tt>#change</tt>:
+  #
+  #  class ReversibleMigrationExample < ActiveRecord::Migration[5.0]
+  #    def up
+  #      create_table :distributors do |t|
+  #        t.string :zipcode
+  #      end
+  #
+  #      execute <<~SQL
+  #        ALTER TABLE distributors
+  #          ADD CONSTRAINT zipchk
+  #            CHECK (char_length(zipcode) = 5) NO INHERIT;
+  #      SQL
+  #    end
+  #
+  #    def down
+  #      execute <<~SQL
+  #        ALTER TABLE distributors
+  #          DROP CONSTRAINT zipchk
+  #      SQL
+  #
+  #      drop_table :distributors
+  #    end
+  #  end
+  #
+  # 2. Use the #reversible method in <tt>#change</tt> method:
+  #
+  #   class ReversibleMigrationExample < ActiveRecord::Migration[5.0]
+  #     def change
+  #       create_table :distributors do |t|
+  #         t.string :zipcode
+  #       end
+  #
+  #       reversible do |dir|
+  #         dir.up do
+  #           execute <<~SQL
+  #             ALTER TABLE distributors
+  #               ADD CONSTRAINT zipchk
+  #                 CHECK (char_length(zipcode) = 5) NO INHERIT;
+  #           SQL
+  #         end
+  #
+  #         dir.down do
+  #           execute <<~SQL
+  #             ALTER TABLE distributors
+  #               DROP CONSTRAINT zipchk
+  #           SQL
+  #         end
+  #       end
+  #     end
+  #   end
+  class IrreversibleMigration < MigrationError
+  end
+
+  class DuplicateMigrationVersionError < MigrationError
+    # nodoc:
+    def initialize: (?untyped? version) -> untyped
+  end
+
+  class DuplicateMigrationNameError < MigrationError
+    # nodoc:
+    def initialize: (?untyped? name) -> untyped
+  end
+
+  class UnknownMigrationVersionError < MigrationError
+    # nodoc:
+    def initialize: (?untyped? version) -> untyped
+  end
+
+  class IllegalMigrationNameError < MigrationError
+    # nodoc:
+    def initialize: (?untyped? name) -> untyped
+  end
+
+  class PendingMigrationError < MigrationError
+    # nodoc:
+    include ActiveSupport::ActionableError
+
+    def initialize: (?untyped? message) -> untyped
+  end
+
+  class ConcurrentMigrationError < MigrationError
+    # nodoc:
+    DEFAULT_MESSAGE: ::String
+
+    RELEASE_LOCK_FAILED_MESSAGE: ::String
+
+    def initialize: (?untyped message) -> untyped
+  end
+
+  class NoEnvironmentInSchemaError < MigrationError
+    # nodoc:
+    def initialize: () -> untyped
+  end
+
+  class ProtectedEnvironmentError < ActiveRecordError
+    # nodoc:
+    def initialize: (?::String env) -> untyped
+  end
+
+  class EnvironmentMismatchError < ActiveRecordError
+    def initialize: (?stored: untyped? stored, ?current: untyped? current) -> untyped
+  end
+
+  # = Active Record Migrations
+  #
+  # Migrations can manage the evolution of a schema used by several physical
+  # databases. It's a solution to the common problem of adding a field to make
+  # a new feature work in your local database, but being unsure of how to
+  # push that change to other developers and to the production server. With
+  # migrations, you can describe the transformations in self-contained classes
+  # that can be checked into version control systems and executed against
+  # another database that might be one, two, or five versions behind.
+  #
+  # Example of a simple migration:
+  #
+  #   class AddSsl < ActiveRecord::Migration[5.0]
+  #     def up
+  #       add_column :accounts, :ssl_enabled, :boolean, default: true
+  #     end
+  #
+  #     def down
+  #       remove_column :accounts, :ssl_enabled
+  #     end
+  #   end
+  #
+  # This migration will add a boolean flag to the accounts table and remove it
+  # if you're backing out of the migration. It shows how all migrations have
+  # two methods +up+ and +down+ that describes the transformations
+  # required to implement or remove the migration. These methods can consist
+  # of both the migration specific methods like +add_column+ and +remove_column+,
+  # but may also contain regular Ruby code for generating data needed for the
+  # transformations.
+  #
+  # Example of a more complex migration that also needs to initialize data:
+  #
+  #   class AddSystemSettings < ActiveRecord::Migration[5.0]
+  #     def up
+  #       create_table :system_settings do |t|
+  #         t.string  :name
+  #         t.string  :label
+  #         t.text    :value
+  #         t.string  :type
+  #         t.integer :position
+  #       end
+  #
+  #       SystemSetting.create  name:  'notice',
+  #                             label: 'Use notice?',
+  #                             value: 1
+  #     end
+  #
+  #     def down
+  #       drop_table :system_settings
+  #     end
+  #   end
+  #
+  # This migration first adds the +system_settings+ table, then creates the very
+  # first row in it using the Active Record model that relies on the table. It
+  # also uses the more advanced +create_table+ syntax where you can specify a
+  # complete table schema in one block call.
+  #
+  # == Available transformations
+  #
+  # === Creation
+  #
+  # * <tt>create_join_table(table_1, table_2, options)</tt>: Creates a join
+  #   table having its name as the lexical order of the first two
+  #   arguments. See
+  #   ActiveRecord::ConnectionAdapters::SchemaStatements#create_join_table for
+  #   details.
+  # * <tt>create_table(name, options)</tt>: Creates a table called +name+ and
+  #   makes the table object available to a block that can then add columns to it,
+  #   following the same format as +add_column+. See example above. The options hash
+  #   is for fragments like "DEFAULT CHARSET=UTF-8" that are appended to the create
+  #   table definition.
+  # * <tt>add_column(table_name, column_name, type, options)</tt>: Adds a new column
+  #   to the table called +table_name+
+  #   named +column_name+ specified to be one of the following types:
+  #   <tt>:string</tt>, <tt>:text</tt>, <tt>:integer</tt>, <tt>:float</tt>,
+  #   <tt>:decimal</tt>, <tt>:datetime</tt>, <tt>:timestamp</tt>, <tt>:time</tt>,
+  #   <tt>:date</tt>, <tt>:binary</tt>, <tt>:boolean</tt>. A default value can be
+  #   specified by passing an +options+ hash like <tt>{ default: 11 }</tt>.
+  #   Other options include <tt>:limit</tt> and <tt>:null</tt> (e.g.
+  #   <tt>{ limit: 50, null: false }</tt>) -- see
+  #   ActiveRecord::ConnectionAdapters::TableDefinition#column for details.
+  # * <tt>add_foreign_key(from_table, to_table, options)</tt>: Adds a new
+  #   foreign key. +from_table+ is the table with the key column, +to_table+ contains
+  #   the referenced primary key.
+  # * <tt>add_index(table_name, column_names, options)</tt>: Adds a new index
+  #   with the name of the column. Other options include
+  #   <tt>:name</tt>, <tt>:unique</tt> (e.g.
+  #   <tt>{ name: 'users_name_index', unique: true }</tt>) and <tt>:order</tt>
+  #   (e.g. <tt>{ order: { name: :desc } }</tt>).
+  # * <tt>add_reference(:table_name, :reference_name)</tt>: Adds a new column
+  #   +reference_name_id+ by default an integer. See
+  #   ActiveRecord::ConnectionAdapters::SchemaStatements#add_reference for details.
+  # * <tt>add_timestamps(table_name, options)</tt>: Adds timestamps (+created_at+
+  #   and +updated_at+) columns to +table_name+.
+  #
+  # === Modification
+  #
+  # * <tt>change_column(table_name, column_name, type, options)</tt>:  Changes
+  #   the column to a different type using the same parameters as add_column.
+  # * <tt>change_column_default(table_name, column_name, default_or_changes)</tt>:
+  #   Sets a default value for +column_name+ defined by +default_or_changes+ on
+  #   +table_name+. Passing a hash containing <tt>:from</tt> and <tt>:to</tt>
+  #   as +default_or_changes+ will make this change reversible in the migration.
+  # * <tt>change_column_null(table_name, column_name, null, default = nil)</tt>:
+  #   Sets or removes a +NOT NULL+ constraint on +column_name+. The +null+ flag
+  #   indicates whether the value can be +NULL+. See
+  #   ActiveRecord::ConnectionAdapters::SchemaStatements#change_column_null for
+  #   details.
+  # * <tt>change_table(name, options)</tt>: Allows to make column alterations to
+  #   the table called +name+. It makes the table object available to a block that
+  #   can then add/remove columns, indexes or foreign keys to it.
+  # * <tt>rename_column(table_name, column_name, new_column_name)</tt>: Renames
+  #   a column but keeps the type and content.
+  # * <tt>rename_index(table_name, old_name, new_name)</tt>: Renames an index.
+  # * <tt>rename_table(old_name, new_name)</tt>: Renames the table called +old_name+
+  #   to +new_name+.
+  #
+  # === Deletion
+  #
+  # * <tt>drop_table(name)</tt>: Drops the table called +name+.
+  # * <tt>drop_join_table(table_1, table_2, options)</tt>: Drops the join table
+  #   specified by the given arguments.
+  # * <tt>remove_column(table_name, column_name, type, options)</tt>: Removes the column
+  #   named +column_name+ from the table called +table_name+.
+  # * <tt>remove_columns(table_name, *column_names)</tt>: Removes the given
+  #   columns from the table definition.
+  # * <tt>remove_foreign_key(from_table, to_table = nil, **options)</tt>: Removes the
+  #   given foreign key from the table called +table_name+.
+  # * <tt>remove_index(table_name, column: column_names)</tt>: Removes the index
+  #   specified by +column_names+.
+  # * <tt>remove_index(table_name, name: index_name)</tt>: Removes the index
+  #   specified by +index_name+.
+  # * <tt>remove_reference(table_name, ref_name, options)</tt>: Removes the
+  #   reference(s) on +table_name+ specified by +ref_name+.
+  # * <tt>remove_timestamps(table_name, options)</tt>: Removes the timestamp
+  #   columns (+created_at+ and +updated_at+) from the table definition.
+  #
+  # == Irreversible transformations
+  #
+  # Some transformations are destructive in a manner that cannot be reversed.
+  # Migrations of that kind should raise an <tt>ActiveRecord::IrreversibleMigration</tt>
+  # exception in their +down+ method.
+  #
+  # == Running migrations from within Rails
+  #
+  # The Rails package has several tools to help create and apply migrations.
+  #
+  # To generate a new migration, you can use
+  #   rails generate migration MyNewMigration
+  #
+  # where MyNewMigration is the name of your migration. The generator will
+  # create an empty migration file <tt>timestamp_my_new_migration.rb</tt>
+  # in the <tt>db/migrate/</tt> directory where <tt>timestamp</tt> is the
+  # UTC formatted date and time that the migration was generated.
+  #
+  # There is a special syntactic shortcut to generate migrations that add fields to a table.
+  #
+  #   rails generate migration add_fieldname_to_tablename fieldname:string
+  #
+  # This will generate the file <tt>timestamp_add_fieldname_to_tablename.rb</tt>, which will look like this:
+  #   class AddFieldnameToTablename < ActiveRecord::Migration[5.0]
+  #     def change
+  #       add_column :tablenames, :fieldname, :string
+  #     end
+  #   end
+  #
+  # To run migrations against the currently configured database, use
+  # <tt>rails db:migrate</tt>. This will update the database by running all of the
+  # pending migrations, creating the <tt>schema_migrations</tt> table
+  # (see "About the schema_migrations table" section below) if missing. It will also
+  # invoke the db:schema:dump command, which will update your db/schema.rb file
+  # to match the structure of your database.
+  #
+  # To roll the database back to a previous migration version, use
+  # <tt>rails db:rollback VERSION=X</tt> where <tt>X</tt> is the version to which
+  # you wish to downgrade. Alternatively, you can also use the STEP option if you
+  # wish to rollback last few migrations. <tt>rails db:rollback STEP=2</tt> will rollback
+  # the latest two migrations.
+  #
+  # If any of the migrations throw an <tt>ActiveRecord::IrreversibleMigration</tt> exception,
+  # that step will fail and you'll have some manual work to do.
+  #
+  # == Database support
+  #
+  # Migrations are currently supported in MySQL, PostgreSQL, SQLite,
+  # SQL Server, and Oracle (all supported databases except DB2).
+  #
+  # == More examples
+  #
+  # Not all migrations change the schema. Some just fix the data:
+  #
+  #   class RemoveEmptyTags < ActiveRecord::Migration[5.0]
+  #     def up
+  #       Tag.all.each { |tag| tag.destroy if tag.pages.empty? }
+  #     end
+  #
+  #     def down
+  #       # not much we can do to restore deleted data
+  #       raise ActiveRecord::IrreversibleMigration, "Can't recover the deleted tags"
+  #     end
+  #   end
+  #
+  # Others remove columns when they migrate up instead of down:
+  #
+  #   class RemoveUnnecessaryItemAttributes < ActiveRecord::Migration[5.0]
+  #     def up
+  #       remove_column :items, :incomplete_items_count
+  #       remove_column :items, :completed_items_count
+  #     end
+  #
+  #     def down
+  #       add_column :items, :incomplete_items_count
+  #       add_column :items, :completed_items_count
+  #     end
+  #   end
+  #
+  # And sometimes you need to do something in SQL not abstracted directly by migrations:
+  #
+  #   class MakeJoinUnique < ActiveRecord::Migration[5.0]
+  #     def up
+  #       execute "ALTER TABLE `pages_linked_pages` ADD UNIQUE `page_id_linked_page_id` (`page_id`,`linked_page_id`)"
+  #     end
+  #
+  #     def down
+  #       execute "ALTER TABLE `pages_linked_pages` DROP INDEX `page_id_linked_page_id`"
+  #     end
+  #   end
+  #
+  # == Using a model after changing its table
+  #
+  # Sometimes you'll want to add a column in a migration and populate it
+  # immediately after. In that case, you'll need to make a call to
+  # <tt>Base#reset_column_information</tt> in order to ensure that the model has the
+  # latest column data from after the new column was added. Example:
+  #
+  #   class AddPeopleSalary < ActiveRecord::Migration[5.0]
+  #     def up
+  #       add_column :people, :salary, :integer
+  #       Person.reset_column_information
+  #       Person.all.each do |p|
+  #         p.update_attribute :salary, SalaryCalculator.compute(p)
+  #       end
+  #     end
+  #   end
+  #
+  # == Controlling verbosity
+  #
+  # By default, migrations will describe the actions they are taking, writing
+  # them to the console as they happen, along with benchmarks describing how
+  # long each step took.
+  #
+  # You can quiet them down by setting ActiveRecord::Migration.verbose = false.
+  #
+  # You can also insert your own messages and benchmarks by using the +say_with_time+
+  # method:
+  #
+  #   def up
+  #     ...
+  #     say_with_time "Updating salaries..." do
+  #       Person.all.each do |p|
+  #         p.update_attribute :salary, SalaryCalculator.compute(p)
+  #       end
+  #     end
+  #     ...
+  #   end
+  #
+  # The phrase "Updating salaries..." would then be printed, along with the
+  # benchmark for the block when the block completes.
+  #
+  # == Timestamped Migrations
+  #
+  # By default, Rails generates migrations that look like:
+  #
+  #    20080717013526_your_migration_name.rb
+  #
+  # The prefix is a generation timestamp (in UTC).
+  #
+  # If you'd prefer to use numeric prefixes, you can turn timestamped migrations
+  # off by setting:
+  #
+  #    config.active_record.timestamped_migrations = false
+  #
+  # In application.rb.
+  #
+  # == Reversible Migrations
+  #
+  # Reversible migrations are migrations that know how to go +down+ for you.
+  # You simply supply the +up+ logic, and the Migration system figures out
+  # how to execute the down commands for you.
+  #
+  # To define a reversible migration, define the +change+ method in your
+  # migration like this:
+  #
+  #   class TenderloveMigration < ActiveRecord::Migration[5.0]
+  #     def change
+  #       create_table(:horses) do |t|
+  #         t.column :content, :text
+  #         t.column :remind_at, :datetime
+  #       end
+  #     end
+  #   end
+  #
+  # This migration will create the horses table for you on the way up, and
+  # automatically figure out how to drop the table on the way down.
+  #
+  # Some commands cannot be reversed. If you care to define how to move up
+  # and down in these cases, you should define the +up+ and +down+ methods
+  # as before.
+  #
+  # If a command cannot be reversed, an
+  # <tt>ActiveRecord::IrreversibleMigration</tt> exception will be raised when
+  # the migration is moving down.
+  #
+  # For a list of commands that are reversible, please see
+  # <tt>ActiveRecord::Migration::CommandRecorder</tt>.
+  #
+  # == Transactional Migrations
+  #
+  # If the database adapter supports DDL transactions, all migrations will
+  # automatically be wrapped in a transaction. There are queries that you
+  # can't execute inside a transaction though, and for these situations
+  # you can turn the automatic transactions off.
+  #
+  #   class ChangeEnum < ActiveRecord::Migration[5.0]
+  #     disable_ddl_transaction!
+  #
+  #     def up
+  #       execute "ALTER TYPE model_size ADD VALUE 'new_value'"
+  #     end
+  #   end
+  #
+  # Remember that you can still open your own transactions, even if you
+  # are in a Migration with <tt>self.disable_ddl_transaction!</tt>.
+  class Migration
+    class Current < Migration
+    end
+
+    def self.inherited: (untyped subclass) -> untyped
+
+    def self.[]: (untyped version) -> untyped
+
+    def self.current_version: () -> untyped
+
+    MigrationFilenameRegexp: untyped
+
+    # This class is used to verify that all migrations have been run before
+    # loading a web page if <tt>config.active_record.migration_error</tt> is set to :page_load
+    class CheckPending
+      def initialize: (untyped app) -> untyped
+
+      def call: (untyped env) -> untyped
+
+      def connection: () -> untyped
+    end
+
+    attr_accessor delegate: untyped
+
+    attr_accessor disable_ddl_transaction: untyped
+
+    def self.nearest_delegate: () -> untyped
+
+    # Raises <tt>ActiveRecord::PendingMigrationError</tt> error if any migrations are pending.
+    def self.check_pending!: (?untyped connection) -> untyped
+
+    def self.load_schema_if_pending!: () -> untyped
+
+    def self.maintain_test_schema!: () -> untyped
+
+    def self.method_missing: (untyped name, *untyped args) { () -> untyped } -> untyped
+
+    def self.migrate: (untyped direction) -> untyped
+
+    # Disable the transaction wrapping this migration.
+    # You can still create your own transactions even after calling #disable_ddl_transaction!
+    #
+    # For more details read the {"Transactional Migrations" section above}[rdoc-ref:Migration].
+    def self.disable_ddl_transaction!: () -> untyped
+
+    def disable_ddl_transaction: () -> untyped
+
+    attr_accessor name: untyped
+
+    attr_accessor version: untyped
+
+    def initialize: (?untyped name, ?untyped? version) -> untyped
+
+    # Reverses the migration commands for the given block and
+    # the given migrations.
+    #
+    # The following migration will remove the table 'horses'
+    # and create the table 'apples' on the way up, and the reverse
+    # on the way down.
+    #
+    #   class FixTLMigration < ActiveRecord::Migration[5.0]
+    #     def change
+    #       revert do
+    #         create_table(:horses) do |t|
+    #           t.text :content
+    #           t.datetime :remind_at
+    #         end
+    #       end
+    #       create_table(:apples) do |t|
+    #         t.string :variety
+    #       end
+    #     end
+    #   end
+    #
+    # Or equivalently, if +TenderloveMigration+ is defined as in the
+    # documentation for Migration:
+    #
+    #   require_relative '20121212123456_tenderlove_migration'
+    #
+    #   class FixupTLMigration < ActiveRecord::Migration[5.0]
+    #     def change
+    #       revert TenderloveMigration
+    #
+    #       create_table(:apples) do |t|
+    #         t.string :variety
+    #       end
+    #     end
+    #   end
+    #
+    # This command can be nested.
+    def revert: (*untyped migration_classes) { () -> untyped } -> untyped
+
+    def reverting?: () -> untyped
+
+    class ReversibleBlockHelper[T] < ::Struct[T]
+      attr_accessor reverting(): untyped
+
+      # nodoc:
+      def up: () { () -> untyped } -> untyped
+
+      def down: () { () -> untyped } -> untyped
+    end
+
+    # Used to specify an operation that can be run in one direction or another.
+    # Call the methods +up+ and +down+ of the yielded object to run a block
+    # only in one given direction.
+    # The whole block will be called in the right order within the migration.
+    #
+    # In the following example, the looping on users will always be done
+    # when the three columns 'first_name', 'last_name' and 'full_name' exist,
+    # even when migrating down:
+    #
+    #    class SplitNameMigration < ActiveRecord::Migration[5.0]
+    #      def change
+    #        add_column :users, :first_name, :string
+    #        add_column :users, :last_name, :string
+    #
+    #        reversible do |dir|
+    #          User.reset_column_information
+    #          User.all.each do |u|
+    #            dir.up   { u.first_name, u.last_name = u.full_name.split(' ') }
+    #            dir.down { u.full_name = "#{u.first_name} #{u.last_name}" }
+    #            u.save
+    #          end
+    #        end
+    #
+    #        revert { add_column :users, :full_name, :string }
+    #      end
+    #    end
+    def reversible: () { (untyped) -> untyped } -> untyped
+
+    # Used to specify an operation that is only run when migrating up
+    # (for example, populating a new column with its initial values).
+    #
+    # In the following example, the new column +published+ will be given
+    # the value +true+ for all existing records.
+    #
+    #    class AddPublishedToPosts < ActiveRecord::Migration[5.2]
+    #      def change
+    #        add_column :posts, :published, :boolean, default: false
+    #        up_only do
+    #          execute "update posts set published = 'true'"
+    #        end
+    #      end
+    #    end
+    def up_only: () { () -> untyped } -> untyped
+
+    # Runs the given migration classes.
+    # Last argument can specify options:
+    # - :direction (default is :up)
+    # - :revert (default is false)
+    def run: (*untyped migration_classes) -> untyped
+
+    def up: () -> (nil | untyped)
+
+    def down: () -> (nil | untyped)
+
+    # Execute this migration in the named direction
+    def migrate: (untyped direction) -> (nil | untyped)
+
+    def exec_migration: (untyped conn, untyped direction) -> untyped
+
+    def write: (?::String text) -> untyped
+
+    def announce: (untyped message) -> untyped
+
+    # Takes a message argument and outputs it as is.
+    # A second boolean argument can be passed to specify whether to indent or not.
+    def say: (untyped message, ?bool subitem) -> untyped
+
+    # Outputs text along with how long it took to run its block.
+    # If the block returns an integer it assumes it is the number of rows affected.
+    def say_with_time: (untyped message) { () -> untyped } -> untyped
+
+    # Takes a block as an argument and suppresses any output generated by the block.
+    def suppress_messages: () { () -> untyped } -> untyped
+
+    def connection: () -> untyped
+
+    def method_missing: (untyped method, *untyped arguments) { () -> untyped } -> untyped
+
+    def copy: (untyped destination, untyped sources, ?::Hash[untyped, untyped] options) -> untyped
+
+    # Finds the correct table name given an Active Record object.
+    # Uses the Active Record object's own table_name, or pre/suffix from the
+    # options passed in.
+    def proper_table_name: (untyped name, ?::Hash[untyped, untyped] options) -> untyped
+
+    # Determines the version number of the next migration.
+    def next_migration_number: (untyped number) -> untyped
+
+    def table_name_options: (?untyped config) -> { table_name_prefix: untyped, table_name_suffix: untyped }
+
+    def execute_block: () { () -> untyped } -> untyped
+
+    def command_recorder: () -> CommandRecorder
+  end
+
+  # MigrationProxy is used to defer loading of the actual migration classes
+  # until they are needed
+  class MigrationProxy[T] < ::Struct[T]
+    attr_accessor name(): untyped
+
+    attr_accessor version(): untyped
+
+    attr_accessor filename(): untyped
+
+    attr_accessor scope(): untyped
+
+    def initialize: (untyped name, untyped version, untyped filename, untyped scope) -> untyped
+
+    def basename: () -> untyped
+
+    def mtime: () -> untyped
+
+    def migration: () -> untyped
+
+    def load_migration: () -> untyped
+  end
+
+  class NullMigration[T] < MigrationProxy[T]
+    # nodoc:
+    def initialize: () -> untyped
+
+    def mtime: () -> 0
+  end
+
+  class MigrationContext
+    # nodoc:
+    attr_reader migrations_paths: untyped
+
+    # nodoc:
+    attr_reader schema_migration: untyped
+
+    def initialize: (untyped migrations_paths, untyped schema_migration) -> untyped
+
+    def migrate: (?untyped? target_version) { () -> untyped } -> untyped
+
+    def rollback: (?::Integer steps) -> untyped
+
+    def forward: (?::Integer steps) -> untyped
+
+    def up: (?untyped? target_version) { (untyped) -> untyped } -> untyped
+
+    def down: (?untyped? target_version) { (untyped) -> untyped } -> untyped
+
+    def run: (untyped direction, untyped target_version) -> untyped
+
+    def open: () -> Migrator
+
+    def get_all_versions: () -> untyped
+
+    def current_version: () -> untyped
+
+    def needs_migration?: () -> untyped
+
+    def any_migrations?: () -> untyped
+
+    def last_migration: () -> untyped
+
+    def migrations: () -> untyped
+
+    def migrations_status: () -> untyped
+
+    def current_environment: () -> untyped
+
+    def protected_environment?: () -> untyped
+
+    def last_stored_environment: () -> (nil | untyped)
+
+    def migration_files: () -> untyped
+
+    def parse_migration_filename: (untyped filename) -> untyped
+
+    def move: (untyped direction, untyped steps) -> untyped
+  end
+
+  class Migrator
+    attr_accessor migrations_paths: untyped
+
+    # For cases where a table doesn't exist like loading from schema cache
+    def self.current_version: () -> untyped
+
+    def initialize: (untyped direction, untyped migrations, untyped schema_migration, ?untyped? target_version) -> untyped
+
+    def current_version: () -> untyped
+
+    def current_migration: () -> untyped
+
+    alias current current_migration
+
+    def run: () -> untyped
+
+    def migrate: () -> untyped
+
+    def runnable: () -> untyped
+
+    def migrations: () -> untyped
+
+    def pending_migrations: () -> untyped
+
+    def migrated: () -> untyped
+
+    def load_migrated: () -> untyped
+
+    # Used for running a specific migration.
+    def run_without_lock: () -> untyped
+
+    # Used for running multiple migrations up to or down to a certain value.
+    def migrate_without_lock: () -> untyped
+
+    # Stores the current environment in the database.
+    def record_environment: () -> (nil | untyped)
+
+    def ran?: (untyped migration) -> untyped
+
+    # Return true if a valid version is not provided.
+    def invalid_target?: () -> untyped
+
+    def execute_migration_in_transaction: (untyped migration, untyped direction) -> untyped
+
+    def target: () -> untyped
+
+    def finish: () -> untyped
+
+    def start: () -> untyped
+
+    def validate: (untyped migrations) -> untyped
+
+    def record_version_state_after_migrating: (untyped version) -> untyped
+
+    def up?: () -> untyped
+
+    def down?: () -> untyped
+
+    # Wrap the migration in a transaction only if supported by the adapter.
+    def ddl_transaction: (untyped migration) { () -> untyped } -> untyped
+
+    def use_transaction?: (untyped migration) -> untyped
+
+    def use_advisory_lock?: () -> untyped
+
+    def with_advisory_lock: () { () -> untyped } -> untyped
+
+    MIGRATOR_SALT: ::Integer
+
+    def generate_migrator_advisory_lock_id: () -> untyped
+  end
+end
+
+module ActiveRecord
+  module ModelSchema
+    extend ActiveSupport::Concern
+
+    def self.derive_join_table_name: (untyped first_table, untyped second_table) -> untyped
+
+    module ClassMethods
+      # Guesses the table name (in forced lower-case) based on the name of the class in the
+      # inheritance hierarchy descending directly from ActiveRecord::Base. So if the hierarchy
+      # looks like: Reply < Message < ActiveRecord::Base, then Message is used
+      # to guess the table name even when called on Reply. The rules used to do the guess
+      # are handled by the Inflector class in Active Support, which knows almost all common
+      # English inflections. You can add new inflections in config/initializers/inflections.rb.
+      #
+      # Nested classes are given table names prefixed by the singular form of
+      # the parent's table name. Enclosing modules are not considered.
+      #
+      # ==== Examples
+      #
+      #   class Invoice < ActiveRecord::Base
+      #   end
+      #
+      #   file                  class               table_name
+      #   invoice.rb            Invoice             invoices
+      #
+      #   class Invoice < ActiveRecord::Base
+      #     class Lineitem < ActiveRecord::Base
+      #     end
+      #   end
+      #
+      #   file                  class               table_name
+      #   invoice.rb            Invoice::Lineitem   invoice_lineitems
+      #
+      #   module Invoice
+      #     class Lineitem < ActiveRecord::Base
+      #     end
+      #   end
+      #
+      #   file                  class               table_name
+      #   invoice/lineitem.rb   Invoice::Lineitem   lineitems
+      #
+      # Additionally, the class-level +table_name_prefix+ is prepended and the
+      # +table_name_suffix+ is appended. So if you have "myapp_" as a prefix,
+      # the table name guess for an Invoice class becomes "myapp_invoices".
+      # Invoice::Lineitem becomes "myapp_invoice_lineitems".
+      #
+      # You can also set your own table name explicitly:
+      #
+      #   class Mouse < ActiveRecord::Base
+      #     self.table_name = "mice"
+      #   end
+      def table_name: () -> untyped
+
+      # Sets the table name explicitly. Example:
+      #
+      #   class Project < ActiveRecord::Base
+      #     self.table_name = "project"
+      #   end
+      def table_name=: (untyped value) -> (nil | untyped)
+
+      # Returns a quoted version of the table name, used to construct SQL statements.
+      def quoted_table_name: () -> untyped
+
+      def reset_table_name: () -> untyped
+
+      def full_table_name_prefix: () -> untyped
+
+      def full_table_name_suffix: () -> untyped
+
+      # The array of names of environments where destructive actions should be prohibited. By default,
+      # the value is <tt>["production"]</tt>.
+      def protected_environments: () -> untyped
+
+      # Sets an array of names of environments where destructive actions should be prohibited.
+      def protected_environments=: (untyped environments) -> untyped
+
+      # Defines the name of the table column which will store the class name on single-table
+      # inheritance situations.
+      #
+      # The default inheritance column name is +type+, which means it's a
+      # reserved word inside Active Record. To be able to use single-table
+      # inheritance with another column name, or to use the column +type+ in
+      # your own model for something else, you can set +inheritance_column+:
+      #
+      #     self.inheritance_column = 'zoink'
+      def inheritance_column: () -> untyped
+
+      # Sets the value of inheritance_column
+      def inheritance_column=: (untyped value) -> untyped
+
+      # The list of columns names the model should ignore. Ignored columns won't have attribute
+      # accessors defined, and won't be referenced in SQL queries.
+      def ignored_columns: () -> untyped
+
+      # Sets the columns names the model should ignore. Ignored columns won't have attribute
+      # accessors defined, and won't be referenced in SQL queries.
+      def ignored_columns=: (untyped columns) -> untyped
+
+      def sequence_name: () -> untyped
+
+      def reset_sequence_name: () -> untyped
+
+      # Sets the name of the sequence to use when generating ids to the given
+      # value, or (if the value is +nil+ or +false+) to the value returned by the
+      # given block. This is required for Oracle and is useful for any
+      # database which relies on sequences for primary key generation.
+      #
+      # If a sequence name is not explicitly set when using Oracle,
+      # it will default to the commonly used pattern of: #{table_name}_seq
+      #
+      # If a sequence name is not explicitly set when using PostgreSQL, it
+      # will discover the sequence corresponding to your primary key for you.
+      #
+      #   class Project < ActiveRecord::Base
+      #     self.sequence_name = "projectseq"   # default would have been "project_seq"
+      #   end
+      def sequence_name=: (untyped value) -> untyped
+
+      # Determines if the primary key values should be selected from their
+      # corresponding sequence before the insert statement.
+      def prefetch_primary_key?: () -> untyped
+
+      # Returns the next value that will be used as the primary key on
+      # an insert statement.
+      def next_sequence_value: () -> untyped
+
+      # Indicates whether the table associated with this class exists
+      def table_exists?: () -> untyped
+
+      def attributes_builder: () -> untyped
+
+      def columns_hash: () -> untyped
+
+      def columns: () -> untyped
+
+      def attribute_types: () -> untyped
+
+      def yaml_encoder: () -> untyped
+
+      # Returns the type of the attribute with the given name, after applying
+      # all modifiers. This method is the only valid source of information for
+      # anything related to the types of a model's attributes. This method will
+      # access the database and load the model's schema if it is required.
+      #
+      # The return value of this method will implement the interface described
+      # by ActiveModel::Type::Value (though the object itself may not subclass
+      # it).
+      #
+      # +attr_name+ The name of the attribute to retrieve the type for. Must be
+      # a string or a symbol.
+      def type_for_attribute: (untyped attr_name) { () -> untyped } -> untyped
+
+      # Returns a hash where the keys are column names and the values are
+      # default values when instantiating the Active Record object for this table.
+      def column_defaults: () -> untyped
+
+      def _default_attributes: () -> untyped
+
+      # Returns an array of column names as strings.
+      def column_names: () -> untyped
+
+      def symbol_column_to_string: (untyped name_symbol) -> untyped
+
+      # Returns an array of column objects where the primary id, all columns ending in "_id" or "_count",
+      # and columns used for single table inheritance have been removed.
+      def content_columns: () -> untyped
+
+      # Resets all the cached information about columns, which will cause them
+      # to be reloaded on the next request.
+      #
+      # The most common usage pattern for this method is probably in a migration,
+      # when just after creating a table you want to populate it with some default
+      # values, eg:
+      #
+      #  class CreateJobLevels < ActiveRecord::Migration[5.0]
+      #    def up
+      #      create_table :job_levels do |t|
+      #        t.integer :id
+      #        t.string :name
+      #
+      #        t.timestamps
+      #      end
+      #
+      #      JobLevel.reset_column_information
+      #      %w{assistant executive manager director}.each do |type|
+      #        JobLevel.create(name: type)
+      #      end
+      #    end
+      #
+      #    def down
+      #      drop_table :job_levels
+      #    end
+      #  end
+      def reset_column_information: () -> untyped
+
+      def initialize_load_schema_monitor: () -> untyped
+
+      def inherited: (untyped child_class) -> untyped
+
+      def schema_loaded?: () -> untyped
+
+      def load_schema: () -> (nil | untyped)
+
+      def load_schema!: () -> untyped
+
+      def reload_schema_from_cache: () -> untyped
+
+      # Guesses the table name, but does not decorate it with prefix and suffix information.
+      def undecorated_table_name: (?untyped class_name) -> untyped
+
+      # Computes and returns a table name according to default conventions.
+      def compute_table_name: () -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module NestedAttributes
+    # nodoc:
+    class TooManyRecords < ActiveRecordError
+    end
+
+    extend ActiveSupport::Concern
+
+    # = Active Record Nested Attributes
+    #
+    # Nested attributes allow you to save attributes on associated records
+    # through the parent. By default nested attribute updating is turned off
+    # and you can enable it using the accepts_nested_attributes_for class
+    # method. When you enable nested attributes an attribute writer is
+    # defined on the model.
+    #
+    # The attribute writer is named after the association, which means that
+    # in the following example, two new methods are added to your model:
+    #
+    # <tt>author_attributes=(attributes)</tt> and
+    # <tt>pages_attributes=(attributes)</tt>.
+    #
+    #   class Book < ActiveRecord::Base
+    #     has_one :author
+    #     has_many :pages
+    #
+    #     accepts_nested_attributes_for :author, :pages
+    #   end
+    #
+    # Note that the <tt>:autosave</tt> option is automatically enabled on every
+    # association that accepts_nested_attributes_for is used for.
+    #
+    # === One-to-one
+    #
+    # Consider a Member model that has one Avatar:
+    #
+    #   class Member < ActiveRecord::Base
+    #     has_one :avatar
+    #     accepts_nested_attributes_for :avatar
+    #   end
+    #
+    # Enabling nested attributes on a one-to-one association allows you to
+    # create the member and avatar in one go:
+    #
+    #   params = { member: { name: 'Jack', avatar_attributes: { icon: 'smiling' } } }
+    #   member = Member.create(params[:member])
+    #   member.avatar.id # => 2
+    #   member.avatar.icon # => 'smiling'
+    #
+    # It also allows you to update the avatar through the member:
+    #
+    #   params = { member: { avatar_attributes: { id: '2', icon: 'sad' } } }
+    #   member.update params[:member]
+    #   member.avatar.icon # => 'sad'
+    #
+    # If you want to update the current avatar without providing the id, you must add <tt>:update_only</tt> option.
+    #
+    #   class Member < ActiveRecord::Base
+    #     has_one :avatar
+    #     accepts_nested_attributes_for :avatar, update_only: true
+    #   end
+    #
+    #   params = { member: { avatar_attributes: { icon: 'sad' } } }
+    #   member.update params[:member]
+    #   member.avatar.id # => 2
+    #   member.avatar.icon # => 'sad'
+    #
+    # By default you will only be able to set and update attributes on the
+    # associated model. If you want to destroy the associated model through the
+    # attributes hash, you have to enable it first using the
+    # <tt>:allow_destroy</tt> option.
+    #
+    #   class Member < ActiveRecord::Base
+    #     has_one :avatar
+    #     accepts_nested_attributes_for :avatar, allow_destroy: true
+    #   end
+    #
+    # Now, when you add the <tt>_destroy</tt> key to the attributes hash, with a
+    # value that evaluates to +true+, you will destroy the associated model:
+    #
+    #   member.avatar_attributes = { id: '2', _destroy: '1' }
+    #   member.avatar.marked_for_destruction? # => true
+    #   member.save
+    #   member.reload.avatar # => nil
+    #
+    # Note that the model will _not_ be destroyed until the parent is saved.
+    #
+    # Also note that the model will not be destroyed unless you also specify
+    # its id in the updated hash.
+    #
+    # === One-to-many
+    #
+    # Consider a member that has a number of posts:
+    #
+    #   class Member < ActiveRecord::Base
+    #     has_many :posts
+    #     accepts_nested_attributes_for :posts
+    #   end
+    #
+    # You can now set or update attributes on the associated posts through
+    # an attribute hash for a member: include the key +:posts_attributes+
+    # with an array of hashes of post attributes as a value.
+    #
+    # For each hash that does _not_ have an <tt>id</tt> key a new record will
+    # be instantiated, unless the hash also contains a <tt>_destroy</tt> key
+    # that evaluates to +true+.
+    #
+    #   params = { member: {
+    #     name: 'joe', posts_attributes: [
+    #       { title: 'Kari, the awesome Ruby documentation browser!' },
+    #       { title: 'The egalitarian assumption of the modern citizen' },
+    #       { title: '', _destroy: '1' } # this will be ignored
+    #     ]
+    #   }}
+    #
+    #   member = Member.create(params[:member])
+    #   member.posts.length # => 2
+    #   member.posts.first.title # => 'Kari, the awesome Ruby documentation browser!'
+    #   member.posts.second.title # => 'The egalitarian assumption of the modern citizen'
+    #
+    # You may also set a +:reject_if+ proc to silently ignore any new record
+    # hashes if they fail to pass your criteria. For example, the previous
+    # example could be rewritten as:
+    #
+    #   class Member < ActiveRecord::Base
+    #     has_many :posts
+    #     accepts_nested_attributes_for :posts, reject_if: proc { |attributes| attributes['title'].blank? }
+    #   end
+    #
+    #   params = { member: {
+    #     name: 'joe', posts_attributes: [
+    #       { title: 'Kari, the awesome Ruby documentation browser!' },
+    #       { title: 'The egalitarian assumption of the modern citizen' },
+    #       { title: '' } # this will be ignored because of the :reject_if proc
+    #     ]
+    #   }}
+    #
+    #   member = Member.create(params[:member])
+    #   member.posts.length # => 2
+    #   member.posts.first.title # => 'Kari, the awesome Ruby documentation browser!'
+    #   member.posts.second.title # => 'The egalitarian assumption of the modern citizen'
+    #
+    # Alternatively, +:reject_if+ also accepts a symbol for using methods:
+    #
+    #   class Member < ActiveRecord::Base
+    #     has_many :posts
+    #     accepts_nested_attributes_for :posts, reject_if: :new_record?
+    #   end
+    #
+    #   class Member < ActiveRecord::Base
+    #     has_many :posts
+    #     accepts_nested_attributes_for :posts, reject_if: :reject_posts
+    #
+    #     def reject_posts(attributes)
+    #       attributes['title'].blank?
+    #     end
+    #   end
+    #
+    # If the hash contains an <tt>id</tt> key that matches an already
+    # associated record, the matching record will be modified:
+    #
+    #   member.attributes = {
+    #     name: 'Joe',
+    #     posts_attributes: [
+    #       { id: 1, title: '[UPDATED] An, as of yet, undisclosed awesome Ruby documentation browser!' },
+    #       { id: 2, title: '[UPDATED] other post' }
+    #     ]
+    #   }
+    #
+    #   member.posts.first.title # => '[UPDATED] An, as of yet, undisclosed awesome Ruby documentation browser!'
+    #   member.posts.second.title # => '[UPDATED] other post'
+    #
+    # However, the above applies if the parent model is being updated as well.
+    # For example, If you wanted to create a +member+ named _joe_ and wanted to
+    # update the +posts+ at the same time, that would give an
+    # ActiveRecord::RecordNotFound error.
+    #
+    # By default the associated records are protected from being destroyed. If
+    # you want to destroy any of the associated records through the attributes
+    # hash, you have to enable it first using the <tt>:allow_destroy</tt>
+    # option. This will allow you to also use the <tt>_destroy</tt> key to
+    # destroy existing records:
+    #
+    #   class Member < ActiveRecord::Base
+    #     has_many :posts
+    #     accepts_nested_attributes_for :posts, allow_destroy: true
+    #   end
+    #
+    #   params = { member: {
+    #     posts_attributes: [{ id: '2', _destroy: '1' }]
+    #   }}
+    #
+    #   member.attributes = params[:member]
+    #   member.posts.detect { |p| p.id == 2 }.marked_for_destruction? # => true
+    #   member.posts.length # => 2
+    #   member.save
+    #   member.reload.posts.length # => 1
+    #
+    # Nested attributes for an associated collection can also be passed in
+    # the form of a hash of hashes instead of an array of hashes:
+    #
+    #   Member.create(
+    #     name: 'joe',
+    #     posts_attributes: {
+    #       first:  { title: 'Foo' },
+    #       second: { title: 'Bar' }
+    #     }
+    #   )
+    #
+    # has the same effect as
+    #
+    #   Member.create(
+    #     name: 'joe',
+    #     posts_attributes: [
+    #       { title: 'Foo' },
+    #       { title: 'Bar' }
+    #     ]
+    #   )
+    #
+    # The keys of the hash which is the value for +:posts_attributes+ are
+    # ignored in this case.
+    # However, it is not allowed to use <tt>'id'</tt> or <tt>:id</tt> for one of
+    # such keys, otherwise the hash will be wrapped in an array and
+    # interpreted as an attribute hash for a single post.
+    #
+    # Passing attributes for an associated collection in the form of a hash
+    # of hashes can be used with hashes generated from HTTP/HTML parameters,
+    # where there may be no natural way to submit an array of hashes.
+    #
+    # === Saving
+    #
+    # All changes to models, including the destruction of those marked for
+    # destruction, are saved and destroyed automatically and atomically when
+    # the parent model is saved. This happens inside the transaction initiated
+    # by the parent's save method. See ActiveRecord::AutosaveAssociation.
+    #
+    # === Validating the presence of a parent model
+    #
+    # If you want to validate that a child record is associated with a parent
+    # record, you can use the +validates_presence_of+ method and the +:inverse_of+
+    # key as this example illustrates:
+    #
+    #   class Member < ActiveRecord::Base
+    #     has_many :posts, inverse_of: :member
+    #     accepts_nested_attributes_for :posts
+    #   end
+    #
+    #   class Post < ActiveRecord::Base
+    #     belongs_to :member, inverse_of: :posts
+    #     validates_presence_of :member
+    #   end
+    #
+    # Note that if you do not specify the +:inverse_of+ option, then
+    # Active Record will try to automatically guess the inverse association
+    # based on heuristics.
+    #
+    # For one-to-one nested associations, if you build the new (in-memory)
+    # child object yourself before assignment, then this module will not
+    # overwrite it, e.g.:
+    #
+    #   class Member < ActiveRecord::Base
+    #     has_one :avatar
+    #     accepts_nested_attributes_for :avatar
+    #
+    #     def avatar
+    #       super || build_avatar(width: 200)
+    #     end
+    #   end
+    #
+    #   member = Member.new
+    #   member.avatar_attributes = {icon: 'sad'}
+    #   member.avatar.width # => 200
+    module ClassMethods
+      REJECT_ALL_BLANK_PROC: untyped
+
+      # Defines an attributes writer for the specified association(s).
+      #
+      # Supported options:
+      # [:allow_destroy]
+      #   If true, destroys any members from the attributes hash with a
+      #   <tt>_destroy</tt> key and a value that evaluates to +true+
+      #   (eg. 1, '1', true, or 'true'). This option is off by default.
+      # [:reject_if]
+      #   Allows you to specify a Proc or a Symbol pointing to a method
+      #   that checks whether a record should be built for a certain attribute
+      #   hash. The hash is passed to the supplied Proc or the method
+      #   and it should return either +true+ or +false+. When no +:reject_if+
+      #   is specified, a record will be built for all attribute hashes that
+      #   do not have a <tt>_destroy</tt> value that evaluates to true.
+      #   Passing <tt>:all_blank</tt> instead of a Proc will create a proc
+      #   that will reject a record where all the attributes are blank excluding
+      #   any value for +_destroy+.
+      # [:limit]
+      #   Allows you to specify the maximum number of associated records that
+      #   can be processed with the nested attributes. Limit also can be specified
+      #   as a Proc or a Symbol pointing to a method that should return a number.
+      #   If the size of the nested attributes array exceeds the specified limit,
+      #   NestedAttributes::TooManyRecords exception is raised. If omitted, any
+      #   number of associations can be processed.
+      #   Note that the +:limit+ option is only applicable to one-to-many
+      #   associations.
+      # [:update_only]
+      #   For a one-to-one association, this option allows you to specify how
+      #   nested attributes are going to be used when an associated record already
+      #   exists. In general, an existing record may either be updated with the
+      #   new set of attribute values or be replaced by a wholly new record
+      #   containing those values. By default the +:update_only+ option is +false+
+      #   and the nested attributes are used to update the existing record only
+      #   if they include the record's <tt>:id</tt> value. Otherwise a new
+      #   record will be instantiated and used to replace the existing one.
+      #   However if the +:update_only+ option is +true+, the nested attributes
+      #   are used to update the record's attributes always, regardless of
+      #   whether the <tt>:id</tt> is present. The option is ignored for collection
+      #   associations.
+      #
+      # Examples:
+      #   # creates avatar_attributes=
+      #   accepts_nested_attributes_for :avatar, reject_if: proc { |attributes| attributes['name'].blank? }
+      #   # creates avatar_attributes=
+      #   accepts_nested_attributes_for :avatar, reject_if: :all_blank
+      #   # creates avatar_attributes= and posts_attributes=
+      #   accepts_nested_attributes_for :avatar, :posts, allow_destroy: true
+      def accepts_nested_attributes_for: (*untyped attr_names) -> untyped
+
+      # Generates a writer method for this association. Serves as a point for
+      # accessing the objects in the association. For example, this method
+      # could generate the following:
+      #
+      #   def pirate_attributes=(attributes)
+      #     assign_nested_attributes_for_one_to_one_association(:pirate, attributes)
+      #   end
+      #
+      # This redirects the attempts to write objects in an association through
+      # the helper methods defined below. Makes it seem like the nested
+      # associations are just regular associations.
+      def generate_association_writer: (untyped association_name, untyped `type`) -> untyped
+    end
+
+    # Returns ActiveRecord::AutosaveAssociation::marked_for_destruction? It's
+    # used in conjunction with fields_for to build a form element for the
+    # destruction of this association.
+    #
+    # See ActionView::Helpers::FormHelper::fields_for for more info.
+    def _destroy: () -> untyped
+
+    # Attribute hash keys that should not be assigned as normal attributes.
+    # These hash keys are nested attributes implementation details.
+    UNASSIGNABLE_KEYS: ::Array[untyped]
+
+    # Assigns the given attributes to the association.
+    #
+    # If an associated record does not yet exist, one will be instantiated. If
+    # an associated record already exists, the method's behavior depends on
+    # the value of the update_only option. If update_only is +false+ and the
+    # given attributes include an <tt>:id</tt> that matches the existing record's
+    # id, then the existing record will be modified. If no <tt>:id</tt> is provided
+    # it will be replaced with a new record. If update_only is +true+ the existing
+    # record will be modified regardless of whether an <tt>:id</tt> is provided.
+    #
+    # If the given attributes include a matching <tt>:id</tt> attribute, or
+    # update_only is true, and a <tt>:_destroy</tt> key set to a truthy value,
+    # then the existing record will be marked for destruction.
+    def assign_nested_attributes_for_one_to_one_association: (untyped association_name, untyped attributes) -> untyped
+
+    # Assigns the given attributes to the collection association.
+    #
+    # Hashes with an <tt>:id</tt> value matching an existing associated record
+    # will update that record. Hashes without an <tt>:id</tt> value will build
+    # a new record for the association. Hashes with a matching <tt>:id</tt>
+    # value and a <tt>:_destroy</tt> key set to a truthy value will mark the
+    # matched record for destruction.
+    #
+    # For example:
+    #
+    #   assign_nested_attributes_for_collection_association(:people, {
+    #     '1' => { id: '1', name: 'Peter' },
+    #     '2' => { name: 'John' },
+    #     '3' => { id: '2', _destroy: true }
+    #   })
+    #
+    # Will update the name of the Person with ID 1, build a new associated
+    # person with the name 'John', and mark the associated Person with ID 2
+    # for destruction.
+    #
+    # Also accepts an Array of attribute hashes:
+    #
+    #   assign_nested_attributes_for_collection_association(:people, [
+    #     { id: '1', name: 'Peter' },
+    #     { name: 'John' },
+    #     { id: '2', _destroy: true }
+    #   ])
+    def assign_nested_attributes_for_collection_association: (untyped association_name, untyped attributes_collection) -> untyped
+
+    # Takes in a limit and checks if the attributes_collection has too many
+    # records. It accepts limit in the form of symbol, proc, or
+    # number-like object (anything that can be compared with an integer).
+    #
+    # Raises TooManyRecords error if the attributes_collection is
+    # larger than the limit.
+    def check_record_limit!: (untyped limit, untyped attributes_collection) -> untyped
+
+    # Updates a record with the +attributes+ or marks it for destruction if
+    # +allow_destroy+ is +true+ and has_destroy_flag? returns +true+.
+    def assign_to_or_mark_for_destruction: (untyped record, untyped attributes, untyped allow_destroy) -> untyped
+
+    # Determines if a hash contains a truthy _destroy key.
+    def has_destroy_flag?: (untyped hash) -> untyped
+
+    # Determines if a new record should be rejected by checking
+    # has_destroy_flag? or if a <tt>:reject_if</tt> proc exists for this
+    # association and evaluates to +true+.
+    def reject_new_record?: (untyped association_name, untyped attributes) -> untyped
+
+    # Determines if a record with the particular +attributes+ should be
+    # rejected by calling the reject_if Symbol or Proc (if defined).
+    # The reject_if option is defined by +accepts_nested_attributes_for+.
+    #
+    # Returns false if there is a +destroy_flag+ on the attributes.
+    def call_reject_if: (untyped association_name, untyped attributes) -> (::FalseClass | untyped)
+
+    # Only take into account the destroy flag if <tt>:allow_destroy</tt> is true
+    def will_be_destroyed?: (untyped association_name, untyped attributes) -> untyped
+
+    def allow_destroy?: (untyped association_name) -> untyped
+
+    def raise_nested_attributes_record_not_found!: (untyped association_name, untyped record_id) -> untyped
+  end
+end
+
+module ActiveRecord
+  # = Active Record No Touching
+  module NoTouching
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      # Lets you selectively disable calls to +touch+ for the
+      # duration of a block.
+      #
+      # ==== Examples
+      #   ActiveRecord::Base.no_touching do
+      #     Project.first.touch  # does nothing
+      #     Message.first.touch  # does nothing
+      #   end
+      #
+      #   Project.no_touching do
+      #     Project.first.touch  # does nothing
+      #     Message.first.touch  # works, but does not touch the associated project
+      #   end
+      #
+      def no_touching: () { () -> untyped } -> untyped
+    end
+
+    def self.apply_to: (untyped klass) { () -> untyped } -> untyped
+
+    def self.applied_to?: (untyped klass) -> untyped
+
+    def self.klasses: () -> untyped
+
+    # Returns +true+ if the class has +no_touching+ set, +false+ otherwise.
+    #
+    #   Project.no_touching do
+    #     Project.first.no_touching? # true
+    #     Message.first.no_touching? # false
+    #   end
+    #
+    def no_touching?: () -> untyped
+
+    def touch_later: () -> untyped
+
+    def touch: () -> untyped
+  end
+end
+
+module ActiveRecord
+  module NullRelation
+    # :nodoc:
+    def pluck: (*untyped column_names) -> ::Array[untyped]
+
+    def delete_all: () -> 0
+
+    def update_all: (untyped _updates) -> 0
+
+    def delete: (untyped _id_or_array) -> 0
+
+    def empty?: () -> ::TrueClass
+
+    def none?: () -> ::TrueClass
+
+    def any?: () -> ::FalseClass
+
+    def one?: () -> ::FalseClass
+
+    def many?: () -> ::FalseClass
+
+    def to_sql: () -> ::String
+
+    def calculate: (untyped operation, untyped _column_name) -> untyped
+
+    def exists?: (?::Symbol _conditions) -> ::FalseClass
+
+    def or: (untyped other) -> untyped
+
+    def exec_queries: () -> untyped
+  end
+end
+
+module ActiveRecord
+  # = Active Record \Persistence
+  module Persistence
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      # Creates an object (or multiple objects) and saves it to the database, if validations pass.
+      # The resulting object is returned whether the object was saved successfully to the database or not.
+      #
+      # The +attributes+ parameter can be either a Hash or an Array of Hashes. These Hashes describe the
+      # attributes on the objects that are to be created.
+      #
+      # ==== Examples
+      #   # Create a single new object
+      #   User.create(first_name: 'Jamie')
+      #
+      #   # Create an Array of new objects
+      #   User.create([{ first_name: 'Jamie' }, { first_name: 'Jeremy' }])
+      #
+      #   # Create a single object and pass it into a block to set other attributes.
+      #   User.create(first_name: 'Jamie') do |u|
+      #     u.is_admin = false
+      #   end
+      #
+      #   # Creating an Array of new objects using a block, where the block is executed for each object:
+      #   User.create([{ first_name: 'Jamie' }, { first_name: 'Jeremy' }]) do |u|
+      #     u.is_admin = false
+      #   end
+      def create: (?untyped? attributes) { () -> untyped } -> untyped
+
+      # Creates an object (or multiple objects) and saves it to the database,
+      # if validations pass. Raises a RecordInvalid error if validations fail,
+      # unlike Base#create.
+      #
+      # The +attributes+ parameter can be either a Hash or an Array of Hashes.
+      # These describe which attributes to be created on the object, or
+      # multiple objects when given an Array of Hashes.
+      def create!: (?untyped? attributes) { () -> untyped } -> untyped
+
+      # Inserts a single record into the database in a single SQL INSERT
+      # statement. It does not instantiate any models nor does it trigger
+      # Active Record callbacks or validations. Though passed values
+      # go through Active Record's type casting and serialization.
+      #
+      # See <tt>ActiveRecord::Persistence#insert_all</tt> for documentation.
+      def insert: (untyped attributes, ?unique_by: untyped? unique_by, ?returning: untyped? returning) -> untyped
+
+      # Inserts multiple records into the database in a single SQL INSERT
+      # statement. It does not instantiate any models nor does it trigger
+      # Active Record callbacks or validations. Though passed values
+      # go through Active Record's type casting and serialization.
+      #
+      # The +attributes+ parameter is an Array of Hashes. Every Hash determines
+      # the attributes for a single row and must have the same keys.
+      #
+      # Rows are considered to be unique by every unique index on the table. Any
+      # duplicate rows are skipped.
+      # Override with <tt>:unique_by</tt> (see below).
+      #
+      # Returns an <tt>ActiveRecord::Result</tt> with its contents based on
+      # <tt>:returning</tt> (see below).
+      #
+      # ==== Options
+      #
+      # [:returning]
+      #   (PostgreSQL only) An array of attributes to return for all successfully
+      #   inserted records, which by default is the primary key.
+      #   Pass <tt>returning: %w[ id name ]</tt> for both id and name
+      #   or <tt>returning: false</tt> to omit the underlying <tt>RETURNING</tt> SQL
+      #   clause entirely.
+      #
+      # [:unique_by]
+      #   (PostgreSQL and SQLite only) By default rows are considered to be unique
+      #   by every unique index on the table. Any duplicate rows are skipped.
+      #
+      #   To skip rows according to just one unique index pass <tt>:unique_by</tt>.
+      #
+      #   Consider a Book model where no duplicate ISBNs make sense, but if any
+      #   row has an existing id, or is not unique by another unique index,
+      #   <tt>ActiveRecord::RecordNotUnique</tt> is raised.
+      #
+      #   Unique indexes can be identified by columns or name:
+      #
+      #     unique_by: :isbn
+      #     unique_by: %i[ author_id name ]
+      #     unique_by: :index_books_on_isbn
+      #
+      # Because it relies on the index information from the database
+      # <tt>:unique_by</tt> is recommended to be paired with
+      # Active Record's schema_cache.
+      #
+      # ==== Example
+      #
+      #   # Insert records and skip inserting any duplicates.
+      #   # Here "Eloquent Ruby" is skipped because its id is not unique.
+      #
+      #   Book.insert_all([
+      #     { id: 1, title: "Rework", author: "David" },
+      #     { id: 1, title: "Eloquent Ruby", author: "Russ" }
+      #   ])
+      def insert_all: (untyped attributes, ?unique_by: untyped? unique_by, ?returning: untyped? returning) -> untyped
+
+      # Inserts a single record into the database in a single SQL INSERT
+      # statement. It does not instantiate any models nor does it trigger
+      # Active Record callbacks or validations. Though passed values
+      # go through Active Record's type casting and serialization.
+      #
+      # See <tt>ActiveRecord::Persistence#insert_all!</tt> for more.
+      def insert!: (untyped attributes, ?returning: untyped? returning) -> untyped
+
+      # Inserts multiple records into the database in a single SQL INSERT
+      # statement. It does not instantiate any models nor does it trigger
+      # Active Record callbacks or validations. Though passed values
+      # go through Active Record's type casting and serialization.
+      #
+      # The +attributes+ parameter is an Array of Hashes. Every Hash determines
+      # the attributes for a single row and must have the same keys.
+      #
+      # Raises <tt>ActiveRecord::RecordNotUnique</tt> if any rows violate a
+      # unique index on the table. In that case, no rows are inserted.
+      #
+      # To skip duplicate rows, see <tt>ActiveRecord::Persistence#insert_all</tt>.
+      # To replace them, see <tt>ActiveRecord::Persistence#upsert_all</tt>.
+      #
+      # Returns an <tt>ActiveRecord::Result</tt> with its contents based on
+      # <tt>:returning</tt> (see below).
+      #
+      # ==== Options
+      #
+      # [:returning]
+      #   (PostgreSQL only) An array of attributes to return for all successfully
+      #   inserted records, which by default is the primary key.
+      #   Pass <tt>returning: %w[ id name ]</tt> for both id and name
+      #   or <tt>returning: false</tt> to omit the underlying <tt>RETURNING</tt> SQL
+      #   clause entirely.
+      #
+      # ==== Examples
+      #
+      #   # Insert multiple records
+      #   Book.insert_all!([
+      #     { title: "Rework", author: "David" },
+      #     { title: "Eloquent Ruby", author: "Russ" }
+      #   ])
+      #
+      #   # Raises ActiveRecord::RecordNotUnique because "Eloquent Ruby"
+      #   # does not have a unique id.
+      #   Book.insert_all!([
+      #     { id: 1, title: "Rework", author: "David" },
+      #     { id: 1, title: "Eloquent Ruby", author: "Russ" }
+      #   ])
+      def insert_all!: (untyped attributes, ?returning: untyped? returning) -> untyped
+
+      # Updates or inserts (upserts) a single record into the database in a
+      # single SQL INSERT statement. It does not instantiate any models nor does
+      # it trigger Active Record callbacks or validations. Though passed values
+      # go through Active Record's type casting and serialization.
+      #
+      # See <tt>ActiveRecord::Persistence#upsert_all</tt> for documentation.
+      def upsert: (untyped attributes, ?unique_by: untyped? unique_by, ?returning: untyped? returning) -> untyped
+
+      # Updates or inserts (upserts) multiple records into the database in a
+      # single SQL INSERT statement. It does not instantiate any models nor does
+      # it trigger Active Record callbacks or validations. Though passed values
+      # go through Active Record's type casting and serialization.
+      #
+      # The +attributes+ parameter is an Array of Hashes. Every Hash determines
+      # the attributes for a single row and must have the same keys.
+      #
+      # Returns an <tt>ActiveRecord::Result</tt> with its contents based on
+      # <tt>:returning</tt> (see below).
+      #
+      # ==== Options
+      #
+      # [:returning]
+      #   (PostgreSQL only) An array of attributes to return for all successfully
+      #   inserted records, which by default is the primary key.
+      #   Pass <tt>returning: %w[ id name ]</tt> for both id and name
+      #   or <tt>returning: false</tt> to omit the underlying <tt>RETURNING</tt> SQL
+      #   clause entirely.
+      #
+      # [:unique_by]
+      #   (PostgreSQL and SQLite only) By default rows are considered to be unique
+      #   by every unique index on the table. Any duplicate rows are skipped.
+      #
+      #   To skip rows according to just one unique index pass <tt>:unique_by</tt>.
+      #
+      #   Consider a Book model where no duplicate ISBNs make sense, but if any
+      #   row has an existing id, or is not unique by another unique index,
+      #   <tt>ActiveRecord::RecordNotUnique</tt> is raised.
+      #
+      #   Unique indexes can be identified by columns or name:
+      #
+      #     unique_by: :isbn
+      #     unique_by: %i[ author_id name ]
+      #     unique_by: :index_books_on_isbn
+      #
+      # Because it relies on the index information from the database
+      # <tt>:unique_by</tt> is recommended to be paired with
+      # Active Record's schema_cache.
+      #
+      # ==== Examples
+      #
+      #   # Inserts multiple records, performing an upsert when records have duplicate ISBNs.
+      #   # Here "Eloquent Ruby" overwrites "Rework" because its ISBN is duplicate.
+      #
+      #   Book.upsert_all([
+      #     { title: "Rework", author: "David", isbn: "1" },
+      #     { title: "Eloquent Ruby", author: "Russ", isbn: "1" }
+      #   ], unique_by: :isbn)
+      #
+      #   Book.find_by(isbn: "1").title # => "Eloquent Ruby"
+      def upsert_all: (untyped attributes, ?unique_by: untyped? unique_by, ?returning: untyped? returning) -> untyped
+
+      # Given an attributes hash, +instantiate+ returns a new instance of
+      # the appropriate class. Accepts only keys as strings.
+      #
+      # For example, +Post.all+ may return Comments, Messages, and Emails
+      # by storing the record's subclass in a +type+ attribute. By calling
+      # +instantiate+ instead of +new+, finder methods ensure they get new
+      # instances of the appropriate class for each record.
+      #
+      # See <tt>ActiveRecord::Inheritance#discriminate_class_for_record</tt> to see
+      # how this "single-table" inheritance mapping is implemented.
+      def instantiate: (untyped attributes, ?::Hash[untyped, untyped] column_types) { () -> untyped } -> untyped
+
+      # Updates an object (or multiple objects) and saves it to the database, if validations pass.
+      # The resulting object is returned whether the object was saved successfully to the database or not.
+      #
+      # ==== Parameters
+      #
+      # * +id+ - This should be the id or an array of ids to be updated.
+      # * +attributes+ - This should be a hash of attributes or an array of hashes.
+      #
+      # ==== Examples
+      #
+      #   # Updates one record
+      #   Person.update(15, user_name: "Samuel", group: "expert")
+      #
+      #   # Updates multiple records
+      #   people = { 1 => { "first_name" => "David" }, 2 => { "first_name" => "Jeremy" } }
+      #   Person.update(people.keys, people.values)
+      #
+      #   # Updates multiple records from the result of a relation
+      #   people = Person.where(group: "expert")
+      #   people.update(group: "masters")
+      #
+      # Note: Updating a large number of records will run an UPDATE
+      # query for each record, which may cause a performance issue.
+      # When running callbacks is not needed for each record update,
+      # it is preferred to use {update_all}[rdoc-ref:Relation#update_all]
+      # for updating all records in a single query.
+      def update: (?::Symbol id, untyped attributes) -> untyped
+
+      # Destroy an object (or multiple objects) that has the given id. The object is instantiated first,
+      # therefore all callbacks and filters are fired off before the object is deleted. This method is
+      # less efficient than #delete but allows cleanup methods and other actions to be run.
+      #
+      # This essentially finds the object (or multiple objects) with the given id, creates a new object
+      # from the attributes, and then calls destroy on it.
+      #
+      # ==== Parameters
+      #
+      # * +id+ - This should be the id or an array of ids to be destroyed.
+      #
+      # ==== Examples
+      #
+      #   # Destroy a single object
+      #   Todo.destroy(1)
+      #
+      #   # Destroy multiple objects
+      #   todos = [1,2,3]
+      #   Todo.destroy(todos)
+      def destroy: (untyped id) -> untyped
+
+      # Deletes the row with a primary key matching the +id+ argument, using an
+      # SQL +DELETE+ statement, and returns the number of rows deleted. Active
+      # Record objects are not instantiated, so the object's callbacks are not
+      # executed, including any <tt>:dependent</tt> association options.
+      #
+      # You can delete multiple rows at once by passing an Array of <tt>id</tt>s.
+      #
+      # Note: Although it is often much faster than the alternative, #destroy,
+      # skipping callbacks might bypass business logic in your application
+      # that ensures referential integrity or performs other essential jobs.
+      #
+      # ==== Examples
+      #
+      #   # Delete a single row
+      #   Todo.delete(1)
+      #
+      #   # Delete multiple rows
+      #   Todo.delete([2,3,4])
+      def delete: (untyped id_or_array) -> untyped
+
+      def _insert_record: (untyped values) -> untyped
+
+      def _update_record: (untyped values, untyped constraints) -> untyped
+
+      def _delete_record: (untyped constraints) -> untyped
+
+      # Given a class, an attributes hash, +instantiate_instance_of+ returns a
+      # new instance of the class. Accepts only keys as strings.
+      def instantiate_instance_of: (untyped klass, untyped attributes, ?::Hash[untyped, untyped] column_types) { () -> untyped } -> untyped
+
+      # Called by +instantiate+ to decide which class to use for a new
+      # record instance.
+      #
+      # See +ActiveRecord::Inheritance#discriminate_class_for_record+ for
+      # the single-table inheritance discriminator.
+      def discriminate_class_for_record: (untyped record) -> untyped
+
+      def _substitute_values: (untyped values) -> untyped
+    end
+
+    # Returns true if this object hasn't been saved yet -- that is, a record
+    # for the object doesn't exist in the database yet; otherwise, returns false.
+    def new_record?: () -> untyped
+
+    # Returns true if this object has been destroyed, otherwise returns false.
+    def destroyed?: () -> untyped
+
+    # Returns true if the record is persisted, i.e. it's not a new record and it was
+    # not destroyed, otherwise returns false.
+    def persisted?: () -> untyped
+
+    #
+    # :call-seq:
+    #   save(*args)
+    #
+    # Saves the model.
+    #
+    # If the model is new, a record gets created in the database, otherwise
+    # the existing record gets updated.
+    #
+    # By default, save always runs validations. If any of them fail the action
+    # is cancelled and #save returns +false+, and the record won't be saved. However, if you supply
+    # <tt>validate: false</tt>, validations are bypassed altogether. See
+    # ActiveRecord::Validations for more information.
+    #
+    # By default, #save also sets the +updated_at+/+updated_on+ attributes to
+    # the current time. However, if you supply <tt>touch: false</tt>, these
+    # timestamps will not be updated.
+    #
+    # There's a series of callbacks associated with #save. If any of the
+    # <tt>before_*</tt> callbacks throws +:abort+ the action is cancelled and
+    # #save returns +false+. See ActiveRecord::Callbacks for further
+    # details.
+    #
+    # Attributes marked as readonly are silently ignored if the record is
+    # being updated.
+    def save: (*untyped args, **untyped options) { () -> untyped } -> untyped
+
+    #
+    # :call-seq:
+    #   save!(*args)
+    #
+    # Saves the model.
+    #
+    # If the model is new, a record gets created in the database, otherwise
+    # the existing record gets updated.
+    #
+    # By default, #save! always runs validations. If any of them fail
+    # ActiveRecord::RecordInvalid gets raised, and the record won't be saved. However, if you supply
+    # <tt>validate: false</tt>, validations are bypassed altogether. See
+    # ActiveRecord::Validations for more information.
+    #
+    # By default, #save! also sets the +updated_at+/+updated_on+ attributes to
+    # the current time. However, if you supply <tt>touch: false</tt>, these
+    # timestamps will not be updated.
+    #
+    # There's a series of callbacks associated with #save!. If any of
+    # the <tt>before_*</tt> callbacks throws +:abort+ the action is cancelled
+    # and #save! raises ActiveRecord::RecordNotSaved. See
+    # ActiveRecord::Callbacks for further details.
+    #
+    # Attributes marked as readonly are silently ignored if the record is
+    # being updated.
+    #
+    # Unless an error is raised, returns true.
+    def save!: (*untyped args, **untyped options) { () -> untyped } -> untyped
+
+    # Deletes the record in the database and freezes this instance to
+    # reflect that no changes should be made (since they can't be
+    # persisted). Returns the frozen instance.
+    #
+    # The row is simply removed with an SQL +DELETE+ statement on the
+    # record's primary key, and no callbacks are executed.
+    #
+    # Note that this will also delete records marked as {#readonly?}[rdoc-ref:Core#readonly?].
+    #
+    # To enforce the object's +before_destroy+ and +after_destroy+
+    # callbacks or any <tt>:dependent</tt> association
+    # options, use <tt>#destroy</tt>.
+    def delete: () -> untyped
+
+    # Deletes the record in the database and freezes this instance to reflect
+    # that no changes should be made (since they can't be persisted).
+    #
+    # There's a series of callbacks associated with #destroy. If the
+    # <tt>before_destroy</tt> callback throws +:abort+ the action is cancelled
+    # and #destroy returns +false+.
+    # See ActiveRecord::Callbacks for further details.
+    def destroy: () -> untyped
+
+    # Deletes the record in the database and freezes this instance to reflect
+    # that no changes should be made (since they can't be persisted).
+    #
+    # There's a series of callbacks associated with #destroy!. If the
+    # <tt>before_destroy</tt> callback throws +:abort+ the action is cancelled
+    # and #destroy! raises ActiveRecord::RecordNotDestroyed.
+    # See ActiveRecord::Callbacks for further details.
+    def destroy!: () -> untyped
+
+    # Returns an instance of the specified +klass+ with the attributes of the
+    # current record. This is mostly useful in relation to single-table
+    # inheritance structures where you want a subclass to appear as the
+    # superclass. This can be used along with record identification in
+    # Action Pack to allow, say, <tt>Client < Company</tt> to do something
+    # like render <tt>partial: @client.becomes(Company)</tt> to render that
+    # instance using the companies/company partial instead of clients/client.
+    #
+    # Note: The new instance will share a link to the same attributes as the original class.
+    # Therefore the sti column value will still be the same.
+    # Any change to the attributes on either instance will affect both instances.
+    # If you want to change the sti column as well, use #becomes! instead.
+    def becomes: (untyped klass) -> untyped
+
+    # Wrapper around #becomes that also changes the instance's sti column value.
+    # This is especially useful if you want to persist the changed class in your
+    # database.
+    #
+    # Note: The old instance's sti column value will be changed too, as both objects
+    # share the same set of attributes.
+    def becomes!: (untyped klass) -> untyped
+
+    # Updates a single attribute and saves the record.
+    # This is especially useful for boolean flags on existing records. Also note that
+    #
+    # * Validation is skipped.
+    # * \Callbacks are invoked.
+    # * updated_at/updated_on column is updated if that column is available.
+    # * Updates all the attributes that are dirty in this object.
+    #
+    # This method raises an ActiveRecord::ActiveRecordError  if the
+    # attribute is marked as readonly.
+    #
+    # Also see #update_column.
+    def update_attribute: (untyped name, untyped value) -> untyped
+
+    # Updates the attributes of the model from the passed-in hash and saves the
+    # record, all wrapped in a transaction. If the object is invalid, the saving
+    # will fail and false will be returned.
+    def update: (untyped attributes) -> untyped
+
+    alias update_attributes update
+
+    # Updates its receiver just like #update but calls #save! instead
+    # of +save+, so an exception is raised if the record is invalid and saving will fail.
+    def update!: (untyped attributes) -> untyped
+
+    alias update_attributes! update!
+
+    # Equivalent to <code>update_columns(name => value)</code>.
+    def update_column: (untyped name, untyped value) -> untyped
+
+    # Updates the attributes directly in the database issuing an UPDATE SQL
+    # statement and sets them in the receiver:
+    #
+    #   user.update_columns(last_request_at: Time.current)
+    #
+    # This is the fastest way to update attributes because it goes straight to
+    # the database, but take into account that in consequence the regular update
+    # procedures are totally bypassed. In particular:
+    #
+    # * \Validations are skipped.
+    # * \Callbacks are skipped.
+    # * +updated_at+/+updated_on+ are not updated.
+    # * However, attributes are serialized with the same rules as ActiveRecord::Relation#update_all
+    #
+    # This method raises an ActiveRecord::ActiveRecordError when called on new
+    # objects, or when at least one of the attributes is marked as readonly.
+    def update_columns: (untyped attributes) -> untyped
+
+    # Initializes +attribute+ to zero if +nil+ and adds the value passed as +by+ (default is 1).
+    # The increment is performed directly on the underlying attribute, no setter is invoked.
+    # Only makes sense for number-based attributes. Returns +self+.
+    def increment: (untyped attribute, ?::Integer by) -> untyped
+
+    # Wrapper around #increment that writes the update to the database.
+    # Only +attribute+ is updated; the record itself is not saved.
+    # This means that any other modified attributes will still be dirty.
+    # Validations and callbacks are skipped. Supports the +touch+ option from
+    # +update_counters+, see that for more.
+    # Returns +self+.
+    def increment!: (untyped attribute, ?::Integer by, ?touch: untyped? touch) -> untyped
+
+    # Initializes +attribute+ to zero if +nil+ and subtracts the value passed as +by+ (default is 1).
+    # The decrement is performed directly on the underlying attribute, no setter is invoked.
+    # Only makes sense for number-based attributes. Returns +self+.
+    def decrement: (untyped attribute, ?::Integer by) -> untyped
+
+    # Wrapper around #decrement that writes the update to the database.
+    # Only +attribute+ is updated; the record itself is not saved.
+    # This means that any other modified attributes will still be dirty.
+    # Validations and callbacks are skipped. Supports the +touch+ option from
+    # +update_counters+, see that for more.
+    # Returns +self+.
+    def decrement!: (untyped attribute, ?::Integer by, ?touch: untyped? touch) -> untyped
+
+    # Assigns to +attribute+ the boolean opposite of <tt>attribute?</tt>. So
+    # if the predicate returns +true+ the attribute will become +false+. This
+    # method toggles directly the underlying value without calling any setter.
+    # Returns +self+.
+    #
+    # Example:
+    #
+    #   user = User.first
+    #   user.banned? # => false
+    #   user.toggle(:banned)
+    #   user.banned? # => true
+    #
+    def toggle: (untyped attribute) -> untyped
+
+    # Wrapper around #toggle that saves the record. This method differs from
+    # its non-bang version in the sense that it passes through the attribute setter.
+    # Saving is not subjected to validation checks. Returns +true+ if the
+    # record could be saved.
+    def toggle!: (untyped attribute) -> untyped
+
+    # Reloads the record from the database.
+    #
+    # This method finds the record by its primary key (which could be assigned
+    # manually) and modifies the receiver in-place:
+    #
+    #   account = Account.new
+    #   # => #<Account id: nil, email: nil>
+    #   account.id = 1
+    #   account.reload
+    #   # Account Load (1.2ms)  SELECT "accounts".* FROM "accounts" WHERE "accounts"."id" = $1 LIMIT 1  [["id", 1]]
+    #   # => #<Account id: 1, email: 'account@example.com'>
+    #
+    # Attributes are reloaded from the database, and caches busted, in
+    # particular the associations cache and the QueryCache.
+    #
+    # If the record no longer exists in the database ActiveRecord::RecordNotFound
+    # is raised. Otherwise, in addition to the in-place modification the method
+    # returns +self+ for convenience.
+    #
+    # The optional <tt>:lock</tt> flag option allows you to lock the reloaded record:
+    #
+    #   reload(lock: true) # reload with pessimistic locking
+    #
+    # Reloading is commonly used in test suites to test something is actually
+    # written to the database, or when some action modifies the corresponding
+    # row in the database but not the object in memory:
+    #
+    #   assert account.deposit!(25)
+    #   assert_equal 25, account.credit        # check it is updated in memory
+    #   assert_equal 25, account.reload.credit # check it is also persisted
+    #
+    # Another common use case is optimistic locking handling:
+    #
+    #   def with_optimistic_retry
+    #     begin
+    #       yield
+    #     rescue ActiveRecord::StaleObjectError
+    #       begin
+    #         # Reload lock_version in particular.
+    #         reload
+    #       rescue ActiveRecord::RecordNotFound
+    #         # If the record is gone there is nothing to do.
+    #       else
+    #         retry
+    #       end
+    #     end
+    #   end
+    #
+    def reload: (?untyped? options) -> untyped
+
+    # Saves the record with the updated_at/on attributes set to the current time
+    # or the time specified.
+    # Please note that no validation is performed and only the +after_touch+,
+    # +after_commit+ and +after_rollback+ callbacks are executed.
+    #
+    # This method can be passed attribute names and an optional time argument.
+    # If attribute names are passed, they are updated along with updated_at/on
+    # attributes. If no time argument is passed, the current time is used as default.
+    #
+    #   product.touch                         # updates updated_at/on with current time
+    #   product.touch(time: Time.new(2015, 2, 16, 0, 0, 0)) # updates updated_at/on with specified time
+    #   product.touch(:designed_at)           # updates the designed_at attribute and updated_at/on
+    #   product.touch(:started_at, :ended_at) # updates started_at, ended_at and updated_at/on attributes
+    #
+    # If used along with {belongs_to}[rdoc-ref:Associations::ClassMethods#belongs_to]
+    # then +touch+ will invoke +touch+ method on associated object.
+    #
+    #   class Brake < ActiveRecord::Base
+    #     belongs_to :car, touch: true
+    #   end
+    #
+    #   class Car < ActiveRecord::Base
+    #     belongs_to :corporation, touch: true
+    #   end
+    #
+    #   # triggers @brake.car.touch and @brake.car.corporation.touch
+    #   @brake.touch
+    #
+    # Note that +touch+ must be used on a persisted object, or else an
+    # ActiveRecordError will be thrown. For example:
+    #
+    #   ball = Ball.new
+    #   ball.touch(:updated_at)   # => raises ActiveRecordError
+    #
+    def touch: (*untyped names, ?time: untyped? time) -> untyped
+
+    # A hook to be overridden by association modules.
+    def destroy_associations: () -> nil
+
+    def destroy_row: () -> untyped
+
+    def _delete_row: () -> untyped
+
+    def _touch_row: (untyped attribute_names, untyped time) -> untyped
+
+    def _update_row: (untyped attribute_names, ?::String attempted_action) -> untyped
+
+    def create_or_update: () { () -> untyped } -> (::FalseClass | untyped)
+
+    # Updates the associated record with values matching those of the instance attributes.
+    # Returns the number of affected rows.
+    def _update_record: (?untyped attribute_names) { (untyped) -> untyped } -> untyped
+
+    # Creates a record with values matching those of the instance attributes
+    # and returns its id.
+    def _create_record: (?untyped attribute_names) { (untyped) -> untyped } -> untyped
+
+    def verify_readonly_attribute: (untyped name) -> untyped
+
+    def _raise_record_not_destroyed: () -> untyped
+
+    # The name of the method used to touch a +belongs_to+ association when the
+    # +:touch+ option is used.
+    def belongs_to_touch_method: () -> :touch
+
+    def _raise_readonly_record_error: () -> untyped
+  end
+end
+
+module ActiveRecord
+  # = Active Record Query Cache
+  class QueryCache
+    module ClassMethods
+      # Enable the query cache within the block if Active Record is configured.
+      # If it's not, it will execute the given block.
+      def cache: () { () -> untyped } -> untyped
+
+      # Disable the query cache within the block if Active Record is configured.
+      # If it's not, it will execute the given block.
+      def uncached: () { () -> untyped } -> untyped
+    end
+
+    def self.run: () -> untyped
+
+    def self.complete: (untyped pools) -> untyped
+
+    def self.install_executor_hooks: (?untyped executor) -> untyped
+  end
+end
+
+module ActiveRecord
+  module Querying
+    QUERYING_METHODS: untyped
+
+    # Executes a custom SQL query against your database and returns all the results. The results will
+    # be returned as an array, with the requested columns encapsulated as attributes of the model you call
+    # this method from. For example, if you call <tt>Product.find_by_sql</tt>, then the results will be returned in
+    # a +Product+ object with the attributes you specified in the SQL query.
+    #
+    # If you call a complicated SQL query which spans multiple tables, the columns specified by the
+    # SELECT will be attributes of the model, whether or not they are columns of the corresponding
+    # table.
+    #
+    # The +sql+ parameter is a full SQL query as a string. It will be called as is; there will be
+    # no database agnostic conversions performed. This should be a last resort because using
+    # database-specific terms will lock you into using that particular database engine, or require you to
+    # change your call if you switch engines.
+    #
+    #   # A simple SQL query spanning multiple tables
+    #   Post.find_by_sql "SELECT p.title, c.author FROM posts p, comments c WHERE p.id = c.post_id"
+    #   # => [#<Post:0x36bff9c @attributes={"title"=>"Ruby Meetup", "author"=>"Quentin"}>, ...]
+    #
+    # You can use the same string replacement techniques as you can with <tt>ActiveRecord::QueryMethods#where</tt>:
+    #
+    #   Post.find_by_sql ["SELECT title FROM posts WHERE author = ? AND created > ?", author_id, start_date]
+    #   Post.find_by_sql ["SELECT body FROM comments WHERE author = :user_id OR approved_by = :user_id", { :user_id => user_id }]
+    def find_by_sql: (untyped sql, ?untyped binds, ?preparable: untyped? preparable) { () -> untyped } -> untyped
+
+    # Returns the result of an SQL statement that should only include a COUNT(*) in the SELECT part.
+    # The use of this method should be restricted to complicated SQL queries that can't be executed
+    # using the ActiveRecord::Calculations class methods. Look into those before using this method,
+    # as it could lock you into a specific database engine or require a code change to switch
+    # database engines.
+    #
+    #   Product.count_by_sql "SELECT COUNT(*) FROM sales s, customers c WHERE s.customer_id = c.id"
+    #   # => 12
+    #
+    # ==== Parameters
+    #
+    # * +sql+ - An SQL statement which should return a count query from the database, see the example above.
+    def count_by_sql: (untyped sql) -> untyped
+  end
+end
+
+module ActiveRecord
+  class Railtie < Rails::Railtie
+    include ActiveRecord::Railties::ControllerRuntime
+  end
+end
+
+module ActiveRecord
+  module Railties
+    module CollectionCacheAssociationLoading
+      # :nodoc:
+      # nodoc:
+      def setup: (untyped context, untyped options, untyped as, untyped block) -> untyped
+
+      def relation_from_options: (?collection: untyped? collection, ?partial: untyped? partial, ?cached: untyped? cached, **untyped _) -> (nil | untyped)
+
+      def collection_without_template: () -> untyped
+
+      def collection_with_template: () -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module Railties
+    module ControllerRuntime
+      # :nodoc:
+      # nodoc:
+      extend ActiveSupport::Concern
+
+      module ClassMethods
+        # :nodoc:
+        def log_process_action: (untyped payload) -> untyped
+      end
+
+      def process_action: (untyped action, *untyped args) -> untyped
+
+      def cleanup_view_runtime: () -> untyped
+
+      def append_info_to_payload: (untyped payload) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module ReadonlyAttributes
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      # Attributes listed as readonly will be used to create a new record but update operations will
+      # ignore these fields.
+      def attr_readonly: (*untyped attributes) -> untyped
+
+      # Returns an array of all the attributes that have been specified as readonly.
+      def readonly_attributes: () -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module Reflection
+    # = Active Record Reflection
+    # :nodoc:
+    extend ActiveSupport::Concern
+
+    def self.create: (untyped macro, untyped name, untyped scope, untyped options, untyped ar) -> untyped
+
+    def self.add_reflection: (untyped ar, untyped name, untyped reflection) -> untyped
+
+    def self.add_aggregate_reflection: (untyped ar, untyped name, untyped reflection) -> untyped
+
+    def self.reflection_class_for: (untyped macro) -> untyped
+
+    # \Reflection enables the ability to examine the associations and aggregations of
+    # Active Record classes and objects. This information, for example,
+    # can be used in a form builder that takes an Active Record object
+    # and creates input fields for all of the attributes depending on their type
+    # and displays the associations to other objects.
+    #
+    # MacroReflection class has info for AggregateReflection and AssociationReflection
+    # classes.
+    module ClassMethods
+      # Returns an array of AggregateReflection objects for all the aggregations in the class.
+      def reflect_on_all_aggregations: () -> untyped
+
+      # Returns the AggregateReflection object for the named +aggregation+ (use the symbol).
+      #
+      #   Account.reflect_on_aggregation(:balance) # => the balance AggregateReflection
+      #
+      def reflect_on_aggregation: (untyped aggregation) -> untyped
+
+      # Returns a Hash of name of the reflection as the key and an AssociationReflection as the value.
+      #
+      #   Account.reflections # => {"balance" => AggregateReflection}
+      #
+      def reflections: () -> untyped
+
+      # Returns an array of AssociationReflection objects for all the
+      # associations in the class. If you only want to reflect on a certain
+      # association type, pass in the symbol (<tt>:has_many</tt>, <tt>:has_one</tt>,
+      # <tt>:belongs_to</tt>) as the first parameter.
+      #
+      # Example:
+      #
+      #   Account.reflect_on_all_associations             # returns an array of all associations
+      #   Account.reflect_on_all_associations(:has_many)  # returns an array of all has_many associations
+      #
+      def reflect_on_all_associations: (?untyped? macro) -> untyped
+
+      # Returns the AssociationReflection object for the +association+ (use the symbol).
+      #
+      #   Account.reflect_on_association(:owner)             # returns the owner AssociationReflection
+      #   Invoice.reflect_on_association(:line_items).macro  # returns :has_many
+      #
+      def reflect_on_association: (untyped association) -> untyped
+
+      def _reflect_on_association: (untyped association) -> untyped
+
+      # Returns an array of AssociationReflection objects for all associations which have <tt>:autosave</tt> enabled.
+      def reflect_on_all_autosave_associations: () -> untyped
+
+      def clear_reflections_cache: () -> untyped
+    end
+
+    class AbstractReflection
+      # Holds all the methods that are shared between MacroReflection and ThroughReflection.
+      #
+      #   AbstractReflection
+      #     MacroReflection
+      #       AggregateReflection
+      #       AssociationReflection
+      #         HasManyReflection
+      #         HasOneReflection
+      #         BelongsToReflection
+      #         HasAndBelongsToManyReflection
+      #     ThroughReflection
+      #     PolymorphicReflection
+      #     RuntimeReflection
+      # :nodoc:
+      def through_reflection?: () -> ::FalseClass
+
+      def table_name: () -> untyped
+
+      # Returns a new, unsaved instance of the associated class. +attributes+ will
+      # be passed to the class's constructor.
+      def build_association: (untyped attributes) { () -> untyped } -> untyped
+
+      # Returns the class name for the macro.
+      #
+      # <tt>composed_of :balance, class_name: 'Money'</tt> returns <tt>'Money'</tt>
+      # <tt>has_many :clients</tt> returns <tt>'Client'</tt>
+      def class_name: () -> untyped
+
+      class JoinKeys[T] < ::Struct[T]
+        attr_accessor key(): untyped
+
+        attr_accessor foreign_key(): untyped
+      end
+
+      def join_keys: () -> untyped
+
+      # Returns a list of scopes that should be applied for this Reflection
+      # object when querying the database.
+      def scopes: () -> untyped
+
+      def join_scope: (untyped table, untyped foreign_table, untyped foreign_klass) -> untyped
+
+      def join_scopes: (untyped table, untyped predicate_builder) -> untyped
+
+      def klass_join_scope: (untyped table, untyped predicate_builder) -> untyped
+
+      def constraints: () -> untyped
+
+      def counter_cache_column: () -> untyped
+
+      def inverse_of: () -> (nil | untyped)
+
+      def check_validity_of_inverse!: () -> untyped
+
+      # This shit is nasty. We need to avoid the following situation:
+      #
+      #   * An associated record is deleted via record.destroy
+      #   * Hence the callbacks run, and they find a belongs_to on the record with a
+      #     :counter_cache options which points back at our owner. So they update the
+      #     counter cache.
+      #   * In which case, we must make sure to *not* update the counter cache, or else
+      #     it will be decremented twice.
+      #
+      # Hence this method.
+      def inverse_which_updates_counter_cache: () -> untyped
+
+      alias inverse_updates_counter_cache? inverse_which_updates_counter_cache
+
+      def inverse_updates_counter_in_memory?: () -> untyped
+
+      # Returns whether a counter cache should be used for this association.
+      #
+      # The counter_cache option must be given on either the owner or inverse
+      # association, and the column must be present on the owner.
+      def has_cached_counter?: () -> untyped
+
+      def counter_must_be_updated_by_has_many?: () -> untyped
+
+      def alias_candidate: (untyped name) -> ::String
+
+      def chain: () -> untyped
+
+      def get_join_keys: (untyped association_klass) -> JoinKeys[untyped]
+
+      def build_scope: (untyped table, ?untyped predicate_builder) -> untyped
+
+      def join_primary_key: () -> untyped
+
+      def join_foreign_key: () -> untyped
+
+      def actual_source_reflection: () -> untyped
+
+      def predicate_builder: (untyped table) -> PredicateBuilder
+
+      def primary_key: (untyped klass) -> untyped
+    end
+
+    # Base class for AggregateReflection and AssociationReflection. Objects of
+    # AggregateReflection and AssociationReflection are returned by the Reflection::ClassMethods.
+    class MacroReflection < AbstractReflection
+      # Returns the name of the macro.
+      #
+      # <tt>composed_of :balance, class_name: 'Money'</tt> returns <tt>:balance</tt>
+      # <tt>has_many :clients</tt> returns <tt>:clients</tt>
+      attr_reader name: untyped
+
+      attr_reader scope: untyped
+
+      # Returns the hash of options used for the macro.
+      #
+      # <tt>composed_of :balance, class_name: 'Money'</tt> returns <tt>{ class_name: "Money" }</tt>
+      # <tt>has_many :clients</tt> returns <tt>{}</tt>
+      attr_reader options: untyped
+
+      attr_reader active_record: untyped
+
+      attr_reader plural_name: untyped
+
+      def initialize: (untyped name, untyped scope, untyped options, untyped active_record) -> untyped
+
+      def autosave=: (untyped autosave) -> untyped
+
+      # Returns the class for the macro.
+      #
+      # <tt>composed_of :balance, class_name: 'Money'</tt> returns the Money class
+      # <tt>has_many :clients</tt> returns the Client class
+      #
+      #   class Company < ActiveRecord::Base
+      #     has_many :clients
+      #   end
+      #
+      #   Company.reflect_on_association(:clients).klass
+      #   # => Client
+      #
+      # <b>Note:</b> Do not call +klass.new+ or +klass.create+ to instantiate
+      # a new association object. Use +build_association+ or +create_association+
+      # instead. This allows plugins to hook into association object creation.
+      def klass: () -> untyped
+
+      def compute_class: (untyped name) -> untyped
+
+      # Returns +true+ if +self+ and +other_aggregation+ have the same +name+ attribute, +active_record+ attribute,
+      # and +other_aggregation+ has an options hash assigned to it.
+      def ==: (untyped other_aggregation) -> untyped
+
+      def scope_for: (untyped relation, ?untyped? owner) -> untyped
+
+      def derive_class_name: () -> untyped
+    end
+
+    class AggregateReflection < MacroReflection
+      # Holds all the metadata about an aggregation as it was specified in the
+      # Active Record class.
+      # nodoc:
+      def mapping: () -> untyped
+    end
+
+    class AssociationReflection < MacroReflection
+      # Holds all the metadata about an association as it was specified in the
+      # Active Record class.
+      # nodoc:
+      def compute_class: (untyped name) -> untyped
+
+      attr_reader type: untyped
+
+      attr_reader foreign_type: untyped
+
+      attr_accessor parent_reflection: untyped
+
+      def initialize: (untyped name, untyped scope, untyped options, untyped active_record) -> untyped
+
+      def association_scope_cache: (untyped conn, untyped owner) { () -> untyped } -> untyped
+
+      def constructable?: () -> untyped
+
+      def join_table: () -> untyped
+
+      def foreign_key: () -> untyped
+
+      def association_foreign_key: () -> untyped
+
+      # klass option is necessary to support loading polymorphic associations
+      def association_primary_key: (?untyped? klass) -> untyped
+
+      def active_record_primary_key: () -> untyped
+
+      def check_validity!: () -> untyped
+
+      def check_preloadable!: () -> (nil | untyped)
+
+      alias check_eager_loadable! check_preloadable!
+
+      def join_id_for: (untyped owner) -> untyped
+
+      def through_reflection: () -> nil
+
+      def source_reflection: () -> untyped
+
+      # A chain of reflections from this one back to the owner. For more see the explanation in
+      # ThroughReflection.
+      def collect_join_chain: () -> ::Array[untyped]
+
+      def clear_association_scope_cache: () -> untyped
+
+      def nested?: () -> ::FalseClass
+
+      def has_scope?: () -> untyped
+
+      def has_inverse?: () -> untyped
+
+      def polymorphic_inverse_of: (untyped associated_class) -> untyped
+
+      # Returns the macro type.
+      #
+      # <tt>has_many :clients</tt> returns <tt>:has_many</tt>
+      def macro: () -> untyped
+
+      # Returns whether or not this association reflection is for a collection
+      # association. Returns +true+ if the +macro+ is either +has_many+ or
+      # +has_and_belongs_to_many+, +false+ otherwise.
+      def collection?: () -> ::FalseClass
+
+      # Returns whether or not the association should be validated as part of
+      # the parent's validation.
+      #
+      # Unless you explicitly disable validation with
+      # <tt>validate: false</tt>, validation will take place when:
+      #
+      # * you explicitly enable validation; <tt>validate: true</tt>
+      # * you use autosave; <tt>autosave: true</tt>
+      # * the association is a +has_many+ association
+      def validate?: () -> untyped
+
+      # Returns +true+ if +self+ is a +belongs_to+ reflection.
+      def belongs_to?: () -> ::FalseClass
+
+      # Returns +true+ if +self+ is a +has_one+ reflection.
+      def has_one?: () -> ::FalseClass
+
+      def association_class: () -> untyped
+
+      def polymorphic?: () -> untyped
+
+      VALID_AUTOMATIC_INVERSE_MACROS: ::Array[untyped]
+
+      INVALID_AUTOMATIC_INVERSE_OPTIONS: ::Array[untyped]
+
+      def add_as_source: (untyped seed) -> untyped
+
+      def add_as_polymorphic_through: (untyped reflection, untyped seed) -> untyped
+
+      def add_as_through: (untyped seed) -> untyped
+
+      def extensions: () -> untyped
+
+      def calculate_constructable: (untyped macro, untyped options) -> ::TrueClass
+
+      # Attempts to find the inverse association name automatically.
+      # If it cannot find a suitable inverse association name, it returns
+      # +nil+.
+      def inverse_name: () -> untyped
+
+      # returns either +nil+ or the inverse association name that it finds.
+      def automatic_inverse_of: () -> untyped
+
+      # Checks if the inverse reflection that is returned from the
+      # +automatic_inverse_of+ method is a valid reflection. We must
+      # make sure that the reflection's active_record name matches up
+      # with the current reflection's klass name.
+      def valid_inverse_reflection?: (untyped reflection) -> untyped
+
+      # Checks to see if the reflection doesn't have any options that prevent
+      # us from being able to guess the inverse automatically. First, the
+      # <tt>inverse_of</tt> option cannot be set to false. Second, we must
+      # have <tt>has_many</tt>, <tt>has_one</tt>, <tt>belongs_to</tt> associations.
+      # Third, we must not have options such as <tt>:foreign_key</tt>
+      # which prevent us from correctly guessing the inverse association.
+      #
+      # Anything with a scope can additionally ruin our attempt at finding an
+      # inverse, so we exclude reflections with scopes.
+      def can_find_inverse_of_automatically?: (untyped reflection) -> untyped
+
+      def derive_class_name: () -> untyped
+
+      def derive_foreign_key: () -> untyped
+
+      def derive_join_table: () -> untyped
+    end
+
+    class HasManyReflection < AssociationReflection
+      # :nodoc:
+      def macro: () -> :has_many
+
+      def collection?: () -> ::TrueClass
+
+      def association_class: () -> untyped
+
+      def association_primary_key: (?untyped? klass) -> untyped
+    end
+
+    class HasOneReflection < AssociationReflection
+      # :nodoc:
+      def macro: () -> :has_one
+
+      def has_one?: () -> ::TrueClass
+
+      def association_class: () -> untyped
+
+      def calculate_constructable: (untyped macro, untyped options) -> untyped
+    end
+
+    class BelongsToReflection < AssociationReflection
+      # :nodoc:
+      def macro: () -> :belongs_to
+
+      def belongs_to?: () -> ::TrueClass
+
+      def association_class: () -> untyped
+
+      def join_primary_key: (?untyped? klass) -> untyped
+
+      def join_foreign_key: () -> untyped
+
+      def can_find_inverse_of_automatically?: (untyped _) -> untyped
+
+      def calculate_constructable: (untyped macro, untyped options) -> untyped
+    end
+
+    class HasAndBelongsToManyReflection < AssociationReflection
+      # :nodoc:
+      def macro: () -> :has_and_belongs_to_many
+
+      def collection?: () -> ::TrueClass
+    end
+
+    class ThroughReflection < AbstractReflection
+      def initialize: (untyped delegate_reflection) -> untyped
+
+      def through_reflection?: () -> ::TrueClass
+
+      def klass: () -> untyped
+
+      # Returns the source of the through reflection. It checks both a singularized
+      # and pluralized form for <tt>:belongs_to</tt> or <tt>:has_many</tt>.
+      #
+      #   class Post < ActiveRecord::Base
+      #     has_many :taggings
+      #     has_many :tags, through: :taggings
+      #   end
+      #
+      #   class Tagging < ActiveRecord::Base
+      #     belongs_to :post
+      #     belongs_to :tag
+      #   end
+      #
+      #   tags_reflection = Post.reflect_on_association(:tags)
+      #   tags_reflection.source_reflection
+      #   # => <ActiveRecord::Reflection::BelongsToReflection: @name=:tag, @active_record=Tagging, @plural_name="tags">
+      #
+      def source_reflection: () -> untyped
+
+      # Returns the AssociationReflection object specified in the <tt>:through</tt> option
+      # of a HasManyThrough or HasOneThrough association.
+      #
+      #   class Post < ActiveRecord::Base
+      #     has_many :taggings
+      #     has_many :tags, through: :taggings
+      #   end
+      #
+      #   tags_reflection = Post.reflect_on_association(:tags)
+      #   tags_reflection.through_reflection
+      #   # => <ActiveRecord::Reflection::HasManyReflection: @name=:taggings, @active_record=Post, @plural_name="taggings">
+      #
+      def through_reflection: () -> untyped
+
+      # Returns an array of reflections which are involved in this association. Each item in the
+      # array corresponds to a table which will be part of the query for this association.
+      #
+      # The chain is built by recursively calling #chain on the source reflection and the through
+      # reflection. The base case for the recursion is a normal association, which just returns
+      # [self] as its #chain.
+      #
+      #   class Post < ActiveRecord::Base
+      #     has_many :taggings
+      #     has_many :tags, through: :taggings
+      #   end
+      #
+      #   tags_reflection = Post.reflect_on_association(:tags)
+      #   tags_reflection.chain
+      #   # => [<ActiveRecord::Reflection::ThroughReflection: @delegate_reflection=#<ActiveRecord::Reflection::HasManyReflection: @name=:tags...>,
+      #         <ActiveRecord::Reflection::HasManyReflection: @name=:taggings, @options={}, @active_record=Post>]
+      #
+      def collect_join_chain: () -> untyped
+
+      def clear_association_scope_cache: () -> untyped
+
+      def scopes: () -> untyped
+
+      def join_scopes: (untyped table, untyped predicate_builder) -> untyped
+
+      def has_scope?: () -> untyped
+
+      # A through association is nested if there would be more than one join table
+      def nested?: () -> untyped
+
+      # We want to use the klass from this reflection, rather than just delegate straight to
+      # the source_reflection, because the source_reflection may be polymorphic. We still
+      # need to respect the source_reflection's :primary_key option, though.
+      def association_primary_key: (?untyped? klass) -> untyped
+
+      # Gets an array of possible <tt>:through</tt> source reflection names in both singular and plural form.
+      #
+      #   class Post < ActiveRecord::Base
+      #     has_many :taggings
+      #     has_many :tags, through: :taggings
+      #   end
+      #
+      #   tags_reflection = Post.reflect_on_association(:tags)
+      #   tags_reflection.source_reflection_names
+      #   # => [:tag, :tags]
+      #
+      def source_reflection_names: () -> untyped
+
+      def source_reflection_name: () -> untyped
+
+      def source_options: () -> untyped
+
+      def through_options: () -> untyped
+
+      def check_validity!: () -> untyped
+
+      def constraints: () -> untyped
+
+      def add_as_source: (untyped seed) -> untyped
+
+      def add_as_polymorphic_through: (untyped reflection, untyped seed) -> untyped
+
+      def add_as_through: (untyped seed) -> untyped
+
+      def actual_source_reflection: () -> untyped
+
+      attr_reader delegate_reflection: untyped
+
+      def collect_join_reflections: (untyped seed) -> untyped
+
+      def inverse_name: () -> untyped
+
+      def derive_class_name: () -> untyped
+    end
+
+    class PolymorphicReflection < AbstractReflection
+      def initialize: (untyped reflection, untyped previous_reflection) -> untyped
+
+      def join_scopes: (untyped table, untyped predicate_builder) -> untyped
+
+      def constraints: () -> untyped
+
+      def source_type_scope: () -> untyped
+    end
+
+    class RuntimeReflection < AbstractReflection
+      def initialize: (untyped reflection, untyped association) -> untyped
+
+      def klass: () -> untyped
+
+      def aliased_table: () -> untyped
+
+      def all_includes: () { () -> untyped } -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module Batches
+    class BatchEnumerator
+      include Enumerable[untyped]
+
+      def initialize: (relation: untyped relation, ?finish: untyped? finish, ?start: untyped? start, ?of: ::Integer of) -> untyped
+
+      # Looping through a collection of records from the database (using the
+      # +all+ method, for example) is very inefficient since it will try to
+      # instantiate all the objects at once.
+      #
+      # In that case, batch processing methods allow you to work with the
+      # records in batches, thereby greatly reducing memory consumption.
+      #
+      #   Person.in_batches.each_record do |person|
+      #     person.do_awesome_stuff
+      #   end
+      #
+      #   Person.where("age > 21").in_batches(of: 10).each_record do |person|
+      #     person.party_all_night!
+      #   end
+      #
+      # If you do not provide a block to #each_record, it will return an Enumerator
+      # for chaining with other methods:
+      #
+      #   Person.in_batches.each_record.with_index do |person, index|
+      #     person.award_trophy(index + 1)
+      #   end
+      def each_record: () { (untyped) -> untyped } -> untyped
+
+      # Yields an ActiveRecord::Relation object for each batch of records.
+      #
+      #   Person.in_batches.each do |relation|
+      #     relation.update_all(awesome: true)
+      #   end
+      def each: () { (untyped) -> untyped } -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module Batches
+    ORDER_IGNORE_MESSAGE: ::String
+
+    # Looping through a collection of records from the database
+    # (using the Scoping::Named::ClassMethods.all method, for example)
+    # is very inefficient since it will try to instantiate all the objects at once.
+    #
+    # In that case, batch processing methods allow you to work
+    # with the records in batches, thereby greatly reducing memory consumption.
+    #
+    # The #find_each method uses #find_in_batches with a batch size of 1000 (or as
+    # specified by the +:batch_size+ option).
+    #
+    #   Person.find_each do |person|
+    #     person.do_awesome_stuff
+    #   end
+    #
+    #   Person.where("age > 21").find_each do |person|
+    #     person.party_all_night!
+    #   end
+    #
+    # If you do not provide a block to #find_each, it will return an Enumerator
+    # for chaining with other methods:
+    #
+    #   Person.find_each.with_index do |person, index|
+    #     person.award_trophy(index + 1)
+    #   end
+    #
+    # ==== Options
+    # * <tt>:batch_size</tt> - Specifies the size of the batch. Defaults to 1000.
+    # * <tt>:start</tt> - Specifies the primary key value to start from, inclusive of the value.
+    # * <tt>:finish</tt> - Specifies the primary key value to end at, inclusive of the value.
+    # * <tt>:error_on_ignore</tt> - Overrides the application config to specify if an error should be raised when
+    #   an order is present in the relation.
+    #
+    # Limits are honored, and if present there is no requirement for the batch
+    # size: it can be less than, equal to, or greater than the limit.
+    #
+    # The options +start+ and +finish+ are especially useful if you want
+    # multiple workers dealing with the same processing queue. You can make
+    # worker 1 handle all the records between id 1 and 9999 and worker 2
+    # handle from 10000 and beyond by setting the +:start+ and +:finish+
+    # option on each worker.
+    #
+    #   # In worker 1, let's process until 9999 records.
+    #   Person.find_each(finish: 9_999) do |person|
+    #     person.party_all_night!
+    #   end
+    #
+    #   # In worker 2, let's process from record 10_000 and onwards.
+    #   Person.find_each(start: 10_000) do |person|
+    #     person.party_all_night!
+    #   end
+    #
+    # NOTE: It's not possible to set the order. That is automatically set to
+    # ascending on the primary key ("id ASC") to make the batch ordering
+    # work. This also means that this method only works when the primary key is
+    # orderable (e.g. an integer or string).
+    #
+    # NOTE: By its nature, batch processing is subject to race conditions if
+    # other processes are modifying the database.
+    def find_each: (?error_on_ignore: untyped? error_on_ignore, ?batch_size: ::Integer batch_size, ?finish: untyped? finish, ?start: untyped? start) { (untyped) -> untyped } -> untyped
+
+    # Yields each batch of records that was found by the find options as
+    # an array.
+    #
+    #   Person.where("age > 21").find_in_batches do |group|
+    #     sleep(50) # Make sure it doesn't get too crowded in there!
+    #     group.each { |person| person.party_all_night! }
+    #   end
+    #
+    # If you do not provide a block to #find_in_batches, it will return an Enumerator
+    # for chaining with other methods:
+    #
+    #   Person.find_in_batches.with_index do |group, batch|
+    #     puts "Processing group ##{batch}"
+    #     group.each(&:recover_from_last_night!)
+    #   end
+    #
+    # To be yielded each record one by one, use #find_each instead.
+    #
+    # ==== Options
+    # * <tt>:batch_size</tt> - Specifies the size of the batch. Defaults to 1000.
+    # * <tt>:start</tt> - Specifies the primary key value to start from, inclusive of the value.
+    # * <tt>:finish</tt> - Specifies the primary key value to end at, inclusive of the value.
+    # * <tt>:error_on_ignore</tt> - Overrides the application config to specify if an error should be raised when
+    #   an order is present in the relation.
+    #
+    # Limits are honored, and if present there is no requirement for the batch
+    # size: it can be less than, equal to, or greater than the limit.
+    #
+    # The options +start+ and +finish+ are especially useful if you want
+    # multiple workers dealing with the same processing queue. You can make
+    # worker 1 handle all the records between id 1 and 9999 and worker 2
+    # handle from 10000 and beyond by setting the +:start+ and +:finish+
+    # option on each worker.
+    #
+    #   # Let's process from record 10_000 on.
+    #   Person.find_in_batches(start: 10_000) do |group|
+    #     group.each { |person| person.party_all_night! }
+    #   end
+    #
+    # NOTE: It's not possible to set the order. That is automatically set to
+    # ascending on the primary key ("id ASC") to make the batch ordering
+    # work. This also means that this method only works when the primary key is
+    # orderable (e.g. an integer or string).
+    #
+    # NOTE: By its nature, batch processing is subject to race conditions if
+    # other processes are modifying the database.
+    def find_in_batches: (?error_on_ignore: untyped? error_on_ignore, ?batch_size: ::Integer batch_size, ?finish: untyped? finish, ?start: untyped? start) { (untyped) -> untyped } -> untyped
+
+    # Yields ActiveRecord::Relation objects to work with a batch of records.
+    #
+    #   Person.where("age > 21").in_batches do |relation|
+    #     relation.delete_all
+    #     sleep(10) # Throttle the delete queries
+    #   end
+    #
+    # If you do not provide a block to #in_batches, it will return a
+    # BatchEnumerator which is enumerable.
+    #
+    #   Person.in_batches.each_with_index do |relation, batch_index|
+    #     puts "Processing relation ##{batch_index}"
+    #     relation.delete_all
+    #   end
+    #
+    # Examples of calling methods on the returned BatchEnumerator object:
+    #
+    #   Person.in_batches.delete_all
+    #   Person.in_batches.update_all(awesome: true)
+    #   Person.in_batches.each_record(&:party_all_night!)
+    #
+    # ==== Options
+    # * <tt>:of</tt> - Specifies the size of the batch. Defaults to 1000.
+    # * <tt>:load</tt> - Specifies if the relation should be loaded. Defaults to false.
+    # * <tt>:start</tt> - Specifies the primary key value to start from, inclusive of the value.
+    # * <tt>:finish</tt> - Specifies the primary key value to end at, inclusive of the value.
+    # * <tt>:error_on_ignore</tt> - Overrides the application config to specify if an error should be raised when
+    #   an order is present in the relation.
+    #
+    # Limits are honored, and if present there is no requirement for the batch
+    # size, it can be less than, equal, or greater than the limit.
+    #
+    # The options +start+ and +finish+ are especially useful if you want
+    # multiple workers dealing with the same processing queue. You can make
+    # worker 1 handle all the records between id 1 and 9999 and worker 2
+    # handle from 10000 and beyond by setting the +:start+ and +:finish+
+    # option on each worker.
+    #
+    #   # Let's process from record 10_000 on.
+    #   Person.in_batches(start: 10_000).update_all(awesome: true)
+    #
+    # An example of calling where query method on the relation:
+    #
+    #   Person.in_batches.each do |relation|
+    #     relation.update_all('age = age + 1')
+    #     relation.where('age > 21').update_all(should_party: true)
+    #     relation.where('age <= 21').delete_all
+    #   end
+    #
+    # NOTE: If you are going to iterate through each record, you should call
+    # #each_record on the yielded BatchEnumerator:
+    #
+    #   Person.in_batches.each_record(&:party_all_night!)
+    #
+    # NOTE: It's not possible to set the order. That is automatically set to
+    # ascending on the primary key ("id ASC") to make the batch ordering
+    # consistent. Therefore the primary key must be orderable, e.g. an integer
+    # or a string.
+    #
+    # NOTE: By its nature, batch processing is subject to race conditions if
+    # other processes are modifying the database.
+    def in_batches: (?error_on_ignore: untyped? error_on_ignore, ?load: bool load, ?finish: untyped? finish, ?start: untyped? start, ?of: ::Integer of) { (untyped) -> untyped } -> (BatchEnumerator | untyped)
+
+    def apply_limits: (untyped relation, untyped start, untyped finish) -> untyped
+
+    def apply_start_limit: (untyped relation, untyped start) -> untyped
+
+    def apply_finish_limit: (untyped relation, untyped finish) -> untyped
+
+    def batch_order: () -> untyped
+
+    def act_on_ignored_order: (untyped error_on_ignore) -> untyped
+  end
+end
+
+module ActiveRecord
+  module Calculations
+    # Count the records.
+    #
+    #   Person.count
+    #   # => the total count of all people
+    #
+    #   Person.count(:age)
+    #   # => returns the total count of all people whose age is present in database
+    #
+    #   Person.count(:all)
+    #   # => performs a COUNT(*) (:all is an alias for '*')
+    #
+    #   Person.distinct.count(:age)
+    #   # => counts the number of different age values
+    #
+    # If #count is used with {Relation#group}[rdoc-ref:QueryMethods#group],
+    # it returns a Hash whose keys represent the aggregated column,
+    # and the values are the respective amounts:
+    #
+    #   Person.group(:city).count
+    #   # => { 'Rome' => 5, 'Paris' => 3 }
+    #
+    # If #count is used with {Relation#group}[rdoc-ref:QueryMethods#group] for multiple columns, it returns a Hash whose
+    # keys are an array containing the individual values of each column and the value
+    # of each key would be the #count.
+    #
+    #   Article.group(:status, :category).count
+    #   # =>  {["draft", "business"]=>10, ["draft", "technology"]=>4,
+    #          ["published", "business"]=>0, ["published", "technology"]=>2}
+    #
+    # If #count is used with {Relation#select}[rdoc-ref:QueryMethods#select], it will count the selected columns:
+    #
+    #   Person.select(:age).count
+    #   # => counts the number of different age values
+    #
+    # Note: not all valid {Relation#select}[rdoc-ref:QueryMethods#select] expressions are valid #count expressions. The specifics differ
+    # between databases. In invalid cases, an error from the database is thrown.
+    def count: (?untyped? column_name) -> untyped
+
+    # Calculates the average value on a given column. Returns +nil+ if there's
+    # no row. See #calculate for examples with options.
+    #
+    #   Person.average(:age) # => 35.8
+    def average: (untyped column_name) -> untyped
+
+    # Calculates the minimum value on a given column. The value is returned
+    # with the same data type of the column, or +nil+ if there's no row. See
+    # #calculate for examples with options.
+    #
+    #   Person.minimum(:age) # => 7
+    def minimum: (untyped column_name) -> untyped
+
+    # Calculates the maximum value on a given column. The value is returned
+    # with the same data type of the column, or +nil+ if there's no row. See
+    # #calculate for examples with options.
+    #
+    #   Person.maximum(:age) # => 93
+    def maximum: (untyped column_name) -> untyped
+
+    # Calculates the sum of values on a given column. The value is returned
+    # with the same data type of the column, +0+ if there's no row. See
+    # #calculate for examples with options.
+    #
+    #   Person.sum(:age) # => 4562
+    def sum: (?untyped? column_name) -> untyped
+
+    # This calculates aggregate values in the given column. Methods for #count, #sum, #average,
+    # #minimum, and #maximum have been added as shortcuts.
+    #
+    #   Person.calculate(:count, :all) # The same as Person.count
+    #   Person.average(:age) # SELECT AVG(age) FROM people...
+    #
+    #   # Selects the minimum age for any family without any minors
+    #   Person.group(:last_name).having("min(age) > 17").minimum(:age)
+    #
+    #   Person.sum("2 * age")
+    #
+    # There are two basic forms of output:
+    #
+    # * Single aggregate value: The single value is type cast to Integer for COUNT, Float
+    #   for AVG, and the given column's type for everything else.
+    #
+    # * Grouped values: This returns an ordered hash of the values and groups them. It
+    #   takes either a column name, or the name of a belongs_to association.
+    #
+    #      values = Person.group('last_name').maximum(:age)
+    #      puts values["Drake"]
+    #      # => 43
+    #
+    #      drake  = Family.find_by(last_name: 'Drake')
+    #      values = Person.group(:family).maximum(:age) # Person belongs_to :family
+    #      puts values[drake]
+    #      # => 43
+    #
+    #      values.each do |family, max_age|
+    #        ...
+    #      end
+    def calculate: (untyped operation, untyped column_name) -> untyped
+
+    # Use #pluck as a shortcut to select one or more attributes without
+    # loading a bunch of records just to grab the attributes you want.
+    #
+    #   Person.pluck(:name)
+    #
+    # instead of
+    #
+    #   Person.all.map(&:name)
+    #
+    # Pluck returns an Array of attribute values type-casted to match
+    # the plucked column names, if they can be deduced. Plucking an SQL fragment
+    # returns String values by default.
+    #
+    #   Person.pluck(:name)
+    #   # SELECT people.name FROM people
+    #   # => ['David', 'Jeremy', 'Jose']
+    #
+    #   Person.pluck(:id, :name)
+    #   # SELECT people.id, people.name FROM people
+    #   # => [[1, 'David'], [2, 'Jeremy'], [3, 'Jose']]
+    #
+    #   Person.distinct.pluck(:role)
+    #   # SELECT DISTINCT role FROM people
+    #   # => ['admin', 'member', 'guest']
+    #
+    #   Person.where(age: 21).limit(5).pluck(:id)
+    #   # SELECT people.id FROM people WHERE people.age = 21 LIMIT 5
+    #   # => [2, 3]
+    #
+    #   Person.pluck(Arel.sql('DATEDIFF(updated_at, created_at)'))
+    #   # SELECT DATEDIFF(updated_at, created_at) FROM people
+    #   # => ['0', '27761', '173']
+    #
+    # See also #ids.
+    #
+    def pluck: (*untyped column_names) -> untyped
+
+    # Pick the value(s) from the named column(s) in the current relation.
+    # This is short-hand for <tt>relation.limit(1).pluck(*column_names).first</tt>, and is primarily useful
+    # when you have a relation that's already narrowed down to a single row.
+    #
+    # Just like #pluck, #pick will only load the actual value, not the entire record object, so it's also
+    # more efficient. The value is, again like with pluck, typecast by the column type.
+    #
+    #   Person.where(id: 1).pick(:name)
+    #   # SELECT people.name FROM people WHERE id = 1 LIMIT 1
+    #   # => 'David'
+    #
+    #   Person.where(id: 1).pick(:name, :email_address)
+    #   # SELECT people.name, people.email_address FROM people WHERE id = 1 LIMIT 1
+    #   # => [ 'David', 'david@loudthinking.com' ]
+    def pick: (*untyped column_names) -> untyped
+
+    # Pluck all the ID's for the relation using the table's primary key
+    #
+    #   Person.ids # SELECT people.id FROM people
+    #   Person.joins(:companies).ids # SELECT people.id FROM people INNER JOIN companies ON companies.person_id = people.id
+    def ids: () -> untyped
+
+    def has_include?: (untyped column_name) -> untyped
+
+    def perform_calculation: (untyped operation, untyped column_name) -> untyped
+
+    def distinct_select?: (untyped column_name) -> untyped
+
+    def aggregate_column: (untyped column_name) -> untyped
+
+    def operation_over_aggregate_column: (untyped column, untyped operation, untyped distinct) -> untyped
+
+    def execute_simple_calculation: (untyped operation, untyped column_name, untyped distinct) -> (0 | untyped)
+
+    def execute_grouped_calculation: (untyped operation, untyped column_name, untyped distinct) -> untyped
+
+    # Converts the given field to the value that the database adapter returns as
+    # a usable column name:
+    #
+    #   column_alias_for("users.id")                 # => "users_id"
+    #   column_alias_for("sum(id)")                  # => "sum_id"
+    #   column_alias_for("count(distinct users.id)") # => "count_distinct_users_id"
+    #   column_alias_for("count(*)")                 # => "count_all"
+    def column_alias_for: (untyped field) -> untyped
+
+    def type_for: (untyped field) { () -> untyped } -> untyped
+
+    def type_cast_calculated_value: (untyped value, untyped `type`, ?untyped? operation) -> untyped
+
+    def select_for_count: () -> untyped
+
+    def build_count_subquery: (untyped relation, untyped column_name, untyped distinct) -> untyped
+  end
+end
+
+module ActiveRecord
+  module Delegation
+    module DelegateCache
+      # :nodoc:
+      # :nodoc:
+      def relation_delegate_class: (untyped klass) -> untyped
+
+      def initialize_relation_delegate_cache: () -> untyped
+
+      def inherited: (untyped child_class) -> untyped
+
+      def generate_relation_method: (untyped method) -> untyped
+
+      def include_relation_methods: (untyped delegate) -> untyped
+
+      def generated_relation_methods: () -> untyped
+    end
+
+    class GeneratedRelationMethods < Module
+      # :nodoc:
+      include Mutex_m
+
+      def generate_method: (untyped method) -> untyped
+    end
+
+    extend ActiveSupport::Concern
+
+    module ClassSpecificRelation
+      # :nodoc:
+      extend ActiveSupport::Concern
+
+      module ClassMethods
+        # :nodoc:
+        def name: () -> untyped
+      end
+
+      def method_missing: (untyped method, *untyped args) { () -> untyped } -> untyped
+    end
+
+    module ClassMethods
+      # :nodoc:
+      def create: (untyped klass, *untyped args, **untyped kwargs) -> untyped
+
+      def relation_class_for: (untyped klass) -> untyped
+    end
+
+    def respond_to_missing?: (untyped method, untyped _) -> untyped
+  end
+end
+
+module ActiveRecord
+  module FinderMethods
+    ONE_AS_ONE: ::String
+
+    # Find by id - This can either be a specific id (1), a list of ids (1, 5, 6), or an array of ids ([5, 6, 10]).
+    # If one or more records cannot be found for the requested ids, then ActiveRecord::RecordNotFound will be raised.
+    # If the primary key is an integer, find by id coerces its arguments by using +to_i+.
+    #
+    #   Person.find(1)          # returns the object for ID = 1
+    #   Person.find("1")        # returns the object for ID = 1
+    #   Person.find("31-sarah") # returns the object for ID = 31
+    #   Person.find(1, 2, 6)    # returns an array for objects with IDs in (1, 2, 6)
+    #   Person.find([7, 17])    # returns an array for objects with IDs in (7, 17)
+    #   Person.find([1])        # returns an array for the object with ID = 1
+    #   Person.where("administrator = 1").order("created_on DESC").find(1)
+    #
+    # NOTE: The returned records are in the same order as the ids you provide.
+    # If you want the results to be sorted by database, you can use ActiveRecord::QueryMethods#where
+    # method and provide an explicit ActiveRecord::QueryMethods#order option.
+    # But ActiveRecord::QueryMethods#where method doesn't raise ActiveRecord::RecordNotFound.
+    #
+    # ==== Find with lock
+    #
+    # Example for find with a lock: Imagine two concurrent transactions:
+    # each will read <tt>person.visits == 2</tt>, add 1 to it, and save, resulting
+    # in two saves of <tt>person.visits = 3</tt>. By locking the row, the second
+    # transaction has to wait until the first is finished; we get the
+    # expected <tt>person.visits == 4</tt>.
+    #
+    #   Person.transaction do
+    #     person = Person.lock(true).find(1)
+    #     person.visits += 1
+    #     person.save!
+    #   end
+    #
+    # ==== Variations of #find
+    #
+    #   Person.where(name: 'Spartacus', rating: 4)
+    #   # returns a chainable list (which can be empty).
+    #
+    #   Person.find_by(name: 'Spartacus', rating: 4)
+    #   # returns the first item or nil.
+    #
+    #   Person.find_or_initialize_by(name: 'Spartacus', rating: 4)
+    #   # returns the first item or returns a new instance (requires you call .save to persist against the database).
+    #
+    #   Person.find_or_create_by(name: 'Spartacus', rating: 4)
+    #   # returns the first item or creates it and returns it.
+    #
+    # ==== Alternatives for #find
+    #
+    #   Person.where(name: 'Spartacus', rating: 4).exists?(conditions = :none)
+    #   # returns a boolean indicating if any record with the given conditions exist.
+    #
+    #   Person.where(name: 'Spartacus', rating: 4).select("field1, field2, field3")
+    #   # returns a chainable list of instances with only the mentioned fields.
+    #
+    #   Person.where(name: 'Spartacus', rating: 4).ids
+    #   # returns an Array of ids.
+    #
+    #   Person.where(name: 'Spartacus', rating: 4).pluck(:field1, :field2)
+    #   # returns an Array of the required fields.
+    def find: (*untyped args) -> untyped
+
+    # Finds the first record matching the specified conditions. There
+    # is no implied ordering so if order matters, you should specify it
+    # yourself.
+    #
+    # If no record is found, returns <tt>nil</tt>.
+    #
+    #   Post.find_by name: 'Spartacus', rating: 4
+    #   Post.find_by "published_at < ?", 2.weeks.ago
+    def find_by: (untyped arg, *untyped args) -> untyped
+
+    # Like #find_by, except that if no record is found, raises
+    # an ActiveRecord::RecordNotFound error.
+    def find_by!: (untyped arg, *untyped args) -> untyped
+
+    # Gives a record (or N records if a parameter is supplied) without any implied
+    # order. The order will depend on the database implementation.
+    # If an order is supplied it will be respected.
+    #
+    #   Person.take # returns an object fetched by SELECT * FROM people LIMIT 1
+    #   Person.take(5) # returns 5 objects fetched by SELECT * FROM people LIMIT 5
+    #   Person.where(["name LIKE '%?'", name]).take
+    def take: (?untyped? limit) -> untyped
+
+    # Same as #take but raises ActiveRecord::RecordNotFound if no record
+    # is found. Note that #take! accepts no arguments.
+    def take!: () -> untyped
+
+    # Find the first record (or first N records if a parameter is supplied).
+    # If no order is defined it will order by primary key.
+    #
+    #   Person.first # returns the first object fetched by SELECT * FROM people ORDER BY people.id LIMIT 1
+    #   Person.where(["user_name = ?", user_name]).first
+    #   Person.where(["user_name = :u", { u: user_name }]).first
+    #   Person.order("created_on DESC").offset(5).first
+    #   Person.first(3) # returns the first three objects fetched by SELECT * FROM people ORDER BY people.id LIMIT 3
+    #
+    def first: (?untyped? limit) -> untyped
+
+    # Same as #first but raises ActiveRecord::RecordNotFound if no record
+    # is found. Note that #first! accepts no arguments.
+    def first!: () -> untyped
+
+    # Find the last record (or last N records if a parameter is supplied).
+    # If no order is defined it will order by primary key.
+    #
+    #   Person.last # returns the last object fetched by SELECT * FROM people
+    #   Person.where(["user_name = ?", user_name]).last
+    #   Person.order("created_on DESC").offset(5).last
+    #   Person.last(3) # returns the last three objects fetched by SELECT * FROM people.
+    #
+    # Take note that in that last case, the results are sorted in ascending order:
+    #
+    #   [#<Person id:2>, #<Person id:3>, #<Person id:4>]
+    #
+    # and not:
+    #
+    #   [#<Person id:4>, #<Person id:3>, #<Person id:2>]
+    def last: (?untyped? limit) -> untyped
+
+    # Same as #last but raises ActiveRecord::RecordNotFound if no record
+    # is found. Note that #last! accepts no arguments.
+    def last!: () -> untyped
+
+    # Find the second record.
+    # If no order is defined it will order by primary key.
+    #
+    #   Person.second # returns the second object fetched by SELECT * FROM people
+    #   Person.offset(3).second # returns the second object from OFFSET 3 (which is OFFSET 4)
+    #   Person.where(["user_name = :u", { u: user_name }]).second
+    def second: () -> untyped
+
+    # Same as #second but raises ActiveRecord::RecordNotFound if no record
+    # is found.
+    def second!: () -> untyped
+
+    # Find the third record.
+    # If no order is defined it will order by primary key.
+    #
+    #   Person.third # returns the third object fetched by SELECT * FROM people
+    #   Person.offset(3).third # returns the third object from OFFSET 3 (which is OFFSET 5)
+    #   Person.where(["user_name = :u", { u: user_name }]).third
+    def third: () -> untyped
+
+    # Same as #third but raises ActiveRecord::RecordNotFound if no record
+    # is found.
+    def third!: () -> untyped
+
+    # Find the fourth record.
+    # If no order is defined it will order by primary key.
+    #
+    #   Person.fourth # returns the fourth object fetched by SELECT * FROM people
+    #   Person.offset(3).fourth # returns the fourth object from OFFSET 3 (which is OFFSET 6)
+    #   Person.where(["user_name = :u", { u: user_name }]).fourth
+    def fourth: () -> untyped
+
+    # Same as #fourth but raises ActiveRecord::RecordNotFound if no record
+    # is found.
+    def fourth!: () -> untyped
+
+    # Find the fifth record.
+    # If no order is defined it will order by primary key.
+    #
+    #   Person.fifth # returns the fifth object fetched by SELECT * FROM people
+    #   Person.offset(3).fifth # returns the fifth object from OFFSET 3 (which is OFFSET 7)
+    #   Person.where(["user_name = :u", { u: user_name }]).fifth
+    def fifth: () -> untyped
+
+    # Same as #fifth but raises ActiveRecord::RecordNotFound if no record
+    # is found.
+    def fifth!: () -> untyped
+
+    # Find the forty-second record. Also known as accessing "the reddit".
+    # If no order is defined it will order by primary key.
+    #
+    #   Person.forty_two # returns the forty-second object fetched by SELECT * FROM people
+    #   Person.offset(3).forty_two # returns the forty-second object from OFFSET 3 (which is OFFSET 44)
+    #   Person.where(["user_name = :u", { u: user_name }]).forty_two
+    def forty_two: () -> untyped
+
+    # Same as #forty_two but raises ActiveRecord::RecordNotFound if no record
+    # is found.
+    def forty_two!: () -> untyped
+
+    # Find the third-to-last record.
+    # If no order is defined it will order by primary key.
+    #
+    #   Person.third_to_last # returns the third-to-last object fetched by SELECT * FROM people
+    #   Person.offset(3).third_to_last # returns the third-to-last object from OFFSET 3
+    #   Person.where(["user_name = :u", { u: user_name }]).third_to_last
+    def third_to_last: () -> untyped
+
+    # Same as #third_to_last but raises ActiveRecord::RecordNotFound if no record
+    # is found.
+    def third_to_last!: () -> untyped
+
+    # Find the second-to-last record.
+    # If no order is defined it will order by primary key.
+    #
+    #   Person.second_to_last # returns the second-to-last object fetched by SELECT * FROM people
+    #   Person.offset(3).second_to_last # returns the second-to-last object from OFFSET 3
+    #   Person.where(["user_name = :u", { u: user_name }]).second_to_last
+    def second_to_last: () -> untyped
+
+    # Same as #second_to_last but raises ActiveRecord::RecordNotFound if no record
+    # is found.
+    def second_to_last!: () -> untyped
+
+    # Returns true if a record exists in the table that matches the +id+ or
+    # conditions given, or false otherwise. The argument can take six forms:
+    #
+    # * Integer - Finds the record with this primary key.
+    # * String - Finds the record with a primary key corresponding to this
+    #   string (such as <tt>'5'</tt>).
+    # * Array - Finds the record that matches these +find+-style conditions
+    #   (such as <tt>['name LIKE ?', "%#{query}%"]</tt>).
+    # * Hash - Finds the record that matches these +find+-style conditions
+    #   (such as <tt>{name: 'David'}</tt>).
+    # * +false+ - Returns always +false+.
+    # * No args - Returns +false+ if the relation is empty, +true+ otherwise.
+    #
+    # For more information about specifying conditions as a hash or array,
+    # see the Conditions section in the introduction to ActiveRecord::Base.
+    #
+    # Note: You can't pass in a condition as a string (like <tt>name =
+    # 'Jamie'</tt>), since it would be sanitized and then queried against
+    # the primary key column, like <tt>id = 'name = \'Jamie\''</tt>.
+    #
+    #   Person.exists?(5)
+    #   Person.exists?('5')
+    #   Person.exists?(['name LIKE ?', "%#{query}%"])
+    #   Person.exists?(id: [1, 4, 8])
+    #   Person.exists?(name: 'David')
+    #   Person.exists?(false)
+    #   Person.exists?
+    #   Person.where(name: 'Spartacus', rating: 4).exists?
+    def exists?: (?::Symbol conditions) -> (::FalseClass | untyped)
+
+    def raise_record_not_found_exception!: (?untyped? ids, ?untyped? result_size, ?untyped? expected_size, ?untyped key, ?untyped? not_found_ids) -> untyped
+
+    def offset_index: () -> untyped
+
+    def construct_relation_for_exists: (untyped conditions) -> untyped
+
+    def apply_join_dependency: (?eager_loading: untyped eager_loading) { (untyped, untyped) -> untyped } -> untyped
+
+    def limited_ids_for: (untyped relation) -> untyped
+
+    def using_limitable_reflections?: (untyped reflections) -> untyped
+
+    def find_with_ids: (*untyped ids) -> (::Array[untyped] | untyped)
+
+    def find_one: (untyped id) -> untyped
+
+    def find_some: (untyped ids) -> untyped
+
+    def find_some_ordered: (untyped ids) -> untyped
+
+    def find_take: () -> untyped
+
+    def find_take_with_limit: (untyped limit) -> untyped
+
+    def find_nth: (untyped index) -> untyped
+
+    def find_nth_with_limit: (untyped index, untyped limit) -> untyped
+
+    def find_nth_from_last: (untyped index) -> untyped
+
+    def find_last: (untyped limit) -> untyped
+
+    def ordered_relation: () -> untyped
+  end
+end
+
+module ActiveRecord
+  class Relation
+    class FromClause
+      # :nodoc:
+      attr_reader value: untyped
+
+      # :nodoc:
+      attr_reader name: untyped
+
+      def initialize: (untyped value, untyped name) -> untyped
+
+      def merge: (untyped other) -> untyped
+
+      def empty?: () -> untyped
+
+      def ==: (untyped other) -> untyped
+
+      def self.empty: () -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  class Relation
+    class HashMerger
+      # :nodoc:
+      attr_reader relation: untyped
+
+      # :nodoc:
+      attr_reader hash: untyped
+
+      def initialize: (untyped relation, untyped hash) -> untyped
+
+      def merge: () -> untyped
+
+      # Applying values to a relation has some side effects. E.g.
+      # interpolation might take place for where values. So we should
+      # build a relation to merge in rather than directly merging
+      # the values.
+      def other: () -> untyped
+    end
+
+    class Merger
+      # :nodoc:
+      attr_reader relation: untyped
+
+      # :nodoc:
+      attr_reader values: untyped
+
+      # :nodoc:
+      attr_reader other: untyped
+
+      def initialize: (untyped relation, untyped other) -> untyped
+
+      NORMAL_VALUES: untyped
+
+      def normal_values: () -> untyped
+
+      def merge: () -> untyped
+
+      def merge_preloads: () -> (nil | untyped)
+
+      def merge_joins: () -> (nil | untyped)
+
+      def merge_outer_joins: () -> (nil | untyped)
+
+      def merge_multi_values: () -> untyped
+
+      def merge_single_values: () -> untyped
+
+      def merge_clauses: () -> untyped
+
+      def replace_from_clause?: () -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  class PredicateBuilder
+    class ArrayHandler
+      # :nodoc:
+      def initialize: (untyped predicate_builder) -> untyped
+
+      def call: (untyped attribute, untyped value) -> untyped
+
+      attr_reader predicate_builder: untyped
+
+      module NullPredicate
+        # :nodoc:
+        def self.or: (untyped other) -> untyped
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  class PredicateBuilder
+    class AssociationQueryValue
+      # :nodoc:
+      def initialize: (untyped associated_table, untyped value) -> untyped
+
+      def queries: () -> ::Array[::Hash[untyped, untyped]]
+
+      attr_reader associated_table: untyped
+
+      attr_reader value: untyped
+
+      def ids: () -> untyped
+
+      def primary_key: () -> untyped
+
+      def convert_to_id: (untyped value) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  class PredicateBuilder
+    class BaseHandler
+      # :nodoc:
+      def initialize: (untyped predicate_builder) -> untyped
+
+      def call: (untyped attribute, untyped value) -> untyped
+
+      attr_reader predicate_builder: untyped
+    end
+  end
+end
+
+module ActiveRecord
+  class PredicateBuilder
+    class BasicObjectHandler
+      # :nodoc:
+      def initialize: (untyped predicate_builder) -> untyped
+
+      def call: (untyped attribute, untyped value) -> untyped
+
+      attr_reader predicate_builder: untyped
+    end
+  end
+end
+
+module ActiveRecord
+  class PredicateBuilder
+    class PolymorphicArrayValue
+      # :nodoc:
+      def initialize: (untyped associated_table, untyped values) -> untyped
+
+      def queries: () -> untyped
+
+      attr_reader associated_table: untyped
+
+      attr_reader values: untyped
+
+      def type_to_ids_mapping: () -> untyped
+
+      def primary_key: (untyped value) -> untyped
+
+      def klass: (untyped value) -> untyped
+
+      def convert_to_id: (untyped value) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  class PredicateBuilder
+    class RangeHandler
+      # :nodoc:
+      class RangeWithBinds[T] < ::Struct[T]
+        attr_accessor begin(): untyped
+
+        attr_accessor end(): untyped
+
+        attr_accessor exclude_end?(): untyped
+      end
+
+      def initialize: (untyped predicate_builder) -> untyped
+
+      def call: (untyped attribute, untyped value) -> untyped
+
+      attr_reader predicate_builder: untyped
+    end
+  end
+end
+
+module ActiveRecord
+  class PredicateBuilder
+    class RelationHandler
+      # :nodoc:
+      def call: (untyped attribute, untyped value) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  class PredicateBuilder
+    def initialize: (untyped table) -> untyped
+
+    def build_from_hash: (untyped attributes) -> untyped
+
+    def self.references: (untyped attributes) -> untyped
+
+    # Define how a class is converted to Arel nodes when passed to +where+.
+    # The handler can be any object that responds to +call+, and will be used
+    # for any value that +===+ the class given. For example:
+    #
+    #     MyCustomDateRange = Struct.new(:start, :end)
+    #     handler = proc do |column, range|
+    #       Arel::Nodes::Between.new(column,
+    #         Arel::Nodes::And.new([range.start, range.end])
+    #       )
+    #     end
+    #     ActiveRecord::PredicateBuilder.new("users").register_handler(MyCustomDateRange, handler)
+    def register_handler: (untyped klass, untyped handler) -> untyped
+
+    def build: (untyped attribute, untyped value) -> untyped
+
+    def build_bind_attribute: (untyped column_name, untyped value) -> Arel::Nodes::BindParam
+
+    def expand_from_hash: (untyped attributes) -> (::Array["1=0"] | untyped)
+
+    attr_reader table: untyped
+
+    def convert_dot_notation_to_hash: (untyped attributes) -> untyped
+
+    def handler_for: (untyped object) -> untyped
+  end
+end
+
+module ActiveRecord
+  class Relation
+    class QueryAttribute < ActiveModel::Attribute
+      # :nodoc:
+      def type_cast: (untyped value) -> untyped
+
+      def value_for_database: () -> untyped
+
+      def with_cast_value: (untyped value) -> QueryAttribute
+
+      def nil?: () -> untyped
+
+      def infinite?: () -> untyped
+
+      def unboundable?: () -> untyped
+
+      def infinity?: (untyped value) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module QueryMethods
+    extend ActiveSupport::Concern
+
+    include ActiveModel::ForbiddenAttributesProtection
+
+    # WhereChain objects act as placeholder for queries in which #where does not have any parameter.
+    # In this case, #where must be chained with #not to return a new relation.
+    class WhereChain
+      include ActiveModel::ForbiddenAttributesProtection
+
+      def initialize: (untyped scope) -> untyped
+
+      # Returns a new relation expressing WHERE + NOT condition according to
+      # the conditions in the arguments.
+      #
+      # #not accepts conditions as a string, array, or hash. See QueryMethods#where for
+      # more details on each format.
+      #
+      #    User.where.not("name = 'Jon'")
+      #    # SELECT * FROM users WHERE NOT (name = 'Jon')
+      #
+      #    User.where.not(["name = ?", "Jon"])
+      #    # SELECT * FROM users WHERE NOT (name = 'Jon')
+      #
+      #    User.where.not(name: "Jon")
+      #    # SELECT * FROM users WHERE name != 'Jon'
+      #
+      #    User.where.not(name: nil)
+      #    # SELECT * FROM users WHERE name IS NOT NULL
+      #
+      #    User.where.not(name: %w(Ko1 Nobu))
+      #    # SELECT * FROM users WHERE name NOT IN ('Ko1', 'Nobu')
+      def not: (untyped opts, *untyped rest) -> untyped
+
+      def not_behaves_as_nor?: (untyped opts) -> (::FalseClass | untyped)
+    end
+
+    FROZEN_EMPTY_ARRAY: untyped
+
+    FROZEN_EMPTY_HASH: untyped
+
+    alias extensions extending_values
+
+    # Specify relationships to be included in the result set. For
+    # example:
+    #
+    #   users = User.includes(:address)
+    #   users.each do |user|
+    #     user.address.city
+    #   end
+    #
+    # allows you to access the +address+ attribute of the +User+ model without
+    # firing an additional query. This will often result in a
+    # performance improvement over a simple join.
+    #
+    # You can also specify multiple relationships, like this:
+    #
+    #   users = User.includes(:address, :friends)
+    #
+    # Loading nested relationships is possible using a Hash:
+    #
+    #   users = User.includes(:address, friends: [:address, :followers])
+    #
+    # === conditions
+    #
+    # If you want to add string conditions to your included models, you'll have
+    # to explicitly reference them. For example:
+    #
+    #   User.includes(:posts).where('posts.name = ?', 'example')
+    #
+    # Will throw an error, but this will work:
+    #
+    #   User.includes(:posts).where('posts.name = ?', 'example').references(:posts)
+    #
+    # Note that #includes works with association names while #references needs
+    # the actual table name.
+    #
+    # If you pass the conditions via hash, you don't need to call #references
+    # explicitly, as #where references the tables for you. For example, this
+    # will work correctly:
+    #
+    #   User.includes(:posts).where(posts: { name: 'example' })
+    def includes: (*untyped args) -> untyped
+
+    def includes!: (*untyped args) -> untyped
+
+    # Forces eager loading by performing a LEFT OUTER JOIN on +args+:
+    #
+    #   User.eager_load(:posts)
+    #   # SELECT "users"."id" AS t0_r0, "users"."name" AS t0_r1, ...
+    #   # FROM "users" LEFT OUTER JOIN "posts" ON "posts"."user_id" =
+    #   # "users"."id"
+    def eager_load: (*untyped args) -> untyped
+
+    def eager_load!: (*untyped args) -> untyped
+
+    # Allows preloading of +args+, in the same way that #includes does:
+    #
+    #   User.preload(:posts)
+    #   # SELECT "posts".* FROM "posts" WHERE "posts"."user_id" IN (1, 2, 3)
+    def preload: (*untyped args) -> untyped
+
+    def preload!: (*untyped args) -> untyped
+
+    # Extracts a named +association+ from the relation. The named association is first preloaded,
+    # then the individual association records are collected from the relation. Like so:
+    #
+    #   account.memberships.extract_associated(:user)
+    #   # => Returns collection of User records
+    #
+    # This is short-hand for:
+    #
+    #   account.memberships.preload(:user).collect(&:user)
+    def extract_associated: (untyped association) -> untyped
+
+    # Use to indicate that the given +table_names+ are referenced by an SQL string,
+    # and should therefore be JOINed in any query rather than loaded separately.
+    # This method only works in conjunction with #includes.
+    # See #includes for more details.
+    #
+    #   User.includes(:posts).where("posts.name = 'foo'")
+    #   # Doesn't JOIN the posts table, resulting in an error.
+    #
+    #   User.includes(:posts).where("posts.name = 'foo'").references(:posts)
+    #   # Query now knows the string references posts, so adds a JOIN
+    def references: (*untyped table_names) -> untyped
+
+    def references!: (*untyped table_names) -> untyped
+
+    # Works in two unique ways.
+    #
+    # First: takes a block so it can be used just like <tt>Array#select</tt>.
+    #
+    #   Model.all.select { |m| m.field == value }
+    #
+    # This will build an array of objects from the database for the scope,
+    # converting them into an array and iterating through them using
+    # <tt>Array#select</tt>.
+    #
+    # Second: Modifies the SELECT statement for the query so that only certain
+    # fields are retrieved:
+    #
+    #   Model.select(:field)
+    #   # => [#<Model id: nil, field: "value">]
+    #
+    # Although in the above example it looks as though this method returns an
+    # array, it actually returns a relation object and can have other query
+    # methods appended to it, such as the other methods in ActiveRecord::QueryMethods.
+    #
+    # The argument to the method can also be an array of fields.
+    #
+    #   Model.select(:field, :other_field, :and_one_more)
+    #   # => [#<Model id: nil, field: "value", other_field: "value", and_one_more: "value">]
+    #
+    # You can also use one or more strings, which will be used unchanged as SELECT fields.
+    #
+    #   Model.select('field AS field_one', 'other_field AS field_two')
+    #   # => [#<Model id: nil, field: "value", other_field: "value">]
+    #
+    # If an alias was specified, it will be accessible from the resulting objects:
+    #
+    #   Model.select('field AS field_one').first.field_one
+    #   # => "value"
+    #
+    # Accessing attributes of an object that do not have fields retrieved by a select
+    # except +id+ will throw ActiveModel::MissingAttributeError:
+    #
+    #   Model.select(:field).first.other_field
+    #   # => ActiveModel::MissingAttributeError: missing attribute: other_field
+    def select: (*untyped fields) -> untyped
+
+    def _select!: (*untyped fields) -> untyped
+
+    # Allows you to change a previously set select statement.
+    #
+    #   Post.select(:title, :body)
+    #   # SELECT `posts`.`title`, `posts`.`body` FROM `posts`
+    #
+    #   Post.select(:title, :body).reselect(:created_at)
+    #   # SELECT `posts`.`created_at` FROM `posts`
+    #
+    # This is short-hand for <tt>unscope(:select).select(fields)</tt>.
+    # Note that we're unscoping the entire select statement.
+    def reselect: (*untyped args) -> untyped
+
+    def reselect!: (*untyped args) -> untyped
+
+    # Allows to specify a group attribute:
+    #
+    #   User.group(:name)
+    #   # SELECT "users".* FROM "users" GROUP BY name
+    #
+    # Returns an array with distinct records based on the +group+ attribute:
+    #
+    #   User.select([:id, :name])
+    #   # => [#<User id: 1, name: "Oscar">, #<User id: 2, name: "Oscar">, #<User id: 3, name: "Foo">]
+    #
+    #   User.group(:name)
+    #   # => [#<User id: 3, name: "Foo", ...>, #<User id: 2, name: "Oscar", ...>]
+    #
+    #   User.group('name AS grouped_name, age')
+    #   # => [#<User id: 3, name: "Foo", age: 21, ...>, #<User id: 2, name: "Oscar", age: 21, ...>, #<User id: 5, name: "Foo", age: 23, ...>]
+    #
+    # Passing in an array of attributes to group by is also supported.
+    #
+    #   User.select([:id, :first_name]).group(:id, :first_name).first(3)
+    #   # => [#<User id: 1, first_name: "Bill">, #<User id: 2, first_name: "Earl">, #<User id: 3, first_name: "Beto">]
+    def group: (*untyped args) -> untyped
+
+    def group!: (*untyped args) -> untyped
+
+    # Allows to specify an order attribute:
+    #
+    #   User.order(:name)
+    #   # SELECT "users".* FROM "users" ORDER BY "users"."name" ASC
+    #
+    #   User.order(email: :desc)
+    #   # SELECT "users".* FROM "users" ORDER BY "users"."email" DESC
+    #
+    #   User.order(:name, email: :desc)
+    #   # SELECT "users".* FROM "users" ORDER BY "users"."name" ASC, "users"."email" DESC
+    #
+    #   User.order('name')
+    #   # SELECT "users".* FROM "users" ORDER BY name
+    #
+    #   User.order('name DESC')
+    #   # SELECT "users".* FROM "users" ORDER BY name DESC
+    #
+    #   User.order('name DESC, email')
+    #   # SELECT "users".* FROM "users" ORDER BY name DESC, email
+    def order: (*untyped args) -> untyped
+
+    def order!: (*untyped args) -> untyped
+
+    # Replaces any existing order defined on the relation with the specified order.
+    #
+    #   User.order('email DESC').reorder('id ASC') # generated SQL has 'ORDER BY id ASC'
+    #
+    # Subsequent calls to order on the same relation will be appended. For example:
+    #
+    #   User.order('email DESC').reorder('id ASC').order('name ASC')
+    #
+    # generates a query with 'ORDER BY id ASC, name ASC'.
+    def reorder: (*untyped args) -> untyped
+
+    def reorder!: (*untyped args) -> untyped
+
+    VALID_UNSCOPING_VALUES: untyped
+
+    # Removes an unwanted relation that is already defined on a chain of relations.
+    # This is useful when passing around chains of relations and would like to
+    # modify the relations without reconstructing the entire chain.
+    #
+    #   User.order('email DESC').unscope(:order) == User.all
+    #
+    # The method arguments are symbols which correspond to the names of the methods
+    # which should be unscoped. The valid arguments are given in VALID_UNSCOPING_VALUES.
+    # The method can also be called with multiple arguments. For example:
+    #
+    #   User.order('email DESC').select('id').where(name: "John")
+    #       .unscope(:order, :select, :where) == User.all
+    #
+    # One can additionally pass a hash as an argument to unscope specific +:where+ values.
+    # This is done by passing a hash with a single key-value pair. The key should be
+    # +:where+ and the value should be the where value to unscope. For example:
+    #
+    #   User.where(name: "John", active: true).unscope(where: :name)
+    #       == User.where(active: true)
+    #
+    # This method is similar to #except, but unlike
+    # #except, it persists across merges:
+    #
+    #   User.order('email').merge(User.except(:order))
+    #       == User.order('email')
+    #
+    #   User.order('email').merge(User.unscope(:order))
+    #       == User.all
+    #
+    # This means it can be used in association definitions:
+    #
+    #   has_many :comments, -> { unscope(where: :trashed) }
+    #
+    def unscope: (*untyped args) -> untyped
+
+    def unscope!: (*untyped args) -> untyped
+
+    # Performs a joins on +args+. The given symbol(s) should match the name of
+    # the association(s).
+    #
+    #   User.joins(:posts)
+    #   # SELECT "users".*
+    #   # FROM "users"
+    #   # INNER JOIN "posts" ON "posts"."user_id" = "users"."id"
+    #
+    # Multiple joins:
+    #
+    #   User.joins(:posts, :account)
+    #   # SELECT "users".*
+    #   # FROM "users"
+    #   # INNER JOIN "posts" ON "posts"."user_id" = "users"."id"
+    #   # INNER JOIN "accounts" ON "accounts"."id" = "users"."account_id"
+    #
+    # Nested joins:
+    #
+    #   User.joins(posts: [:comments])
+    #   # SELECT "users".*
+    #   # FROM "users"
+    #   # INNER JOIN "posts" ON "posts"."user_id" = "users"."id"
+    #   # INNER JOIN "comments" "comments_posts"
+    #   #   ON "comments_posts"."post_id" = "posts"."id"
+    #
+    # You can use strings in order to customize your joins:
+    #
+    #   User.joins("LEFT JOIN bookmarks ON bookmarks.bookmarkable_type = 'Post' AND bookmarks.user_id = users.id")
+    #   # SELECT "users".* FROM "users" LEFT JOIN bookmarks ON bookmarks.bookmarkable_type = 'Post' AND bookmarks.user_id = users.id
+    def joins: (*untyped args) -> untyped
+
+    def joins!: (*untyped args) -> untyped
+
+    # Performs a left outer joins on +args+:
+    #
+    #   User.left_outer_joins(:posts)
+    #   => SELECT "users".* FROM "users" LEFT OUTER JOIN "posts" ON "posts"."user_id" = "users"."id"
+    #
+    def left_outer_joins: (*untyped args) -> untyped
+
+    alias left_joins left_outer_joins
+
+    def left_outer_joins!: (*untyped args) -> untyped
+
+    # Returns a new relation, which is the result of filtering the current relation
+    # according to the conditions in the arguments.
+    #
+    # #where accepts conditions in one of several formats. In the examples below, the resulting
+    # SQL is given as an illustration; the actual query generated may be different depending
+    # on the database adapter.
+    #
+    # === string
+    #
+    # A single string, without additional arguments, is passed to the query
+    # constructor as an SQL fragment, and used in the where clause of the query.
+    #
+    #    Client.where("orders_count = '2'")
+    #    # SELECT * from clients where orders_count = '2';
+    #
+    # Note that building your own string from user input may expose your application
+    # to injection attacks if not done properly. As an alternative, it is recommended
+    # to use one of the following methods.
+    #
+    # === array
+    #
+    # If an array is passed, then the first element of the array is treated as a template, and
+    # the remaining elements are inserted into the template to generate the condition.
+    # Active Record takes care of building the query to avoid injection attacks, and will
+    # convert from the ruby type to the database type where needed. Elements are inserted
+    # into the string in the order in which they appear.
+    #
+    #   User.where(["name = ? and email = ?", "Joe", "joe@example.com"])
+    #   # SELECT * FROM users WHERE name = 'Joe' AND email = 'joe@example.com';
+    #
+    # Alternatively, you can use named placeholders in the template, and pass a hash as the
+    # second element of the array. The names in the template are replaced with the corresponding
+    # values from the hash.
+    #
+    #   User.where(["name = :name and email = :email", { name: "Joe", email: "joe@example.com" }])
+    #   # SELECT * FROM users WHERE name = 'Joe' AND email = 'joe@example.com';
+    #
+    # This can make for more readable code in complex queries.
+    #
+    # Lastly, you can use sprintf-style % escapes in the template. This works slightly differently
+    # than the previous methods; you are responsible for ensuring that the values in the template
+    # are properly quoted. The values are passed to the connector for quoting, but the caller
+    # is responsible for ensuring they are enclosed in quotes in the resulting SQL. After quoting,
+    # the values are inserted using the same escapes as the Ruby core method +Kernel::sprintf+.
+    #
+    #   User.where(["name = '%s' and email = '%s'", "Joe", "joe@example.com"])
+    #   # SELECT * FROM users WHERE name = 'Joe' AND email = 'joe@example.com';
+    #
+    # If #where is called with multiple arguments, these are treated as if they were passed as
+    # the elements of a single array.
+    #
+    #   User.where("name = :name and email = :email", { name: "Joe", email: "joe@example.com" })
+    #   # SELECT * FROM users WHERE name = 'Joe' AND email = 'joe@example.com';
+    #
+    # When using strings to specify conditions, you can use any operator available from
+    # the database. While this provides the most flexibility, you can also unintentionally introduce
+    # dependencies on the underlying database. If your code is intended for general consumption,
+    # test with multiple database backends.
+    #
+    # === hash
+    #
+    # #where will also accept a hash condition, in which the keys are fields and the values
+    # are values to be searched for.
+    #
+    # Fields can be symbols or strings. Values can be single values, arrays, or ranges.
+    #
+    #    User.where({ name: "Joe", email: "joe@example.com" })
+    #    # SELECT * FROM users WHERE name = 'Joe' AND email = 'joe@example.com'
+    #
+    #    User.where({ name: ["Alice", "Bob"]})
+    #    # SELECT * FROM users WHERE name IN ('Alice', 'Bob')
+    #
+    #    User.where({ created_at: (Time.now.midnight - 1.day)..Time.now.midnight })
+    #    # SELECT * FROM users WHERE (created_at BETWEEN '2012-06-09 07:00:00.000000' AND '2012-06-10 07:00:00.000000')
+    #
+    # In the case of a belongs_to relationship, an association key can be used
+    # to specify the model if an ActiveRecord object is used as the value.
+    #
+    #    author = Author.find(1)
+    #
+    #    # The following queries will be equivalent:
+    #    Post.where(author: author)
+    #    Post.where(author_id: author)
+    #
+    # This also works with polymorphic belongs_to relationships:
+    #
+    #    treasure = Treasure.create(name: 'gold coins')
+    #    treasure.price_estimates << PriceEstimate.create(price: 125)
+    #
+    #    # The following queries will be equivalent:
+    #    PriceEstimate.where(estimate_of: treasure)
+    #    PriceEstimate.where(estimate_of_type: 'Treasure', estimate_of_id: treasure)
+    #
+    # === Joins
+    #
+    # If the relation is the result of a join, you may create a condition which uses any of the
+    # tables in the join. For string and array conditions, use the table name in the condition.
+    #
+    #    User.joins(:posts).where("posts.created_at < ?", Time.now)
+    #
+    # For hash conditions, you can either use the table name in the key, or use a sub-hash.
+    #
+    #    User.joins(:posts).where({ "posts.published" => true })
+    #    User.joins(:posts).where({ posts: { published: true } })
+    #
+    # === no argument
+    #
+    # If no argument is passed, #where returns a new instance of WhereChain, that
+    # can be chained with #not to return a new relation that negates the where clause.
+    #
+    #    User.where.not(name: "Jon")
+    #    # SELECT * FROM users WHERE name != 'Jon'
+    #
+    # See WhereChain for more details on #not.
+    #
+    # === blank condition
+    #
+    # If the condition is any blank-ish object, then #where is a no-op and returns
+    # the current relation.
+    def where: (?::Symbol opts, *untyped rest) -> untyped
+
+    def where!: (untyped opts, *untyped rest) -> untyped
+
+    # Allows you to change a previously set where condition for a given attribute, instead of appending to that condition.
+    #
+    #   Post.where(trashed: true).where(trashed: false)
+    #   # WHERE `trashed` = 1 AND `trashed` = 0
+    #
+    #   Post.where(trashed: true).rewhere(trashed: false)
+    #   # WHERE `trashed` = 0
+    #
+    #   Post.where(active: true).where(trashed: true).rewhere(trashed: false)
+    #   # WHERE `active` = 1 AND `trashed` = 0
+    #
+    # This is short-hand for <tt>unscope(where: conditions.keys).where(conditions)</tt>.
+    # Note that unlike reorder, we're only unscoping the named conditions -- not the entire where statement.
+    def rewhere: (untyped conditions) -> untyped
+
+    # Returns a new relation, which is the logical union of this relation and the one passed as an
+    # argument.
+    #
+    # The two relations must be structurally compatible: they must be scoping the same model, and
+    # they must differ only by #where (if no #group has been defined) or #having (if a #group is
+    # present). Neither relation may have a #limit, #offset, or #distinct set.
+    #
+    #    Post.where("id = 1").or(Post.where("author_id = 3"))
+    #    # SELECT `posts`.* FROM `posts` WHERE ((id = 1) OR (author_id = 3))
+    #
+    def or: (untyped other) -> untyped
+
+    def or!: (untyped other) -> untyped
+
+    # Allows to specify a HAVING clause. Note that you can't use HAVING
+    # without also specifying a GROUP clause.
+    #
+    #   Order.having('SUM(price) > 30').group('user_id')
+    def having: (untyped opts, *untyped rest) -> untyped
+
+    def having!: (untyped opts, *untyped rest) -> untyped
+
+    # Specifies a limit for the number of records to retrieve.
+    #
+    #   User.limit(10) # generated SQL has 'LIMIT 10'
+    #
+    #   User.limit(10).limit(20) # generated SQL has 'LIMIT 20'
+    def limit: (untyped value) -> untyped
+
+    def limit!: (untyped value) -> untyped
+
+    # Specifies the number of rows to skip before returning rows.
+    #
+    #   User.offset(10) # generated SQL has "OFFSET 10"
+    #
+    # Should be used with order.
+    #
+    #   User.offset(10).order("name ASC")
+    def offset: (untyped value) -> untyped
+
+    def offset!: (untyped value) -> untyped
+
+    # Specifies locking settings (default to +true+). For more information
+    # on locking, please see ActiveRecord::Locking.
+    def lock: (?bool locks) -> untyped
+
+    def lock!: (?bool locks) -> untyped
+
+    # Returns a chainable relation with zero records.
+    #
+    # The returned relation implements the Null Object pattern. It is an
+    # object with defined null behavior and always returns an empty array of
+    # records without querying the database.
+    #
+    # Any subsequent condition chained to the returned relation will continue
+    # generating an empty relation and will not fire any query to the database.
+    #
+    # Used in cases where a method or scope could return zero records but the
+    # result needs to be chainable.
+    #
+    # For example:
+    #
+    #   @posts = current_user.visible_posts.where(name: params[:name])
+    #   # the visible_posts method is expected to return a chainable Relation
+    #
+    #   def visible_posts
+    #     case role
+    #     when 'Country Manager'
+    #       Post.where(country: country)
+    #     when 'Reviewer'
+    #       Post.published
+    #     when 'Bad User'
+    #       Post.none # It can't be chained if [] is returned.
+    #     end
+    #   end
+    #
+    def none: () -> untyped
+
+    def none!: () -> untyped
+
+    # Sets readonly attributes for the returned relation. If value is
+    # true (default), attempting to update a record will result in an error.
+    #
+    #   users = User.readonly
+    #   users.first.save
+    #   => ActiveRecord::ReadOnlyRecord: User is marked as readonly
+    def readonly: (?bool value) -> untyped
+
+    def readonly!: (?bool value) -> untyped
+
+    # Sets attributes to be used when creating new records from a
+    # relation object.
+    #
+    #   users = User.where(name: 'Oscar')
+    #   users.new.name # => 'Oscar'
+    #
+    #   users = users.create_with(name: 'DHH')
+    #   users.new.name # => 'DHH'
+    #
+    # You can pass +nil+ to #create_with to reset attributes:
+    #
+    #   users = users.create_with(nil)
+    #   users.new.name # => 'Oscar'
+    def create_with: (untyped value) -> untyped
+
+    def create_with!: (untyped value) -> untyped
+
+    # Specifies table from which the records will be fetched. For example:
+    #
+    #   Topic.select('title').from('posts')
+    #   # SELECT title FROM posts
+    #
+    # Can accept other relation objects. For example:
+    #
+    #   Topic.select('title').from(Topic.approved)
+    #   # SELECT title FROM (SELECT * FROM topics WHERE approved = 't') subquery
+    #
+    #   Topic.select('a.title').from(Topic.approved, :a)
+    #   # SELECT a.title FROM (SELECT * FROM topics WHERE approved = 't') a
+    #
+    def from: (untyped value, ?untyped? subquery_name) -> untyped
+
+    def from!: (untyped value, ?untyped? subquery_name) -> untyped
+
+    # Specifies whether the records should be unique or not. For example:
+    #
+    #   User.select(:name)
+    #   # Might return two records with the same name
+    #
+    #   User.select(:name).distinct
+    #   # Returns 1 record per distinct name
+    #
+    #   User.select(:name).distinct.distinct(false)
+    #   # You can also remove the uniqueness
+    def distinct: (?bool value) -> untyped
+
+    def distinct!: (?bool value) -> untyped
+
+    # Used to extend a scope with additional methods, either through
+    # a module or through a block provided.
+    #
+    # The object returned is a relation, which can be further extended.
+    #
+    # === Using a module
+    #
+    #   module Pagination
+    #     def page(number)
+    #       # pagination code goes here
+    #     end
+    #   end
+    #
+    #   scope = Model.all.extending(Pagination)
+    #   scope.page(params[:page])
+    #
+    # You can also pass a list of modules:
+    #
+    #   scope = Model.all.extending(Pagination, SomethingElse)
+    #
+    # === Using a block
+    #
+    #   scope = Model.all.extending do
+    #     def page(number)
+    #       # pagination code goes here
+    #     end
+    #   end
+    #   scope.page(params[:page])
+    #
+    # You can also use a block and a module list:
+    #
+    #   scope = Model.all.extending(Pagination) do
+    #     def per_page(number)
+    #       # pagination code goes here
+    #     end
+    #   end
+    def extending: (*untyped modules) { () -> untyped } -> untyped
+
+    def extending!: (*untyped modules) { () -> untyped } -> untyped
+
+    # Specify optimizer hints to be used in the SELECT statement.
+    #
+    # Example (for MySQL):
+    #
+    #   Topic.optimizer_hints("MAX_EXECUTION_TIME(50000)", "NO_INDEX_MERGE(topics)")
+    #   # SELECT /*+ MAX_EXECUTION_TIME(50000) NO_INDEX_MERGE(topics) */ `topics`.* FROM `topics`
+    #
+    # Example (for PostgreSQL with pg_hint_plan):
+    #
+    #   Topic.optimizer_hints("SeqScan(topics)", "Parallel(topics 8)")
+    #   # SELECT /*+ SeqScan(topics) Parallel(topics 8) */ "topics".* FROM "topics"
+    def optimizer_hints: (*untyped args) -> untyped
+
+    def optimizer_hints!: (*untyped args) -> untyped
+
+    # Reverse the existing order clause on the relation.
+    #
+    #   User.order('name ASC').reverse_order # generated SQL has 'ORDER BY name DESC'
+    def reverse_order: () -> untyped
+
+    def reverse_order!: () -> untyped
+
+    def skip_query_cache!: (?bool value) -> untyped
+
+    def skip_preloading!: () -> untyped
+
+    # Adds an SQL comment to queries generated from this relation. For example:
+    #
+    #   User.annotate("selecting user names").select(:name)
+    #   # SELECT "users"."name" FROM "users" /* selecting user names */
+    #
+    #   User.annotate("selecting", "user", "names").select(:name)
+    #   # SELECT "users"."name" FROM "users" /* selecting */ /* user */ /* names */
+    #
+    # The SQL block comment delimiters, "/*" and "*/", will be added automatically.
+    def annotate: (*untyped args) -> untyped
+
+    def annotate!: (*untyped args) -> untyped
+
+    def arel: (?untyped? aliases) -> untyped
+
+    def construct_join_dependency: (untyped associations, untyped join_type) -> ActiveRecord::Associations::JoinDependency
+
+    def build_subquery: (untyped subquery_alias, untyped select_value) -> untyped
+
+    def assert_mutability!: () -> untyped
+
+    def build_arel: (untyped aliases) -> untyped
+
+    def build_from: () -> untyped
+
+    def select_association_list: (untyped associations) { () -> untyped } -> untyped
+
+    def valid_association_list: (untyped associations) -> untyped
+
+    def build_left_outer_joins: (untyped manager, untyped outer_joins, untyped aliases) -> untyped
+
+    def build_joins: (untyped manager, untyped joins, untyped aliases) -> untyped
+
+    def build_join_query: (untyped manager, untyped buckets, untyped join_type, untyped aliases) -> untyped
+
+    def build_select: (untyped arel) -> untyped
+
+    def arel_columns: (untyped columns) -> untyped
+
+    def arel_column: (untyped field) { (untyped) -> untyped } -> untyped
+
+    def table_name_matches?: (untyped from) -> untyped
+
+    def reverse_sql_order: (untyped order_query) -> (::Array[untyped] | untyped)
+
+    def does_not_support_reverse?: (untyped order) -> untyped
+
+    def build_order: (untyped arel) -> untyped
+
+    VALID_DIRECTIONS: untyped
+
+    def validate_order_args: (untyped args) -> untyped
+
+    def preprocess_order_args: (untyped order_args) -> untyped
+
+    def order_column: (untyped field) -> untyped
+
+    # Checks to make sure that the arguments are not blank. Note that if some
+    # blank-like object were initially passed into the query method, then this
+    # method will not raise an error.
+    #
+    # Example:
+    #
+    #    Post.references()   # raises an error
+    #    Post.references([]) # does not raise an error
+    #
+    # This particular method should be called with a method_name and the args
+    # passed into that method as an input. For example:
+    #
+    # def references(*args)
+    #   check_if_method_has_arguments!("references", args)
+    #   ...
+    # end
+    def check_if_method_has_arguments!: (untyped method_name, untyped args) -> untyped
+
+    STRUCTURAL_OR_METHODS: untyped
+
+    def structurally_incompatible_values_for_or: (untyped other) -> untyped
+
+    def where_clause_factory: () -> untyped
+
+    alias having_clause_factory where_clause_factory
+
+    DEFAULT_VALUES: ::Hash[untyped, untyped]
+  end
+end
+
+module ActiveRecord
+  class Relation
+    module RecordFetchWarning
+      # When this module is prepended to ActiveRecord::Relation and
+      # +config.active_record.warn_on_records_fetched_greater_than+ is
+      # set to an integer, if the number of records a query returns is
+      # greater than the value of +warn_on_records_fetched_greater_than+,
+      # a warning is logged. This allows for the detection of queries that
+      # return a large number of records, which could cause memory bloat.
+      #
+      # In most cases, fetching large number of records can be performed
+      # efficiently using the ActiveRecord::Batches methods.
+      # See ActiveRecord::Batches for more information.
+      def exec_queries: () -> untyped
+
+      class QueryRegistry
+        # :nodoc:
+        extend ActiveSupport::PerThreadRegistry
+
+        attr_reader queries: untyped
+
+        def initialize: () -> untyped
+
+        def reset: () -> untyped
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module SpawnMethods
+    def spawn: () -> untyped
+
+    # Merges in the conditions from <tt>other</tt>, if <tt>other</tt> is an ActiveRecord::Relation.
+    # Returns an array representing the intersection of the resulting records with <tt>other</tt>, if <tt>other</tt> is an array.
+    #
+    #   Post.where(published: true).joins(:comments).merge( Comment.where(spam: false) )
+    #   # Performs a single join query with both where conditions.
+    #
+    #   recent_posts = Post.order('created_at DESC').first(5)
+    #   Post.where(published: true).merge(recent_posts)
+    #   # Returns the intersection of all published posts with the 5 most recently created posts.
+    #   # (This is just an example. You'd probably want to do this with a single query!)
+    #
+    # Procs will be evaluated by merge:
+    #
+    #   Post.where(published: true).merge(-> { joins(:comments) })
+    #   # => Post.where(published: true).joins(:comments)
+    #
+    # This is mainly intended for sharing common conditions between multiple associations.
+    def merge: (untyped other) -> untyped
+
+    def merge!: (untyped other) -> untyped
+
+    # Removes from the query the condition(s) specified in +skips+.
+    #
+    #   Post.order('id asc').except(:order)                  # discards the order condition
+    #   Post.where('id > 10').order('id asc').except(:where) # discards the where condition but keeps the order
+    def except: (*untyped skips) -> untyped
+
+    # Removes any condition from the query other than the one(s) specified in +onlies+.
+    #
+    #   Post.order('id asc').only(:where)         # discards the order condition
+    #   Post.order('id asc').only(:where, :order) # uses the specified order
+    def only: (*untyped onlies) -> untyped
+
+    def relation_with: (untyped values) -> untyped
+  end
+end
+
+module ActiveRecord
+  class Relation
+    class WhereClause
+      def initialize: (untyped predicates) -> untyped
+
+      def +: (untyped other) -> WhereClause
+
+      def -: (untyped other) -> WhereClause
+
+      def merge: (untyped other) -> WhereClause
+
+      def except: (*untyped columns) -> WhereClause
+
+      def or: (untyped other) -> untyped
+
+      def to_h: (?untyped? table_name) -> untyped
+
+      def ast: () -> Arel::Nodes::And
+
+      def ==: (untyped other) -> untyped
+
+      def invert: (?::Symbol as) -> WhereClause
+
+      def self.empty: () -> untyped
+
+      attr_reader predicates: untyped
+
+      def referenced_columns: () -> untyped
+
+      def equalities: (untyped predicates) -> untyped
+
+      def predicates_unreferenced_by: (untyped other) -> untyped
+
+      def equality_node?: (untyped node) -> untyped
+
+      def invert_predicate: (untyped node) -> untyped
+
+      def except_predicates: (untyped columns) -> untyped
+
+      def predicates_with_wrapped_sql_literals: () -> untyped
+
+      ARRAY_WITH_EMPTY_STRING: ::Array[untyped]
+
+      def non_empty_predicates: () -> untyped
+
+      def wrap_sql_literal: (untyped node) -> Arel::Nodes::Grouping
+
+      def extract_node_value: (untyped node) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  class Relation
+    class WhereClauseFactory
+      # :nodoc:
+      def initialize: (untyped klass, untyped predicate_builder) -> untyped
+
+      def build: (untyped opts, untyped other) -> WhereClause
+
+      attr_reader klass: untyped
+
+      attr_reader predicate_builder: untyped
+    end
+  end
+end
+
+module ActiveRecord
+  # = Active Record \Relation
+  class Relation
+    MULTI_VALUE_METHODS: ::Array[untyped]
+
+    SINGLE_VALUE_METHODS: ::Array[untyped]
+
+    CLAUSE_METHODS: ::Array[untyped]
+
+    INVALID_METHODS_FOR_DELETE_ALL: ::Array[untyped]
+
+    VALUE_METHODS: untyped
+
+    include Enumerable[untyped]
+
+    include FinderMethods
+
+    include Calculations
+
+    include SpawnMethods
+
+    include QueryMethods
+
+    include Batches
+
+    include Explain
+
+    include Delegation
+
+    attr_reader table: untyped
+
+    attr_reader klass: untyped
+
+    attr_reader loaded: untyped
+
+    attr_reader predicate_builder: untyped
+
+    attr_accessor skip_preloading_value: untyped
+
+    alias model klass
+
+    alias loaded? loaded
+
+    alias locked? lock_value
+
+    def initialize: (untyped klass, ?values: ::Hash[untyped, untyped] values, ?predicate_builder: untyped predicate_builder, ?table: untyped table) -> untyped
+
+    def initialize_copy: (untyped other) -> untyped
+
+    def arel_attribute: (untyped name) -> untyped
+
+    def bind_attribute: (untyped name, untyped value) { (untyped, untyped) -> untyped } -> untyped
+
+    # Initializes new record from relation while maintaining the current
+    # scope.
+    #
+    # Expects arguments in the same format as {ActiveRecord::Base.new}[rdoc-ref:Core.new].
+    #
+    #   users = User.where(name: 'DHH')
+    #   user = users.new # => #<User id: nil, name: "DHH", created_at: nil, updated_at: nil>
+    #
+    # You can also pass a block to new with the new record as argument:
+    #
+    #   user = users.new { |user| user.name = 'Oscar' }
+    #   user.name # => Oscar
+    def new: (?untyped? attributes) { () -> untyped } -> untyped
+
+    alias build new
+
+    # Tries to create a new record with the same scoped attributes
+    # defined in the relation. Returns the initialized object if validation fails.
+    #
+    # Expects arguments in the same format as
+    # {ActiveRecord::Base.create}[rdoc-ref:Persistence::ClassMethods#create].
+    #
+    # ==== Examples
+    #
+    #   users = User.where(name: 'Oscar')
+    #   users.create # => #<User id: 3, name: "Oscar", ...>
+    #
+    #   users.create(name: 'fxn')
+    #   users.create # => #<User id: 4, name: "fxn", ...>
+    #
+    #   users.create { |user| user.name = 'tenderlove' }
+    #   # => #<User id: 5, name: "tenderlove", ...>
+    #
+    #   users.create(name: nil) # validation on name
+    #   # => #<User id: nil, name: nil, ...>
+    def create: (?untyped? attributes) { () -> untyped } -> untyped
+
+    # Similar to #create, but calls
+    # {create!}[rdoc-ref:Persistence::ClassMethods#create!]
+    # on the base class. Raises an exception if a validation error occurs.
+    #
+    # Expects arguments in the same format as
+    # {ActiveRecord::Base.create!}[rdoc-ref:Persistence::ClassMethods#create!].
+    def create!: (?untyped? attributes) { () -> untyped } -> untyped
+
+    def first_or_create: (?untyped? attributes) { () -> untyped } -> untyped
+
+    def first_or_create!: (?untyped? attributes) { () -> untyped } -> untyped
+
+    def first_or_initialize: (?untyped? attributes) { () -> untyped } -> untyped
+
+    # Finds the first record with the given attributes, or creates a record
+    # with the attributes if one is not found:
+    #
+    #   # Find the first user named "Pen(trim non-ascii characters)lope" or create a new one.
+    #   User.find_or_create_by(first_name: 'Pen(trim non-ascii characters)lope')
+    #   # => #<User id: 1, first_name: "Pen(trim non-ascii characters)lope", last_name: nil>
+    #
+    #   # Find the first user named "Pen(trim non-ascii characters)lope" or create a new one.
+    #   # We already have one so the existing record will be returned.
+    #   User.find_or_create_by(first_name: 'Pen(trim non-ascii characters)lope')
+    #   # => #<User id: 1, first_name: "Pen(trim non-ascii characters)lope", last_name: nil>
+    #
+    #   # Find the first user named "Scarlett" or create a new one with
+    #   # a particular last name.
+    #   User.create_with(last_name: 'Johansson').find_or_create_by(first_name: 'Scarlett')
+    #   # => #<User id: 2, first_name: "Scarlett", last_name: "Johansson">
+    #
+    # This method accepts a block, which is passed down to #create. The last example
+    # above can be alternatively written this way:
+    #
+    #   # Find the first user named "Scarlett" or create a new one with a
+    #   # different last name.
+    #   User.find_or_create_by(first_name: 'Scarlett') do |user|
+    #     user.last_name = 'Johansson'
+    #   end
+    #   # => #<User id: 2, first_name: "Scarlett", last_name: "Johansson">
+    #
+    # This method always returns a record, but if creation was attempted and
+    # failed due to validation errors it won't be persisted, you get what
+    # #create returns in such situation.
+    #
+    # Please note <b>this method is not atomic</b>, it runs first a SELECT, and if
+    # there are no results an INSERT is attempted. If there are other threads
+    # or processes there is a race condition between both calls and it could
+    # be the case that you end up with two similar records.
+    #
+    # If this might be a problem for your application, please see #create_or_find_by.
+    def find_or_create_by: (untyped attributes) { () -> untyped } -> untyped
+
+    # Like #find_or_create_by, but calls
+    # {create!}[rdoc-ref:Persistence::ClassMethods#create!] so an exception
+    # is raised if the created record is invalid.
+    def find_or_create_by!: (untyped attributes) { () -> untyped } -> untyped
+
+    # Attempts to create a record with the given attributes in a table that has a unique constraint
+    # on one or several of its columns. If a row already exists with one or several of these
+    # unique constraints, the exception such an insertion would normally raise is caught,
+    # and the existing record with those attributes is found using #find_by!.
+    #
+    # This is similar to #find_or_create_by, but avoids the problem of stale reads between the SELECT
+    # and the INSERT, as that method needs to first query the table, then attempt to insert a row
+    # if none is found.
+    #
+    # There are several drawbacks to #create_or_find_by, though:
+    #
+    # * The underlying table must have the relevant columns defined with unique constraints.
+    # * A unique constraint violation may be triggered by only one, or at least less than all,
+    #   of the given attributes. This means that the subsequent #find_by! may fail to find a
+    #   matching record, which will then raise an <tt>ActiveRecord::RecordNotFound</tt> exception,
+    #   rather than a record with the given attributes.
+    # * While we avoid the race condition between SELECT -> INSERT from #find_or_create_by,
+    #   we actually have another race condition between INSERT -> SELECT, which can be triggered
+    #   if a DELETE between those two statements is run by another client. But for most applications,
+    #   that's a significantly less likely condition to hit.
+    # * It relies on exception handling to handle control flow, which may be marginally slower.
+    # * The primary key may auto-increment on each create, even if it fails. This can accelerate
+    #   the problem of running out of integers, if the underlying table is still stuck on a primary
+    #   key of type int (note: All Rails apps since 5.1+ have defaulted to bigint, which is not liable
+    #   to this problem).
+    #
+    # This method will return a record if all given attributes are covered by unique constraints
+    # (unless the INSERT -> DELETE -> SELECT race condition is triggered), but if creation was attempted
+    # and failed due to validation errors it won't be persisted, you get what #create returns in
+    # such situation.
+    def create_or_find_by: (untyped attributes) { () -> untyped } -> untyped
+
+    # Like #create_or_find_by, but calls
+    # {create!}[rdoc-ref:Persistence::ClassMethods#create!] so an exception
+    # is raised if the created record is invalid.
+    def create_or_find_by!: (untyped attributes) { () -> untyped } -> untyped
+
+    # Like #find_or_create_by, but calls {new}[rdoc-ref:Core#new]
+    # instead of {create}[rdoc-ref:Persistence::ClassMethods#create].
+    def find_or_initialize_by: (untyped attributes) { () -> untyped } -> untyped
+
+    # Runs EXPLAIN on the query or queries triggered by this relation and
+    # returns the result as a string. The string is formatted imitating the
+    # ones printed by the database shell.
+    #
+    # Note that this method actually runs the queries, since the results of some
+    # are needed by the next ones when eager loading is going on.
+    #
+    # Please see further details in the
+    # {Active Record Query Interface guide}[https://guides.rubyonrails.org/active_record_querying.html#running-explain].
+    def explain: () -> untyped
+
+    # Converts relation objects to Array.
+    def to_ary: () -> untyped
+
+    alias to_a to_ary
+
+    def records: () -> untyped
+
+    # Serializes the relation objects Array.
+    def encode_with: (untyped coder) -> untyped
+
+    # Returns size of the records.
+    def size: () -> untyped
+
+    # Returns true if there are no records.
+    def empty?: () -> untyped
+
+    # Returns true if there are no records.
+    def none?: () -> untyped
+
+    # Returns true if there are any records.
+    def any?: () -> untyped
+
+    # Returns true if there is exactly one record.
+    def one?: () -> untyped
+
+    # Returns true if there is more than one record.
+    def many?: () -> untyped
+
+    # Returns a stable cache key that can be used to identify this query.
+    # The cache key is built with a fingerprint of the SQL query.
+    #
+    #    Product.where("name like ?", "%Cosmic Encounter%").cache_key
+    #    # => "products/query-1850ab3d302391b85b8693e941286659"
+    #
+    # If ActiveRecord::Base.collection_cache_versioning is turned off, as it was
+    # in Rails 6.0 and earlier, the cache key will also include a version.
+    #
+    #    ActiveRecord::Base.collection_cache_versioning = false
+    #    Product.where("name like ?", "%Cosmic Encounter%").cache_key
+    #    # => "products/query-1850ab3d302391b85b8693e941286659-1-20150714212553907087000"
+    #
+    # You can also pass a custom timestamp column to fetch the timestamp of the
+    # last updated record.
+    #
+    #   Product.where("name like ?", "%Game%").cache_key(:last_reviewed_at)
+    def cache_key: (?::Symbol timestamp_column) -> untyped
+
+    def compute_cache_key: (?::Symbol timestamp_column) -> untyped
+
+    # Returns a cache version that can be used together with the cache key to form
+    # a recyclable caching scheme. The cache version is built with the number of records
+    # matching the query, and the timestamp of the last updated record. When a new record
+    # comes to match the query, or any of the existing records is updated or deleted,
+    # the cache version changes.
+    #
+    # If the collection is loaded, the method will iterate through the records
+    # to generate the timestamp, otherwise it will trigger one SQL query like:
+    #
+    #    SELECT COUNT(*), MAX("products"."updated_at") FROM "products" WHERE (name like '%Cosmic Encounter%')
+    def cache_version: (?::Symbol timestamp_column) -> untyped
+
+    def compute_cache_version: (untyped timestamp_column) -> untyped
+
+    # Returns a cache key along with the version.
+    def cache_key_with_version: () -> untyped
+
+    # Scope all queries to the current scope.
+    #
+    #   Comment.where(post_id: 1).scoping do
+    #     Comment.first
+    #   end
+    #   # => SELECT "comments".* FROM "comments" WHERE "comments"."post_id" = 1 ORDER BY "comments"."id" ASC LIMIT 1
+    #
+    # Please check unscoped if you want to remove all previous scopes (including
+    # the default_scope) during the execution of a block.
+    def scoping: () { () -> untyped } -> untyped
+
+    def _exec_scope: (untyped name, *untyped args) { () -> untyped } -> untyped
+
+    # Updates all records in the current relation with details given. This method constructs a single SQL UPDATE
+    # statement and sends it straight to the database. It does not instantiate the involved models and it does not
+    # trigger Active Record callbacks or validations. However, values passed to #update_all will still go through
+    # Active Record's normal type casting and serialization.
+    #
+    # Note: As Active Record callbacks are not triggered, this method will not automatically update +updated_at+/+updated_on+ columns.
+    #
+    # ==== Parameters
+    #
+    # * +updates+ - A string, array, or hash representing the SET part of an SQL statement.
+    #
+    # ==== Examples
+    #
+    #   # Update all customers with the given attributes
+    #   Customer.update_all wants_email: true
+    #
+    #   # Update all books with 'Rails' in their title
+    #   Book.where('title LIKE ?', '%Rails%').update_all(author: 'David')
+    #
+    #   # Update all books that match conditions, but limit it to 5 ordered by date
+    #   Book.where('title LIKE ?', '%Rails%').order(:created_at).limit(5).update_all(author: 'David')
+    #
+    #   # Update all invoices and set the number column to its id value.
+    #   Invoice.update_all('number = id')
+    def update_all: (untyped updates) -> untyped
+
+    def update: (?::Symbol id, untyped attributes) -> untyped
+
+    def update_counters: (untyped counters) -> untyped
+
+    # Touches all records in the current relation without instantiating records first with the +updated_at+/+updated_on+ attributes
+    # set to the current time or the time specified.
+    # This method can be passed attribute names and an optional time argument.
+    # If attribute names are passed, they are updated along with +updated_at+/+updated_on+ attributes.
+    # If no time argument is passed, the current time is used as default.
+    #
+    # === Examples
+    #
+    #   # Touch all records
+    #   Person.all.touch_all
+    #   # => "UPDATE \"people\" SET \"updated_at\" = '2018-01-04 22:55:23.132670'"
+    #
+    #   # Touch multiple records with a custom attribute
+    #   Person.all.touch_all(:created_at)
+    #   # => "UPDATE \"people\" SET \"updated_at\" = '2018-01-04 22:55:23.132670', \"created_at\" = '2018-01-04 22:55:23.132670'"
+    #
+    #   # Touch multiple records with a specified time
+    #   Person.all.touch_all(time: Time.new(2020, 5, 16, 0, 0, 0))
+    #   # => "UPDATE \"people\" SET \"updated_at\" = '2020-05-16 00:00:00'"
+    #
+    #   # Touch records with scope
+    #   Person.where(name: 'David').touch_all
+    #   # => "UPDATE \"people\" SET \"updated_at\" = '2018-01-04 22:55:23.132670' WHERE \"people\".\"name\" = 'David'"
+    def touch_all: (*untyped names, ?time: untyped? time) -> untyped
+
+    # Destroys the records by instantiating each
+    # record and calling its {#destroy}[rdoc-ref:Persistence#destroy] method.
+    # Each object's callbacks are executed (including <tt>:dependent</tt> association options).
+    # Returns the collection of objects that were destroyed; each will be frozen, to
+    # reflect that no changes should be made (since they can't be persisted).
+    #
+    # Note: Instantiation, callback execution, and deletion of each
+    # record can be time consuming when you're removing many records at
+    # once. It generates at least one SQL +DELETE+ query per record (or
+    # possibly more, to enforce your callbacks). If you want to delete many
+    # rows quickly, without concern for their associations or callbacks, use
+    # #delete_all instead.
+    #
+    # ==== Examples
+    #
+    #   Person.where(age: 0..18).destroy_all
+    def destroy_all: () -> untyped
+
+    # Deletes the records without instantiating the records
+    # first, and hence not calling the {#destroy}[rdoc-ref:Persistence#destroy]
+    # method nor invoking callbacks.
+    # This is a single SQL DELETE statement that goes straight to the database, much more
+    # efficient than #destroy_all. Be careful with relations though, in particular
+    # <tt>:dependent</tt> rules defined on associations are not honored. Returns the
+    # number of rows affected.
+    #
+    #   Post.where(person_id: 5).where(category: ['Something', 'Else']).delete_all
+    #
+    # Both calls delete the affected posts all at once with a single DELETE statement.
+    # If you need to destroy dependent associations or call your <tt>before_*</tt> or
+    # +after_destroy+ callbacks, use the #destroy_all method instead.
+    #
+    # If an invalid method is supplied, #delete_all raises an ActiveRecordError:
+    #
+    #   Post.distinct.delete_all
+    #   # => ActiveRecord::ActiveRecordError: delete_all doesn't support distinct
+    def delete_all: () -> untyped
+
+    # Finds and destroys all records matching the specified conditions.
+    # This is short-hand for <tt>relation.where(condition).destroy_all</tt>.
+    # Returns the collection of objects that were destroyed.
+    #
+    # If no record is found, returns empty array.
+    #
+    #   Person.destroy_by(id: 13)
+    #   Person.destroy_by(name: 'Spartacus', rating: 4)
+    #   Person.destroy_by("published_at < ?", 2.weeks.ago)
+    def destroy_by: (*untyped args) -> untyped
+
+    # Finds and deletes all records matching the specified conditions.
+    # This is short-hand for <tt>relation.where(condition).delete_all</tt>.
+    # Returns the number of rows affected.
+    #
+    # If no record is found, returns <tt>0</tt> as zero rows were affected.
+    #
+    #   Person.delete_by(id: 13)
+    #   Person.delete_by(name: 'Spartacus', rating: 4)
+    #   Person.delete_by("published_at < ?", 2.weeks.ago)
+    def delete_by: (*untyped args) -> untyped
+
+    # Causes the records to be loaded from the database if they have not
+    # been loaded already. You can use this if for some reason you need
+    # to explicitly load some records before actually using them. The
+    # return value is the relation itself, not the records.
+    #
+    #   Post.where(published: true).load # => #<ActiveRecord::Relation>
+    def load: () { () -> untyped } -> untyped
+
+    # Forces reloading of relation.
+    def reload: () -> untyped
+
+    def reset: () -> untyped
+
+    # Returns sql statement for the relation.
+    #
+    #   User.where(name: 'Oscar').to_sql
+    #   # => SELECT "users".* FROM "users"  WHERE "users"."name" = 'Oscar'
+    def to_sql: () -> untyped
+
+    # Returns a hash of where conditions.
+    #
+    #   User.where(name: 'Oscar').where_values_hash
+    #   # => {name: "Oscar"}
+    def where_values_hash: (?untyped relation_table_name) -> untyped
+
+    def scope_for_create: () -> untyped
+
+    # Returns true if relation needs eager loading.
+    def eager_loading?: () -> untyped
+
+    # Joins that are also marked for preloading. In which case we should just eager load them.
+    # Note that this is a naive implementation because we could have strings and symbols which
+    # represent the same association, but that aren't matched by this. Also, we could have
+    # nested hashes which partially match, e.g. { a: :b } & { a: [:b, :c] }
+    def joined_includes_values: () -> untyped
+
+    # Compares two relations for equality.
+    def ==: (untyped other) -> untyped
+
+    def pretty_print: (untyped q) -> untyped
+
+    # Returns true if relation is blank.
+    def blank?: () -> untyped
+
+    def values: () -> untyped
+
+    def inspect: () -> ::String
+
+    def empty_scope?: () -> untyped
+
+    def has_limit_or_offset?: () -> untyped
+
+    def alias_tracker: (?untyped joins, ?untyped? aliases) -> untyped
+
+    def preload_associations: (untyped records) -> untyped
+
+    attr_reader _deprecated_scope_source: untyped
+
+    attr_writer _deprecated_scope_source: untyped
+
+    def load_records: (untyped records) -> untyped
+
+    def null_relation?: () -> untyped
+
+    def already_in_scope?: () -> untyped
+
+    def _deprecated_spawn: (untyped name) -> untyped
+
+    def _deprecated_scope_block: (untyped name) { (untyped) -> untyped } -> untyped
+
+    def _scoping: (untyped scope) { () -> untyped } -> untyped
+
+    def _substitute_values: (untyped values) -> untyped
+
+    def _increment_attribute: (untyped attribute, ?::Integer value) -> untyped
+
+    def exec_queries: () { () -> untyped } -> untyped
+
+    def skip_query_cache_if_necessary: () { () -> untyped } -> untyped
+
+    def build_preloader: () -> ActiveRecord::Associations::Preloader
+
+    def references_eager_loaded_tables?: () -> untyped
+
+    def tables_in_string: (untyped string) -> (::Array[untyped] | untyped)
+  end
+end
+
+module ActiveRecord
+  # #
+  # This class encapsulates a result returned from calling
+  # {#exec_query}[rdoc-ref:ConnectionAdapters::DatabaseStatements#exec_query]
+  # on any database connection adapter. For example:
+  #
+  #   result = ActiveRecord::Base.connection.exec_query('SELECT id, title, body FROM posts')
+  #   result # => #<ActiveRecord::Result:0xdeadbeef>
+  #
+  #   # Get the column names of the result:
+  #   result.columns
+  #   # => ["id", "title", "body"]
+  #
+  #   # Get the record values of the result:
+  #   result.rows
+  #   # => [[1, "title_1", "body_1"],
+  #         [2, "title_2", "body_2"],
+  #         ...
+  #        ]
+  #
+  #   # Get an array of hashes representing the result (column => value):
+  #   result.to_a
+  #   # => [{"id" => 1, "title" => "title_1", "body" => "body_1"},
+  #         {"id" => 2, "title" => "title_2", "body" => "body_2"},
+  #         ...
+  #        ]
+  #
+  #   # ActiveRecord::Result also includes Enumerable.
+  #   result.each do |row|
+  #     puts row['title'] + " " + row['body']
+  #   end
+  class Result
+    include Enumerable[untyped]
+
+    attr_reader columns: untyped
+
+    attr_reader rows: untyped
+
+    attr_reader column_types: untyped
+
+    def initialize: (untyped columns, untyped rows, ?::Hash[untyped, untyped] column_types) -> untyped
+
+    # Returns true if this result set includes the column named +name+
+    def includes_column?: (untyped name) -> untyped
+
+    # Returns the number of elements in the rows array.
+    def length: () -> untyped
+
+    # Calls the given block once for each element in row collection, passing
+    # row as parameter.
+    #
+    # Returns an +Enumerator+ if no block is given.
+    def each: () { (untyped) -> untyped } -> untyped
+
+    def to_hash: () -> untyped
+
+    alias map! map
+
+    alias collect! map
+
+    # Returns true if there are no records, otherwise false.
+    def empty?: () -> untyped
+
+    # Returns an array of hashes representing each row record.
+    def to_ary: () -> untyped
+
+    alias to_a to_ary
+
+    def []: (untyped idx) -> untyped
+
+    # Returns the first record from the rows collection.
+    # If the rows collection is empty, returns +nil+.
+    def first: () -> (nil | untyped)
+
+    # Returns the last record from the rows collection.
+    # If the rows collection is empty, returns +nil+.
+    def last: () -> (nil | untyped)
+
+    def cast_values: (?::Hash[untyped, untyped] type_overrides) -> untyped
+
+    def initialize_copy: (untyped other) -> untyped
+
+    def column_type: (untyped name, ?::Hash[untyped, untyped] type_overrides) -> untyped
+
+    def hash_rows: () -> untyped
+  end
+end
+
+module ActiveRecord
+  class RuntimeRegistry
+    # This is a thread locals registry for Active Record. For example:
+    #
+    #   ActiveRecord::RuntimeRegistry.connection_handler
+    #
+    # returns the connection handler local to the current thread.
+    #
+    # See the documentation of ActiveSupport::PerThreadRegistry
+    # for further details.
+    # :nodoc:
+    extend ActiveSupport::PerThreadRegistry
+
+    attr_accessor connection_handler: untyped
+
+    attr_accessor sql_runtime: untyped
+  end
+end
+
+module ActiveRecord
+  module Sanitization
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      # Accepts an array or string of SQL conditions and sanitizes
+      # them into a valid SQL fragment for a WHERE clause.
+      #
+      #   sanitize_sql_for_conditions(["name=? and group_id=?", "foo'bar", 4])
+      #   # => "name='foo''bar' and group_id=4"
+      #
+      #   sanitize_sql_for_conditions(["name=:name and group_id=:group_id", name: "foo'bar", group_id: 4])
+      #   # => "name='foo''bar' and group_id='4'"
+      #
+      #   sanitize_sql_for_conditions(["name='%s' and group_id='%s'", "foo'bar", 4])
+      #   # => "name='foo''bar' and group_id='4'"
+      #
+      #   sanitize_sql_for_conditions("name='foo''bar' and group_id='4'")
+      #   # => "name='foo''bar' and group_id='4'"
+      def sanitize_sql_for_conditions: (untyped condition) -> (nil | untyped)
+
+      alias sanitize_sql sanitize_sql_for_conditions
+
+      # Accepts an array, hash, or string of SQL conditions and sanitizes
+      # them into a valid SQL fragment for a SET clause.
+      #
+      #   sanitize_sql_for_assignment(["name=? and group_id=?", nil, 4])
+      #   # => "name=NULL and group_id=4"
+      #
+      #   sanitize_sql_for_assignment(["name=:name and group_id=:group_id", name: nil, group_id: 4])
+      #   # => "name=NULL and group_id=4"
+      #
+      #   Post.sanitize_sql_for_assignment({ name: nil, group_id: 4 })
+      #   # => "`posts`.`name` = NULL, `posts`.`group_id` = 4"
+      #
+      #   sanitize_sql_for_assignment("name=NULL and group_id='4'")
+      #   # => "name=NULL and group_id='4'"
+      def sanitize_sql_for_assignment: (untyped assignments, ?untyped default_table_name) -> untyped
+
+      # Accepts an array, or string of SQL conditions and sanitizes
+      # them into a valid SQL fragment for an ORDER clause.
+      #
+      #   sanitize_sql_for_order(["field(id, ?)", [1,3,2]])
+      #   # => "field(id, 1,3,2)"
+      #
+      #   sanitize_sql_for_order("id ASC")
+      #   # => "id ASC"
+      def sanitize_sql_for_order: (untyped condition) -> untyped
+
+      # Sanitizes a hash of attribute/value pairs into SQL conditions for a SET clause.
+      #
+      #   sanitize_sql_hash_for_assignment({ status: nil, group_id: 1 }, "posts")
+      #   # => "`posts`.`status` = NULL, `posts`.`group_id` = 1"
+      def sanitize_sql_hash_for_assignment: (untyped attrs, untyped table) -> untyped
+
+      # Sanitizes a +string+ so that it is safe to use within an SQL
+      # LIKE statement. This method uses +escape_character+ to escape all occurrences of "\", "_" and "%".
+      #
+      #   sanitize_sql_like("100%")
+      #   # => "100\\%"
+      #
+      #   sanitize_sql_like("snake_cased_string")
+      #   # => "snake\\_cased\\_string"
+      #
+      #   sanitize_sql_like("100%", "!")
+      #   # => "100!%"
+      #
+      #   sanitize_sql_like("snake_cased_string", "!")
+      #   # => "snake!_cased!_string"
+      def sanitize_sql_like: (untyped string, ?::String escape_character) -> untyped
+
+      # Accepts an array of conditions. The array has each value
+      # sanitized and interpolated into the SQL statement.
+      #
+      #   sanitize_sql_array(["name=? and group_id=?", "foo'bar", 4])
+      #   # => "name='foo''bar' and group_id=4"
+      #
+      #   sanitize_sql_array(["name=:name and group_id=:group_id", name: "foo'bar", group_id: 4])
+      #   # => "name='foo''bar' and group_id=4"
+      #
+      #   sanitize_sql_array(["name='%s' and group_id='%s'", "foo'bar", 4])
+      #   # => "name='foo''bar' and group_id='4'"
+      def sanitize_sql_array: (untyped ary) -> untyped
+
+      def disallow_raw_sql!: (untyped args, ?permit: untyped permit) -> (nil | untyped)
+
+      def replace_bind_variables: (untyped statement, untyped values) -> untyped
+
+      def replace_bind_variable: (untyped value, ?untyped c) -> untyped
+
+      def replace_named_bind_variables: (untyped statement, untyped bind_vars) -> untyped
+
+      def quote_bound_value: (untyped value, ?untyped c) -> untyped
+
+      def raise_if_bind_arity_mismatch: (untyped statement, untyped expected, untyped provided) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  # = Active Record \Schema
+  #
+  # Allows programmers to programmatically define a schema in a portable
+  # DSL. This means you can define tables, indexes, etc. without using SQL
+  # directly, so your applications can more easily support multiple
+  # databases.
+  #
+  # Usage:
+  #
+  #   ActiveRecord::Schema.define do
+  #     create_table :authors do |t|
+  #       t.string :name, null: false
+  #     end
+  #
+  #     add_index :authors, :name, :unique
+  #
+  #     create_table :posts do |t|
+  #       t.integer :author_id, null: false
+  #       t.string :subject
+  #       t.text :body
+  #       t.boolean :private, default: false
+  #     end
+  #
+  #     add_index :posts, :author_id
+  #   end
+  #
+  # ActiveRecord::Schema is only supported by database adapters that also
+  # support migrations, the two features being very similar.
+  class Schema < Migration::Current
+    # Eval the given block. All methods available to the current connection
+    # adapter are available within the block, so you can easily use the
+    # database definition DSL to build up your schema (
+    # {create_table}[rdoc-ref:ConnectionAdapters::SchemaStatements#create_table],
+    # {add_index}[rdoc-ref:ConnectionAdapters::SchemaStatements#add_index], etc.).
+    #
+    # The +info+ hash is optional, and if given is used to define metadata
+    # about the current schema (currently, only the schema's version):
+    #
+    #   ActiveRecord::Schema.define(version: 2038_01_19_000001) do
+    #     ...
+    #   end
+    def self.define: (?::Hash[untyped, untyped] info) { () -> untyped } -> untyped
+
+    def define: (untyped info) { () -> untyped } -> untyped
+  end
+end
+
+module ActiveRecord
+  class SchemaDumper
+    def self.dump: (?untyped connection, ?untyped stream, ?untyped config) -> untyped
+
+    def self.generate_options: (untyped config) -> { table_name_prefix: untyped, table_name_suffix: untyped }
+
+    def dump: (untyped stream) -> untyped
+
+    attr_accessor table_name: untyped
+
+    def initialize: (untyped connection, ?::Hash[untyped, untyped] options) -> untyped
+
+    # turns 20170404131909 into "2017_04_04_131909"
+    def formatted_version: () -> untyped
+
+    def define_params: () -> untyped
+
+    def header: (untyped stream) -> untyped
+
+    def trailer: (untyped stream) -> untyped
+
+    # extensions are only supported by PostgreSQL
+    def extensions: (untyped stream) -> nil
+
+    def tables: (untyped stream) -> untyped
+
+    def table: (untyped table, untyped stream) -> untyped
+
+    # Keep it for indexing materialized views
+    def indexes: (untyped table, untyped stream) -> untyped
+
+    def indexes_in_create: (untyped table, untyped stream) -> untyped
+
+    def index_parts: (untyped index) -> untyped
+
+    def foreign_keys: (untyped table, untyped stream) -> untyped
+
+    def format_colspec: (untyped colspec) -> untyped
+
+    def format_options: (untyped options) -> untyped
+
+    def format_index_parts: (untyped options) -> untyped
+
+    def remove_prefix_and_suffix: (untyped table) -> untyped
+
+    def ignored?: (untyped table_name) -> untyped
+  end
+end
+
+module ActiveRecord
+  class SchemaMigration < ActiveRecord::Base
+    def self._internal?: () -> ::TrueClass
+
+    def self.primary_key: () -> "version"
+
+    def self.table_name: () -> ::String
+
+    def self.table_exists?: () -> untyped
+
+    def self.create_table: () -> untyped
+
+    def self.drop_table: () -> untyped
+
+    def self.normalize_migration_number: (untyped number) -> untyped
+
+    def self.normalized_versions: () -> untyped
+
+    def self.all_versions: () -> untyped
+
+    def version: () -> untyped
+  end
+end
+
+module ActiveRecord
+  module Scoping
+    module Default
+      extend ActiveSupport::Concern
+
+      module ClassMethods
+        # Returns a scope for the model without the previously set scopes.
+        #
+        #   class Post < ActiveRecord::Base
+        #     def self.default_scope
+        #       where(published: true)
+        #     end
+        #   end
+        #
+        #   Post.all                                  # Fires "SELECT * FROM posts WHERE published = true"
+        #   Post.unscoped.all                         # Fires "SELECT * FROM posts"
+        #   Post.where(published: false).unscoped.all # Fires "SELECT * FROM posts"
+        #
+        # This method also accepts a block. All queries inside the block will
+        # not use the previously set scopes.
+        #
+        #   Post.unscoped {
+        #     Post.limit(10) # Fires "SELECT * FROM posts LIMIT 10"
+        #   }
+        def unscoped: () { () -> untyped } -> untyped
+
+        def scope_attributes?: () -> untyped
+
+        def before_remove_const: () -> untyped
+
+        def default_scope: (?untyped? scope) { () -> untyped } -> untyped
+
+        def build_default_scope: (?untyped relation) -> (nil | untyped)
+
+        def ignore_default_scope?: () -> untyped
+
+        def ignore_default_scope=: (untyped ignore) -> untyped
+
+        # The ignore_default_scope flag is used to prevent an infinite recursion
+        # situation where a default scope references a scope which has a default
+        # scope which references a scope...
+        def evaluate_default_scope: () { () -> untyped } -> (nil | untyped)
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  # = Active Record \Named \Scopes
+  module Scoping
+    module Named
+      extend ActiveSupport::Concern
+
+      module ClassMethods
+        # Returns an ActiveRecord::Relation scope object.
+        #
+        #   posts = Post.all
+        #   posts.size # Fires "select count(*) from  posts" and returns the count
+        #   posts.each {|p| puts p.name } # Fires "select * from posts" and loads post objects
+        #
+        #   fruits = Fruit.all
+        #   fruits = fruits.where(color: 'red') if options[:red_only]
+        #   fruits = fruits.limit(10) if limited?
+        #
+        # You can define a scope that applies to all finders using
+        # {default_scope}[rdoc-ref:Scoping::Default::ClassMethods#default_scope].
+        def all: () -> untyped
+
+        def scope_for_association: (?untyped scope) -> untyped
+
+        # Returns a scope for the model with default scopes.
+        def default_scoped: (?untyped scope) -> untyped
+
+        def default_extensions: () -> untyped
+
+        # Adds a class method for retrieving and querying objects.
+        # The method is intended to return an ActiveRecord::Relation
+        # object, which is composable with other scopes.
+        # If it returns +nil+ or +false+, an
+        # {all}[rdoc-ref:Scoping::Named::ClassMethods#all] scope is returned instead.
+        #
+        # A \scope represents a narrowing of a database query, such as
+        # <tt>where(color: :red).select('shirts.*').includes(:washing_instructions)</tt>.
+        #
+        #   class Shirt < ActiveRecord::Base
+        #     scope :red, -> { where(color: 'red') }
+        #     scope :dry_clean_only, -> { joins(:washing_instructions).where('washing_instructions.dry_clean_only = ?', true) }
+        #   end
+        #
+        # The above calls to #scope define class methods <tt>Shirt.red</tt> and
+        # <tt>Shirt.dry_clean_only</tt>. <tt>Shirt.red</tt>, in effect,
+        # represents the query <tt>Shirt.where(color: 'red')</tt>.
+        #
+        # You should always pass a callable object to the scopes defined
+        # with #scope. This ensures that the scope is re-evaluated each
+        # time it is called.
+        #
+        # Note that this is simply 'syntactic sugar' for defining an actual
+        # class method:
+        #
+        #   class Shirt < ActiveRecord::Base
+        #     def self.red
+        #       where(color: 'red')
+        #     end
+        #   end
+        #
+        # Unlike <tt>Shirt.find(...)</tt>, however, the object returned by
+        # <tt>Shirt.red</tt> is not an Array but an ActiveRecord::Relation,
+        # which is composable with other scopes; it resembles the association object
+        # constructed by a {has_many}[rdoc-ref:Associations::ClassMethods#has_many]
+        # declaration. For instance, you can invoke <tt>Shirt.red.first</tt>, <tt>Shirt.red.count</tt>,
+        # <tt>Shirt.red.where(size: 'small')</tt>. Also, just as with the
+        # association objects, named \scopes act like an Array, implementing
+        # Enumerable; <tt>Shirt.red.each(&block)</tt>, <tt>Shirt.red.first</tt>,
+        # and <tt>Shirt.red.inject(memo, &block)</tt> all behave as if
+        # <tt>Shirt.red</tt> really was an array.
+        #
+        # These named \scopes are composable. For instance,
+        # <tt>Shirt.red.dry_clean_only</tt> will produce all shirts that are
+        # both red and dry clean only. Nested finds and calculations also work
+        # with these compositions: <tt>Shirt.red.dry_clean_only.count</tt>
+        # returns the number of garments for which these criteria obtain.
+        # Similarly with <tt>Shirt.red.dry_clean_only.average(:thread_count)</tt>.
+        #
+        # All scopes are available as class methods on the ActiveRecord::Base
+        # descendant upon which the \scopes were defined. But they are also
+        # available to {has_many}[rdoc-ref:Associations::ClassMethods#has_many]
+        # associations. If,
+        #
+        #   class Person < ActiveRecord::Base
+        #     has_many :shirts
+        #   end
+        #
+        # then <tt>elton.shirts.red.dry_clean_only</tt> will return all of
+        # Elton's red, dry clean only shirts.
+        #
+        # \Named scopes can also have extensions, just as with
+        # {has_many}[rdoc-ref:Associations::ClassMethods#has_many] declarations:
+        #
+        #   class Shirt < ActiveRecord::Base
+        #     scope :red, -> { where(color: 'red') } do
+        #       def dom_id
+        #         'red_shirts'
+        #       end
+        #     end
+        #   end
+        #
+        # Scopes can also be used while creating/building a record.
+        #
+        #   class Article < ActiveRecord::Base
+        #     scope :published, -> { where(published: true) }
+        #   end
+        #
+        #   Article.published.new.published    # => true
+        #   Article.published.create.published # => true
+        #
+        # \Class methods on your model are automatically available
+        # on scopes. Assuming the following setup:
+        #
+        #   class Article < ActiveRecord::Base
+        #     scope :published, -> { where(published: true) }
+        #     scope :featured, -> { where(featured: true) }
+        #
+        #     def self.latest_article
+        #       order('published_at desc').first
+        #     end
+        #
+        #     def self.titles
+        #       pluck(:title)
+        #     end
+        #   end
+        #
+        # We are able to call the methods like this:
+        #
+        #   Article.published.featured.latest_article
+        #   Article.featured.titles
+        def scope: (untyped name, untyped body) { () -> untyped } -> untyped
+
+        def valid_scope_name?: (untyped name) -> untyped
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module Scoping
+    extend ActiveSupport::Concern
+
+    include Default
+
+    include Named
+
+    module ClassMethods
+      # :nodoc:
+      # Collects attributes from scopes that should be applied when creating
+      # an AR instance for the particular class this is called on.
+      def scope_attributes: () -> untyped
+
+      # Are there attributes associated with this scope?
+      def scope_attributes?: () -> untyped
+
+      def current_scope: (?bool skip_inherited_scope) -> untyped
+
+      def current_scope=: (untyped scope) -> untyped
+    end
+
+    def populate_with_current_scope_attributes: () -> (nil | untyped)
+
+    def initialize_internals_callback: () -> untyped
+
+    class ScopeRegistry
+      # This class stores the +:current_scope+ and +:ignore_default_scope+ values
+      # for different classes. The registry is stored as a thread local, which is
+      # accessed through +ScopeRegistry.current+.
+      #
+      # This class allows you to store and get the scope values on different
+      # classes and different types of scopes. For example, if you are attempting
+      # to get the current_scope for the +Board+ model, then you would use the
+      # following code:
+      #
+      #   registry = ActiveRecord::Scoping::ScopeRegistry
+      #   registry.set_value_for(:current_scope, Board, some_new_scope)
+      #
+      # Now when you run:
+      #
+      #   registry.value_for(:current_scope, Board)
+      #
+      # You will obtain whatever was defined in +some_new_scope+. The #value_for
+      # and #set_value_for methods are delegated to the current ScopeRegistry
+      # object, so the above example code can also be called as:
+      #
+      #   ActiveRecord::Scoping::ScopeRegistry.set_value_for(:current_scope,
+      #       Board, some_new_scope)
+      # :nodoc:
+      extend ActiveSupport::PerThreadRegistry
+
+      VALID_SCOPE_TYPES: ::Array[untyped]
+
+      def initialize: () -> untyped
+
+      # Obtains the value for a given +scope_type+ and +model+.
+      def value_for: (untyped scope_type, untyped model, ?bool skip_inherited_scope) -> untyped
+
+      # Sets the +value+ for a given +scope_type+ and +model+.
+      def set_value_for: (untyped scope_type, untyped model, untyped value) -> untyped
+
+      def raise_invalid_scope_type!: (untyped scope_type) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module SecureToken
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      # Example using #has_secure_token
+      #
+      #   # Schema: User(token:string, auth_token:string)
+      #   class User < ActiveRecord::Base
+      #     has_secure_token
+      #     has_secure_token :auth_token
+      #   end
+      #
+      #   user = User.new
+      #   user.save
+      #   user.token # => "pX27zsMN2ViQKta1bGfLmVJE"
+      #   user.auth_token # => "77TMHrHJFvFDwodq8w7Ev2m7"
+      #   user.regenerate_token # => true
+      #   user.regenerate_auth_token # => true
+      #
+      # <tt>SecureRandom::base58</tt> is used to generate the 24-character unique token, so collisions are highly unlikely.
+      #
+      # Note that it's still possible to generate a race condition in the database in the same way that
+      # {validates_uniqueness_of}[rdoc-ref:Validations::ClassMethods#validates_uniqueness_of] can.
+      # You're encouraged to add a unique index in the database to deal with this even more unlikely scenario.
+      def has_secure_token: (?::Symbol attribute) -> untyped
+
+      def generate_unique_secure_token: () -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  # nodoc:
+  # = Active Record \Serialization
+  module Serialization
+    extend ActiveSupport::Concern
+
+    include ActiveModel::Serializers::JSON
+
+    def serializable_hash: (?untyped? options) -> untyped
+  end
+end
+
+module ActiveRecord
+  class StatementCache
+    class Substitute
+    end
+
+    class Query
+      # :nodoc:
+      def initialize: (untyped sql) -> untyped
+
+      def sql_for: (untyped binds, untyped connection) -> untyped
+    end
+
+    class PartialQuery < Query
+      # :nodoc:
+      def initialize: (untyped values) -> untyped
+
+      def sql_for: (untyped binds, untyped connection) -> untyped
+    end
+
+    class PartialQueryCollector
+      def initialize: () -> untyped
+
+      def <<: (untyped str) -> untyped
+
+      def add_bind: (untyped obj) -> untyped
+
+      def value: () -> ::Array[untyped]
+    end
+
+    def self.query: (untyped sql) -> Query
+
+    def self.partial_query: (untyped values) -> PartialQuery
+
+    def self.partial_query_collector: () -> PartialQueryCollector
+
+    class Params
+      # :nodoc:
+      def bind: () -> Substitute
+    end
+
+    class BindMap
+      # :nodoc:
+      def initialize: (untyped bound_attributes) -> untyped
+
+      def bind: (untyped values) -> untyped
+    end
+
+    def self.create: (untyped connection, ?untyped? callable) { () -> untyped } -> untyped
+
+    def initialize: (untyped query_builder, untyped bind_map, untyped klass) -> untyped
+
+    def execute: (untyped params, untyped connection) { () -> untyped } -> untyped
+
+    def self.unsupported_value?: (untyped value) -> untyped
+
+    attr_reader query_builder: untyped
+
+    attr_reader bind_map: untyped
+
+    attr_reader klass: untyped
+  end
+end
+
+module ActiveRecord
+  # Store gives you a thin wrapper around serialize for the purpose of storing hashes in a single column.
+  # It's like a simple key/value store baked into your record when you don't care about being able to
+  # query that store outside the context of a single record.
+  #
+  # You can then declare accessors to this store that are then accessible just like any other attribute
+  # of the model. This is very helpful for easily exposing store keys to a form or elsewhere that's
+  # already built around just accessing attributes on the model.
+  #
+  # Every accessor comes with dirty tracking methods (+key_changed?+, +key_was+ and +key_change+) and
+  # methods to access the changes made during the last save (+saved_change_to_key?+, +saved_change_to_key+ and
+  # +key_before_last_save+).
+  #
+  # NOTE: There is no +key_will_change!+ method for accessors, use +store_will_change!+ instead.
+  #
+  # Make sure that you declare the database column used for the serialized store as a text, so there's
+  # plenty of room.
+  #
+  # You can set custom coder to encode/decode your serialized attributes to/from different formats.
+  # JSON, YAML, Marshal are supported out of the box. Generally it can be any wrapper that provides +load+ and +dump+.
+  #
+  # NOTE: If you are using structured database data types (eg. PostgreSQL +hstore+/+json+, or MySQL 5.7+
+  # +json+) there is no need for the serialization provided by {.store}[rdoc-ref:rdoc-ref:ClassMethods#store].
+  # Simply use {.store_accessor}[rdoc-ref:ClassMethods#store_accessor] instead to generate
+  # the accessor methods. Be aware that these columns use a string keyed hash and do not allow access
+  # using a symbol.
+  #
+  # NOTE: The default validations with the exception of +uniqueness+ will work.
+  # For example, if you want to check for +uniqueness+ with +hstore+ you will
+  # need to use a custom validation to handle it.
+  #
+  # Examples:
+  #
+  #   class User < ActiveRecord::Base
+  #     store :settings, accessors: [ :color, :homepage ], coder: JSON
+  #     store :parent, accessors: [ :name ], coder: JSON, prefix: true
+  #     store :spouse, accessors: [ :name ], coder: JSON, prefix: :partner
+  #     store :settings, accessors: [ :two_factor_auth ], suffix: true
+  #     store :settings, accessors: [ :login_retry ], suffix: :config
+  #   end
+  #
+  #   u = User.new(color: 'black', homepage: '37signals.com', parent_name: 'Mary', partner_name: 'Lily')
+  #   u.color                          # Accessor stored attribute
+  #   u.parent_name                    # Accessor stored attribute with prefix
+  #   u.partner_name                   # Accessor stored attribute with custom prefix
+  #   u.two_factor_auth_settings       # Accessor stored attribute with suffix
+  #   u.login_retry_config             # Accessor stored attribute with custom suffix
+  #   u.settings[:country] = 'Denmark' # Any attribute, even if not specified with an accessor
+  #
+  #   # There is no difference between strings and symbols for accessing custom attributes
+  #   u.settings[:country]  # => 'Denmark'
+  #   u.settings['country'] # => 'Denmark'
+  #
+  #   # Dirty tracking
+  #   u.color = 'green'
+  #   u.color_changed? # => true
+  #   u.color_was # => 'black'
+  #   u.color_change # => ['black', 'red']
+  #
+  #   # Add additional accessors to an existing store through store_accessor
+  #   class SuperUser < User
+  #     store_accessor :settings, :privileges, :servants
+  #     store_accessor :parent, :birthday, prefix: true
+  #     store_accessor :settings, :secret_question, suffix: :config
+  #   end
+  #
+  # The stored attribute names can be retrieved using {.stored_attributes}[rdoc-ref:rdoc-ref:ClassMethods#stored_attributes].
+  #
+  #   User.stored_attributes[:settings] # [:color, :homepage, :two_factor_auth, :login_retry]
+  #
+  # == Overwriting default accessors
+  #
+  # All stored values are automatically available through accessors on the Active Record
+  # object, but sometimes you want to specialize this behavior. This can be done by overwriting
+  # the default accessors (using the same name as the attribute) and calling <tt>super</tt>
+  # to actually change things.
+  #
+  #   class Song < ActiveRecord::Base
+  #     # Uses a stored integer to hold the volume adjustment of the song
+  #     store :settings, accessors: [:volume_adjustment]
+  #
+  #     def volume_adjustment=(decibels)
+  #       super(decibels.to_i)
+  #     end
+  #
+  #     def volume_adjustment
+  #       super.to_i
+  #     end
+  #   end
+  module Store
+    extend ActiveSupport::Concern
+
+    attr_accessor local_stored_attributes: untyped
+
+    module ClassMethods
+      def store: (untyped store_attribute, ?::Hash[untyped, untyped] options) -> untyped
+
+      def store_accessor: (untyped store_attribute, *untyped keys, ?suffix: untyped? suffix, ?prefix: untyped? prefix) -> (::FalseClass | nil | untyped)
+
+      def _store_accessors_module: () -> untyped
+
+      def stored_attributes: () -> untyped
+    end
+
+    def read_store_attribute: (untyped store_attribute, untyped key) -> untyped
+
+    def write_store_attribute: (untyped store_attribute, untyped key, untyped value) -> untyped
+
+    def store_accessor_for: (untyped store_attribute) -> untyped
+
+    class HashAccessor
+      # :nodoc:
+      def self.read: (untyped object, untyped attribute, untyped key) -> untyped
+
+      def self.write: (untyped object, untyped attribute, untyped key, untyped value) -> untyped
+
+      def self.prepare: (untyped object, untyped attribute) -> untyped
+    end
+
+    class StringKeyedHashAccessor < HashAccessor
+      # :nodoc:
+      def self.read: (untyped object, untyped attribute, untyped key) -> untyped
+
+      def self.write: (untyped object, untyped attribute, untyped key, untyped value) -> untyped
+    end
+
+    class IndifferentHashAccessor < ActiveRecord::Store::HashAccessor
+      # :nodoc:
+      def self.prepare: (untyped object, untyped store_attribute) -> untyped
+    end
+
+    class IndifferentCoder
+      # :nodoc:
+      def initialize: (untyped attr_name, untyped coder_or_class_name) -> untyped
+
+      def dump: (untyped obj) -> untyped
+
+      def load: (untyped yaml) -> untyped
+
+      def self.as_indifferent_hash: (untyped obj) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  # ActiveRecord::Suppressor prevents the receiver from being saved during
+  # a given block.
+  #
+  # For example, here's a pattern of creating notifications when new comments
+  # are posted. (The notification may in turn trigger an email, a push
+  # notification, or just appear in the UI somewhere):
+  #
+  #   class Comment < ActiveRecord::Base
+  #     belongs_to :commentable, polymorphic: true
+  #     after_create -> { Notification.create! comment: self,
+  #       recipients: commentable.recipients }
+  #   end
+  #
+  # That's what you want the bulk of the time. New comment creates a new
+  # Notification. But there may well be off cases, like copying a commentable
+  # and its comments, where you don't want that. So you'd have a concern
+  # something like this:
+  #
+  #   module Copyable
+  #     def copy_to(destination)
+  #       Notification.suppress do
+  #         # Copy logic that creates new comments that we do not want
+  #         # triggering notifications.
+  #       end
+  #     end
+  #   end
+  module Suppressor
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      def suppress: () { () -> untyped } -> untyped
+    end
+
+    def save: () -> untyped
+
+    def save!: () -> untyped
+  end
+
+  class SuppressorRegistry
+    # :nodoc:
+    extend ActiveSupport::PerThreadRegistry
+
+    attr_reader suppressed: untyped
+
+    def initialize: () -> untyped
+  end
+end
+
+module ActiveRecord
+  class TableMetadata
+    def initialize: (untyped klass, untyped arel_table, ?untyped? association, ?untyped types) -> untyped
+
+    def resolve_column_aliases: (untyped hash) -> untyped
+
+    def arel_attribute: (untyped column_name) -> untyped
+
+    def `type`: (untyped column_name) -> untyped
+
+    def has_column?: (untyped column_name) -> untyped
+
+    def associated_with?: (untyped association_name) -> untyped
+
+    def associated_table: (untyped table_name) -> untyped
+
+    def associated_predicate_builder: (untyped table_name) -> untyped
+
+    def polymorphic_association?: () -> untyped
+
+    def aggregated_with?: (untyped aggregation_name) -> untyped
+
+    def reflect_on_aggregation: (untyped aggregation_name) -> untyped
+
+    def predicate_builder: () -> untyped
+
+    attr_reader klass: untyped
+
+    attr_reader types: untyped
+
+    attr_reader arel_table: untyped
+
+    attr_reader association: untyped
+  end
+end
+
+module ActiveRecord
+  module Tasks
+    class DatabaseAlreadyExists < StandardError
+    end
+
+    class DatabaseNotSupported < StandardError
+    end
+
+    # ActiveRecord::Tasks::DatabaseTasks is a utility class, which encapsulates
+    # logic behind common tasks used to manage database and migrations.
+    #
+    # The tasks defined here are used with Rails commands provided by Active Record.
+    #
+    # In order to use DatabaseTasks, a few config values need to be set. All the needed
+    # config values are set by Rails already, so it's necessary to do it only if you
+    # want to change the defaults or when you want to use Active Record outside of Rails
+    # (in such case after configuring the database tasks, you can also use the rake tasks
+    # defined in Active Record).
+    #
+    # The possible config values are:
+    #
+    # * +env+: current environment (like Rails.env).
+    # * +database_configuration+: configuration of your databases (as in +config/database.yml+).
+    # * +db_dir+: your +db+ directory.
+    # * +fixtures_path+: a path to fixtures directory.
+    # * +migrations_paths+: a list of paths to directories with migrations.
+    # * +seed_loader+: an object which will load seeds, it needs to respond to the +load_seed+ method.
+    # * +root+: a path to the root of the application.
+    #
+    # Example usage of DatabaseTasks outside Rails could look as such:
+    #
+    #   include ActiveRecord::Tasks
+    #   DatabaseTasks.database_configuration = YAML.load_file('my_database_config.yml')
+    #   DatabaseTasks.db_dir = 'db'
+    #   # other settings...
+    #
+    #   DatabaseTasks.create_current('production')
+    module DatabaseTasks
+      attr_writer current_config: untyped
+
+      attr_writer db_dir: untyped
+
+      attr_writer migrations_paths: untyped
+
+      attr_writer fixtures_path: untyped
+
+      attr_writer root: untyped
+
+      attr_writer env: untyped
+
+      attr_writer seed_loader: untyped
+
+      attr_accessor database_configuration: untyped
+
+      LOCAL_HOSTS: ::Array[untyped]
+
+      def check_protected_environments!: () -> untyped
+
+      def register_task: (untyped pattern, untyped task) -> untyped
+
+      def db_dir: () -> untyped
+
+      def migrations_paths: () -> untyped
+
+      def fixtures_path: () -> untyped
+
+      def root: () -> untyped
+
+      def env: () -> untyped
+
+      def spec: () -> untyped
+
+      def seed_loader: () -> untyped
+
+      def current_config: (?::Hash[untyped, untyped] options) -> untyped
+
+      def create: (*untyped arguments) -> untyped
+
+      def create_all: () -> untyped
+
+      def setup_initial_database_yaml: () -> (::Hash[untyped, untyped] | untyped)
+
+      def for_each: (untyped databases) { (untyped) -> untyped } -> (::Hash[untyped, untyped] | nil | untyped)
+
+      def raise_for_multi_db: (?untyped environment, command: untyped command) -> untyped
+
+      def create_current: (?untyped environment, ?untyped? spec_name) -> untyped
+
+      def drop: (*untyped arguments) -> untyped
+
+      def drop_all: () -> untyped
+
+      def drop_current: (?untyped environment) -> untyped
+
+      def truncate_tables: (untyped configuration) -> untyped
+
+      def truncate_all: (?untyped environment) -> untyped
+
+      def migrate: () -> untyped
+
+      def migrate_status: () -> untyped
+
+      def check_target_version: () -> untyped
+
+      def target_version: () -> untyped
+
+      def charset_current: (?untyped environment, ?untyped specification_name) -> untyped
+
+      def charset: (*untyped arguments) -> untyped
+
+      def collation_current: (?untyped environment, ?untyped specification_name) -> untyped
+
+      def collation: (*untyped arguments) -> untyped
+
+      def purge: (untyped configuration) -> untyped
+
+      def purge_all: () -> untyped
+
+      def purge_current: (?untyped environment) -> untyped
+
+      def structure_dump: (*untyped arguments) -> untyped
+
+      def structure_load: (*untyped arguments) -> untyped
+
+      def load_schema: (untyped configuration, ?untyped format, ?untyped? file, ?untyped environment, ?::String spec_name) -> untyped
+
+      def schema_up_to_date?: (untyped configuration, ?untyped format, ?untyped? file, ?untyped environment, ?::String spec_name) -> (::TrueClass | ::FalseClass | untyped)
+
+      def reconstruct_from_schema: (untyped configuration, ?untyped format, ?untyped? file, ?untyped environment, ?::String spec_name) -> untyped
+
+      def dump_schema: (untyped configuration, ?untyped format, ?::String spec_name) -> untyped
+
+      def schema_file: (?untyped format) -> untyped
+
+      def schema_file_type: (?untyped format) -> untyped
+
+      def dump_filename: (untyped namespace, ?untyped format) -> untyped
+
+      def cache_dump_filename: (untyped namespace) -> untyped
+
+      def load_schema_current: (?untyped format, ?untyped? file, ?untyped environment) -> untyped
+
+      def check_schema_file: (untyped filename) -> untyped
+
+      def load_seed: () -> untyped
+
+      # Dumps the schema cache in YAML format for the connection into the file
+      #
+      # ==== Examples:
+      #   ActiveRecord::Tasks::DatabaseTasks.dump_schema_cache(ActiveRecord::Base.connection, "tmp/schema_dump.yaml")
+      def dump_schema_cache: (untyped conn, untyped filename) -> untyped
+
+      def verbose?: () -> untyped
+
+      def class_for_adapter: (untyped adapter) -> untyped
+
+      def each_current_configuration: (untyped environment, ?untyped? spec_name) { (untyped, untyped, untyped) -> untyped } -> untyped
+
+      def each_local_configuration: () { (untyped) -> untyped } -> untyped
+
+      def local_database?: (untyped configuration) -> untyped
+
+      def schema_sha1: (untyped file) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module Tasks
+    class MySQLDatabaseTasks
+      # :nodoc:
+      # :nodoc:
+      ER_DB_CREATE_EXISTS: ::Integer
+
+      def initialize: (untyped configuration) -> untyped
+
+      def create: () -> untyped
+
+      def drop: () -> untyped
+
+      def purge: () -> untyped
+
+      def charset: () -> untyped
+
+      def collation: () -> untyped
+
+      def structure_dump: (untyped filename, untyped extra_flags) -> untyped
+
+      def structure_load: (untyped filename, untyped extra_flags) -> untyped
+
+      attr_reader configuration: untyped
+
+      def configuration_without_database: () -> untyped
+
+      def creation_options: () -> untyped
+
+      def prepare_command_options: () -> untyped
+
+      def run_cmd: (untyped cmd, untyped args, untyped action) -> untyped
+
+      def run_cmd_error: (untyped cmd, untyped args, untyped action) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module Tasks
+    class PostgreSQLDatabaseTasks
+      # :nodoc:
+      # :nodoc:
+      DEFAULT_ENCODING: untyped
+
+      ON_ERROR_STOP_1: ::String
+
+      SQL_COMMENT_BEGIN: ::String
+
+      def initialize: (untyped configuration) -> untyped
+
+      def create: (?bool master_established) -> untyped
+
+      def drop: () -> untyped
+
+      def charset: () -> untyped
+
+      def collation: () -> untyped
+
+      def purge: () -> untyped
+
+      def structure_dump: (untyped filename, untyped extra_flags) -> untyped
+
+      def structure_load: (untyped filename, untyped extra_flags) -> untyped
+
+      attr_reader configuration: untyped
+
+      def encoding: () -> untyped
+
+      def establish_master_connection: () -> untyped
+
+      def set_psql_env: () -> untyped
+
+      def run_cmd: (untyped cmd, untyped args, untyped action) -> untyped
+
+      def run_cmd_error: (untyped cmd, untyped args, untyped action) -> untyped
+
+      def remove_sql_header_comments: (untyped filename) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module Tasks
+    class SQLiteDatabaseTasks
+      def initialize: (untyped configuration, ?untyped root) -> untyped
+
+      def create: () -> untyped
+
+      def drop: () -> untyped
+
+      def purge: () -> untyped
+
+      def charset: () -> untyped
+
+      def structure_dump: (untyped filename, untyped extra_flags) -> untyped
+
+      def structure_load: (untyped filename, untyped extra_flags) -> untyped
+
+      attr_reader configuration: untyped
+
+      attr_reader root: untyped
+
+      def run_cmd: (untyped cmd, untyped args, untyped `out`) -> untyped
+
+      def run_cmd_error: (untyped cmd, untyped args) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module TestDatabases
+    def self.create_and_load_schema: (untyped i, env_name: untyped env_name) -> untyped
+  end
+end
+
+module ActiveRecord
+  module TestFixtures
+    extend ActiveSupport::Concern
+
+    def before_setup: () -> untyped
+
+    def after_teardown: () -> untyped
+
+    module ClassMethods
+      # Sets the model class for a fixture when the class name cannot be inferred from the fixture name.
+      #
+      # Examples:
+      #
+      #   set_fixture_class some_fixture:        SomeModel,
+      #                     'namespaced/fixture' => Another::Model
+      #
+      # The keys must be the fixture names, that coincide with the short paths to the fixture files.
+      def set_fixture_class: (?::Hash[untyped, untyped] class_names) -> untyped
+
+      def fixtures: (*untyped fixture_set_names) -> untyped
+
+      def setup_fixture_accessors: (?untyped? fixture_set_names) -> untyped
+
+      def uses_transaction: (*untyped methods) -> untyped
+
+      def uses_transaction?: (untyped method) -> untyped
+    end
+
+    def run_in_transaction?: () -> untyped
+
+    def setup_fixtures: (?untyped config) -> untyped
+
+    def teardown_fixtures: () -> untyped
+
+    def enlist_fixture_connections: () -> untyped
+
+    # Shares the writing connection pool with connections on
+    # other handlers.
+    #
+    # In an application with a primary and replica the test fixtures
+    # need to share a connection pool so that the reading connection
+    # can see data in the open transaction on the writing connection.
+    def setup_shared_connection_pool: () -> (nil | untyped)
+
+    def load_fixtures: (untyped config) -> untyped
+
+    def instantiate_fixtures: () -> untyped
+
+    def load_instances?: () -> untyped
+  end
+end
+
+module ActiveRecord
+  # = Active Record \Timestamp
+  #
+  # Active Record automatically timestamps create and update operations if the
+  # table has fields named <tt>created_at/created_on</tt> or
+  # <tt>updated_at/updated_on</tt>.
+  #
+  # Timestamping can be turned off by setting:
+  #
+  #   config.active_record.record_timestamps = false
+  #
+  # Timestamps are in UTC by default but you can use the local timezone by setting:
+  #
+  #   config.active_record.default_timezone = :local
+  #
+  # == Time Zone aware attributes
+  #
+  # Active Record keeps all the <tt>datetime</tt> and <tt>time</tt> columns
+  # timezone aware. By default, these values are stored in the database as UTC
+  # and converted back to the current <tt>Time.zone</tt> when pulled from the database.
+  #
+  # This feature can be turned off completely by setting:
+  #
+  #   config.active_record.time_zone_aware_attributes = false
+  #
+  # You can also specify that only <tt>datetime</tt> columns should be time-zone
+  # aware (while <tt>time</tt> should not) by setting:
+  #
+  #   ActiveRecord::Base.time_zone_aware_types = [:datetime]
+  #
+  # You can also add database specific timezone aware types. For example, for PostgreSQL:
+  #
+  #   ActiveRecord::Base.time_zone_aware_types += [:tsrange, :tstzrange]
+  #
+  # Finally, you can indicate specific attributes of a model for which time zone
+  # conversion should not applied, for instance by setting:
+  #
+  #   class Topic < ActiveRecord::Base
+  #     self.skip_time_zone_conversion_for_attributes = [:written_on]
+  #   end
+  module Timestamp
+    extend ActiveSupport::Concern
+
+    def initialize_dup: (untyped other) -> untyped
+
+    module ClassMethods
+      # :nodoc:
+      def touch_attributes_with_time: (*untyped names, ?time: untyped? time) -> untyped
+
+      def timestamp_attributes_for_create_in_model: () -> untyped
+
+      def timestamp_attributes_for_update_in_model: () -> untyped
+
+      def all_timestamp_attributes_in_model: () -> untyped
+
+      def current_time_from_proper_timezone: () -> untyped
+
+      def timestamp_attributes_for_create: () -> ::Array["created_at" | "created_on"]
+
+      def timestamp_attributes_for_update: () -> ::Array["updated_at" | "updated_on"]
+
+      def reload_schema_from_cache: () -> untyped
+    end
+
+    def _create_record: () -> untyped
+
+    def _update_record: () -> untyped
+
+    def create_or_update: (?touch: bool touch) -> untyped
+
+    def should_record_timestamps?: () -> untyped
+
+    def timestamp_attributes_for_create_in_model: () -> untyped
+
+    def timestamp_attributes_for_update_in_model: () -> untyped
+
+    def all_timestamp_attributes_in_model: () -> untyped
+
+    def current_time_from_proper_timezone: () -> untyped
+
+    def max_updated_column_timestamp: () -> untyped
+
+    # Clear attributes and changed_attributes
+    def clear_timestamp_attributes: () -> untyped
+  end
+end
+
+module ActiveRecord
+  module TouchLater
+    # = Active Record Touch Later
+    # :nodoc:
+    extend ActiveSupport::Concern
+
+    def touch_later: (*untyped names) -> untyped
+
+    def touch: (*untyped names, ?time: untyped? time) -> untyped
+
+    def surreptitiously_touch: (untyped attrs) -> untyped
+
+    def touch_deferred_attributes: () -> untyped
+
+    def has_defer_touch_attrs?: () -> untyped
+
+    def belongs_to_touch_method: () -> :touch_later
+  end
+end
+
+module ActiveRecord
+  # See ActiveRecord::Transactions::ClassMethods for documentation.
+  module Transactions
+    extend ActiveSupport::Concern
+
+    # nodoc:
+    ACTIONS: ::Array[untyped]
+
+    # = Active Record Transactions
+    #
+    # \Transactions are protective blocks where SQL statements are only permanent
+    # if they can all succeed as one atomic action. The classic example is a
+    # transfer between two accounts where you can only have a deposit if the
+    # withdrawal succeeded and vice versa. \Transactions enforce the integrity of
+    # the database and guard the data against program errors or database
+    # break-downs. So basically you should use transaction blocks whenever you
+    # have a number of statements that must be executed together or not at all.
+    #
+    # For example:
+    #
+    #   ActiveRecord::Base.transaction do
+    #     david.withdrawal(100)
+    #     mary.deposit(100)
+    #   end
+    #
+    # This example will only take money from David and give it to Mary if neither
+    # +withdrawal+ nor +deposit+ raise an exception. Exceptions will force a
+    # ROLLBACK that returns the database to the state before the transaction
+    # began. Be aware, though, that the objects will _not_ have their instance
+    # data returned to their pre-transactional state.
+    #
+    # == Different Active Record classes in a single transaction
+    #
+    # Though the #transaction class method is called on some Active Record class,
+    # the objects within the transaction block need not all be instances of
+    # that class. This is because transactions are per-database connection, not
+    # per-model.
+    #
+    # In this example a +balance+ record is transactionally saved even
+    # though #transaction is called on the +Account+ class:
+    #
+    #   Account.transaction do
+    #     balance.save!
+    #     account.save!
+    #   end
+    #
+    # The #transaction method is also available as a model instance method.
+    # For example, you can also do this:
+    #
+    #   balance.transaction do
+    #     balance.save!
+    #     account.save!
+    #   end
+    #
+    # == Transactions are not distributed across database connections
+    #
+    # A transaction acts on a single database connection. If you have
+    # multiple class-specific databases, the transaction will not protect
+    # interaction among them. One workaround is to begin a transaction
+    # on each class whose models you alter:
+    #
+    #   Student.transaction do
+    #     Course.transaction do
+    #       course.enroll(student)
+    #       student.units += course.units
+    #     end
+    #   end
+    #
+    # This is a poor solution, but fully distributed transactions are beyond
+    # the scope of Active Record.
+    #
+    # == +save+ and +destroy+ are automatically wrapped in a transaction
+    #
+    # Both {#save}[rdoc-ref:Persistence#save] and
+    # {#destroy}[rdoc-ref:Persistence#destroy] come wrapped in a transaction that ensures
+    # that whatever you do in validations or callbacks will happen under its
+    # protected cover. So you can use validations to check for values that
+    # the transaction depends on or you can raise exceptions in the callbacks
+    # to rollback, including <tt>after_*</tt> callbacks.
+    #
+    # As a consequence changes to the database are not seen outside your connection
+    # until the operation is complete. For example, if you try to update the index
+    # of a search engine in +after_save+ the indexer won't see the updated record.
+    # The #after_commit callback is the only one that is triggered once the update
+    # is committed. See below.
+    #
+    # == Exception handling and rolling back
+    #
+    # Also have in mind that exceptions thrown within a transaction block will
+    # be propagated (after triggering the ROLLBACK), so you should be ready to
+    # catch those in your application code.
+    #
+    # One exception is the ActiveRecord::Rollback exception, which will trigger
+    # a ROLLBACK when raised, but not be re-raised by the transaction block.
+    #
+    # *Warning*: one should not catch ActiveRecord::StatementInvalid exceptions
+    # inside a transaction block. ActiveRecord::StatementInvalid exceptions indicate that an
+    # error occurred at the database level, for example when a unique constraint
+    # is violated. On some database systems, such as PostgreSQL, database errors
+    # inside a transaction cause the entire transaction to become unusable
+    # until it's restarted from the beginning. Here is an example which
+    # demonstrates the problem:
+    #
+    #   # Suppose that we have a Number model with a unique column called 'i'.
+    #   Number.transaction do
+    #     Number.create(i: 0)
+    #     begin
+    #       # This will raise a unique constraint error...
+    #       Number.create(i: 0)
+    #     rescue ActiveRecord::StatementInvalid
+    #       # ...which we ignore.
+    #     end
+    #
+    #     # On PostgreSQL, the transaction is now unusable. The following
+    #     # statement will cause a PostgreSQL error, even though the unique
+    #     # constraint is no longer violated:
+    #     Number.create(i: 1)
+    #     # => "PG::Error: ERROR:  current transaction is aborted, commands
+    #     #     ignored until end of transaction block"
+    #   end
+    #
+    # One should restart the entire transaction if an
+    # ActiveRecord::StatementInvalid occurred.
+    #
+    # == Nested transactions
+    #
+    # #transaction calls can be nested. By default, this makes all database
+    # statements in the nested transaction block become part of the parent
+    # transaction. For example, the following behavior may be surprising:
+    #
+    #   User.transaction do
+    #     User.create(username: 'Kotori')
+    #     User.transaction do
+    #       User.create(username: 'Nemu')
+    #       raise ActiveRecord::Rollback
+    #     end
+    #   end
+    #
+    # creates both "Kotori" and "Nemu". Reason is the ActiveRecord::Rollback
+    # exception in the nested block does not issue a ROLLBACK. Since these exceptions
+    # are captured in transaction blocks, the parent block does not see it and the
+    # real transaction is committed.
+    #
+    # In order to get a ROLLBACK for the nested transaction you may ask for a real
+    # sub-transaction by passing <tt>requires_new: true</tt>. If anything goes wrong,
+    # the database rolls back to the beginning of the sub-transaction without rolling
+    # back the parent transaction. If we add it to the previous example:
+    #
+    #   User.transaction do
+    #     User.create(username: 'Kotori')
+    #     User.transaction(requires_new: true) do
+    #       User.create(username: 'Nemu')
+    #       raise ActiveRecord::Rollback
+    #     end
+    #   end
+    #
+    # only "Kotori" is created. This works on MySQL and PostgreSQL. SQLite3 version >= '3.6.8' also supports it.
+    #
+    # Most databases don't support true nested transactions. At the time of
+    # writing, the only database that we're aware of that supports true nested
+    # transactions, is MS-SQL. Because of this, Active Record emulates nested
+    # transactions by using savepoints on MySQL and PostgreSQL. See
+    # https://dev.mysql.com/doc/refman/5.7/en/savepoint.html
+    # for more information about savepoints.
+    #
+    # === \Callbacks
+    #
+    # There are two types of callbacks associated with committing and rolling back transactions:
+    # #after_commit and #after_rollback.
+    #
+    # #after_commit callbacks are called on every record saved or destroyed within a
+    # transaction immediately after the transaction is committed. #after_rollback callbacks
+    # are called on every record saved or destroyed within a transaction immediately after the
+    # transaction or savepoint is rolled back.
+    #
+    # These callbacks are useful for interacting with other systems since you will be guaranteed
+    # that the callback is only executed when the database is in a permanent state. For example,
+    # #after_commit is a good spot to put in a hook to clearing a cache since clearing it from
+    # within a transaction could trigger the cache to be regenerated before the database is updated.
+    #
+    # === Caveats
+    #
+    # If you're on MySQL, then do not use Data Definition Language (DDL) operations in nested
+    # transactions blocks that are emulated with savepoints. That is, do not execute statements
+    # like 'CREATE TABLE' inside such blocks. This is because MySQL automatically
+    # releases all savepoints upon executing a DDL operation. When +transaction+
+    # is finished and tries to release the savepoint it created earlier, a
+    # database error will occur because the savepoint has already been
+    # automatically released. The following example demonstrates the problem:
+    #
+    #   Model.connection.transaction do                           # BEGIN
+    #     Model.connection.transaction(requires_new: true) do     # CREATE SAVEPOINT active_record_1
+    #       Model.connection.create_table(...)                    # active_record_1 now automatically released
+    #     end                                                     # RELEASE SAVEPOINT active_record_1
+    #                                                             # ^^^^ BOOM! database error!
+    #   end
+    #
+    # Note that "TRUNCATE" is also a MySQL DDL statement!
+    module ClassMethods
+      # See the ConnectionAdapters::DatabaseStatements#transaction API docs.
+      def transaction: (**untyped options) { () -> untyped } -> untyped
+
+      def before_commit: (*untyped args) { () -> untyped } -> untyped
+
+      # This callback is called after a record has been created, updated, or destroyed.
+      #
+      # You can specify that the callback should only be fired by a certain action with
+      # the +:on+ option:
+      #
+      #   after_commit :do_foo, on: :create
+      #   after_commit :do_bar, on: :update
+      #   after_commit :do_baz, on: :destroy
+      #
+      #   after_commit :do_foo_bar, on: [:create, :update]
+      #   after_commit :do_bar_baz, on: [:update, :destroy]
+      #
+      def after_commit: (*untyped args) { () -> untyped } -> untyped
+
+      # Shortcut for <tt>after_commit :hook, on: [ :create, :update ]</tt>.
+      def after_save_commit: (*untyped args) { () -> untyped } -> untyped
+
+      # Shortcut for <tt>after_commit :hook, on: :create</tt>.
+      def after_create_commit: (*untyped args) { () -> untyped } -> untyped
+
+      # Shortcut for <tt>after_commit :hook, on: :update</tt>.
+      def after_update_commit: (*untyped args) { () -> untyped } -> untyped
+
+      # Shortcut for <tt>after_commit :hook, on: :destroy</tt>.
+      def after_destroy_commit: (*untyped args) { () -> untyped } -> untyped
+
+      # This callback is called after a create, update, or destroy are rolled back.
+      #
+      # Please check the documentation of #after_commit for options.
+      def after_rollback: (*untyped args) { () -> untyped } -> untyped
+
+      def before_commit_without_transaction_enrollment: (*untyped args) { () -> untyped } -> untyped
+
+      def after_commit_without_transaction_enrollment: (*untyped args) { () -> untyped } -> untyped
+
+      def after_rollback_without_transaction_enrollment: (*untyped args) { () -> untyped } -> untyped
+
+      def set_options_for_callbacks!: (untyped args, ?::Hash[untyped, untyped] enforced_options) -> untyped
+
+      def assert_valid_transaction_action: (untyped actions) -> untyped
+    end
+
+    # See ActiveRecord::Transactions::ClassMethods for detailed documentation.
+    def transaction: (?::Hash[untyped, untyped] options) { () -> untyped } -> untyped
+
+    def destroy: () -> untyped
+
+    def save: () -> untyped
+
+    def save!: () -> untyped
+
+    def touch: () -> untyped
+
+    def before_committed!: () -> untyped
+
+    def committed!: (?should_run_callbacks: bool should_run_callbacks) -> untyped
+
+    def rolledback!: (?should_run_callbacks: bool should_run_callbacks, ?force_restore_state: bool force_restore_state) -> untyped
+
+    # Executes +method+ within a transaction and captures its return value as a
+    # status flag. If the status is true the transaction is committed, otherwise
+    # a ROLLBACK is issued. In any case the status flag is returned.
+    #
+    # This method is available within the context of an ActiveRecord::Base
+    # instance.
+    def with_transaction_returning_status: () { () -> untyped } -> untyped
+
+    def trigger_transactional_callbacks?: () -> untyped
+
+    attr_reader _committed_already_called: untyped
+
+    attr_reader _trigger_update_callback: untyped
+
+    attr_reader _trigger_destroy_callback: untyped
+
+    # Save the new record state and id of a record so it can be restored later if a transaction fails.
+    def remember_transaction_record_state: () -> untyped
+
+    # Clear the new record state and id of a record.
+    def clear_transaction_record_state: () -> (nil | untyped)
+
+    # Force to clear the transaction record state.
+    def force_clear_transaction_record_state: () -> untyped
+
+    # Restore the new record state and id of a record that was previously saved by a call to save_record_state.
+    def restore_transaction_record_state: (?bool force_restore_state) -> untyped
+
+    # Determine if a transaction included an action for :create, :update, or :destroy. Used in filtering callbacks.
+    def transaction_include_any_action?: (untyped actions) -> untyped
+
+    # Add the record to the current transaction so that the #after_rollback and #after_commit
+    # callbacks can be called.
+    def add_to_transaction: () -> untyped
+
+    def has_transactional_callbacks?: () -> untyped
+
+    # Updates the attributes on this particular Active Record object so that
+    # if it's associated with a transaction, then the state of the Active Record
+    # object will be updated to reflect the current state of the transaction.
+    #
+    # The <tt>@transaction_state</tt> variable stores the states of the associated
+    # transaction. This relies on the fact that a transaction can only be in
+    # one rollback or commit (otherwise a list of states would be required).
+    # Each Active Record object inside of a transaction carries that transaction's
+    # TransactionState.
+    #
+    # This method checks to see if the ActiveRecord object's state reflects
+    # the TransactionState, and rolls back or commits the Active Record object
+    # as appropriate.
+    def sync_with_transaction_state: () -> untyped
+  end
+end
+
+module ActiveRecord
+  module Translation
+    include ActiveModel::Translation
+
+    def lookup_ancestors: () -> untyped
+
+    def i18n_scope: () -> :activerecord
+  end
+end
+
+module ActiveRecord
+  # :stopdoc:
+  module Type
+    class AdapterSpecificRegistry < ActiveModel::Type::Registry
+      def add_modifier: (untyped options, untyped klass, **untyped args) -> untyped
+
+      def registration_klass: () -> untyped
+
+      def find_registration: (untyped symbol, *untyped args, **untyped kwargs) -> untyped
+    end
+
+    class Registration
+      def initialize: (untyped name, untyped block, ?override: untyped? override, ?adapter: untyped? adapter) -> untyped
+
+      def call: (untyped _registry, *untyped args, ?adapter: untyped? adapter, **untyped kwargs) -> untyped
+
+      def matches?: (untyped type_name, *untyped args, **untyped kwargs) -> untyped
+
+      def <=>: (untyped other) -> untyped
+
+      attr_reader name: untyped
+
+      attr_reader block: untyped
+
+      attr_reader adapter: untyped
+
+      attr_reader override: untyped
+
+      def priority: () -> untyped
+
+      def priority_except_adapter: () -> untyped
+
+      def matches_adapter?: (?adapter: untyped? adapter) -> untyped
+
+      def conflicts_with?: (untyped other) -> untyped
+
+      def same_priority_except_adapter?: (untyped other) -> untyped
+
+      def has_adapter_conflict?: (untyped other) -> untyped
+    end
+
+    class DecorationRegistration < Registration
+      def initialize: (untyped options, untyped klass, ?adapter: untyped? adapter) -> untyped
+
+      def call: (untyped registry, *untyped args, **untyped kwargs) -> untyped
+
+      def matches?: (*untyped args, **untyped kwargs) -> untyped
+
+      def priority: () -> untyped
+
+      attr_reader options: untyped
+
+      attr_reader klass: untyped
+
+      def matches_options?: (**untyped kwargs) -> untyped
+    end
+  end
+
+  class TypeConflictError < StandardError
+  end
+end
+
+module ActiveRecord
+  module Type
+    class Date < ActiveModel::Type::Date
+      include Internal::Timezone
+    end
+  end
+end
+
+module ActiveRecord
+  module Type
+    class DateTime < ActiveModel::Type::DateTime
+      include Internal::Timezone
+    end
+  end
+end
+
+module ActiveRecord
+  module Type
+    class DecimalWithoutScale < ActiveModel::Type::BigInteger
+      # :nodoc:
+      def `type`: () -> :decimal
+
+      def type_cast_for_schema: (untyped value) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module Type
+    class HashLookupTypeMap < TypeMap
+      # :nodoc:
+      def alias_type: (untyped `type`, untyped alias_type) -> untyped
+
+      def key?: (untyped key) -> untyped
+
+      def keys: () -> untyped
+
+      def perform_fetch: (untyped `type`, *untyped args) { () -> untyped } -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module Type
+    module Internal
+      module Timezone
+        def is_utc?: () -> untyped
+
+        def default_timezone: () -> untyped
+      end
+    end
+  end
+end
+
+module ActiveRecord
+  module Type
+    class Json < ActiveModel::Type::Value
+      include ActiveModel::Type::Helpers::Mutable
+
+      def `type`: () -> :json
+
+      def deserialize: (untyped value) -> untyped
+
+      def serialize: (untyped value) -> untyped
+
+      def changed_in_place?: (untyped raw_old_value, untyped new_value) -> untyped
+
+      def accessor: () -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module Type
+    class Serialized
+      # Note: It inherits unnamed class, but omitted
+      include ActiveModel::Type::Helpers::Mutable
+
+      attr_reader subtype: untyped
+
+      attr_reader coder: untyped
+
+      def initialize: (untyped subtype, untyped coder) -> untyped
+
+      def deserialize: (untyped value) -> untyped
+
+      def serialize: (untyped value) -> (nil | untyped)
+
+      def inspect: () -> untyped
+
+      def changed_in_place?: (untyped raw_old_value, untyped value) -> (::FalseClass | untyped)
+
+      def accessor: () -> untyped
+
+      def assert_valid_value: (untyped value) -> untyped
+
+      def force_equality?: (untyped value) -> untyped
+
+      def default_value?: (untyped value) -> untyped
+
+      def encoded: (untyped value) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module Type
+    class Text < ActiveModel::Type::String
+      # :nodoc:
+      def `type`: () -> :text
+    end
+  end
+end
+
+module ActiveRecord
+  module Type
+    class Time < ActiveModel::Type::Time
+      include Internal::Timezone
+
+      class Value
+      end
+
+      def serialize: (untyped value) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module Type
+    class TypeMap
+      # :nodoc:
+      def initialize: () -> untyped
+
+      def lookup: (untyped lookup_key, *untyped args) -> untyped
+
+      def fetch: (untyped lookup_key, *untyped args) { () -> untyped } -> untyped
+
+      def register_type: (untyped key, ?untyped? value) { () -> untyped } -> untyped
+
+      def alias_type: (untyped key, untyped target_key) -> untyped
+
+      def clear: () -> untyped
+
+      def perform_fetch: (untyped lookup_key, *untyped args) { (untyped, untyped) -> untyped } -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module Type
+    class UnsignedInteger < ActiveModel::Type::Integer
+      def max_value: () -> untyped
+
+      def min_value: () -> 0
+    end
+  end
+end
+
+module ActiveRecord
+  module Type
+    attr_accessor registry: untyped
+
+    # Add a new type to the registry, allowing it to be referenced as a
+    # symbol by {ActiveRecord::Base.attribute}[rdoc-ref:Attributes::ClassMethods#attribute].
+    # If your type is only meant to be used with a specific database adapter, you can
+    # do so by passing <tt>adapter: :postgresql</tt>. If your type has the same
+    # name as a native type for the current adapter, an exception will be
+    # raised unless you specify an +:override+ option. <tt>override: true</tt> will
+    # cause your type to be used instead of the native type. <tt>override:
+    # false</tt> will cause the native type to be used over yours if one exists.
+    def self.register: (untyped type_name, ?untyped? klass, **untyped options) { () -> untyped } -> untyped
+
+    def self.lookup: (*untyped args, ?adapter: untyped adapter, **untyped kwargs) -> untyped
+
+    def self.default_value: () -> untyped
+
+    def self.current_adapter_name: () -> untyped
+
+    BigInteger: untyped
+
+    Binary: untyped
+
+    Boolean: untyped
+
+    Decimal: untyped
+
+    Float: untyped
+
+    Integer: untyped
+
+    String: untyped
+
+    Value: untyped
+  end
+end
+
+module ActiveRecord
+  module TypeCaster
+    class Connection
+      # :nodoc:
+      def initialize: (untyped klass, untyped table_name) -> untyped
+
+      def type_cast_for_database: (untyped attr_name, untyped value) -> untyped
+
+      def type_for_attribute: (untyped attr_name) -> untyped
+
+      attr_reader table_name: untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module TypeCaster
+    class Map
+      # :nodoc:
+      def initialize: (untyped types) -> untyped
+
+      def type_cast_for_database: (untyped attr_name, untyped value) -> untyped
+
+      attr_reader types: untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module TypeCaster
+  end
+end
+
+module ActiveRecord
+  module Validations
+    class AbsenceValidator < ActiveModel::Validations::AbsenceValidator
+      # :nodoc:
+      def validate_each: (untyped record, untyped attribute, untyped association_or_value) -> untyped
+    end
+
+    module ClassMethods
+      # Validates that the specified attributes are not present (as defined by
+      # Object#present?). If the attribute is an association, the associated object
+      # is considered absent if it was marked for destruction.
+      #
+      # See ActiveModel::Validations::HelperMethods.validates_absence_of for more information.
+      def validates_absence_of: (*untyped attr_names) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module Validations
+    class AssociatedValidator < ActiveModel::EachValidator
+      # nodoc:
+      def validate_each: (untyped record, untyped attribute, untyped value) -> untyped
+
+      def valid_object?: (untyped record) -> untyped
+    end
+
+    module ClassMethods
+      # Validates whether the associated object or objects are all valid.
+      # Works with any kind of association.
+      #
+      #   class Book < ActiveRecord::Base
+      #     has_many :pages
+      #     belongs_to :library
+      #
+      #     validates_associated :pages, :library
+      #   end
+      #
+      # WARNING: This validation must not be used on both ends of an association.
+      # Doing so will lead to a circular dependency and cause infinite recursion.
+      #
+      # NOTE: This validation will not fail if the association hasn't been
+      # assigned. If you want to ensure that the association is both present and
+      # guaranteed to be valid, you also need to use
+      # {validates_presence_of}[rdoc-ref:Validations::ClassMethods#validates_presence_of].
+      #
+      # Configuration options:
+      #
+      # * <tt>:message</tt> - A custom error message (default is: "is invalid").
+      # * <tt>:on</tt> - Specifies the contexts where this validation is active.
+      #   Runs in all validation contexts by default +nil+. You can pass a symbol
+      #   or an array of symbols. (e.g. <tt>on: :create</tt> or
+      #   <tt>on: :custom_validation_context</tt> or
+      #   <tt>on: [:create, :custom_validation_context]</tt>)
+      # * <tt>:if</tt> - Specifies a method, proc or string to call to determine
+      #   if the validation should occur (e.g. <tt>if: :allow_validation</tt>,
+      #   or <tt>if: Proc.new { |user| user.signup_step > 2 }</tt>). The method,
+      #   proc or string should return or evaluate to a +true+ or +false+ value.
+      # * <tt>:unless</tt> - Specifies a method, proc or string to call to
+      #   determine if the validation should not occur (e.g. <tt>unless: :skip_validation</tt>,
+      #   or <tt>unless: Proc.new { |user| user.signup_step <= 2 }</tt>). The
+      #   method, proc or string should return or evaluate to a +true+ or +false+
+      #   value.
+      def validates_associated: (*untyped attr_names) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module Validations
+    class LengthValidator < ActiveModel::Validations::LengthValidator
+      # :nodoc:
+      def validate_each: (untyped record, untyped attribute, untyped association_or_value) -> untyped
+    end
+
+    module ClassMethods
+      # Validates that the specified attributes match the length restrictions supplied.
+      # If the attribute is an association, records that are marked for destruction are not counted.
+      #
+      # See ActiveModel::Validations::HelperMethods.validates_length_of for more information.
+      def validates_length_of: (*untyped attr_names) -> untyped
+
+      alias validates_size_of validates_length_of
+    end
+  end
+end
+
+module ActiveRecord
+  module Validations
+    class PresenceValidator < ActiveModel::Validations::PresenceValidator
+      # :nodoc:
+      def validate_each: (untyped record, untyped attribute, untyped association_or_value) -> untyped
+    end
+
+    module ClassMethods
+      # Validates that the specified attributes are not blank (as defined by
+      # Object#blank?), and, if the attribute is an association, that the
+      # associated object is not marked for destruction. Happens by default
+      # on save.
+      #
+      #   class Person < ActiveRecord::Base
+      #     has_one :face
+      #     validates_presence_of :face
+      #   end
+      #
+      # The face attribute must be in the object and it cannot be blank or marked
+      # for destruction.
+      #
+      # If you want to validate the presence of a boolean field (where the real values
+      # are true and false), you will want to use
+      # <tt>validates_inclusion_of :field_name, in: [true, false]</tt>.
+      #
+      # This is due to the way Object#blank? handles boolean values:
+      # <tt>false.blank? # => true</tt>.
+      #
+      # This validator defers to the Active Model validation for presence, adding the
+      # check to see that an associated object is not marked for destruction. This
+      # prevents the parent object from validating successfully and saving, which then
+      # deletes the associated object, thus putting the parent object into an invalid
+      # state.
+      #
+      # NOTE: This validation will not fail while using it with an association
+      # if the latter was assigned but not valid. If you want to ensure that
+      # it is both present and valid, you also need to use
+      # {validates_associated}[rdoc-ref:Validations::ClassMethods#validates_associated].
+      #
+      # Configuration options:
+      # * <tt>:message</tt> - A custom error message (default is: "can't be blank").
+      # * <tt>:on</tt> - Specifies the contexts where this validation is active.
+      #   Runs in all validation contexts by default +nil+. You can pass a symbol
+      #   or an array of symbols. (e.g. <tt>on: :create</tt> or
+      #   <tt>on: :custom_validation_context</tt> or
+      #   <tt>on: [:create, :custom_validation_context]</tt>)
+      # * <tt>:if</tt> - Specifies a method, proc or string to call to determine if
+      #   the validation should occur (e.g. <tt>if: :allow_validation</tt>, or
+      #   <tt>if: Proc.new { |user| user.signup_step > 2 }</tt>). The method, proc
+      #   or string should return or evaluate to a +true+ or +false+ value.
+      # * <tt>:unless</tt> - Specifies a method, proc or string to call to determine
+      #   if the validation should not occur (e.g. <tt>unless: :skip_validation</tt>,
+      #   or <tt>unless: Proc.new { |user| user.signup_step <= 2 }</tt>). The method,
+      #   proc or string should return or evaluate to a +true+ or +false+ value.
+      # * <tt>:strict</tt> - Specifies whether validation should be strict.
+      #   See ActiveModel::Validations#validates! for more information.
+      def validates_presence_of: (*untyped attr_names) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module Validations
+    class UniquenessValidator < ActiveModel::EachValidator
+      # :nodoc:
+      def initialize: (untyped options) -> untyped
+
+      def validate_each: (untyped record, untyped attribute, untyped value) -> untyped
+
+      # The check for an existing value should be run from a class that
+      # isn't abstract. This means working down from the current class
+      # (self), to the first non-abstract class. Since classes don't know
+      # their subclasses, we have to build the hierarchy between self and
+      # the record's class.
+      def find_finder_class_for: (untyped record) -> untyped
+
+      def build_relation: (untyped klass, untyped attribute, untyped value) -> untyped
+
+      def scope_relation: (untyped record, untyped relation) -> untyped
+
+      def map_enum_attribute: (untyped klass, untyped attribute, untyped value) -> untyped
+    end
+
+    module ClassMethods
+      # Validates whether the value of the specified attributes are unique
+      # across the system. Useful for making sure that only one user
+      # can be named "davidhh".
+      #
+      #   class Person < ActiveRecord::Base
+      #     validates_uniqueness_of :user_name
+      #   end
+      #
+      # It can also validate whether the value of the specified attributes are
+      # unique based on a <tt>:scope</tt> parameter:
+      #
+      #   class Person < ActiveRecord::Base
+      #     validates_uniqueness_of :user_name, scope: :account_id
+      #   end
+      #
+      # Or even multiple scope parameters. For example, making sure that a
+      # teacher can only be on the schedule once per semester for a particular
+      # class.
+      #
+      #   class TeacherSchedule < ActiveRecord::Base
+      #     validates_uniqueness_of :teacher_id, scope: [:semester_id, :class_id]
+      #   end
+      #
+      # It is also possible to limit the uniqueness constraint to a set of
+      # records matching certain conditions. In this example archived articles
+      # are not being taken into consideration when validating uniqueness
+      # of the title attribute:
+      #
+      #   class Article < ActiveRecord::Base
+      #     validates_uniqueness_of :title, conditions: -> { where.not(status: 'archived') }
+      #   end
+      #
+      # When the record is created, a check is performed to make sure that no
+      # record exists in the database with the given value for the specified
+      # attribute (that maps to a column). When the record is updated,
+      # the same check is made but disregarding the record itself.
+      #
+      # Configuration options:
+      #
+      # * <tt>:message</tt> - Specifies a custom error message (default is:
+      #   "has already been taken").
+      # * <tt>:scope</tt> - One or more columns by which to limit the scope of
+      #   the uniqueness constraint.
+      # * <tt>:conditions</tt> - Specify the conditions to be included as a
+      #   <tt>WHERE</tt> SQL fragment to limit the uniqueness constraint lookup
+      #   (e.g. <tt>conditions: -> { where(status: 'active') }</tt>).
+      # * <tt>:case_sensitive</tt> - Looks for an exact match. Ignored by
+      #   non-text columns (+true+ by default).
+      # * <tt>:allow_nil</tt> - If set to +true+, skips this validation if the
+      #   attribute is +nil+ (default is +false+).
+      # * <tt>:allow_blank</tt> - If set to +true+, skips this validation if the
+      #   attribute is blank (default is +false+).
+      # * <tt>:if</tt> - Specifies a method, proc or string to call to determine
+      #   if the validation should occur (e.g. <tt>if: :allow_validation</tt>,
+      #   or <tt>if: Proc.new { |user| user.signup_step > 2 }</tt>). The method,
+      #   proc or string should return or evaluate to a +true+ or +false+ value.
+      # * <tt>:unless</tt> - Specifies a method, proc or string to call to
+      #   determine if the validation should not occur (e.g. <tt>unless: :skip_validation</tt>,
+      #   or <tt>unless: Proc.new { |user| user.signup_step <= 2 }</tt>). The
+      #   method, proc or string should return or evaluate to a +true+ or +false+
+      #   value.
+      #
+      # === Concurrency and integrity
+      #
+      # Using this validation method in conjunction with
+      # {ActiveRecord::Base#save}[rdoc-ref:Persistence#save]
+      # does not guarantee the absence of duplicate record insertions, because
+      # uniqueness checks on the application level are inherently prone to race
+      # conditions. For example, suppose that two users try to post a Comment at
+      # the same time, and a Comment's title must be unique. At the database-level,
+      # the actions performed by these users could be interleaved in the following manner:
+      #
+      #               User 1                 |               User 2
+      #  ------------------------------------+--------------------------------------
+      #  # User 1 checks whether there's     |
+      #  # already a comment with the title  |
+      #  # 'My Post'. This is not the case.  |
+      #  SELECT * FROM comments              |
+      #  WHERE title = 'My Post'             |
+      #                                      |
+      #                                      | # User 2 does the same thing and also
+      #                                      | # infers that their title is unique.
+      #                                      | SELECT * FROM comments
+      #                                      | WHERE title = 'My Post'
+      #                                      |
+      #  # User 1 inserts their comment.     |
+      #  INSERT INTO comments                |
+      #  (title, content) VALUES             |
+      #  ('My Post', 'hi!')                  |
+      #                                      |
+      #                                      | # User 2 does the same thing.
+      #                                      | INSERT INTO comments
+      #                                      | (title, content) VALUES
+      #                                      | ('My Post', 'hello!')
+      #                                      |
+      #                                      | # ^^^^^^
+      #                                      | # Boom! We now have a duplicate
+      #                                      | # title!
+      #
+      # The best way to work around this problem is to add a unique index to the database table using
+      # {connection.add_index}[rdoc-ref:ConnectionAdapters::SchemaStatements#add_index].
+      # In the rare case that a race condition occurs, the database will guarantee
+      # the field's uniqueness.
+      #
+      # When the database catches such a duplicate insertion,
+      # {ActiveRecord::Base#save}[rdoc-ref:Persistence#save] will raise an ActiveRecord::StatementInvalid
+      # exception. You can either choose to let this error propagate (which
+      # will result in the default Rails exception page being shown), or you
+      # can catch it and restart the transaction (e.g. by telling the user
+      # that the title already exists, and asking them to re-enter the title).
+      # This technique is also known as
+      # {optimistic concurrency control}[https://en.wikipedia.org/wiki/Optimistic_concurrency_control].
+      #
+      # The bundled ActiveRecord::ConnectionAdapters distinguish unique index
+      # constraint errors from other types of database errors by throwing an
+      # ActiveRecord::RecordNotUnique exception. For other adapters you will
+      # have to parse the (database-specific) exception message to detect such
+      # a case.
+      #
+      # The following bundled adapters throw the ActiveRecord::RecordNotUnique exception:
+      #
+      # * ActiveRecord::ConnectionAdapters::Mysql2Adapter.
+      # * ActiveRecord::ConnectionAdapters::SQLite3Adapter.
+      # * ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.
+      def validates_uniqueness_of: (*untyped attr_names) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  # = Active Record \RecordInvalid
+  #
+  # Raised by {ActiveRecord::Base#save!}[rdoc-ref:Persistence#save!] and
+  # {ActiveRecord::Base#create!}[rdoc-ref:Persistence::ClassMethods#create!] when the record is invalid.
+  # Use the #record method to retrieve the record which did not validate.
+  #
+  #   begin
+  #     complex_operation_that_internally_calls_save!
+  #   rescue ActiveRecord::RecordInvalid => invalid
+  #     puts invalid.record.errors
+  #   end
+  class RecordInvalid < ActiveRecordError
+    attr_reader record: untyped
+
+    def initialize: (?untyped? record) -> untyped
+  end
+
+  # = Active Record \Validations
+  #
+  # Active Record includes the majority of its validations from ActiveModel::Validations
+  # all of which accept the <tt>:on</tt> argument to define the context where the
+  # validations are active. Active Record will always supply either the context of
+  # <tt>:create</tt> or <tt>:update</tt> dependent on whether the model is a
+  # {new_record?}[rdoc-ref:Persistence#new_record?].
+  module Validations
+    extend ActiveSupport::Concern
+
+    include ActiveModel::Validations
+
+    # The validation process on save can be skipped by passing <tt>validate: false</tt>.
+    # The validation context can be changed by passing <tt>context: context</tt>.
+    # The regular {ActiveRecord::Base#save}[rdoc-ref:Persistence#save] method is replaced
+    # with this when the validations module is mixed in, which it is by default.
+    def save: (**untyped options) -> untyped
+
+    # Attempts to save the record just like {ActiveRecord::Base#save}[rdoc-ref:Base#save] but
+    # will raise an ActiveRecord::RecordInvalid exception instead of returning +false+ if the record is not valid.
+    def save!: (**untyped options) -> untyped
+
+    # Runs all the validations within the specified context. Returns +true+ if
+    # no errors are found, +false+ otherwise.
+    #
+    # Aliased as #validate.
+    #
+    # If the argument is +false+ (default is +nil+), the context is set to <tt>:create</tt> if
+    # {new_record?}[rdoc-ref:Persistence#new_record?] is +true+, and to <tt>:update</tt> if it is not.
+    #
+    # \Validations with no <tt>:on</tt> option will run no matter the context. \Validations with
+    # some <tt>:on</tt> option will only run in the specified context.
+    def valid?: (?untyped? context) -> untyped
+
+    alias validate valid?
+
+    def default_validation_context: () -> untyped
+
+    def raise_validation_error: () -> untyped
+
+    def perform_validations: (?::Hash[untyped, untyped] options) -> untyped
+  end
+end
+
+module ActiveRecord
+  # Returns the version of the currently loaded ActiveRecord as a <tt>Gem::Version</tt>
+  def self.version: () -> untyped
+end
+
+module ActiveRecord
+  extend ActiveSupport::Autoload
+
+  module Coders
+  end
+
+  module AttributeMethods
+    extend ActiveSupport::Autoload
+  end
+
+  module Locking
+    extend ActiveSupport::Autoload
+  end
+
+  module ConnectionAdapters
+    extend ActiveSupport::Autoload
+  end
+
+  module Scoping
+    extend ActiveSupport::Autoload
+  end
+
+  module Middleware
+    extend ActiveSupport::Autoload
+  end
+
+  module Tasks
+    extend ActiveSupport::Autoload
+  end
+
+  def self.eager_load!: () -> untyped
+end
+
+module Arel
+  # :nodoc: all
+  module AliasPredication
+    def as: (untyped other) -> Nodes::As
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Attributes
+    class Attribute
+      # Note: It inherits unnamed class, but omitted
+      include Arel::Expressions
+
+      include Arel::Predications
+
+      include Arel::AliasPredication
+
+      include Arel::OrderPredications
+
+      include Arel::Math
+
+      # #
+      # Create a node for lowering this attribute
+      def lower: () -> untyped
+
+      def type_cast_for_database: (untyped value) -> untyped
+
+      def able_to_type_cast?: () -> untyped
+    end
+
+    class String < Attribute
+    end
+
+    class Time < Attribute
+    end
+
+    class Boolean < Attribute
+    end
+
+    class Decimal < Attribute
+    end
+
+    class Float < Attribute
+    end
+
+    class Integer < Attribute
+    end
+
+    class Undefined < Attribute
+    end
+  end
+
+  Attribute: untyped
+end
+
+module Arel
+  # :nodoc: all
+  module Attributes
+    # #
+    # Factory method to wrap a raw database +column+ to an Arel Attribute.
+    def self.for: (untyped column) -> untyped
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Collectors
+    class Bind
+      def initialize: () -> untyped
+
+      def <<: (untyped str) -> untyped
+
+      def add_bind: (untyped bind) -> untyped
+
+      def value: () -> untyped
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Collectors
+    class Composite
+      def initialize: (untyped left, untyped right) -> untyped
+
+      def <<: (untyped str) -> untyped
+
+      def add_bind: (untyped bind) { () -> untyped } -> untyped
+
+      def value: () -> ::Array[untyped]
+
+      attr_reader left: untyped
+
+      attr_reader right: untyped
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Collectors
+    class PlainString
+      def initialize: () -> untyped
+
+      def value: () -> untyped
+
+      def <<: (untyped str) -> untyped
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Collectors
+    class SQLString < PlainString
+      def initialize: () -> untyped
+
+      def add_bind: (untyped bind) { (untyped) -> untyped } -> untyped
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Collectors
+    class SubstituteBinds
+      def initialize: (untyped quoter, untyped delegate_collector) -> untyped
+
+      def <<: (untyped str) -> untyped
+
+      def add_bind: (untyped bind) -> untyped
+
+      def value: () -> untyped
+
+      attr_reader quoter: untyped
+
+      attr_reader delegate: untyped
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  # #
+  # FIXME hopefully we can remove this
+  module Crud
+    def compile_update: (untyped values, untyped pk) -> untyped
+
+    def compile_insert: (untyped values) -> untyped
+
+    def create_insert: () -> InsertManager
+
+    def compile_delete: () -> untyped
+  end
+end
+
+module Arel
+  # :nodoc: all
+  class DeleteManager < Arel::TreeManager
+    include TreeManager::StatementMethods
+
+    def initialize: () -> untyped
+
+    def from: (untyped relation) -> untyped
+  end
+end
+
+module Arel
+  # :nodoc: all
+  class ArelError < StandardError
+  end
+
+  class EmptyJoinError < ArelError
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Expressions
+    def count: (?bool distinct) -> Nodes::Count
+
+    def sum: () -> Nodes::Sum
+
+    def maximum: () -> Nodes::Max
+
+    def minimum: () -> Nodes::Min
+
+    def average: () -> Nodes::Avg
+
+    def extract: (untyped field) -> Nodes::Extract
+  end
+end
+
+module Arel
+  # :nodoc: all
+  # #
+  # Methods for creating various nodes
+  module FactoryMethods
+    def create_true: () -> Arel::Nodes::True
+
+    def create_false: () -> Arel::Nodes::False
+
+    def create_table_alias: (untyped relation, untyped name) -> Nodes::TableAlias
+
+    def create_join: (untyped to, ?untyped? constraint, ?untyped klass) -> untyped
+
+    def create_string_join: (untyped to) -> untyped
+
+    def create_and: (untyped clauses) -> Nodes::And
+
+    def create_on: (untyped expr) -> Nodes::On
+
+    def grouping: (untyped expr) -> Nodes::Grouping
+
+    # #
+    # Create a LOWER() function
+    def lower: (untyped column) -> Nodes::NamedFunction
+
+    def coalesce: (*untyped exprs) -> Nodes::NamedFunction
+  end
+end
+
+module Arel
+  # :nodoc: all
+  class InsertManager < Arel::TreeManager
+    def initialize: () -> untyped
+
+    def into: (untyped table) -> untyped
+
+    def columns: () -> untyped
+
+    def values=: (untyped val) -> untyped
+
+    def select: (untyped select) -> untyped
+
+    def insert: (untyped fields) -> (nil | untyped)
+
+    def create_values: (untyped values) -> Nodes::ValuesList
+
+    def create_values_list: (untyped rows) -> Nodes::ValuesList
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Math
+    def *: (untyped other) -> Arel::Nodes::Multiplication
+
+    def +: (untyped other) -> Arel::Nodes::Grouping
+
+    def -: (untyped other) -> Arel::Nodes::Grouping
+
+    def /: (untyped other) -> Arel::Nodes::Division
+
+    def &: (untyped other) -> Arel::Nodes::Grouping
+
+    def |: (untyped other) -> Arel::Nodes::Grouping
+
+    def ^: (untyped other) -> Arel::Nodes::Grouping
+
+    def <<: (untyped other) -> Arel::Nodes::Grouping
+
+    def >>: (untyped other) -> Arel::Nodes::Grouping
+
+    def ~: () -> Arel::Nodes::BitwiseNot
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Nodes
+    class And < Arel::Nodes::NodeExpression
+      attr_reader children: untyped
+
+      def initialize: (untyped children) -> untyped
+
+      def left: () -> untyped
+
+      def right: () -> untyped
+
+      def hash: () -> untyped
+
+      def eql?: (untyped other) -> untyped
+
+      alias == eql?
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Nodes
+    class Ascending < Ordering
+      def reverse: () -> Descending
+
+      def direction: () -> :asc
+
+      def ascending?: () -> ::TrueClass
+
+      def descending?: () -> ::FalseClass
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Nodes
+    class Binary < Arel::Nodes::NodeExpression
+      attr_accessor left: untyped
+
+      attr_accessor right: untyped
+
+      def initialize: (untyped left, untyped right) -> untyped
+
+      def initialize_copy: (untyped other) -> untyped
+
+      def hash: () -> untyped
+
+      def eql?: (untyped other) -> untyped
+
+      alias == eql?
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Nodes
+    class BindParam < Node
+      attr_reader value: untyped
+
+      def initialize: (untyped value) -> untyped
+
+      def hash: () -> untyped
+
+      def eql?: (untyped other) -> untyped
+
+      alias == eql?
+
+      def nil?: () -> untyped
+
+      def infinite?: () -> untyped
+
+      def unboundable?: () -> untyped
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Nodes
+    class Case < Arel::Nodes::NodeExpression
+      attr_accessor case: untyped
+
+      attr_accessor conditions: untyped
+
+      attr_accessor default: untyped
+
+      def initialize: (?untyped? expression, ?untyped? default) -> untyped
+
+      def when: (untyped condition, ?untyped? expression) -> untyped
+
+      def then: (untyped expression) -> untyped
+
+      def else: (untyped expression) -> untyped
+
+      def initialize_copy: (untyped other) -> untyped
+
+      def hash: () -> untyped
+
+      def eql?: (untyped other) -> untyped
+
+      alias == eql?
+    end
+
+    class When < Binary
+    end
+
+    class Else < Unary
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Nodes
+    class Casted < Arel::Nodes::NodeExpression
+      # :nodoc:
+      attr_reader val: untyped
+
+      # :nodoc:
+      attr_reader attribute: untyped
+
+      def initialize: (untyped val, untyped attribute) -> untyped
+
+      def nil?: () -> untyped
+
+      def hash: () -> untyped
+
+      def eql?: (untyped other) -> untyped
+
+      alias == eql?
+    end
+
+    class Quoted < Arel::Nodes::Unary
+      # :nodoc:
+      alias val value
+
+      def nil?: () -> untyped
+
+      def infinite?: () -> untyped
+    end
+
+    def self.build_quoted: (untyped other, ?untyped? attribute) -> untyped
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Nodes
+    class Comment < Arel::Nodes::Node
+      attr_reader values: untyped
+
+      def initialize: (untyped values) -> untyped
+
+      def initialize_copy: (untyped other) -> untyped
+
+      def hash: () -> untyped
+
+      def eql?: (untyped other) -> untyped
+
+      alias == eql?
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Nodes
+    class Count < Arel::Nodes::Function
+      def initialize: (untyped expr, ?bool distinct, ?untyped? aliaz) -> untyped
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Nodes
+    class DeleteStatement < Arel::Nodes::Node
+      attr_accessor left: untyped
+
+      attr_accessor right: untyped
+
+      attr_accessor orders: untyped
+
+      attr_accessor limit: untyped
+
+      attr_accessor offset: untyped
+
+      attr_accessor key: untyped
+
+      alias relation left
+
+      alias relation= left=
+
+      alias wheres right
+
+      alias wheres= right=
+
+      def initialize: (?untyped? relation, ?untyped wheres) -> untyped
+
+      def initialize_copy: (untyped other) -> untyped
+
+      def hash: () -> untyped
+
+      def eql?: (untyped other) -> untyped
+
+      alias == eql?
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Nodes
+    class Descending < Ordering
+      def reverse: () -> Ascending
+
+      def direction: () -> :desc
+
+      def ascending?: () -> ::FalseClass
+
+      def descending?: () -> ::TrueClass
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Nodes
+    class Equality < Arel::Nodes::Binary
+      def operator: () -> Symbol
+
+      alias operand1 left
+
+      alias operand2 right
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Nodes
+    class Extract < Arel::Nodes::Unary
+      attr_accessor field: untyped
+
+      def initialize: (untyped expr, untyped field) -> untyped
+
+      def hash: () -> untyped
+
+      def eql?: (untyped other) -> untyped
+
+      alias == eql?
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Nodes
+    class False < Arel::Nodes::NodeExpression
+      def hash: () -> untyped
+
+      def eql?: (untyped other) -> untyped
+
+      alias == eql?
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Nodes
+    class FullOuterJoin < Arel::Nodes::Join
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Nodes
+    class Function < Arel::Nodes::NodeExpression
+      include Arel::WindowPredications
+
+      attr_accessor expressions: untyped
+
+      attr_accessor alias: untyped
+
+      attr_accessor distinct: untyped
+
+      def initialize: (untyped expr, ?untyped? aliaz) -> untyped
+
+      def as: (untyped aliaz) -> untyped
+
+      def hash: () -> untyped
+
+      def eql?: (untyped other) -> untyped
+
+      alias == eql?
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Nodes
+    class Grouping < Unary
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Nodes
+    class In < Equality
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Nodes
+    class InfixOperation < Binary
+      include Arel::Expressions
+
+      include Arel::Predications
+
+      include Arel::OrderPredications
+
+      include Arel::AliasPredication
+
+      include Arel::Math
+
+      attr_reader operator: untyped
+
+      def initialize: (untyped operator, untyped left, untyped right) -> untyped
+    end
+
+    class Multiplication < InfixOperation
+      def initialize: (untyped left, untyped right) -> untyped
+    end
+
+    class Division < InfixOperation
+      def initialize: (untyped left, untyped right) -> untyped
+    end
+
+    class Addition < InfixOperation
+      def initialize: (untyped left, untyped right) -> untyped
+    end
+
+    class Subtraction < InfixOperation
+      def initialize: (untyped left, untyped right) -> untyped
+    end
+
+    class Concat < InfixOperation
+      def initialize: (untyped left, untyped right) -> untyped
+    end
+
+    class BitwiseAnd < InfixOperation
+      def initialize: (untyped left, untyped right) -> untyped
+    end
+
+    class BitwiseOr < InfixOperation
+      def initialize: (untyped left, untyped right) -> untyped
+    end
+
+    class BitwiseXor < InfixOperation
+      def initialize: (untyped left, untyped right) -> untyped
+    end
+
+    class BitwiseShiftLeft < InfixOperation
+      def initialize: (untyped left, untyped right) -> untyped
+    end
+
+    class BitwiseShiftRight < InfixOperation
+      def initialize: (untyped left, untyped right) -> untyped
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Nodes
+    class InnerJoin < Arel::Nodes::Join
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Nodes
+    class InsertStatement < Arel::Nodes::Node
+      attr_accessor relation: untyped
+
+      attr_accessor columns: untyped
+
+      attr_accessor values: untyped
+
+      attr_accessor select: untyped
+
+      def initialize: () -> untyped
+
+      def initialize_copy: (untyped other) -> untyped
+
+      def hash: () -> untyped
+
+      def eql?: (untyped other) -> untyped
+
+      alias == eql?
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Nodes
+    class JoinSource < Arel::Nodes::Binary
+      def initialize: (untyped single_source, ?untyped joinop) -> untyped
+
+      def empty?: () -> untyped
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Nodes
+    class Matches < Binary
+      attr_reader escape: untyped
+
+      attr_accessor case_sensitive: untyped
+
+      def initialize: (untyped left, untyped right, ?untyped? escape, ?bool case_sensitive) -> untyped
+    end
+
+    class DoesNotMatch < Matches
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Nodes
+    class NamedFunction < Arel::Nodes::Function
+      attr_accessor name: untyped
+
+      def initialize: (untyped name, untyped expr, ?untyped? aliaz) -> untyped
+
+      def hash: () -> untyped
+
+      def eql?: (untyped other) -> untyped
+
+      alias == eql?
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Nodes
+    # #
+    # Abstract base class for all AST nodes
+    class Node
+      include Arel::FactoryMethods
+
+      include Enumerable[untyped]
+
+      # #
+      # Factory method to create a Nodes::Not node that has the recipient of
+      # the caller as a child.
+      def not: () -> Nodes::Not
+
+      # #
+      # Factory method to create a Nodes::Grouping node that has an Nodes::Or
+      # node as a child.
+      def or: (untyped right) -> Nodes::Grouping
+
+      # #
+      # Factory method to create an Nodes::And node.
+      def and: (untyped right) -> Nodes::And
+
+      # FIXME: this method should go away.  I don't like people calling
+      # to_sql on non-head nodes.  This forces us to walk the AST until we
+      # can find a node that has a "relation" member.
+      #
+      # Maybe we should just use `Table.engine`?  :'(
+      def to_sql: (?untyped engine) -> untyped
+
+      # Iterate through AST, nodes will be yielded depth-first
+      def each: () { () -> untyped } -> untyped
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Nodes
+    class NodeExpression < Arel::Nodes::Node
+      include Arel::Expressions
+
+      include Arel::Predications
+
+      include Arel::AliasPredication
+
+      include Arel::OrderPredications
+
+      include Arel::Math
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Nodes
+    class OuterJoin < Arel::Nodes::Join
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Nodes
+    class Over < Binary
+      include Arel::AliasPredication
+
+      def initialize: (untyped left, ?untyped? right) -> untyped
+
+      def operator: () -> "OVER"
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Nodes
+    class Regexp < Binary
+      attr_accessor case_sensitive: untyped
+
+      def initialize: (untyped left, untyped right, ?bool case_sensitive) -> untyped
+    end
+
+    class NotRegexp < Regexp
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Nodes
+    class RightOuterJoin < Arel::Nodes::Join
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Nodes
+    class SelectCore < Arel::Nodes::Node
+      attr_accessor projections: untyped
+
+      attr_accessor wheres: untyped
+
+      attr_accessor groups: untyped
+
+      attr_accessor windows: untyped
+
+      attr_accessor comment: untyped
+
+      attr_accessor havings: untyped
+
+      attr_accessor source: untyped
+
+      attr_accessor set_quantifier: untyped
+
+      attr_accessor optimizer_hints: untyped
+
+      def initialize: () -> untyped
+
+      def from: () -> untyped
+
+      def from=: (untyped value) -> untyped
+
+      alias froms= from=
+
+      alias froms from
+
+      def initialize_copy: (untyped other) -> untyped
+
+      def hash: () -> untyped
+
+      def eql?: (untyped other) -> untyped
+
+      alias == eql?
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Nodes
+    class SelectStatement < Arel::Nodes::NodeExpression
+      attr_reader cores: untyped
+
+      attr_accessor limit: untyped
+
+      attr_accessor orders: untyped
+
+      attr_accessor lock: untyped
+
+      attr_accessor offset: untyped
+
+      attr_accessor with: untyped
+
+      def initialize: (?::Array[untyped] cores) -> untyped
+
+      def initialize_copy: (untyped other) -> untyped
+
+      def hash: () -> untyped
+
+      def eql?: (untyped other) -> untyped
+
+      alias == eql?
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Nodes
+    class SqlLiteral < String
+      include Arel::Expressions
+
+      include Arel::Predications
+
+      include Arel::AliasPredication
+
+      include Arel::OrderPredications
+
+      def encode_with: (untyped coder) -> untyped
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Nodes
+    class StringJoin < Arel::Nodes::Join
+      def initialize: (untyped left, ?untyped? right) -> untyped
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Nodes
+    class TableAlias < Arel::Nodes::Binary
+      alias name right
+
+      alias relation left
+
+      alias table_alias name
+
+      def []: (untyped name) -> ::Arel::Attributes::Attribute
+
+      def table_name: () -> untyped
+
+      def type_cast_for_database: (*untyped args) -> untyped
+
+      def able_to_type_cast?: () -> untyped
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Nodes
+    class Distinct < Arel::Nodes::NodeExpression
+      def hash: () -> untyped
+
+      def eql?: (untyped other) -> untyped
+
+      alias == eql?
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Nodes
+    class True < Arel::Nodes::NodeExpression
+      def hash: () -> untyped
+
+      def eql?: (untyped other) -> untyped
+
+      alias == eql?
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Nodes
+    class Unary < Arel::Nodes::NodeExpression
+      attr_accessor expr: untyped
+
+      alias value expr
+
+      def initialize: (untyped expr) -> untyped
+
+      def hash: () -> untyped
+
+      def eql?: (untyped other) -> untyped
+
+      alias == eql?
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Nodes
+    class UnaryOperation < Unary
+      attr_reader operator: untyped
+
+      def initialize: (untyped operator, untyped operand) -> untyped
+    end
+
+    class BitwiseNot < UnaryOperation
+      def initialize: (untyped operand) -> untyped
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Nodes
+    class UnqualifiedColumn < Arel::Nodes::Unary
+      alias attribute expr
+
+      alias attribute= expr=
+
+      def relation: () -> untyped
+
+      def column: () -> untyped
+
+      def name: () -> untyped
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Nodes
+    class UpdateStatement < Arel::Nodes::Node
+      attr_accessor relation: untyped
+
+      attr_accessor wheres: untyped
+
+      attr_accessor values: untyped
+
+      attr_accessor orders: untyped
+
+      attr_accessor limit: untyped
+
+      attr_accessor offset: untyped
+
+      attr_accessor key: untyped
+
+      def initialize: () -> untyped
+
+      def initialize_copy: (untyped other) -> untyped
+
+      def hash: () -> untyped
+
+      def eql?: (untyped other) -> untyped
+
+      alias == eql?
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Nodes
+    class ValuesList < Unary
+      alias rows expr
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Nodes
+    class Window < Arel::Nodes::Node
+      attr_accessor orders: untyped
+
+      attr_accessor framing: untyped
+
+      attr_accessor partitions: untyped
+
+      def initialize: () -> untyped
+
+      def order: (*untyped expr) -> untyped
+
+      def partition: (*untyped expr) -> untyped
+
+      def frame: (untyped expr) -> untyped
+
+      def rows: (?untyped? expr) -> untyped
+
+      def range: (?untyped? expr) -> untyped
+
+      def initialize_copy: (untyped other) -> untyped
+
+      def hash: () -> untyped
+
+      def eql?: (untyped other) -> untyped
+
+      alias == eql?
+    end
+
+    class NamedWindow < Window
+      attr_accessor name: untyped
+
+      def initialize: (untyped name) -> untyped
+
+      def initialize_copy: (untyped other) -> untyped
+
+      def hash: () -> untyped
+
+      def eql?: (untyped other) -> untyped
+
+      alias == eql?
+    end
+
+    class Rows < Unary
+      def initialize: (?untyped? expr) -> untyped
+    end
+
+    class Range[out Elem] < Unary
+      def initialize: (?untyped? expr) -> untyped
+    end
+
+    class CurrentRow < Node
+      def hash: () -> untyped
+
+      def eql?: (untyped other) -> untyped
+
+      alias == eql?
+    end
+
+    class Preceding < Unary
+      def initialize: (?untyped? expr) -> untyped
+    end
+
+    class Following < Unary
+      def initialize: (?untyped? expr) -> untyped
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Nodes
+    class With < Arel::Nodes::Unary
+      alias children expr
+    end
+
+    class WithRecursive < With
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module OrderPredications
+    def asc: () -> Nodes::Ascending
+
+    def desc: () -> Nodes::Descending
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Predications
+    def not_eq: (untyped other) -> Nodes::NotEqual
+
+    def not_eq_any: (untyped others) -> untyped
+
+    def not_eq_all: (untyped others) -> untyped
+
+    def eq: (untyped other) -> Nodes::Equality
+
+    def is_not_distinct_from: (untyped other) -> Nodes::IsNotDistinctFrom
+
+    def is_distinct_from: (untyped other) -> Nodes::IsDistinctFrom
+
+    def eq_any: (untyped others) -> untyped
+
+    def eq_all: (untyped others) -> untyped
+
+    def between: (untyped other) -> untyped
+
+    def `in`: (untyped other) -> untyped
+
+    def in_any: (untyped others) -> untyped
+
+    def in_all: (untyped others) -> untyped
+
+    def not_between: (untyped other) -> untyped
+
+    def not_in: (untyped other) -> untyped
+
+    def not_in_any: (untyped others) -> untyped
+
+    def not_in_all: (untyped others) -> untyped
+
+    def matches: (untyped other, ?untyped? escape, ?bool case_sensitive) -> Nodes::Matches
+
+    def matches_regexp: (untyped other, ?bool case_sensitive) -> Nodes::Regexp
+
+    def matches_any: (untyped others, ?untyped? escape, ?bool case_sensitive) -> untyped
+
+    def matches_all: (untyped others, ?untyped? escape, ?bool case_sensitive) -> untyped
+
+    def does_not_match: (untyped other, ?untyped? escape, ?bool case_sensitive) -> Nodes::DoesNotMatch
+
+    def does_not_match_regexp: (untyped other, ?bool case_sensitive) -> Nodes::NotRegexp
+
+    def does_not_match_any: (untyped others, ?untyped? escape) -> untyped
+
+    def does_not_match_all: (untyped others, ?untyped? escape) -> untyped
+
+    def gteq: (untyped right) -> Nodes::GreaterThanOrEqual
+
+    def gteq_any: (untyped others) -> untyped
+
+    def gteq_all: (untyped others) -> untyped
+
+    def gt: (untyped right) -> Nodes::GreaterThan
+
+    def gt_any: (untyped others) -> untyped
+
+    def gt_all: (untyped others) -> untyped
+
+    def lt: (untyped right) -> Nodes::LessThan
+
+    def lt_any: (untyped others) -> untyped
+
+    def lt_all: (untyped others) -> untyped
+
+    def lteq: (untyped right) -> Nodes::LessThanOrEqual
+
+    def lteq_any: (untyped others) -> untyped
+
+    def lteq_all: (untyped others) -> untyped
+
+    def when: (untyped right) -> untyped
+
+    def concat: (untyped other) -> Nodes::Concat
+
+    def grouping_any: (untyped method_id, untyped others, *untyped extras) -> Nodes::Grouping
+
+    def grouping_all: (untyped method_id, untyped others, *untyped extras) -> Nodes::Grouping
+
+    def quoted_node: (untyped other) -> untyped
+
+    def quoted_array: (untyped others) -> untyped
+
+    def infinity?: (untyped value) -> untyped
+
+    def unboundable?: (untyped value) -> untyped
+
+    def open_ended?: (untyped value) -> untyped
+  end
+end
+
+module Arel
+  # :nodoc: all
+  class SelectManager < Arel::TreeManager
+    include Arel::Crud
+
+    STRING_OR_SYMBOL_CLASS: ::Array[untyped]
+
+    def initialize: (?untyped? table) -> untyped
+
+    def initialize_copy: (untyped other) -> untyped
+
+    def limit: () -> untyped
+
+    alias taken limit
+
+    def constraints: () -> untyped
+
+    def offset: () -> untyped
+
+    def skip: (untyped amount) -> untyped
+
+    alias offset= skip
+
+    # #
+    # Produces an Arel::Nodes::Exists node
+    def exists: () -> Arel::Nodes::Exists
+
+    def as: (untyped other) -> untyped
+
+    def lock: (?untyped locking) -> untyped
+
+    def locked: () -> untyped
+
+    def on: (*untyped exprs) -> untyped
+
+    def group: (*untyped columns) -> untyped
+
+    def from: (untyped table) -> untyped
+
+    def froms: () -> untyped
+
+    def join: (untyped relation, ?untyped klass) -> untyped
+
+    def outer_join: (untyped relation) -> untyped
+
+    def having: (untyped expr) -> untyped
+
+    def window: (untyped name) -> untyped
+
+    def project: (*untyped projections) -> untyped
+
+    def projections: () -> untyped
+
+    def projections=: (untyped projections) -> untyped
+
+    def optimizer_hints: (*untyped hints) -> untyped
+
+    def distinct: (?bool value) -> untyped
+
+    def distinct_on: (untyped value) -> untyped
+
+    def order: (*untyped expr) -> untyped
+
+    def orders: () -> untyped
+
+    def where_sql: (?untyped engine) -> (nil | Nodes::SqlLiteral)
+
+    def union: (untyped operation, ?untyped? other) -> untyped
+
+    def intersect: (untyped other) -> Nodes::Intersect
+
+    def except: (untyped other) -> Nodes::Except
+
+    alias minus except
+
+    def lateral: (?untyped? table_name) -> Nodes::Lateral
+
+    def with: (*untyped subqueries) -> untyped
+
+    def take: (untyped limit) -> untyped
+
+    alias limit= take
+
+    def join_sources: () -> untyped
+
+    def source: () -> untyped
+
+    def comment: (*untyped values) -> untyped
+
+    def collapse: (untyped exprs) -> untyped
+  end
+end
+
+module Arel
+  # :nodoc: all
+  class Table
+    include Arel::Crud
+
+    include Arel::FactoryMethods
+
+    attr_accessor engine: untyped
+
+    attr_accessor name: untyped
+
+    attr_accessor table_alias: untyped
+
+    # TableAlias and Table both have a #table_name which is the name of the underlying table
+    alias table_name name
+
+    def initialize: (untyped name, ?type_caster: untyped? type_caster, ?as: untyped? as) -> untyped
+
+    def `alias`: (?::String name) -> Nodes::TableAlias
+
+    def from: () -> SelectManager
+
+    def join: (untyped relation, ?untyped klass) -> untyped
+
+    def outer_join: (untyped relation) -> untyped
+
+    def group: (*untyped columns) -> untyped
+
+    def order: (*untyped expr) -> untyped
+
+    def where: (untyped condition) -> untyped
+
+    def project: (*untyped things) -> untyped
+
+    def take: (untyped amount) -> untyped
+
+    def skip: (untyped amount) -> untyped
+
+    def having: (untyped expr) -> untyped
+
+    def []: (untyped name) -> untyped
+
+    def hash: () -> untyped
+
+    def eql?: (untyped other) -> untyped
+
+    alias == eql?
+
+    def type_cast_for_database: (untyped attribute_name, untyped value) -> untyped
+
+    def able_to_type_cast?: () -> untyped
+
+    attr_reader type_caster: untyped
+  end
+end
+
+module Arel
+  # :nodoc: all
+  class TreeManager
+    include Arel::FactoryMethods
+
+    module StatementMethods
+      def take: (untyped limit) -> untyped
+
+      def offset: (untyped offset) -> untyped
+
+      def order: (*untyped expr) -> untyped
+
+      def key=: (untyped key) -> untyped
+
+      def key: () -> untyped
+
+      def wheres=: (untyped exprs) -> untyped
+
+      def where: (untyped expr) -> untyped
+    end
+
+    attr_reader ast: untyped
+
+    def initialize: () -> untyped
+
+    def to_dot: () -> untyped
+
+    def to_sql: (?untyped engine) -> untyped
+
+    def initialize_copy: (untyped other) -> untyped
+
+    def where: (untyped expr) -> untyped
+  end
+end
+
+module Arel
+  # :nodoc: all
+  class UpdateManager < Arel::TreeManager
+    include TreeManager::StatementMethods
+
+    def initialize: () -> untyped
+
+    # #
+    # UPDATE +table+
+    def table: (untyped table) -> untyped
+
+    def set: (untyped values) -> untyped
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Visitors
+    class DepthFirst < Arel::Visitors::Visitor
+      def initialize: (?untyped? block) -> untyped
+
+      def visit: (untyped o, ?untyped? _) -> untyped
+
+      def unary: (untyped o) -> untyped
+
+      alias visit_Arel_Nodes_Else unary
+
+      alias visit_Arel_Nodes_Group unary
+
+      alias visit_Arel_Nodes_Cube unary
+
+      alias visit_Arel_Nodes_RollUp unary
+
+      alias visit_Arel_Nodes_GroupingSet unary
+
+      alias visit_Arel_Nodes_GroupingElement unary
+
+      alias visit_Arel_Nodes_Grouping unary
+
+      alias visit_Arel_Nodes_Having unary
+
+      alias visit_Arel_Nodes_Lateral unary
+
+      alias visit_Arel_Nodes_Limit unary
+
+      alias visit_Arel_Nodes_Not unary
+
+      alias visit_Arel_Nodes_Offset unary
+
+      alias visit_Arel_Nodes_On unary
+
+      alias visit_Arel_Nodes_Ordering unary
+
+      alias visit_Arel_Nodes_Ascending unary
+
+      alias visit_Arel_Nodes_Descending unary
+
+      alias visit_Arel_Nodes_UnqualifiedColumn unary
+
+      alias visit_Arel_Nodes_OptimizerHints unary
+
+      alias visit_Arel_Nodes_ValuesList unary
+
+      def function: (untyped o) -> untyped
+
+      alias visit_Arel_Nodes_Avg function
+
+      alias visit_Arel_Nodes_Exists function
+
+      alias visit_Arel_Nodes_Max function
+
+      alias visit_Arel_Nodes_Min function
+
+      alias visit_Arel_Nodes_Sum function
+
+      def visit_Arel_Nodes_NamedFunction: (untyped o) -> untyped
+
+      def visit_Arel_Nodes_Count: (untyped o) -> untyped
+
+      def visit_Arel_Nodes_Case: (untyped o) -> untyped
+
+      def nary: (untyped o) -> untyped
+
+      alias visit_Arel_Nodes_And nary
+
+      def binary: (untyped o) -> untyped
+
+      alias visit_Arel_Nodes_As binary
+
+      alias visit_Arel_Nodes_Assignment binary
+
+      alias visit_Arel_Nodes_Between binary
+
+      alias visit_Arel_Nodes_Concat binary
+
+      alias visit_Arel_Nodes_DeleteStatement binary
+
+      alias visit_Arel_Nodes_DoesNotMatch binary
+
+      alias visit_Arel_Nodes_Equality binary
+
+      alias visit_Arel_Nodes_FullOuterJoin binary
+
+      alias visit_Arel_Nodes_GreaterThan binary
+
+      alias visit_Arel_Nodes_GreaterThanOrEqual binary
+
+      alias visit_Arel_Nodes_In binary
+
+      alias visit_Arel_Nodes_InfixOperation binary
+
+      alias visit_Arel_Nodes_JoinSource binary
+
+      alias visit_Arel_Nodes_InnerJoin binary
+
+      alias visit_Arel_Nodes_LessThan binary
+
+      alias visit_Arel_Nodes_LessThanOrEqual binary
+
+      alias visit_Arel_Nodes_Matches binary
+
+      alias visit_Arel_Nodes_NotEqual binary
+
+      alias visit_Arel_Nodes_NotIn binary
+
+      alias visit_Arel_Nodes_NotRegexp binary
+
+      alias visit_Arel_Nodes_IsNotDistinctFrom binary
+
+      alias visit_Arel_Nodes_IsDistinctFrom binary
+
+      alias visit_Arel_Nodes_Or binary
+
+      alias visit_Arel_Nodes_OuterJoin binary
+
+      alias visit_Arel_Nodes_Regexp binary
+
+      alias visit_Arel_Nodes_RightOuterJoin binary
+
+      alias visit_Arel_Nodes_TableAlias binary
+
+      alias visit_Arel_Nodes_When binary
+
+      def visit_Arel_Nodes_StringJoin: (untyped o) -> untyped
+
+      def visit_Arel_Attribute: (untyped o) -> untyped
+
+      alias visit_Arel_Attributes_Integer visit_Arel_Attribute
+
+      alias visit_Arel_Attributes_Float visit_Arel_Attribute
+
+      alias visit_Arel_Attributes_String visit_Arel_Attribute
+
+      alias visit_Arel_Attributes_Time visit_Arel_Attribute
+
+      alias visit_Arel_Attributes_Boolean visit_Arel_Attribute
+
+      alias visit_Arel_Attributes_Attribute visit_Arel_Attribute
+
+      alias visit_Arel_Attributes_Decimal visit_Arel_Attribute
+
+      def visit_Arel_Table: (untyped o) -> untyped
+
+      def terminal: (untyped o) -> nil
+
+      alias visit_ActiveSupport_Multibyte_Chars terminal
+
+      alias visit_ActiveSupport_StringInquirer terminal
+
+      alias visit_Arel_Nodes_Lock terminal
+
+      alias visit_Arel_Nodes_Node terminal
+
+      alias visit_Arel_Nodes_SqlLiteral terminal
+
+      alias visit_Arel_Nodes_BindParam terminal
+
+      alias visit_Arel_Nodes_Window terminal
+
+      alias visit_Arel_Nodes_True terminal
+
+      alias visit_Arel_Nodes_False terminal
+
+      alias visit_BigDecimal terminal
+
+      alias visit_Class terminal
+
+      alias visit_Date terminal
+
+      alias visit_DateTime terminal
+
+      alias visit_FalseClass terminal
+
+      alias visit_Float terminal
+
+      alias visit_Integer terminal
+
+      alias visit_NilClass terminal
+
+      alias visit_String terminal
+
+      alias visit_Symbol terminal
+
+      alias visit_Time terminal
+
+      alias visit_TrueClass terminal
+
+      def visit_Arel_Nodes_InsertStatement: (untyped o) -> untyped
+
+      def visit_Arel_Nodes_SelectCore: (untyped o) -> untyped
+
+      def visit_Arel_Nodes_SelectStatement: (untyped o) -> untyped
+
+      def visit_Arel_Nodes_UpdateStatement: (untyped o) -> untyped
+
+      def visit_Arel_Nodes_Comment: (untyped o) -> untyped
+
+      def visit_Array: (untyped o) -> untyped
+
+      alias visit_Set visit_Array
+
+      def visit_Hash: (untyped o) -> untyped
+
+      DISPATCH: untyped
+
+      def get_dispatch_cache: () -> untyped
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Visitors
+    class Dot < Arel::Visitors::Visitor
+      class Node
+        # :nodoc:
+        attr_accessor name: untyped
+
+        # :nodoc:
+        attr_accessor id: untyped
+
+        # :nodoc:
+        attr_accessor fields: untyped
+
+        def initialize: (untyped name, untyped id, ?untyped fields) -> untyped
+      end
+
+      class Edge
+      end
+
+      def initialize: () -> untyped
+
+      def accept: (untyped object, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_Ordering: (untyped o) -> untyped
+
+      def visit_Arel_Nodes_TableAlias: (untyped o) -> untyped
+
+      def visit_Arel_Nodes_Count: (untyped o) -> untyped
+
+      def visit_Arel_Nodes_ValuesList: (untyped o) -> untyped
+
+      def visit_Arel_Nodes_StringJoin: (untyped o) -> untyped
+
+      def visit_Arel_Nodes_InnerJoin: (untyped o) -> untyped
+
+      alias visit_Arel_Nodes_FullOuterJoin visit_Arel_Nodes_InnerJoin
+
+      alias visit_Arel_Nodes_OuterJoin visit_Arel_Nodes_InnerJoin
+
+      alias visit_Arel_Nodes_RightOuterJoin visit_Arel_Nodes_InnerJoin
+
+      def visit_Arel_Nodes_DeleteStatement: (untyped o) -> untyped
+
+      def unary: (untyped o) -> untyped
+
+      alias visit_Arel_Nodes_Group unary
+
+      alias visit_Arel_Nodes_Cube unary
+
+      alias visit_Arel_Nodes_RollUp unary
+
+      alias visit_Arel_Nodes_GroupingSet unary
+
+      alias visit_Arel_Nodes_GroupingElement unary
+
+      alias visit_Arel_Nodes_Grouping unary
+
+      alias visit_Arel_Nodes_Having unary
+
+      alias visit_Arel_Nodes_Limit unary
+
+      alias visit_Arel_Nodes_Not unary
+
+      alias visit_Arel_Nodes_Offset unary
+
+      alias visit_Arel_Nodes_On unary
+
+      alias visit_Arel_Nodes_UnqualifiedColumn unary
+
+      alias visit_Arel_Nodes_OptimizerHints unary
+
+      alias visit_Arel_Nodes_Preceding unary
+
+      alias visit_Arel_Nodes_Following unary
+
+      alias visit_Arel_Nodes_Rows unary
+
+      alias visit_Arel_Nodes_Range unary
+
+      def window: (untyped o) -> untyped
+
+      alias visit_Arel_Nodes_Window window
+
+      def named_window: (untyped o) -> untyped
+
+      alias visit_Arel_Nodes_NamedWindow named_window
+
+      def function: (untyped o) -> untyped
+
+      alias visit_Arel_Nodes_Exists function
+
+      alias visit_Arel_Nodes_Min function
+
+      alias visit_Arel_Nodes_Max function
+
+      alias visit_Arel_Nodes_Avg function
+
+      alias visit_Arel_Nodes_Sum function
+
+      def extract: (untyped o) -> untyped
+
+      alias visit_Arel_Nodes_Extract extract
+
+      def visit_Arel_Nodes_NamedFunction: (untyped o) -> untyped
+
+      def visit_Arel_Nodes_InsertStatement: (untyped o) -> untyped
+
+      def visit_Arel_Nodes_SelectCore: (untyped o) -> untyped
+
+      def visit_Arel_Nodes_SelectStatement: (untyped o) -> untyped
+
+      def visit_Arel_Nodes_UpdateStatement: (untyped o) -> untyped
+
+      def visit_Arel_Table: (untyped o) -> untyped
+
+      def visit_Arel_Nodes_Casted: (untyped o) -> untyped
+
+      def visit_Arel_Attribute: (untyped o) -> untyped
+
+      alias visit_Arel_Attributes_Integer visit_Arel_Attribute
+
+      alias visit_Arel_Attributes_Float visit_Arel_Attribute
+
+      alias visit_Arel_Attributes_String visit_Arel_Attribute
+
+      alias visit_Arel_Attributes_Time visit_Arel_Attribute
+
+      alias visit_Arel_Attributes_Boolean visit_Arel_Attribute
+
+      alias visit_Arel_Attributes_Attribute visit_Arel_Attribute
+
+      def nary: (untyped o) -> untyped
+
+      alias visit_Arel_Nodes_And nary
+
+      def binary: (untyped o) -> untyped
+
+      alias visit_Arel_Nodes_As binary
+
+      alias visit_Arel_Nodes_Assignment binary
+
+      alias visit_Arel_Nodes_Between binary
+
+      alias visit_Arel_Nodes_Concat binary
+
+      alias visit_Arel_Nodes_DoesNotMatch binary
+
+      alias visit_Arel_Nodes_Equality binary
+
+      alias visit_Arel_Nodes_GreaterThan binary
+
+      alias visit_Arel_Nodes_GreaterThanOrEqual binary
+
+      alias visit_Arel_Nodes_In binary
+
+      alias visit_Arel_Nodes_JoinSource binary
+
+      alias visit_Arel_Nodes_LessThan binary
+
+      alias visit_Arel_Nodes_LessThanOrEqual binary
+
+      alias visit_Arel_Nodes_IsNotDistinctFrom binary
+
+      alias visit_Arel_Nodes_IsDistinctFrom binary
+
+      alias visit_Arel_Nodes_Matches binary
+
+      alias visit_Arel_Nodes_NotEqual binary
+
+      alias visit_Arel_Nodes_NotIn binary
+
+      alias visit_Arel_Nodes_Or binary
+
+      alias visit_Arel_Nodes_Over binary
+
+      def visit_String: (untyped o) -> untyped
+
+      alias visit_Time visit_String
+
+      alias visit_Date visit_String
+
+      alias visit_DateTime visit_String
+
+      alias visit_NilClass visit_String
+
+      alias visit_TrueClass visit_String
+
+      alias visit_FalseClass visit_String
+
+      alias visit_Integer visit_String
+
+      alias visit_BigDecimal visit_String
+
+      alias visit_Float visit_String
+
+      alias visit_Symbol visit_String
+
+      alias visit_Arel_Nodes_SqlLiteral visit_String
+
+      def visit_Arel_Nodes_BindParam: (untyped o) -> nil
+
+      def visit_Hash: (untyped o) -> untyped
+
+      def visit_Array: (untyped o) -> untyped
+
+      alias visit_Set visit_Array
+
+      def visit_Arel_Nodes_Comment: (untyped o) -> untyped
+
+      def visit_edge: (untyped o, untyped method) -> untyped
+
+      def visit: (untyped o) -> (nil | untyped)
+
+      def edge: (untyped name) { () -> untyped } -> untyped
+
+      def with_node: (untyped node) { () -> untyped } -> untyped
+
+      def quote: (untyped string) -> untyped
+
+      def to_dot: () -> untyped
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Visitors
+    class IBM_DB < Arel::Visitors::ToSql
+      def visit_Arel_Nodes_SelectCore: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_OptimizerHints: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_Limit: (untyped o, untyped collector) -> untyped
+
+      def is_distinct_from: (untyped o, untyped collector) -> untyped
+
+      def collect_optimizer_hints: (untyped o, untyped collector) -> untyped
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Visitors
+    class Informix < Arel::Visitors::ToSql
+      def visit_Arel_Nodes_SelectStatement: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_SelectCore: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_OptimizerHints: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_Offset: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_Limit: (untyped o, untyped collector) -> untyped
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Visitors
+    class MSSQL < Arel::Visitors::ToSql
+      class RowNumber[T] < ::Struct[T]
+        attr_accessor children(): untyped
+      end
+
+      def initialize: () -> untyped
+
+      def visit_Arel_Nodes_IsNotDistinctFrom: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_IsDistinctFrom: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Visitors_MSSQL_RowNumber: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_SelectStatement: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_SelectCore: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_OptimizerHints: (untyped o, untyped collector) -> untyped
+
+      def get_offset_limit_clause: (untyped o) -> untyped
+
+      def visit_Arel_Nodes_DeleteStatement: (untyped o, untyped collector) -> untyped
+
+      def collect_optimizer_hints: (untyped o, untyped collector) -> untyped
+
+      def determine_order_by: (untyped orders, untyped x) -> untyped
+
+      def row_num_literal: (untyped order_by) -> RowNumber[untyped]
+
+      def select_count?: (untyped x) -> untyped
+
+      # FIXME raise exception of there is no pk?
+      def find_left_table_pk: (untyped o) -> untyped
+
+      def find_primary_key: (untyped o) -> untyped
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Visitors
+    class MySQL < Arel::Visitors::ToSql
+      def visit_Arel_Nodes_Bin: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_UnqualifiedColumn: (untyped o, untyped collector) -> untyped
+
+      # #
+      # :'(
+      # http://dev.mysql.com/doc/refman/5.0/en/select.html#id3482214
+      def visit_Arel_Nodes_SelectStatement: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_SelectCore: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_Concat: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_IsNotDistinctFrom: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_IsDistinctFrom: (untyped o, untyped collector) -> untyped
+
+      # In the simple case, MySQL allows us to place JOINs directly into the UPDATE
+      # query. However, this does not allow for LIMIT, OFFSET and ORDER. To support
+      # these, we must use a subquery.
+      def prepare_update_statement: (untyped o) -> untyped
+
+      alias prepare_delete_statement prepare_update_statement
+
+      # MySQL is too stupid to create a temporary table for use subquery, so we have
+      # to give it some prompting in the form of a subsubquery.
+      def build_subselect: (untyped key, untyped o) -> untyped
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Visitors
+    class Oracle < Arel::Visitors::ToSql
+      def visit_Arel_Nodes_SelectStatement: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_Limit: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_Offset: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_Except: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_UpdateStatement: (untyped o, untyped collector) -> untyped
+
+      # #
+      # Hacks for the order clauses specific to Oracle
+      def order_hacks: (untyped o) -> untyped
+
+      # Split string by commas but count opening and closing brackets
+      # and ignore commas inside brackets.
+      def split_order_string: (untyped string) -> untyped
+
+      def visit_Arel_Nodes_BindParam: (untyped o, untyped collector) -> untyped
+
+      def is_distinct_from: (untyped o, untyped collector) -> untyped
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Visitors
+    class Oracle12 < Arel::Visitors::ToSql
+      def visit_Arel_Nodes_SelectStatement: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_SelectOptions: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_Limit: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_Offset: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_Except: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_UpdateStatement: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_BindParam: (untyped o, untyped collector) -> untyped
+
+      def is_distinct_from: (untyped o, untyped collector) -> untyped
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Visitors
+    class PostgreSQL < Arel::Visitors::ToSql
+      def visit_Arel_Nodes_Matches: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_DoesNotMatch: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_Regexp: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_NotRegexp: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_DistinctOn: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_BindParam: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_GroupingElement: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_Cube: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_RollUp: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_GroupingSet: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_Lateral: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_IsNotDistinctFrom: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_IsDistinctFrom: (untyped o, untyped collector) -> untyped
+
+      # Used by Lateral visitor to enclose select queries in parentheses
+      def grouping_parentheses: (untyped o, untyped collector) -> untyped
+
+      # Utilized by GroupingSet, Cube & RollUp visitors to
+      # handle grouping aggregation semantics
+      def grouping_array_or_grouping_element: (untyped o, untyped collector) -> untyped
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Visitors
+    class SQLite < Arel::Visitors::ToSql
+      # Locks are not supported in SQLite
+      def visit_Arel_Nodes_Lock: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_SelectStatement: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_True: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_False: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_IsNotDistinctFrom: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_IsDistinctFrom: (untyped o, untyped collector) -> untyped
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Visitors
+    class UnsupportedVisitError < StandardError
+      def initialize: (untyped object) -> untyped
+    end
+
+    class ToSql < Arel::Visitors::Visitor
+      def initialize: (untyped connection) -> untyped
+
+      def compile: (untyped node, ?untyped collector) -> untyped
+
+      def visit_Arel_Nodes_DeleteStatement: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_UpdateStatement: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_InsertStatement: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_Exists: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_Casted: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_Quoted: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_True: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_False: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_ValuesList: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_SelectStatement: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_SelectOptions: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_SelectCore: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_OptimizerHints: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_Comment: (untyped o, untyped collector) -> untyped
+
+      def collect_nodes_for: (untyped nodes, untyped collector, untyped spacer, ?::String connector) -> untyped
+
+      def visit_Arel_Nodes_Bin: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_Distinct: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_DistinctOn: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_With: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_WithRecursive: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_Union: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_UnionAll: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_Intersect: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_Except: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_NamedWindow: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_Window: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_Rows: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_Range: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_Preceding: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_Following: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_CurrentRow: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_Over: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_Offset: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_Limit: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_Lock: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_Grouping: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_SelectManager: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_Ascending: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_Descending: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_Group: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_NamedFunction: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_Extract: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_Count: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_Sum: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_Max: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_Min: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_Avg: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_TableAlias: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_Between: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_GreaterThanOrEqual: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_GreaterThan: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_LessThanOrEqual: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_LessThan: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_Matches: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_DoesNotMatch: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_JoinSource: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_Regexp: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_NotRegexp: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_StringJoin: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_FullOuterJoin: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_OuterJoin: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_RightOuterJoin: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_InnerJoin: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_On: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_Not: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Table: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_In: (untyped o, untyped collector) -> untyped
+
+      def collect_in_clause: (untyped left, untyped right, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_NotIn: (untyped o, untyped collector) -> untyped
+
+      def collect_not_in_clause: (untyped left, untyped right, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_And: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_Or: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_Assignment: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_Equality: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_IsNotDistinctFrom: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_IsDistinctFrom: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_NotEqual: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_As: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_Case: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_When: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_Else: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_UnqualifiedColumn: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Attributes_Attribute: (untyped o, untyped collector) -> untyped
+
+      alias visit_Arel_Attributes_Integer visit_Arel_Attributes_Attribute
+
+      alias visit_Arel_Attributes_Float visit_Arel_Attributes_Attribute
+
+      alias visit_Arel_Attributes_Decimal visit_Arel_Attributes_Attribute
+
+      alias visit_Arel_Attributes_String visit_Arel_Attributes_Attribute
+
+      alias visit_Arel_Attributes_Time visit_Arel_Attributes_Attribute
+
+      alias visit_Arel_Attributes_Boolean visit_Arel_Attributes_Attribute
+
+      def literal: (untyped o, untyped collector) -> untyped
+
+      def visit_Arel_Nodes_BindParam: (untyped o, untyped collector) -> untyped
+
+      alias visit_Arel_Nodes_SqlLiteral literal
+
+      alias visit_Integer literal
+
+      def quoted: (untyped o, untyped a) -> untyped
+
+      def unsupported: (untyped o, untyped collector) -> untyped
+
+      alias visit_ActiveSupport_Multibyte_Chars unsupported
+
+      alias visit_ActiveSupport_StringInquirer unsupported
+
+      alias visit_BigDecimal unsupported
+
+      alias visit_Class unsupported
+
+      alias visit_Date unsupported
+
+      alias visit_DateTime unsupported
+
+      alias visit_FalseClass unsupported
+
+      alias visit_Float unsupported
+
+      alias visit_Hash unsupported
+
+      alias visit_NilClass unsupported
+
+      alias visit_String unsupported
+
+      alias visit_Symbol unsupported
+
+      alias visit_Time unsupported
+
+      alias visit_TrueClass unsupported
+
+      def visit_Arel_Nodes_InfixOperation: (untyped o, untyped collector) -> untyped
+
+      alias visit_Arel_Nodes_Addition visit_Arel_Nodes_InfixOperation
+
+      alias visit_Arel_Nodes_Subtraction visit_Arel_Nodes_InfixOperation
+
+      alias visit_Arel_Nodes_Multiplication visit_Arel_Nodes_InfixOperation
+
+      alias visit_Arel_Nodes_Division visit_Arel_Nodes_InfixOperation
+
+      def visit_Arel_Nodes_UnaryOperation: (untyped o, untyped collector) -> untyped
+
+      def visit_Array: (untyped o, untyped collector) -> untyped
+
+      alias visit_Set visit_Array
+
+      def quote: (untyped value) -> untyped
+
+      def quote_table_name: (untyped name) -> untyped
+
+      def quote_column_name: (untyped name) -> untyped
+
+      def sanitize_as_sql_comment: (untyped value) -> untyped
+
+      def collect_optimizer_hints: (untyped o, untyped collector) -> untyped
+
+      def maybe_visit: (untyped thing, untyped collector) -> untyped
+
+      def inject_join: (untyped list, untyped collector, untyped join_str) -> untyped
+
+      def unboundable?: (untyped value) -> untyped
+
+      def has_join_sources?: (untyped o) -> untyped
+
+      def has_limit_or_offset_or_orders?: (untyped o) -> untyped
+
+      # The default strategy for an UPDATE with joins is to use a subquery. This doesn't work
+      # on MySQL (even when aliasing the tables), but MySQL allows using JOIN directly in
+      # an UPDATE statement, so in the MySQL visitor we redefine this to do that.
+      def prepare_update_statement: (untyped o) -> untyped
+
+      alias prepare_delete_statement prepare_update_statement
+
+      # FIXME: we should probably have a 2-pass visitor for this
+      def build_subselect: (untyped key, untyped o) -> untyped
+
+      def infix_value: (untyped o, untyped collector, untyped value) -> untyped
+
+      def infix_value_with_paren: (untyped o, untyped collector, untyped value, ?bool suppress_parens) -> untyped
+
+      def aggregate: (untyped name, untyped o, untyped collector) -> untyped
+
+      def is_distinct_from: (untyped o, untyped collector) -> untyped
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Visitors
+    class Visitor
+      def initialize: () -> untyped
+
+      def accept: (untyped object, ?untyped? collector) -> untyped
+
+      attr_reader dispatch: untyped
+
+      def self.dispatch_cache: () -> untyped
+
+      def get_dispatch_cache: () -> untyped
+
+      def visit: (untyped object, ?untyped? collector) -> untyped
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Visitors
+    class WhereSql < Arel::Visitors::ToSql
+      def initialize: (untyped inner_visitor, *untyped args) { () -> untyped } -> untyped
+
+      def visit_Arel_Nodes_SelectCore: (untyped o, untyped collector) -> untyped
+    end
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module Visitors
+  end
+end
+
+module Arel
+  # :nodoc: all
+  module WindowPredications
+    def over: (?untyped? expr) -> Nodes::Over
+  end
+end
+
+module Arel
+  VERSION: ::String
+
+  # Wrap a known-safe SQL string for passing to query methods, e.g.
+  #
+  #   Post.order(Arel.sql("length(title)")).last
+  #
+  # Great caution should be taken to avoid SQL injection vulnerabilities.
+  # This method should not be used with unsafe values such as request
+  # parameters or model attributes.
+  def self.sql: (untyped raw_sql) -> Arel::Nodes::SqlLiteral
+
+  def self.star: () -> untyped
+
+  def self.arel_node?: (untyped value) -> untyped
+
+  def self.fetch_attribute: (untyped value) { (untyped) -> untyped } -> untyped
+
+  Node: untyped
+end
+
+module ActiveRecord
+  module Generators
+    class ApplicationRecordGenerator < ::Rails::Generators::Base
+      # FIXME: Change this file to a symlink once RubyGems 2.5.0 is required.
+      def create_application_record: () -> untyped
+
+      def application_record_file_name: () -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module Generators
+    class MigrationGenerator < Base
+      def create_migration_file: () -> untyped
+
+      attr_reader migration_action: untyped
+
+      attr_reader join_tables: untyped
+
+      # Sets the default migration template that is being used for the generation of the migration.
+      # Depending on command line arguments, the migration template and the table name instance
+      # variables are set up.
+      def set_local_assigns!: () -> untyped
+
+      def set_index_names: () -> untyped
+
+      def index_name_for: (untyped attribute) -> untyped
+
+      def attributes_with_index: () -> untyped
+
+      # A migration file name can only contain underscores (_), lowercase characters,
+      # and numbers 0-9. Any other file name will raise an IllegalMigrationNameError.
+      def validate_file_name!: () -> untyped
+
+      def normalize_table_name: (untyped _table_name) -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module Generators
+    # :nodoc:
+    module Migration
+      extend ActiveSupport::Concern
+
+      include Rails::Generators::Migration
+
+      module ClassMethods
+        # Implement the required interface for Rails::Generators::Migration.
+        def next_migration_number: (untyped dirname) -> untyped
+      end
+
+      def primary_key_type: () -> untyped
+
+      def db_migrate_path: () -> untyped
+
+      def default_migrate_path: () -> untyped
+
+      def configured_migrate_path: () -> (nil | untyped)
+    end
+  end
+end
+
+module ActiveRecord
+  module Generators
+    class ModelGenerator < Base
+      # creates the migration file for the model.
+      def create_migration_file: () -> (nil | untyped)
+
+      def create_model_file: () -> untyped
+
+      def create_module_file: () -> (nil | untyped)
+
+      def attributes_with_index: () -> untyped
+
+      # Used by the migration template to determine the parent name of the model
+      def parent_class_name: () -> untyped
+    end
+  end
+end
+
+module ActiveRecord
+  module Generators
+    class Base < Rails::Generators::NamedBase
+      # :nodoc:
+      # :nodoc:
+      include ActiveRecord::Generators::Migration
+
+      # Set the current directory as base for the inherited generators.
+      def self.base_root: () -> untyped
+    end
+  end
+end
+

--- a/gems/activerecord/6.0.3.2/activerecord.rbs
+++ b/gems/activerecord/6.0.3.2/activerecord.rbs
@@ -1,0 +1,229 @@
+module ActiveRecord
+  class Base
+    def self.abstract_class=: (bool) -> void
+    def self.scope: (Symbol, ^(*untyped) -> untyped ) -> void
+                  | (Symbol) { (*untyped) -> untyped } -> void
+    def self.belongs_to: (Symbol, ?untyped, **untyped) -> void
+    def self.has_many: (Symbol, ?untyped, **untyped) -> void
+    def self.has_one: (Symbol, ?untyped, **untyped) -> void
+    def self.transaction: [T] () { () -> T } -> T
+    def self.create!: (**untyped) -> instance
+    def self.validate: (*untyped) -> void
+    def self.validates: (*untyped) -> void
+    def self.enum: (Hash[Symbol, untyped]) -> void
+
+    # callbacks
+    def self.after_commit: (*untyped) -> void
+    def self.after_create: (*untyped) -> void
+    def self.after_destroy: (*untyped) -> void
+    def self.after_rollback: (*untyped) -> void
+    def self.after_save: (*untyped) -> void
+    def self.after_update: (*untyped) -> void
+    def self.after_validation: (*untyped) -> void
+    def self.around_create: (*untyped) -> void
+    def self.around_destroy: (*untyped) -> void
+    def self.around_save: (*untyped) -> void
+    def self.around_update: (*untyped) -> void
+    def self.before_create: (*untyped) -> void
+    def self.before_destroy: (*untyped) -> void
+    def self.before_save: (*untyped) -> void
+    def self.before_update: (*untyped) -> void
+    def self.before_validation: (*untyped) -> void
+
+    def self.columns: () -> Array[untyped]
+    def self.reflect_on_all_associations: (?Symbol) -> Array[untyped]
+
+    def will_save_change_to_attribute?: (String | Symbol attr_name, ?from: untyped, ?to: untyped) -> bool
+
+    def save!: (?validate: bool, ?touch: bool) -> self
+    def save: () -> bool
+    def update!: (*untyped) -> self
+    def update: (*untyped) -> bool
+    def destroy!: () -> self
+    def destroy: () -> bool
+    def valid?: () -> bool
+    def invalid?: () -> bool
+    def errors: () -> untyped
+    def []: (Symbol) -> untyped
+    def []=: (Symbol, untyped) -> untyped
+  end
+end
+
+interface _ActiveRecord_Relation[Model]
+  def all: () -> self
+  def ids: () -> Array[Integer]
+  def none: () -> self
+  def pluck: (Symbol | String column) -> Array[untyped]
+           | (*Symbol | String columns) -> Array[Array[untyped]]
+  def where: (*untyped) -> self
+  def not: (*untyped) -> self
+  def exists?: (*untyped) -> bool
+  def order: (*untyped) -> self
+  def group: (*Symbol | String) -> untyped
+  def distinct: () -> self
+  def or: (self) -> self
+  def merge: (self) -> self
+  def joins: (*String | Symbol) -> self
+           | (Hash[untyped, untyped]) -> self
+  def left_joins: (*String | Symbol) -> self
+           | (Hash[untyped, untyped]) -> self
+  def left_outer_joins: (*String | Symbol) -> self
+                      | (Hash[untyped, untyped]) -> self
+  def includes: (*String | Symbol) -> self
+              | (Hash[untyped, untyped]) -> self
+  def eager_load: (*String | Symbol) -> self
+                | (Hash[untyped, untyped]) -> self
+  def preload: (*String | Symbol) -> self
+             | (Hash[untyped, untyped]) -> self
+  def find_by: (*untyped) -> Model?
+  def find_by!: (*untyped) -> Model
+  def find: (Integer id) -> Model
+  def first: () -> Model
+           | (Integer count) -> Array[Model]
+  def last: () -> Model
+           | (Integer count) -> Array[Model]
+  def find_each: (?batch_size: Integer, ?start: Integer, ?finish: Integer, ?error_on_ignore: bool) { (Model) -> void } -> nil
+  def find_in_batches: (?batch_size: Integer, ?start: Integer, ?finish: Integer, ?error_on_ignore: bool) { (self) -> void } -> nil
+  def destroy_all: () -> untyped
+  def delete_all: () -> untyped
+  def update_all: (*untyped) -> untyped
+  def each: () { (Model) -> void } -> self
+end
+
+interface _ActiveRecord_Relation_ClassMethods[Model, Relation]
+  def all: () -> Relation
+  def ids: () -> Array[Integer]
+  def none: () -> Relation
+  def pluck: (Symbol | String column) -> Array[untyped]
+           | (*Symbol | String columns) -> Array[Array[untyped]]
+  def where: (*untyped) -> Relation
+  def exists?: (*untyped) -> bool
+  def order: (*untyped) -> Relation
+  def group: (*Symbol | String) -> untyped
+  def distinct: () -> self
+  def or: (Relation) -> Relation
+  def merge: (Relation) -> Relation
+  def joins: (*String | Symbol) -> self
+           | (Hash[untyped, untyped]) -> self
+  def left_joins: (*String | Symbol) -> self
+           | (Hash[untyped, untyped]) -> self
+  def left_outer_joins: (*String | Symbol) -> self
+                      | (Hash[untyped, untyped]) -> self
+  def includes: (*String | Symbol) -> self
+              | (Hash[untyped, untyped]) -> self
+  def eager_load: (*String | Symbol) -> self
+                | (Hash[untyped, untyped]) -> self
+  def preload: (*String | Symbol) -> self
+             | (Hash[untyped, untyped]) -> self
+  def find_by: (*untyped) -> Model?
+  def find_by!: (*untyped) -> Model
+  def find: (Integer id) -> Model
+  def first: () -> Model
+           | (Integer count) -> Array[Model]
+  def last: () -> Model
+           | (Integer count) -> Array[Model]
+  def find_each: (?batch_size: Integer, ?start: Integer, ?finish: Integer, ?error_on_ignore: bool) { (Model) -> void } -> nil
+  def find_in_batches: (?batch_size: Integer, ?start: Integer, ?finish: Integer, ?error_on_ignore: bool) { (self) -> void } -> nil
+  def destroy_all: () -> untyped
+  def delete_all: () -> untyped
+  def update_all: (*untyped) -> untyped
+end
+
+# https://github.com/rails/rails/blob/fbe2433be6e052a1acac63c7faf287c52ed3c5ba/activerecord/lib/arel/nodes/unary.rb
+module Arel
+  module Nodes
+    class Bin < Unary
+    end
+    class Cube < Unary
+    end
+    class DistinctOn < Unary
+    end
+    class Group < Unary
+    end
+    class GroupingElement < Unary
+    end
+    class GroupingSet < Unary
+    end
+    class Lateral < Unary
+    end
+    class Limit < Unary
+    end
+    class Lock < Unary
+    end
+    class Not < Unary
+    end
+    class Offset < Unary
+    end
+    class On < Unary
+    end
+    class OptimizerHints < Unary
+    end
+    class Ordering < Unary
+    end
+    class RollUp < Unary
+    end
+  end
+end
+
+# https://github.com/rails/rails/blob/fbe2433be6e052a1acac63c7faf287c52ed3c5ba/activerecord/lib/arel/nodes/binary.rb
+module Arel
+  module Nodes
+    class As < Binary
+    end
+    class Assignment < Binary
+    end
+    class Between < Binary
+    end
+    class GreaterThan < Binary
+    end
+    class GreaterThanOrEqual < Binary
+    end
+    class Join < Binary
+    end
+    class LessThan < Binary
+    end
+    class LessThanOrEqual < Binary
+    end
+    class NotEqual < Binary
+    end
+    class NotIn < Binary
+    end
+    class Or < Binary
+    end
+    class Union < Binary
+    end
+    class UnionAll < Binary
+    end
+    class Intersect < Binary
+    end
+    class Except < Binary
+    end
+  end
+end
+
+# https://github.com/rails/rails/blob/fbe2433be6e052a1acac63c7faf287c52ed3c5ba/activerecord/lib/arel/nodes/equality.rb
+module Arel
+  module Nodes
+    class IsDistinctFrom < Equality
+    end
+
+    class IsNotDistinctFrom < Equality
+    end
+  end
+end
+
+# https://github.com/rails/rails/blob/fbe2433be6e052a1acac63c7faf287c52ed3c5ba/activerecord/lib/arel/nodes/function.rb
+module Arel
+  module Nodes
+    class Sum < Function
+    end
+    class Exists < Function
+    end
+    class Max < Function
+    end
+    class Min < Function
+    end
+    class Avg < Function
+    end
+  end
+end

--- a/gems/activerecord/6.0.3.2/patch.rbs
+++ b/gems/activerecord/6.0.3.2/patch.rbs
@@ -1,0 +1,84 @@
+module ActiveRecord
+  class Relation
+    # alias bug: https://github.com/ruby/rbs/issues/458
+    def lock_value: () -> untyped
+  end
+
+  module QueryMethods
+    # It is defined with meta programming
+    def extending_values: () -> untyped
+  end
+
+  module ConnectionAdapters
+    module PostgreSQL
+      module OID
+        class Uuid < ActiveModel::Type::Value
+          # alias bug: https://github.com/ruby/rbs/issues/458
+          def deserialize: (*untyped) -> untyped
+        end
+      end
+    end
+  end
+
+  module ConnectionAdapters
+    class PostgreSQLAdapter < AbstractAdapter
+      def database_version: (*untyped) -> untyped
+    end
+  end
+
+  class Migration
+    class CommandRecorder
+      # They are defined with meta programming
+      def add_reference: (*untyped) -> untyped
+      def remove_reference: (*untyped) -> untyped
+      def invert_add_reference: (*untyped) -> untyped
+      def invert_remove_reference: (*untyped) -> untyped
+    end
+  end
+
+  class Result
+    # alias bug: https://github.com/ruby/rbs/issues/458
+    def map: [U] () { (untyped arg0) -> U } -> ::Array[U]
+           | () -> ::Enumerator[untyped, ::Array[untyped]]
+  end
+end
+
+module Arel
+  module Nodes
+    class Quoted < Arel::Nodes::Unary
+      # alias bug: https://github.com/ruby/rbs/issues/458
+      def value: () -> untyped
+    end
+
+    class Equality < Arel::Nodes::Binary
+      # alias bug: https://github.com/ruby/rbs/issues/458
+      def left: () -> untyped
+      # alias bug: https://github.com/ruby/rbs/issues/458
+      def right: () -> untyped
+    end
+
+    class TableAlias < Arel::Nodes::Binary
+      # alias bug: https://github.com/ruby/rbs/issues/458
+      def left: () -> untyped
+      # alias bug: https://github.com/ruby/rbs/issues/458
+      def right: () -> untyped
+    end
+
+    class UnqualifiedColumn < Arel::Nodes::Unary
+      # alias bug: https://github.com/ruby/rbs/issues/458
+      def expr: () -> untyped
+      # alias bug: https://github.com/ruby/rbs/issues/458
+      def expr=: (untyped) -> untyped
+    end
+
+    class ValuesList < Unary
+      # alias bug: https://github.com/ruby/rbs/issues/458
+      def expr: () -> untyped
+    end
+
+    class With < Arel::Nodes::Unary
+      # alias bug: https://github.com/ruby/rbs/issues/458
+      def expr: () -> untyped
+    end
+  end
+end

--- a/gems/activesupport/6.0.3.2/activesupport-generated.rbs
+++ b/gems/activesupport/6.0.3.2/activesupport-generated.rbs
@@ -1,3 +1,27 @@
+# The generated code is based on Ruby on Rails source code
+# You can find the license of Ruby on Rails from following.
+
+#Copyright (c) 2005-2019 David Heinemeier Hansson
+#
+#Permission is hereby granted, free of charge, to any person obtaining
+#a copy of this software and associated documentation files (the
+#"Software"), to deal in the Software without restriction, including
+#without limitation the rights to use, copy, modify, merge, publish,
+#distribute, sublicense, and/or sell copies of the Software, and to
+#permit persons to whom the Software is furnished to do so, subject to
+#the following conditions:
+#
+#The above copyright notice and this permission notice shall be
+#included in all copies or substantial portions of the Software.
+#
+#THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+#EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+#MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+#LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+#OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+#WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 module ActiveSupport
   # Actionable errors let's you define actions to resolve an error.
   #

--- a/gems/activesupport/6.0.3.2/activesupport-generated.rbs
+++ b/gems/activesupport/6.0.3.2/activesupport-generated.rbs
@@ -77,6 +77,8 @@ module ActiveSupport
     #   variants.any?(:desktop, :watch)    # => false
     def any?: (*untyped candidates) -> untyped
 
+    private
+
     def respond_to_missing?: (untyped name, ?bool include_private) -> untyped
 
     def method_missing: (untyped name, *untyped args) -> untyped
@@ -143,6 +145,8 @@ module ActiveSupport
     # need to see entire filepaths in the backtrace that you had already
     # filtered out.
     def remove_filters!: () -> untyped
+
+    private
 
     FORMATTED_GEMS_PATTERN: untyped
 
@@ -237,6 +241,8 @@ module ActiveSupport
 
       def delete_matched: (untyped matcher, ?untyped? options) -> untyped
 
+      private
+
       def read_entry: (untyped key, **untyped options) -> untyped
 
       def write_entry: (untyped key, untyped entry, **untyped options) -> (::FalseClass | ::TrueClass)
@@ -283,6 +289,8 @@ module ActiveSupport
     # an in-memory cache inside of a block.
     class MemCacheStore < Store
       module LocalCacheWithRaw
+        private
+
         def write_entry: (untyped key, untyped entry, **untyped options) -> untyped
       end
 
@@ -321,6 +329,8 @@ module ActiveSupport
 
       # Get the statistics from the memcached servers.
       def stats: () -> untyped
+
+      private
 
       # Read an entry from the cache.
       def read_entry: (untyped key, **untyped options) -> untyped
@@ -393,6 +403,8 @@ module ActiveSupport
 
       def synchronize: () { () -> untyped } -> untyped
 
+      private
+
       PER_ENTRY_OVERHEAD: ::Integer
 
       def cached_size: (untyped key, untyped entry) -> untyped
@@ -430,6 +442,8 @@ module ActiveSupport
       def decrement: (untyped name, ?::Integer amount, ?untyped? options) -> nil
 
       def delete_matched: (untyped matcher, ?untyped? options) -> nil
+
+      private
 
       def read_entry: (untyped key, **untyped options) -> nil
 
@@ -477,12 +491,16 @@ module ActiveSupport
       def self.supports_cache_versioning?: () -> ::TrueClass
 
       module LocalCacheWithRaw
+        private
+
         def write_entry: (untyped key, untyped entry, **untyped options) -> untyped
 
         def write_multi_entries: (untyped entries, **untyped options) -> untyped
       end
 
       def self.build_redis: (?url: untyped? url, ?redis: untyped? redis, **untyped redis_options) -> untyped
+
+      private
 
       def self.build_redis_distributed_client: (urls: untyped urls, **untyped redis_options) -> untyped
 
@@ -683,6 +701,8 @@ module ActiveSupport
 
         def decrement: (untyped name, ?::Integer amount, **untyped options) -> untyped
 
+        private
+
         def read_entry: (untyped key, **untyped options) -> untyped
 
         def read_multi_entries: (untyped keys, **untyped options) -> untyped
@@ -784,6 +804,8 @@ module ActiveSupport
     # The +key+ argument can also respond to +cache_key+ or +to_param+.
     def self.expand_cache_key: (untyped key, ?untyped? namespace) -> untyped
 
+    private
+
     def self.retrieve_cache_key: (untyped key) -> untyped
 
     # Obtains the specified cache store class, given the name of the +store+.
@@ -838,6 +860,8 @@ module ActiveSupport
       attr_reader options: untyped
 
       alias silence? silence
+
+      private
 
       def self.retrieve_pool_options: (untyped options) -> untyped
 
@@ -1169,6 +1193,8 @@ module ActiveSupport
       # serialize entries to protect against accidental cache modifications.
       def dup_value!: () -> untyped
 
+      private
+
       def compress!: (untyped compress_threshold) -> untyped
 
       def compressed?: () -> untyped
@@ -1261,6 +1287,8 @@ module ActiveSupport
     # as possible that we were here.
     def run_callbacks: (untyped kind) { () -> untyped } -> untyped
 
+    private
+
     # A hook invoked every time a before callback is halted.
     # This can be overridden in ActiveSupport::Callbacks implementors in order
     # to provide better debugging/logging.
@@ -1331,6 +1359,8 @@ module ActiveSupport
       def apply: (untyped callback_sequence) -> untyped
 
       def current_scopes: () -> untyped
+
+      private
 
       def check_conditionals: (untyped conditionals) -> untyped
 
@@ -1436,6 +1466,8 @@ module ActiveSupport
       def `prepend`: (*untyped callbacks) -> untyped
 
       attr_reader chain: untyped
+
+      private
 
       def append_one: (untyped callback) -> untyped
 
@@ -1806,6 +1838,8 @@ module ActiveSupport
       # to proceed.
       def yield_shares: (?block_share: bool block_share, ?compatible: untyped compatible, ?purpose: untyped? purpose) { () -> untyped } -> untyped
 
+      private
+
       # Must be called within synchronize
       def busy_for_exclusive?: (untyped purpose) -> untyped
 
@@ -1835,6 +1869,8 @@ module ActiveSupport
       def config: () -> untyped
 
       def configure: () { (untyped) -> untyped } -> untyped
+
+      private
 
       def config_accessor: (*untyped names, ?instance_accessor: bool instance_accessor, ?instance_writer: bool instance_writer, ?instance_reader: bool instance_reader) { () -> untyped } -> untyped
     end
@@ -2717,6 +2753,8 @@ module DateAndTime
     #   today.prev_occurring(:thursday)  # => Thu, 07 Dec 2017
     def prev_occurring: (untyped day_of_week) -> untyped
 
+    private
+
     def first_hour: (untyped date_or_time) -> untyped
 
     def last_hour: (untyped date_or_time) -> untyped
@@ -2750,6 +2788,8 @@ module DateAndTime
     #   Time.utc(2000).in_time_zone('Alaska') # => Fri, 31 Dec 1999 15:00:00 AKST -09:00
     #   Date.new(2000).in_time_zone('Alaska') # => Sat, 01 Jan 2000 00:00:00 AKST -09:00
     def in_time_zone: (?untyped zone) -> untyped
+
+    private
 
     def time_with_zone: (untyped time, untyped zone) -> untyped
   end
@@ -2974,6 +3014,8 @@ class DateTime
 
   # Returns the fraction of a second as nanoseconds
   def nsec: () -> untyped
+
+  private
 
   def offset_in_seconds: () -> untyped
 
@@ -3251,6 +3293,8 @@ module ActiveSupport
 
     def to_h: () -> untyped
 
+    private
+
     def normalize_keys: (untyped params) -> untyped
 
     def deep_to_h: (untyped value) -> untyped
@@ -3311,6 +3355,8 @@ class Hash[unchecked out K, unchecked out V]
   # This includes the values from the root hash and from all
   # nested hashes and arrays.
   def deep_transform_values!: () { () -> untyped } -> untyped
+
+  private
 
   # support methods for deep transforming nested hashes and arrays
   def _deep_transform_values_in_object: (untyped object) { (untyped) -> untyped } -> untyped
@@ -3441,6 +3487,8 @@ class Hash[unchecked out K, unchecked out V]
   # nested hashes and arrays.
   def deep_symbolize_keys!: () -> untyped
 
+  private
+
   # support methods for deep transforming nested hashes and arrays
   def _deep_transform_keys_in_object: (untyped object) { (untyped) -> untyped } -> untyped
 
@@ -3539,7 +3587,7 @@ module Kernel
   # A shortcut to define a toplevel concern, not within a module.
   #
   # See Module::Concerning for more.
-  def concern: (untyped topic) { () -> untyped } -> untyped
+  def self?.concern: (untyped topic) { () -> untyped } -> untyped
 end
 
 module Kernel
@@ -3551,15 +3599,15 @@ module Kernel
   #   end
   #
   #   noisy_call # warning voiced
-  def silence_warnings: () { () -> untyped } -> untyped
+  def self?.silence_warnings: () { () -> untyped } -> untyped
 
   # Sets $VERBOSE to +true+ for the duration of the block and back to its
   # original value afterwards.
-  def enable_warnings: () { () -> untyped } -> untyped
+  def self?.enable_warnings: () { () -> untyped } -> untyped
 
   # Sets $VERBOSE for the duration of the block and back to its original
   # value afterwards.
-  def with_warnings: (untyped flag) { () -> untyped } -> untyped
+  def self?.with_warnings: (untyped flag) { () -> untyped } -> untyped
 
   # Blocks and ignores any exception passed as argument if raised within the block.
   #
@@ -3569,7 +3617,7 @@ module Kernel
   #   end
   #
   #   puts 'This code gets executed and nothing related to ZeroDivisionError was seen'
-  def suppress: (*untyped exception_classes) { () -> untyped } -> untyped
+  def self?.suppress: (*untyped exception_classes) { () -> untyped } -> untyped
 end
 
 module Kernel
@@ -3652,6 +3700,8 @@ class Module
   alias attr_internal attr_internal_accessor
 
   attr_accessor attr_internal_naming_format: untyped
+
+  private
 
   def attr_internal_ivar_name: (untyped attr) -> untyped
 
@@ -5162,6 +5212,8 @@ module ActiveSupport
 
     def step: (?::Integer n) { () -> untyped } -> untyped
 
+    private
+
     def ensure_iteration_allowed: () -> untyped
   end
 end
@@ -5756,11 +5808,11 @@ class ERB
     #
     #   puts html_escape('is a > 0 & a < 10?')
     #   # => is a &gt; 0 &amp; a &lt; 10?
-    def html_escape: (untyped s) -> untyped
+    def self?.html_escape: (untyped s) -> untyped
 
     alias h html_escape
 
-    def unwrapped_html_escape: (untyped s) -> untyped
+    def self?.unwrapped_html_escape: (untyped s) -> untyped
 
     # A utility method for escaping HTML without affecting existing escaped entities.
     #
@@ -5769,7 +5821,7 @@ class ERB
     #
     #   html_escape_once('&lt;&lt; Accept & Checkout')
     #   # => "&lt;&lt; Accept &amp; Checkout"
-    def html_escape_once: (untyped s) -> untyped
+    def self?.html_escape_once: (untyped s) -> untyped
 
     # A utility method for escaping HTML entities in JSON strings. Specifically, the
     # &, > and < characters are replaced with their equivalent unicode escaped form -
@@ -5826,7 +5878,7 @@ class ERB
     # is recommended that you always apply this helper (other libraries, such as the
     # JSON gem, do not provide this kind of protection by default; also some gems
     # might override +to_json+ to bypass Active Support's encoder).
-    def json_escape: (untyped s) -> untyped
+    def self?.json_escape: (untyped s) -> untyped
   end
 end
 
@@ -5887,6 +5939,8 @@ module ActiveSupport
     def to_param: () -> untyped
 
     def encode_with: (untyped coder) -> untyped
+
+    private
 
     def html_escape_interpolated_argument: (untyped arg) -> untyped
 
@@ -6355,6 +6409,8 @@ module ActiveSupport
 
     def self.clear_all: () -> untyped
 
+    private
+
     def self.generated_attribute_methods: () -> untyped
 
     def self.current_instances: () -> untyped
@@ -6485,6 +6541,8 @@ module ActiveSupport
 
       def self.take_over: (enable_reloading: untyped enable_reloading) -> untyped
 
+      private
+
       def self.setup_autoloaders: (untyped enable_reloading) -> untyped
 
       def self.autoload_once?: (untyped autoload_path) -> untyped
@@ -6500,6 +6558,10 @@ end
 
 module ActiveSupport
   module Dependencies
+    # nodoc:
+    # nodoc:
+    extend ::ActiveSupport::Dependencies
+
     UNBOUND_METHOD_MODULE_NAME: untyped
 
     # Execute the supplied block without interference from any
@@ -6544,6 +6606,8 @@ module ActiveSupport
       # Add a set of modules to the watch stack, remembering the initial
       # constants.
       def watch_namespaces: (untyped namespaces) -> untyped
+
+      private
 
       def pop_modules: (untyped modules) -> untyped
     end
@@ -6605,6 +6669,8 @@ module ActiveSupport
       # Returns +true+ if the constant was not previously marked for unloading,
       # +false+ otherwise.
       def unloadable: (untyped const_desc) -> untyped
+
+      private
 
       def load: (untyped file, ?bool wrap) -> untyped
 
@@ -6744,6 +6810,8 @@ module ActiveSupport
 
     def log: (untyped message) -> untyped
 
+    private
+
     # Returns the original name of a class or module even if `name` has been
     # overridden.
     def real_mod_name: (untyped mod) -> untyped
@@ -6801,6 +6869,8 @@ module ActiveSupport
       #     # custom stuff
       #   }
       def behavior=: (untyped behavior) -> untyped
+
+      private
 
       def arity_coerce: (untyped behavior) -> untyped
     end
@@ -6922,6 +6992,8 @@ module ActiveSupport
       # logs rely on it for diagnostics.
       def inspect: () -> untyped
 
+      private
+
       def method_missing: (untyped called, *untyped args) { () -> untyped } -> untyped
     end
 
@@ -6938,6 +7010,8 @@ module ActiveSupport
     #   # => "#<Object:0x007fb9b34c34b0>"
     class DeprecatedObjectProxy < DeprecationProxy
       def initialize: (untyped object, untyped message, ?untyped deprecator) -> untyped
+
+      private
 
       def target: () -> untyped
 
@@ -6979,6 +7053,8 @@ module ActiveSupport
     class DeprecatedInstanceVariableProxy < DeprecationProxy
       def initialize: (untyped `instance`, untyped method, ?::String var, ?untyped deprecator) -> untyped
 
+      private
+
       def target: () -> untyped
 
       def warn: (untyped callstack, untyped called, untyped args) -> untyped
@@ -7017,6 +7093,8 @@ module ActiveSupport
       #   PLANETS.class # => Array
       def `class`: () -> untyped
 
+      private
+
       def target: () -> untyped
 
       def const_missing: (untyped name) -> untyped
@@ -7054,6 +7132,8 @@ module ActiveSupport
       def silence: () { () -> untyped } -> untyped
 
       def deprecation_warning: (untyped deprecated_method_name, ?untyped? message, ?untyped? caller_backtrace) -> untyped
+
+      private
 
       # Outputs a deprecation warning message
       #
@@ -7118,6 +7198,8 @@ module ActiveSupport
     # This is the only method that is not thread safe, but is only ever called
     # during the eager loading phase.
     def self.store_inherited: (untyped klass, untyped descendant) -> untyped
+
+    private
 
     def self.accumulate_descendants: (untyped klass, untyped acc) -> untyped
 
@@ -7207,6 +7289,8 @@ module ActiveSupport
 
       def parse!: () -> untyped
 
+      private
+
       def finished?: () -> untyped
 
       # Parses number which can be a float with either comma or period.
@@ -7231,6 +7315,8 @@ module ActiveSupport
 
       # Builds and returns output string.
       def serialize: () -> ("PT0S" | ::String)
+
+      private
 
       # Return pair of duration's parts and whole duration sign.
       # Parts are summarized (as they can become repetitive due to addition, etc).
@@ -7268,6 +7354,8 @@ module ActiveSupport
       def /: (untyped other) -> untyped
 
       def %: (untyped other) -> untyped
+
+      private
 
       def calculate: (untyped op, untyped other) -> untyped
 
@@ -7324,6 +7412,8 @@ module ActiveSupport
     #   ActiveSupport::Duration.build(2716146).parts  # => {:months=>1, :days=>1}
     #
     def self.build: (untyped value) -> untyped
+
+    private
 
     def self.calculate_total_seconds: (untyped parts) -> untyped
 
@@ -7448,6 +7538,8 @@ module ActiveSupport
 
     def config: () -> untyped
 
+    private
+
     def options: () -> untyped
 
     def deserialize: (untyped config) -> untyped
@@ -7485,6 +7577,8 @@ module ActiveSupport
     def write: (untyped contents) -> untyped
 
     def change: () { () -> untyped } -> untyped
+
+    private
 
     def writing: (untyped contents) { (untyped) -> untyped } -> untyped
 
@@ -7540,6 +7634,8 @@ module ActiveSupport
 
     def execute_if_updated: () { () -> untyped } -> untyped
 
+    private
+
     def boot!: () -> untyped
 
     def shutdown!: () -> untyped
@@ -7566,6 +7662,8 @@ module ActiveSupport
 
       # Filters out directories which are descendants of others in the collection (stable).
       def filter_out_descendants: (untyped dirs) -> untyped
+
+      private
 
       def ascendant_of?: (untyped base, untyped other) -> untyped
     end
@@ -7636,6 +7734,8 @@ module ActiveSupport
     # Where possible, prefer +wrap+.
     def complete!: () -> untyped
 
+    private
+
     def hook_state: () -> untyped
   end
 end
@@ -7695,6 +7795,8 @@ module ActiveSupport
 
     # Execute the block given if updated.
     def execute_if_updated: () { () -> untyped } -> untyped
+
+    private
 
     def watched: () -> untyped
 
@@ -8027,6 +8129,8 @@ module ActiveSupport
     # Convert to a regular hash with string keys.
     def to_hash: () -> untyped
 
+    private
+
     def convert_key: (untyped key) -> untyped
 
     def convert_value: (untyped value, ?::Hash[untyped, untyped] options) -> untyped
@@ -8066,6 +8170,8 @@ end
 
 module ActiveSupport
   module Inflector
+    extend ::ActiveSupport::Inflector
+
     # A singleton instance of this class is yielded by Inflector.inflections,
     # which can then be used to specify additional inflection rules. If passed
     # an optional locale, rules for other languages can be specified. The
@@ -8095,6 +8201,8 @@ module ActiveSupport
         def add: (untyped words) -> untyped
 
         def uncountable?: (untyped str) -> untyped
+
+        private
 
         def to_regex: (untyped string) -> ::Regexp
       end
@@ -8217,6 +8325,8 @@ module ActiveSupport
       #   clear :plurals
       def clear: (?::Symbol scope) -> untyped
 
+      private
+
       def define_acronym_regex_patterns: () -> untyped
     end
 
@@ -8244,6 +8354,8 @@ module ActiveSupport
   # require it for your application or wish to define rules for languages other
   # than English, please correct or add them yourself (explained below).
   module Inflector
+    extend ::ActiveSupport::Inflector
+
     # Returns the plural form of the word in the string.
     #
     # If passed an optional +locale+ parameter, the word will be
@@ -8477,6 +8589,8 @@ module ActiveSupport
     #   ordinalize(-1021) # => "-1021st"
     def ordinalize: (untyped number) -> untyped
 
+    private
+
     # Mounts a regular expression, returned as a string to ease interpolation,
     # that will match part by part the given constant.
     #
@@ -8609,6 +8723,8 @@ module ActiveSupport
     #   end
     def self.parse_error: () -> untyped
 
+    private
+
     def self.convert_dates_from: (untyped data) -> untyped
   end
 end
@@ -8632,6 +8748,8 @@ module ActiveSupport
 
         # Encode the given object into a JSON string
         def encode: (untyped value) -> untyped
+
+        private
 
         # Rails does more escaping than the JSON gem natively does (we
         # escape \u2028 and \u2029 and optionally >, <, & to work around
@@ -8748,6 +8866,8 @@ module ActiveSupport
     def on_load: (untyped name, ?::Hash[untyped, untyped] options) { () -> untyped } -> untyped
 
     def run_load_hooks: (untyped name, ?untyped base) -> untyped
+
+    private
 
     def with_execution_control: (untyped name, untyped block, untyped once) { () -> untyped } -> untyped
 
@@ -8913,6 +9033,8 @@ module ActiveSupport
     def start: (untyped name, untyped id, untyped payload) -> untyped
 
     def finish: (untyped name, untyped id, untyped payload) -> untyped
+
+    private
 
     def color: (untyped text, untyped color, ?bool bold) -> (untyped | ::String)
   end
@@ -9101,6 +9223,8 @@ module ActiveSupport
     # Given a cipher, returns the key length of the cipher to help generate the key of desired size
     def self.key_len: (?untyped cipher) -> untyped
 
+    private
+
     def _encrypt: (untyped value, **untyped metadata_options) -> untyped
 
     def _decrypt: (untyped encrypted_message, untyped purpose) -> untyped
@@ -9270,6 +9394,8 @@ module ActiveSupport
     #   verifier.generate 'a private message' # => "BAhJIhRwcml2YXRlLW1lc3NhZ2UGOgZFVA==--e2d724331ebdee96a10fb99b089508d1c72bd772"
     def generate: (untyped value, ?purpose: untyped? purpose, ?expires_in: untyped? expires_in, ?expires_at: untyped? expires_at) -> ::String
 
+    private
+
     def encode: (untyped data) -> untyped
 
     def decode: (untyped data) -> untyped
@@ -9290,6 +9416,8 @@ module ActiveSupport
       def self.wrap: (untyped message, ?purpose: untyped? purpose, ?expires_in: untyped? expires_in, ?expires_at: untyped? expires_at) -> untyped
 
       def self.verify: (untyped message, untyped purpose) -> untyped
+
+      private
 
       def self.pick_expiry: (untyped expires_at, untyped expires_in) -> untyped
 
@@ -9337,6 +9465,8 @@ module ActiveSupport
 
         def decrypt_and_verify: (*untyped args, ?on_rotation: untyped? on_rotation, **untyped options) -> untyped
 
+        private
+
         def build_rotation: (?untyped secret, ?untyped sign_secret, untyped options) -> untyped
       end
 
@@ -9345,8 +9475,12 @@ module ActiveSupport
 
         def verified: (*untyped args, ?on_rotation: untyped? on_rotation, **untyped options) -> untyped
 
+        private
+
         def build_rotation: (?untyped secret, untyped options) -> untyped
       end
+
+      private
 
       def run_rotations: (untyped on_rotation) { (untyped) -> untyped } -> untyped
     end
@@ -9490,6 +9624,8 @@ module ActiveSupport
 
       def as_json: (?untyped? options) -> untyped
 
+      private
+
       def chars: (untyped string) -> untyped
     end
   end
@@ -9498,6 +9634,8 @@ end
 module ActiveSupport
   module Multibyte
     module Unicode
+      extend ::ActiveSupport::Multibyte::Unicode
+
       # A list of all available normalization forms.
       # See https://www.unicode.org/reports/tr15/tr15-29.html for more
       # information about normalization.
@@ -9549,6 +9687,8 @@ module ActiveSupport
       #   the following: <tt>:c</tt>, <tt>:kc</tt>, <tt>:d</tt>, or <tt>:kd</tt>.
       #   Default is ActiveSupport::Multibyte::Unicode.default_normalization_form.
       def normalize: (untyped string, ?untyped? form) -> untyped
+
+      private
 
       def recode_windows1252_chars: (untyped string) -> untyped
     end
@@ -9656,6 +9796,8 @@ module ActiveSupport
 
           def finish: (untyped name, untyped id, untyped payload) -> untyped
 
+          private
+
           def build_event: (untyped name, untyped id, untyped payload) -> ActiveSupport::Notifications::Event
         end
 
@@ -9701,6 +9843,8 @@ module ActiveSupport
       def finish: (untyped name, untyped payload) -> untyped
 
       def finish_with_state: (untyped listeners_state, untyped name, untyped payload) -> untyped
+
+      private
 
       def unique_id: () -> untyped
     end
@@ -9759,6 +9903,8 @@ module ActiveSupport
       def <<: (untyped event) -> untyped
 
       def parent_of?: (untyped event) -> untyped
+
+      private
 
       def now: () -> untyped
 
@@ -10010,6 +10156,8 @@ module ActiveSupport
 
       def execute: () -> untyped
 
+      private
+
       def options: () -> untyped
 
       def format_options: () -> untyped
@@ -10034,6 +10182,8 @@ module ActiveSupport
     class NumberToCurrencyConverter < NumberConverter
       def convert: () -> untyped
 
+      private
+
       def options: () -> untyped
 
       def i18n_opts: () -> untyped
@@ -10047,6 +10197,8 @@ module ActiveSupport
       DEFAULT_DELIMITER_REGEX: untyped
 
       def convert: () -> untyped
+
+      private
 
       def parts: () -> untyped
 
@@ -10064,6 +10216,8 @@ module ActiveSupport
       INVERTED_DECIMAL_UNITS: untyped
 
       def convert: () -> untyped
+
+      private
 
       def format: () -> untyped
 
@@ -10083,6 +10237,8 @@ module ActiveSupport
       STORAGE_UNITS: ::Array[untyped]
 
       def convert: () -> untyped
+
+      private
 
       def conversion_format: () -> untyped
 
@@ -10113,6 +10269,8 @@ module ActiveSupport
       # nodoc:
       def convert: () -> untyped
 
+      private
+
       def convert_to_phone_number: (untyped number) -> untyped
 
       def convert_with_area_code: (untyped number) -> untyped
@@ -10137,6 +10295,8 @@ module ActiveSupport
     class NumberToRoundedConverter < NumberConverter
       def convert: () -> untyped
 
+      private
+
       def strip_insignificant_zeros: () -> untyped
 
       def format_number: (untyped number) -> untyped
@@ -10156,6 +10316,8 @@ module ActiveSupport
 
       def digit_count: (untyped number) -> (1 | untyped)
 
+      private
+
       def round_without_significant: (untyped number) -> untyped
 
       def round_significant: (untyped number) -> (0 | untyped)
@@ -10174,6 +10336,8 @@ end
 module ActiveSupport
   module NumberHelper
     extend ActiveSupport::Autoload
+
+    extend ::ActiveSupport::NumberHelper
 
     # Formats a +number+ into a phone number (US by default e.g., (555)
     # 123-9876). You can customize the format in the +options+ hash.
@@ -10526,6 +10690,8 @@ module ActiveSupport
   class OptionMerger
     def initialize: (untyped context, untyped options) -> untyped
 
+    private
+
     def method_missing: (untyped method, *untyped arguments) { () -> untyped } -> untyped
 
     def invoke_method: (untyped method, untyped arguments, untyped options) { () -> untyped } -> untyped
@@ -10656,6 +10822,8 @@ module ActiveSupport
     # Returns filtered value for given key. For +Proc+ filters, third block argument is not populated.
     def filter_param: (untyped key, untyped value) -> untyped
 
+    private
+
     def compiled_filter: () -> untyped
 
     class CompiledFilter
@@ -10717,6 +10885,8 @@ module ActiveSupport
     def self.extended: (untyped object) -> untyped
 
     def `instance`: () -> untyped
+
+    private
 
     def method_missing: (untyped name, *untyped args) { () -> untyped } -> untyped
   end
@@ -10858,6 +11028,8 @@ module ActiveSupport
 
       def handler_for_rescue: (untyped exception, ?object: untyped object) -> untyped
 
+      private
+
       def find_rescue_handler: (untyped exception) -> untyped
 
       def constantize_rescue_handler_class: (untyped class_or_name) -> untyped
@@ -10877,13 +11049,13 @@ module ActiveSupport
     #
     # The values compared should be of fixed length, such as strings
     # that have already been processed by HMAC. Raises in case of length mismatch.
-    def fixed_length_secure_compare: (untyped a, untyped b) -> untyped
+    def self?.fixed_length_secure_compare: (untyped a, untyped b) -> untyped
 
     # Constant time string comparison, for variable length strings.
     #
     # The values are first processed by SHA256, so that we don't leak length info
     # via timing attacks.
-    def secure_compare: (untyped a, untyped b) -> untyped
+    def self?.secure_compare: (untyped a, untyped b) -> untyped
   end
 end
 
@@ -10904,6 +11076,8 @@ module ActiveSupport
   #   vehicle.car?   # => true
   #   vehicle.bike?  # => false
   class StringInquirer < String
+    private
+
     def respond_to_missing?: (untyped method_name, ?bool include_private) -> untyped
 
     def method_missing: (untyped method_name, *untyped arguments) -> untyped
@@ -10946,6 +11120,8 @@ module ActiveSupport
     def self.method_added: (untyped event) -> untyped
 
     def self.subscribers: () -> untyped
+
+    private
 
     attr_reader subscriber: untyped
 
@@ -11425,6 +11601,8 @@ end
 module ActiveSupport
   module Testing
     module MethodCallAssertions
+      private
+
       def assert_called: (untyped object, untyped method_name, ?untyped? message, ?returns: untyped? returns, ?times: ::Integer times) { () -> untyped } -> untyped
 
       def assert_called_with: (untyped object, untyped method_name, untyped args, ?returns: untyped? returns) { () -> untyped } -> untyped
@@ -11474,6 +11652,8 @@ module ActiveSupport
 
       def shutdown: () -> untyped
 
+      private
+
       def add_setup_exception: (untyped result, untyped setup_exception) -> untyped
     end
   end
@@ -11515,6 +11695,8 @@ end
 module ActiveSupport
   module Testing
     module Stream
+      private
+
       def silence_stream: (untyped stream) { () -> untyped } -> untyped
 
       def quietly: () { () -> untyped } -> untyped
@@ -11533,6 +11715,8 @@ module ActiveSupport
       attr_writer tagged_logger: untyped
 
       def before_setup: () -> untyped
+
+      private
 
       def tagged_logger: () -> untyped
     end
@@ -11558,6 +11742,8 @@ module ActiveSupport
       def unstub_all!: () -> untyped
 
       def stubbing: (untyped object, untyped method_name) -> untyped
+
+      private
 
       def unstub_object: (untyped stub) -> untyped
     end
@@ -11648,6 +11834,8 @@ module ActiveSupport
       #   end
       #   Time.current # => Sun, 09 Jul 2017 15:34:50 EST -05:00
       def freeze_time: () { () -> untyped } -> untyped
+
+      private
 
       def simple_stubs: () -> untyped
     end
@@ -12033,6 +12221,8 @@ module ActiveSupport
     # TimeWithZone with the existing +time_zone+.
     def method_missing: (untyped sym, *untyped args) { () -> untyped } -> untyped
 
+    private
+
     def get_period_and_ensure_valid_local_time: (untyped period) -> untyped
 
     def transfer_time_values_to_utc_constructor: (untyped time) -> untyped
@@ -12110,6 +12300,8 @@ module ActiveSupport
     def self.country_zones: (untyped country_code) -> untyped
 
     def self.clear: () -> untyped
+
+    private
 
     def self.load_country_zones: (untyped code) -> untyped
 
@@ -12292,6 +12484,9 @@ end
 
 module ActiveSupport
   module XmlMini_JDOM
+    # nodoc:
+    extend ::ActiveSupport::XmlMini_JDOM
+
     CONTENT_KEY: ::String
 
     NODE_TYPE_NAMES: ::Array[untyped]
@@ -12300,6 +12495,8 @@ module ActiveSupport
     # data::
     #   XML Document string or IO to parse
     def parse: (untyped data) -> untyped
+
+    private
 
     # Convert an XML element and merge into the hash
     #
@@ -12361,6 +12558,9 @@ end
 
 module ActiveSupport
   module XmlMini_LibXML
+    # nodoc:
+    extend ::ActiveSupport::XmlMini_LibXML
+
     # Parse an XML Document string or IO into a simple hash using libxml.
     # data::
     #   XML Document string or IO to parse
@@ -12392,6 +12592,9 @@ end
 
 module ActiveSupport
   module XmlMini_LibXMLSAX
+    # nodoc:
+    extend ::ActiveSupport::XmlMini_LibXMLSAX
+
     # Class that will build the hash while the XML document
     # is being parsed using SAX events.
     class HashBuilder
@@ -12426,6 +12629,9 @@ end
 
 module ActiveSupport
   module XmlMini_Nokogiri
+    # nodoc:
+    extend ::ActiveSupport::XmlMini_Nokogiri
+
     # Parse an XML Document string or IO into a simple hash using libxml / nokogiri.
     # data::
     #   XML Document string or IO to parse
@@ -12454,6 +12660,9 @@ end
 
 module ActiveSupport
   module XmlMini_NokogiriSAX
+    # nodoc:
+    extend ::ActiveSupport::XmlMini_NokogiriSAX
+
     # Class that will build the hash while the XML document
     # is being parsed using SAX events.
     class HashBuilder < Nokogiri::XML::SAX::Document
@@ -12488,6 +12697,9 @@ end
 
 module ActiveSupport
   module XmlMini_REXML
+    # nodoc:
+    extend ::ActiveSupport::XmlMini_REXML
+
     CONTENT_KEY: ::String
 
     # Parse an XML Document string or IO into a simple hash.
@@ -12498,6 +12710,8 @@ module ActiveSupport
     # data::
     #   XML Document string or IO to parse
     def parse: (untyped data) -> untyped
+
+    private
 
     # Convert an XML element and merge into the hash
     #
@@ -12556,6 +12770,8 @@ module ActiveSupport
   #   gem 'libxml-ruby', '=0.9.7'
   #   XmlMini.backend = 'LibXML'
   module XmlMini
+    extend ::ActiveSupport::XmlMini
+
     module FileLike
       # This module decorates files deserialized using Hash.from_xml with
       # the <tt>original_filename</tt> and <tt>content_type</tt> methods.
@@ -12592,6 +12808,8 @@ module ActiveSupport
 
     def rename_key: (untyped key, ?::Hash[untyped, untyped] options) -> untyped
 
+    private
+
     def _dasherize: (untyped key) -> ::String
 
     # TODO: Add support for other encodings
@@ -12626,8 +12844,6 @@ class Object
   #   Benchmark.ms { User.all }
   #   # => 0.074
   def self.ms: () { () -> untyped } -> untyped
-
-  alias orig_sum sum
 
   def unescape: (untyped str, ?untyped escaped) -> untyped
 end

--- a/gems/activesupport/6.0.3.2/activesupport-generated.rbs
+++ b/gems/activesupport/6.0.3.2/activesupport-generated.rbs
@@ -1,0 +1,12610 @@
+module ActiveSupport
+  # Actionable errors let's you define actions to resolve an error.
+  #
+  # To make an error actionable, include the <tt>ActiveSupport::ActionableError</tt>
+  # module and invoke the +action+ class macro to define the action. An action
+  # needs a name and a block to execute.
+  module ActionableError
+    extend Concern
+
+    class NonActionable < StandardError
+    end
+
+    def self.actions: (untyped error) -> untyped
+
+    def self.dispatch: (untyped error, untyped name) -> untyped
+
+    module ClassMethods
+      # Defines an action that can resolve the error.
+      #
+      #   class PendingMigrationError < MigrationError
+      #     include ActiveSupport::ActionableError
+      #
+      #     action "Run pending migrations" do
+      #       ActiveRecord::Tasks::DatabaseTasks.migrate
+      #     end
+      #   end
+      def action: (untyped name) { () -> untyped } -> untyped
+    end
+  end
+end
+
+module ActiveSupport
+  # Wrapping an array in an +ArrayInquirer+ gives a friendlier way to check
+  # its string-like contents:
+  #
+  #   variants = ActiveSupport::ArrayInquirer.new([:phone, :tablet])
+  #
+  #   variants.phone?    # => true
+  #   variants.tablet?   # => true
+  #   variants.desktop?  # => false
+  class ArrayInquirer[T] < Array[T]
+    # Passes each element of +candidates+ collection to ArrayInquirer collection.
+    # The method returns true if any element from the ArrayInquirer collection
+    # is equal to the stringified or symbolized form of any element in the +candidates+ collection.
+    #
+    # If +candidates+ collection is not given, method returns true.
+    #
+    #   variants = ActiveSupport::ArrayInquirer.new([:phone, :tablet])
+    #
+    #   variants.any?                      # => true
+    #   variants.any?(:phone, :tablet)     # => true
+    #   variants.any?('phone', 'desktop')  # => true
+    #   variants.any?(:desktop, :watch)    # => false
+    def any?: (*untyped candidates) -> untyped
+
+    def respond_to_missing?: (untyped name, ?bool include_private) -> untyped
+
+    def method_missing: (untyped name, *untyped args) -> untyped
+  end
+end
+
+module ActiveSupport
+  # Backtraces often include many lines that are not relevant for the context
+  # under review. This makes it hard to find the signal amongst the backtrace
+  # noise, and adds debugging time. With a BacktraceCleaner, filters and
+  # silencers are used to remove the noisy lines, so that only the most relevant
+  # lines remain.
+  #
+  # Filters are used to modify lines of data, while silencers are used to remove
+  # lines entirely. The typical filter use case is to remove lengthy path
+  # information from the start of each line, and view file paths relevant to the
+  # app directory instead of the file system root. The typical silencer use case
+  # is to exclude the output of a noisy library from the backtrace, so that you
+  # can focus on the rest.
+  #
+  #   bc = ActiveSupport::BacktraceCleaner.new
+  #   bc.add_filter   { |line| line.gsub(Rails.root.to_s, '') } # strip the Rails.root prefix
+  #   bc.add_silencer { |line| line =~ /puma|rubygems/ } # skip any lines from puma or rubygems
+  #   bc.clean(exception.backtrace) # perform the cleanup
+  #
+  # To reconfigure an existing BacktraceCleaner (like the default one in Rails)
+  # and show as much data as possible, you can always call
+  # <tt>BacktraceCleaner#remove_silencers!</tt>, which will restore the
+  # backtrace to a pristine state. If you need to reconfigure an existing
+  # BacktraceCleaner so that it does not filter or modify the paths of any lines
+  # of the backtrace, you can call <tt>BacktraceCleaner#remove_filters!</tt>
+  # These two methods will give you a completely untouched backtrace.
+  #
+  # Inspired by the Quiet Backtrace gem by thoughtbot.
+  class BacktraceCleaner
+    def initialize: () -> untyped
+
+    # Returns the backtrace after all filters and silencers have been run
+    # against it. Filters run first, then silencers.
+    def clean: (untyped backtrace, ?::Symbol kind) -> untyped
+
+    alias filter clean
+
+    # Adds a filter from the block provided. Each line in the backtrace will be
+    # mapped against this filter.
+    #
+    #   # Will turn "/my/rails/root/app/models/person.rb" into "/app/models/person.rb"
+    #   backtrace_cleaner.add_filter { |line| line.gsub(Rails.root, '') }
+    def add_filter: () { () -> untyped } -> untyped
+
+    # Adds a silencer from the block provided. If the silencer returns +true+
+    # for a given line, it will be excluded from the clean backtrace.
+    #
+    #   # Will reject all lines that include the word "puma", like "/gems/puma/server.rb" or "/app/my_puma_server/rb"
+    #   backtrace_cleaner.add_silencer { |line| line =~ /puma/ }
+    def add_silencer: () { () -> untyped } -> untyped
+
+    # Removes all silencers, but leaves in the filters. Useful if your
+    # context of debugging suddenly expands as you suspect a bug in one of
+    # the libraries you use.
+    def remove_silencers!: () -> untyped
+
+    # Removes all filters, but leaves in the silencers. Useful if you suddenly
+    # need to see entire filepaths in the backtrace that you had already
+    # filtered out.
+    def remove_filters!: () -> untyped
+
+    FORMATTED_GEMS_PATTERN: untyped
+
+    def add_gem_filter: () -> (nil | untyped)
+
+    def add_gem_silencer: () -> untyped
+
+    def add_stdlib_silencer: () -> untyped
+
+    def filter_backtrace: (untyped backtrace) -> untyped
+
+    def silence: (untyped backtrace) -> untyped
+
+    def noise: (untyped backtrace) -> untyped
+  end
+end
+
+module ActiveSupport
+  module Benchmarkable
+    # Allows you to measure the execution time of a block in a template and
+    # records the result to the log. Wrap this block around expensive operations
+    # or possible bottlenecks to get a time reading for the operation. For
+    # example, let's say you thought your file processing method was taking too
+    # long; you could wrap it in a benchmark block.
+    #
+    #  <% benchmark 'Process data files' do %>
+    #    <%= expensive_files_operation %>
+    #  <% end %>
+    #
+    # That would add something like "Process data files (345.2ms)" to the log,
+    # which you can then use to compare timings when optimizing your code.
+    #
+    # You may give an optional logger level (<tt>:debug</tt>, <tt>:info</tt>,
+    # <tt>:warn</tt>, <tt>:error</tt>) as the <tt>:level</tt> option. The
+    # default logger level value is <tt>:info</tt>.
+    #
+    #  <% benchmark 'Low-level files', level: :debug do %>
+    #    <%= lowlevel_files_operation %>
+    #  <% end %>
+    #
+    # Finally, you can pass true as the third argument to silence all log
+    # activity (other than the timing information) from inside the block. This
+    # is great for boiling down a noisy block to just a single statement that
+    # produces one log line:
+    #
+    #  <% benchmark 'Process data files', level: :info, silence: true do %>
+    #    <%= expensive_and_chatty_files_operation %>
+    #  <% end %>
+    def benchmark: (?::String message, ?::Hash[untyped, untyped] options) { () -> untyped } -> untyped
+  end
+end
+
+module ActiveSupport
+  module Cache
+    # A cache store implementation which stores everything on the filesystem.
+    #
+    # FileStore implements the Strategy::LocalCache strategy which implements
+    # an in-memory cache inside of a block.
+    class FileStore < Store
+      attr_reader cache_path: untyped
+
+      DIR_FORMATTER: ::String
+
+      FILENAME_MAX_SIZE: ::Integer
+
+      FILEPATH_MAX_SIZE: ::Integer
+
+      # max filename size on file system is 255, minus room for timestamp and random characters appended by Tempfile (used by atomic write)
+      # max is 1024, plus some room
+      GITKEEP_FILES: untyped
+
+      def initialize: (untyped cache_path, ?untyped? options) -> untyped
+
+      # Advertise cache versioning support.
+      def self.supports_cache_versioning?: () -> ::TrueClass
+
+      # Deletes all items from the cache. In this case it deletes all the entries in the specified
+      # file store directory except for .keep or .gitkeep. Be careful which directory is specified in your
+      # config file when using +FileStore+ because everything in that directory will be deleted.
+      def clear: (?untyped? options) -> untyped
+
+      # Preemptively iterates through all stored keys and removes the ones which have expired.
+      def cleanup: (?untyped? options) -> untyped
+
+      # Increments an already existing integer value that is stored in the cache.
+      # If the key is not found nothing is done.
+      def increment: (untyped name, ?::Integer amount, ?untyped? options) -> untyped
+
+      # Decrements an already existing integer value that is stored in the cache.
+      # If the key is not found nothing is done.
+      def decrement: (untyped name, ?::Integer amount, ?untyped? options) -> untyped
+
+      def delete_matched: (untyped matcher, ?untyped? options) -> untyped
+
+      def read_entry: (untyped key, **untyped options) -> untyped
+
+      def write_entry: (untyped key, untyped entry, **untyped options) -> (::FalseClass | ::TrueClass)
+
+      def delete_entry: (untyped key, **untyped options) -> untyped
+
+      # Lock a file for a block so only one process can modify it at a time.
+      def lock_file: (untyped file_name) { () -> untyped } -> untyped
+
+      # Translate a key into a file path.
+      def normalize_key: (untyped key, untyped options) -> untyped
+
+      # Translate a file path into a key.
+      def file_path_key: (untyped path) -> untyped
+
+      # Delete empty directories in the cache.
+      def delete_empty_directories: (untyped dir) -> (nil | untyped)
+
+      # Make sure a file path's directories exist.
+      def ensure_cache_path: (untyped path) -> untyped
+
+      def search_dir: (untyped dir) { () -> untyped } -> (nil | untyped)
+
+      # Modifies the amount of an already existing integer value that is stored in the cache.
+      # If the key is not found nothing is done.
+      def modify_value: (untyped name, untyped amount, untyped options) -> untyped
+    end
+  end
+end
+
+module ActiveSupport
+  module Cache
+    # A cache store implementation which stores data in Memcached:
+    # https://memcached.org
+    #
+    # This is currently the most popular cache store for production websites.
+    #
+    # Special features:
+    # - Clustering and load balancing. One can specify multiple memcached servers,
+    #   and MemCacheStore will load balance between all available servers. If a
+    #   server goes down, then MemCacheStore will ignore it until it comes back up.
+    #
+    # MemCacheStore implements the Strategy::LocalCache strategy which implements
+    # an in-memory cache inside of a block.
+    class MemCacheStore < Store
+      module LocalCacheWithRaw
+        def write_entry: (untyped key, untyped entry, **untyped options) -> untyped
+      end
+
+      # Advertise cache versioning support.
+      def self.supports_cache_versioning?: () -> ::TrueClass
+
+      ESCAPE_KEY_CHARS: untyped
+
+      def self.build_mem_cache: (*untyped addresses) -> untyped
+
+      # Creates a new MemCacheStore object, with the given memcached server
+      # addresses. Each address is either a host name, or a host-with-port string
+      # in the form of "host_name:port". For example:
+      #
+      #   ActiveSupport::Cache::MemCacheStore.new("localhost", "server-downstairs.localnetwork:8229")
+      #
+      # If no addresses are specified, then MemCacheStore will connect to
+      # localhost port 11211 (the default memcached port).
+      def initialize: (*untyped addresses) -> untyped
+
+      # Increment a cached value. This method uses the memcached incr atomic
+      # operator and can only be used on values written with the :raw option.
+      # Calling it on a value not stored with :raw will initialize that value
+      # to zero.
+      def increment: (untyped name, ?::Integer amount, ?untyped? options) -> untyped
+
+      # Decrement a cached value. This method uses the memcached decr atomic
+      # operator and can only be used on values written with the :raw option.
+      # Calling it on a value not stored with :raw will initialize that value
+      # to zero.
+      def decrement: (untyped name, ?::Integer amount, ?untyped? options) -> untyped
+
+      # Clear the entire cache on all memcached servers. This method should
+      # be used with care when shared cache is being used.
+      def clear: (?untyped? options) -> untyped
+
+      # Get the statistics from the memcached servers.
+      def stats: () -> untyped
+
+      # Read an entry from the cache.
+      def read_entry: (untyped key, **untyped options) -> untyped
+
+      # Write an entry to the cache.
+      def write_entry: (untyped key, untyped entry, **untyped options) -> untyped
+
+      # Reads multiple entries from the cache implementation.
+      def read_multi_entries: (untyped names, **untyped options) -> untyped
+
+      # Delete an entry from the cache.
+      def delete_entry: (untyped key, **untyped options) -> untyped
+
+      # Memcache keys are binaries. So we need to force their encoding to binary
+      # before applying the regular expression to ensure we are escaping all
+      # characters properly.
+      def normalize_key: (untyped key, untyped options) -> untyped
+
+      def deserialize_entry: (untyped entry) -> untyped
+
+      def rescue_error_with: (untyped fallback) { () -> untyped } -> untyped
+    end
+  end
+end
+
+module ActiveSupport
+  module Cache
+    # A cache store implementation which stores everything into memory in the
+    # same process. If you're running multiple Ruby on Rails server processes
+    # (which is the case if you're using Phusion Passenger or puma clustered mode),
+    # then this means that Rails server process instances won't be able
+    # to share cache data with each other and this may not be the most
+    # appropriate cache in that scenario.
+    #
+    # This cache has a bounded size specified by the :size options to the
+    # initializer (default is 32Mb). When the cache exceeds the allotted size,
+    # a cleanup will occur which tries to prune the cache down to three quarters
+    # of the maximum size by removing the least recently used entries.
+    #
+    # MemoryStore is thread-safe.
+    class MemoryStore < Store
+      def initialize: (?untyped? options) -> untyped
+
+      # Advertise cache versioning support.
+      def self.supports_cache_versioning?: () -> ::TrueClass
+
+      # Delete all data stored in a given cache store.
+      def clear: (?untyped? options) -> untyped
+
+      # Preemptively iterates through all stored keys and removes the ones which have expired.
+      def cleanup: (?untyped? options) -> untyped
+
+      # To ensure entries fit within the specified memory prune the cache by removing the least
+      # recently accessed entries.
+      def prune: (untyped target_size, ?untyped? max_time) -> (nil | untyped)
+
+      # Returns true if the cache is currently being pruned.
+      def pruning?: () -> untyped
+
+      # Increment an integer value in the cache.
+      def increment: (untyped name, ?::Integer amount, ?untyped? options) -> untyped
+
+      # Decrement an integer value in the cache.
+      def decrement: (untyped name, ?::Integer amount, ?untyped? options) -> untyped
+
+      # Deletes cache entries if the cache key matches a given pattern.
+      def delete_matched: (untyped matcher, ?untyped? options) -> untyped
+
+      def inspect: () -> ::String
+
+      def synchronize: () { () -> untyped } -> untyped
+
+      PER_ENTRY_OVERHEAD: ::Integer
+
+      def cached_size: (untyped key, untyped entry) -> untyped
+
+      def read_entry: (untyped key, **untyped options) -> untyped
+
+      def write_entry: (untyped key, untyped entry, **untyped options) -> (::FalseClass | untyped)
+
+      def delete_entry: (untyped key, **untyped options) -> untyped
+
+      def modify_value: (untyped name, untyped amount, untyped options) -> untyped
+    end
+  end
+end
+
+module ActiveSupport
+  module Cache
+    # A cache store implementation which doesn't actually store anything. Useful in
+    # development and test environments where you don't want caching turned on but
+    # need to go through the caching interface.
+    #
+    # This cache does implement the local cache strategy, so values will actually
+    # be cached inside blocks that utilize this strategy. See
+    # ActiveSupport::Cache::Strategy::LocalCache for more details.
+    class NullStore < Store
+      # Advertise cache versioning support.
+      def self.supports_cache_versioning?: () -> ::TrueClass
+
+      def clear: (?untyped? options) -> nil
+
+      def cleanup: (?untyped? options) -> nil
+
+      def increment: (untyped name, ?::Integer amount, ?untyped? options) -> nil
+
+      def decrement: (untyped name, ?::Integer amount, ?untyped? options) -> nil
+
+      def delete_matched: (untyped matcher, ?untyped? options) -> nil
+
+      def read_entry: (untyped key, **untyped options) -> nil
+
+      def write_entry: (untyped key, untyped entry, **untyped options) -> ::TrueClass
+
+      def delete_entry: (untyped key, **untyped options) -> ::FalseClass
+    end
+  end
+end
+
+module ActiveSupport
+  module Cache
+    module ConnectionPoolLike
+      def with: () { (untyped) -> untyped } -> untyped
+    end
+
+    # Redis cache store.
+    #
+    # Deployment note: Take care to use a *dedicated Redis cache* rather
+    # than pointing this at your existing Redis server. It won't cope well
+    # with mixed usage patterns and it won't expire cache entries by default.
+    #
+    # Redis cache server setup guide: https://redis.io/topics/lru-cache
+    #
+    # * Supports vanilla Redis, hiredis, and Redis::Distributed.
+    # * Supports Memcached-like sharding across Redises with Redis::Distributed.
+    # * Fault tolerant. If the Redis server is unavailable, no exceptions are
+    #   raised. Cache fetches are all misses and writes are dropped.
+    # * Local cache. Hot in-memory primary cache within block/middleware scope.
+    # * +read_multi+ and +write_multi+ support for Redis mget/mset. Use Redis::Distributed
+    #   4.0.1+ for distributed mget support.
+    # * +delete_matched+ support for Redis KEYS globs.
+    class RedisCacheStore < Store
+      # Keys are truncated with their own SHA2 digest if they exceed 1kB
+      MAX_KEY_BYTESIZE: ::Integer
+
+      DEFAULT_REDIS_OPTIONS: ::Hash[untyped, untyped]
+
+      DEFAULT_ERROR_HANDLER: untyped
+
+      # The maximum number of entries to receive per SCAN call.
+      SCAN_BATCH_SIZE: ::Integer
+
+      # Advertise cache versioning support.
+      def self.supports_cache_versioning?: () -> ::TrueClass
+
+      module LocalCacheWithRaw
+        def write_entry: (untyped key, untyped entry, **untyped options) -> untyped
+
+        def write_multi_entries: (untyped entries, **untyped options) -> untyped
+      end
+
+      def self.build_redis: (?url: untyped? url, ?redis: untyped? redis, **untyped redis_options) -> untyped
+
+      def self.build_redis_distributed_client: (urls: untyped urls, **untyped redis_options) -> untyped
+
+      def self.build_redis_client: (url: untyped url, **untyped redis_options) -> untyped
+
+      attr_reader redis_options: untyped
+
+      attr_reader max_key_bytesize: untyped
+
+      # Creates a new Redis cache store.
+      #
+      # Handles four options: :redis block, :redis instance, single :url
+      # string, and multiple :url strings.
+      #
+      #   Option  Class       Result
+      #   :redis  Proc    ->  options[:redis].call
+      #   :redis  Object  ->  options[:redis]
+      #   :url    String  ->  Redis.new(url: (trim non-ascii characters))
+      #   :url    Array   ->  Redis::Distributed.new([{ url: (trim non-ascii characters) }, { url: (trim non-ascii characters) }, (trim non-ascii characters)])
+      #
+      # No namespace is set by default. Provide one if the Redis cache
+      # server is shared with other apps: <tt>namespace: 'myapp-cache'</tt>.
+      #
+      # Compression is enabled by default with a 1kB threshold, so cached
+      # values larger than 1kB are automatically compressed. Disable by
+      # passing <tt>compress: false</tt> or change the threshold by passing
+      # <tt>compress_threshold: 4.kilobytes</tt>.
+      #
+      # No expiry is set on cache entries by default. Redis is expected to
+      # be configured with an eviction policy that automatically deletes
+      # least-recently or -frequently used keys when it reaches max memory.
+      # See https://redis.io/topics/lru-cache for cache server setup.
+      #
+      # Race condition TTL is not set by default. This can be used to avoid
+      # "thundering herd" cache writes when hot cache entries are expired.
+      # See <tt>ActiveSupport::Cache::Store#fetch</tt> for more.
+      def initialize: (?error_handler: untyped error_handler, ?race_condition_ttl: untyped? race_condition_ttl, ?expires_in: untyped? expires_in, ?compress_threshold: untyped compress_threshold, ?compress: bool compress, ?namespace: untyped? namespace, **untyped redis_options) -> untyped
+
+      def redis: () -> untyped
+
+      def inspect: () -> ::String
+
+      # Cache Store API implementation.
+      #
+      # Read multiple values at once. Returns a hash of requested keys ->
+      # fetched values.
+      def read_multi: (*untyped names) -> untyped
+
+      # Cache Store API implementation.
+      #
+      # Supports Redis KEYS glob patterns:
+      #
+      #   h?llo matches hello, hallo and hxllo
+      #   h*llo matches hllo and heeeello
+      #   h[ae]llo matches hello and hallo, but not hillo
+      #   h[^e]llo matches hallo, hbllo, ... but not hello
+      #   h[a-b]llo matches hallo and hbllo
+      #
+      # Use \ to escape special characters if you want to match them verbatim.
+      #
+      # See https://redis.io/commands/KEYS for more.
+      #
+      # Failsafe: Raises errors.
+      def delete_matched: (untyped matcher, ?untyped? options) -> untyped
+
+      # Cache Store API implementation.
+      #
+      # Increment a cached value. This method uses the Redis incr atomic
+      # operator and can only be used on values written with the :raw option.
+      # Calling it on a value not stored with :raw will initialize that value
+      # to zero.
+      #
+      # Failsafe: Raises errors.
+      def increment: (untyped name, ?::Integer amount, ?untyped? options) -> untyped
+
+      # Cache Store API implementation.
+      #
+      # Decrement a cached value. This method uses the Redis decr atomic
+      # operator and can only be used on values written with the :raw option.
+      # Calling it on a value not stored with :raw will initialize that value
+      # to zero.
+      #
+      # Failsafe: Raises errors.
+      def decrement: (untyped name, ?::Integer amount, ?untyped? options) -> untyped
+
+      # Cache Store API implementation.
+      #
+      # Removes expired entries. Handled natively by Redis least-recently-/
+      # least-frequently-used expiry, so manual cleanup is not supported.
+      def cleanup: (?untyped? options) -> untyped
+
+      # Clear the entire cache on all Redis servers. Safe to use on
+      # shared servers if the cache is namespaced.
+      #
+      # Failsafe: Raises errors.
+      def clear: (?untyped? options) -> untyped
+
+      def mget_capable?: () -> untyped
+
+      def mset_capable?: () -> untyped
+
+      def set_redis_capabilities: () -> untyped
+
+      # Store provider interface:
+      # Read an entry from the cache.
+      def read_entry: (untyped key, **untyped options) -> untyped
+
+      def read_multi_entries: (untyped names, **untyped options) -> untyped
+
+      def read_multi_mget: (*untyped names) -> (::Hash[untyped, untyped] | untyped)
+
+      # Write an entry to the cache.
+      #
+      # Requires Redis 2.6.12+ for extended SET options.
+      def write_entry: (untyped key, untyped entry, ?race_condition_ttl: untyped? race_condition_ttl, ?expires_in: untyped? expires_in, ?raw: bool raw, ?unless_exist: bool unless_exist, **untyped options) -> untyped
+
+      def write_key_expiry: (untyped client, untyped key, untyped options) -> untyped
+
+      # Delete an entry from the cache.
+      def delete_entry: (untyped key, untyped options) -> untyped
+
+      # Nonstandard store provider API to write multiple values at once.
+      def write_multi_entries: (untyped entries, ?expires_in: untyped? expires_in, **untyped options) -> untyped
+
+      # Truncate keys that exceed 1kB.
+      def normalize_key: (untyped key, untyped options) -> untyped
+
+      def truncate_key: (untyped key) -> untyped
+
+      def deserialize_entry: (untyped serialized_entry, raw: untyped raw) -> untyped
+
+      def serialize_entry: (untyped entry, ?raw: bool raw) -> untyped
+
+      def serialize_entries: (untyped entries, ?raw: bool raw) -> untyped
+
+      def failsafe: (untyped method, ?returning: untyped? returning) { () -> untyped } -> untyped
+
+      def handle_exception: (returning: untyped returning, method: untyped method, exception: untyped exception) -> untyped
+    end
+  end
+end
+
+module ActiveSupport
+  module Cache
+    module Strategy
+      # Caches that implement LocalCache will be backed by an in-memory cache for the
+      # duration of a block. Repeated calls to the cache for the same key will hit the
+      # in-memory cache for faster access.
+      module LocalCache
+        class LocalCacheRegistry
+          # Class for storing and registering the local caches.
+          # :nodoc:
+          extend ActiveSupport::PerThreadRegistry
+
+          def initialize: () -> untyped
+
+          def cache_for: (untyped local_cache_key) -> untyped
+
+          def set_cache_for: (untyped local_cache_key, untyped value) -> untyped
+
+          def self.set_cache_for: (untyped l, untyped v) -> untyped
+
+          def self.cache_for: (untyped l) -> untyped
+        end
+
+        # Simple memory backed cache. This cache is not thread safe and is intended only
+        # for serving as a temporary memory cache for a single thread.
+        class LocalStore < Store
+          def initialize: () -> untyped
+
+          def synchronize: () { () -> untyped } -> untyped
+
+          def clear: (?untyped? options) -> untyped
+
+          def read_entry: (untyped key, **untyped options) -> untyped
+
+          def read_multi_entries: (untyped keys, **untyped options) -> untyped
+
+          def write_entry: (untyped key, untyped value, **untyped options) -> ::TrueClass
+
+          def delete_entry: (untyped key, **untyped options) -> untyped
+
+          def fetch_entry: (untyped key, ?untyped? options) { () -> untyped } -> untyped
+        end
+
+        # Use a local cache for the duration of block.
+        def with_local_cache: () { () -> untyped } -> untyped
+
+        # Middleware class can be inserted as a Rack handler to be local cache for the
+        # duration of request.
+        def middleware: () -> untyped
+
+        def clear: (**untyped options) -> untyped
+
+        def cleanup: (**untyped options) -> untyped
+
+        def increment: (untyped name, ?::Integer amount, **untyped options) -> untyped
+
+        def decrement: (untyped name, ?::Integer amount, **untyped options) -> untyped
+
+        def read_entry: (untyped key, **untyped options) -> untyped
+
+        def read_multi_entries: (untyped keys, **untyped options) -> untyped
+
+        def write_entry: (untyped key, untyped entry, **untyped options) -> untyped
+
+        def delete_entry: (untyped key, **untyped options) -> untyped
+
+        def write_cache_value: (untyped name, untyped value, **untyped options) -> untyped
+
+        def local_cache_key: () -> untyped
+
+        def local_cache: () -> untyped
+
+        def bypass_local_cache: () { () -> untyped } -> untyped
+
+        def use_temporary_local_cache: (untyped temporary_cache) { () -> untyped } -> untyped
+      end
+    end
+  end
+end
+
+module ActiveSupport
+  module Cache
+    module Strategy
+      module LocalCache
+        class Middleware
+          # -
+          # This class wraps up local storage for middlewares. Only the middleware method should
+          # construct them.
+          # :nodoc:
+          attr_reader name: untyped
+
+          # -
+          # This class wraps up local storage for middlewares. Only the middleware method should
+          # construct them.
+          # :nodoc:
+          attr_reader local_cache_key: untyped
+
+          def initialize: (untyped name, untyped local_cache_key) -> untyped
+
+          def new: (untyped app) -> untyped
+
+          def call: (untyped env) -> untyped
+        end
+      end
+    end
+  end
+end
+
+module ActiveSupport
+  # See ActiveSupport::Cache::Store for documentation.
+  module Cache
+    # These options mean something to all cache implementations. Individual cache
+    # implementations may support additional options.
+    UNIVERSAL_OPTIONS: ::Array[untyped]
+
+    module Strategy
+    end
+
+    # Creates a new Store object according to the given options.
+    #
+    # If no arguments are passed to this method, then a new
+    # ActiveSupport::Cache::MemoryStore object will be returned.
+    #
+    # If you pass a Symbol as the first argument, then a corresponding cache
+    # store class under the ActiveSupport::Cache namespace will be created.
+    # For example:
+    #
+    #   ActiveSupport::Cache.lookup_store(:memory_store)
+    #   # => returns a new ActiveSupport::Cache::MemoryStore object
+    #
+    #   ActiveSupport::Cache.lookup_store(:mem_cache_store)
+    #   # => returns a new ActiveSupport::Cache::MemCacheStore object
+    #
+    # Any additional arguments will be passed to the corresponding cache store
+    # class's constructor:
+    #
+    #   ActiveSupport::Cache.lookup_store(:file_store, '/tmp/cache')
+    #   # => same as: ActiveSupport::Cache::FileStore.new('/tmp/cache')
+    #
+    # If the first argument is not a Symbol, then it will simply be returned:
+    #
+    #   ActiveSupport::Cache.lookup_store(MyOwnCacheStore.new)
+    #   # => returns MyOwnCacheStore.new
+    def self.lookup_store: (?untyped? store, *untyped parameters) -> untyped
+
+    # Expands out the +key+ argument into a key that can be used for the
+    # cache store. Optionally accepts a namespace, and all keys will be
+    # scoped within that namespace.
+    #
+    # If the +key+ argument provided is an array, or responds to +to_a+, then
+    # each of elements in the array will be turned into parameters/keys and
+    # concatenated into a single key. For example:
+    #
+    #   ActiveSupport::Cache.expand_cache_key([:foo, :bar])               # => "foo/bar"
+    #   ActiveSupport::Cache.expand_cache_key([:foo, :bar], "namespace")  # => "namespace/foo/bar"
+    #
+    # The +key+ argument can also respond to +cache_key+ or +to_param+.
+    def self.expand_cache_key: (untyped key, ?untyped? namespace) -> untyped
+
+    def self.retrieve_cache_key: (untyped key) -> untyped
+
+    # Obtains the specified cache store class, given the name of the +store+.
+    # Raises an error when the store class cannot be found.
+    def self.retrieve_store_class: (untyped store) -> untyped
+
+    # An abstract cache store class. There are multiple cache store
+    # implementations, each having its own additional features. See the classes
+    # under the ActiveSupport::Cache module, e.g.
+    # ActiveSupport::Cache::MemCacheStore. MemCacheStore is currently the most
+    # popular cache store for large production websites.
+    #
+    # Some implementations may not support all methods beyond the basic cache
+    # methods of +fetch+, +write+, +read+, +exist?+, and +delete+.
+    #
+    # ActiveSupport::Cache::Store can store any serializable Ruby object.
+    #
+    #   cache = ActiveSupport::Cache::MemoryStore.new
+    #
+    #   cache.read('city')   # => nil
+    #   cache.write('city', "Duckburgh")
+    #   cache.read('city')   # => "Duckburgh"
+    #
+    # Keys are always translated into Strings and are case sensitive. When an
+    # object is specified as a key and has a +cache_key+ method defined, this
+    # method will be called to define the key.  Otherwise, the +to_param+
+    # method will be called. Hashes and Arrays can also be used as keys. The
+    # elements will be delimited by slashes, and the elements within a Hash
+    # will be sorted by key so they are consistent.
+    #
+    #   cache.read('city') == cache.read(:city)   # => true
+    #
+    # Nil values can be cached.
+    #
+    # If your cache is on a shared infrastructure, you can define a namespace
+    # for your cache entries. If a namespace is defined, it will be prefixed on
+    # to every key. The namespace can be either a static value or a Proc. If it
+    # is a Proc, it will be invoked when each key is evaluated so that you can
+    # use application logic to invalidate keys.
+    #
+    #   cache.namespace = -> { @last_mod_time }  # Set the namespace to a variable
+    #   @last_mod_time = Time.now  # Invalidate the entire cache by changing namespace
+    #
+    # Cached data larger than 1kB are compressed by default. To turn off
+    # compression, pass <tt>compress: false</tt> to the initializer or to
+    # individual +fetch+ or +write+ method calls. The 1kB compression
+    # threshold is configurable with the <tt>:compress_threshold</tt> option,
+    # specified in bytes.
+    class Store
+      attr_reader silence: untyped
+
+      attr_reader options: untyped
+
+      alias silence? silence
+
+      def self.retrieve_pool_options: (untyped options) -> untyped
+
+      def self.ensure_connection_pool_added!: () -> untyped
+
+      # Creates a new cache. The options will be passed to any write method calls
+      # except for <tt>:namespace</tt> which can be used to set the global
+      # namespace for the cache.
+      def initialize: (?untyped? options) -> untyped
+
+      # Silences the logger.
+      def silence!: () -> untyped
+
+      # Silences the logger within a block.
+      def mute: () { () -> untyped } -> untyped
+
+      # Fetches data from the cache, using the given key. If there is data in
+      # the cache with the given key, then that data is returned.
+      #
+      # If there is no such data in the cache (a cache miss), then +nil+ will be
+      # returned. However, if a block has been passed, that block will be passed
+      # the key and executed in the event of a cache miss. The return value of the
+      # block will be written to the cache under the given cache key, and that
+      # return value will be returned.
+      #
+      #   cache.write('today', 'Monday')
+      #   cache.fetch('today')  # => "Monday"
+      #
+      #   cache.fetch('city')   # => nil
+      #   cache.fetch('city') do
+      #     'Duckburgh'
+      #   end
+      #   cache.fetch('city')   # => "Duckburgh"
+      #
+      # You may also specify additional options via the +options+ argument.
+      # Setting <tt>force: true</tt> forces a cache "miss," meaning we treat
+      # the cache value as missing even if it's present. Passing a block is
+      # required when +force+ is true so this always results in a cache write.
+      #
+      #   cache.write('today', 'Monday')
+      #   cache.fetch('today', force: true) { 'Tuesday' } # => 'Tuesday'
+      #   cache.fetch('today', force: true) # => ArgumentError
+      #
+      # The +:force+ option is useful when you're calling some other method to
+      # ask whether you should force a cache write. Otherwise, it's clearer to
+      # just call <tt>Cache#write</tt>.
+      #
+      # Setting <tt>skip_nil: true</tt> will not cache nil result:
+      #
+      #   cache.fetch('foo') { nil }
+      #   cache.fetch('bar', skip_nil: true) { nil }
+      #   cache.exist?('foo') # => true
+      #   cache.exist?('bar') # => false
+      #
+      #
+      # Setting <tt>compress: false</tt> disables compression of the cache entry.
+      #
+      # Setting <tt>:expires_in</tt> will set an expiration time on the cache.
+      # All caches support auto-expiring content after a specified number of
+      # seconds. This value can be specified as an option to the constructor
+      # (in which case all entries will be affected), or it can be supplied to
+      # the +fetch+ or +write+ method to effect just one entry.
+      #
+      #   cache = ActiveSupport::Cache::MemoryStore.new(expires_in: 5.minutes)
+      #   cache.write(key, value, expires_in: 1.minute) # Set a lower value for one entry
+      #
+      # Setting <tt>:version</tt> verifies the cache stored under <tt>name</tt>
+      # is of the same version. nil is returned on mismatches despite contents.
+      # This feature is used to support recyclable cache keys.
+      #
+      # Setting <tt>:race_condition_ttl</tt> is very useful in situations where
+      # a cache entry is used very frequently and is under heavy load. If a
+      # cache expires and due to heavy load several different processes will try
+      # to read data natively and then they all will try to write to cache. To
+      # avoid that case the first process to find an expired cache entry will
+      # bump the cache expiration time by the value set in <tt>:race_condition_ttl</tt>.
+      # Yes, this process is extending the time for a stale value by another few
+      # seconds. Because of extended life of the previous cache, other processes
+      # will continue to use slightly stale data for a just a bit longer. In the
+      # meantime that first process will go ahead and will write into cache the
+      # new value. After that all the processes will start getting the new value.
+      # The key is to keep <tt>:race_condition_ttl</tt> small.
+      #
+      # If the process regenerating the entry errors out, the entry will be
+      # regenerated after the specified number of seconds. Also note that the
+      # life of stale cache is extended only if it expired recently. Otherwise
+      # a new value is generated and <tt>:race_condition_ttl</tt> does not play
+      # any role.
+      #
+      #   # Set all values to expire after one minute.
+      #   cache = ActiveSupport::Cache::MemoryStore.new(expires_in: 1.minute)
+      #
+      #   cache.write('foo', 'original value')
+      #   val_1 = nil
+      #   val_2 = nil
+      #   sleep 60
+      #
+      #   Thread.new do
+      #     val_1 = cache.fetch('foo', race_condition_ttl: 10.seconds) do
+      #       sleep 1
+      #       'new value 1'
+      #     end
+      #   end
+      #
+      #   Thread.new do
+      #     val_2 = cache.fetch('foo', race_condition_ttl: 10.seconds) do
+      #       'new value 2'
+      #     end
+      #   end
+      #
+      #   cache.fetch('foo') # => "original value"
+      #   sleep 10 # First thread extended the life of cache by another 10 seconds
+      #   cache.fetch('foo') # => "new value 1"
+      #   val_1 # => "new value 1"
+      #   val_2 # => "original value"
+      #
+      # Other options will be handled by the specific cache store implementation.
+      # Internally, #fetch calls #read_entry, and calls #write_entry on a cache
+      # miss. +options+ will be passed to the #read and #write calls.
+      #
+      # For example, MemCacheStore's #write method supports the +:raw+
+      # option, which tells the memcached server to store all values as strings.
+      # We can use this option with #fetch too:
+      #
+      #   cache = ActiveSupport::Cache::MemCacheStore.new
+      #   cache.fetch("foo", force: true, raw: true) do
+      #     :bar
+      #   end
+      #   cache.fetch('foo') # => "bar"
+      def fetch: (untyped name, ?untyped? options) { (untyped) -> untyped } -> untyped
+
+      # Reads data from the cache, using the given key. If there is data in
+      # the cache with the given key, then that data is returned. Otherwise,
+      # +nil+ is returned.
+      #
+      # Note, if data was written with the <tt>:expires_in</tt> or
+      # <tt>:version</tt> options, both of these conditions are applied before
+      # the data is returned.
+      #
+      # Options are passed to the underlying cache implementation.
+      def read: (untyped name, ?untyped? options) -> untyped
+
+      # Reads multiple values at once from the cache. Options can be passed
+      # in the last argument.
+      #
+      # Some cache implementation may optimize this method.
+      #
+      # Returns a hash mapping the names provided to the values found.
+      def read_multi: (*untyped names) -> untyped
+
+      # Cache Storage API to write multiple values at once.
+      def write_multi: (untyped hash, ?untyped? options) -> untyped
+
+      # Fetches data from the cache, using the given keys. If there is data in
+      # the cache with the given keys, then that data is returned. Otherwise,
+      # the supplied block is called for each key for which there was no data,
+      # and the result will be written to the cache and returned.
+      # Therefore, you need to pass a block that returns the data to be written
+      # to the cache. If you do not want to write the cache when the cache is
+      # not found, use #read_multi.
+      #
+      # Returns a hash with the data for each of the names. For example:
+      #
+      #   cache.write("bim", "bam")
+      #   cache.fetch_multi("bim", "unknown_key") do |key|
+      #     "Fallback value for key: #{key}"
+      #   end
+      #   # => { "bim" => "bam",
+      #   #      "unknown_key" => "Fallback value for key: unknown_key" }
+      #
+      # Options are passed to the underlying cache implementation. For example:
+      #
+      #   cache.fetch_multi("fizz", expires_in: 5.seconds) do |key|
+      #     "buzz"
+      #   end
+      #   # => {"fizz"=>"buzz"}
+      #   cache.read("fizz")
+      #   # => "buzz"
+      #   sleep(6)
+      #   cache.read("fizz")
+      #   # => nil
+      def fetch_multi: (*untyped names) { (untyped) -> untyped } -> untyped
+
+      # Writes the value to the cache, with the key.
+      #
+      # Options are passed to the underlying cache implementation.
+      def write: (untyped name, untyped value, ?untyped? options) -> untyped
+
+      # Deletes an entry in the cache. Returns +true+ if an entry is deleted.
+      #
+      # Options are passed to the underlying cache implementation.
+      def delete: (untyped name, ?untyped? options) -> untyped
+
+      # Returns +true+ if the cache contains an entry for the given key.
+      #
+      # Options are passed to the underlying cache implementation.
+      def exist?: (untyped name, ?untyped? options) -> untyped
+
+      # Deletes all entries with keys matching the pattern.
+      #
+      # Options are passed to the underlying cache implementation.
+      #
+      # Some implementations may not support this method.
+      def delete_matched: (untyped matcher, ?untyped? options) -> untyped
+
+      # Increments an integer value in the cache.
+      #
+      # Options are passed to the underlying cache implementation.
+      #
+      # Some implementations may not support this method.
+      def increment: (untyped name, ?::Integer amount, ?untyped? options) -> untyped
+
+      # Decrements an integer value in the cache.
+      #
+      # Options are passed to the underlying cache implementation.
+      #
+      # Some implementations may not support this method.
+      def decrement: (untyped name, ?::Integer amount, ?untyped? options) -> untyped
+
+      # Cleanups the cache by removing expired entries.
+      #
+      # Options are passed to the underlying cache implementation.
+      #
+      # Some implementations may not support this method.
+      def cleanup: (?untyped? options) -> untyped
+
+      # Clears the entire cache. Be careful with this method since it could
+      # affect other processes if shared cache is being used.
+      #
+      # The options hash is passed to the underlying cache implementation.
+      #
+      # Some implementations may not support this method.
+      def clear: (?untyped? options) -> untyped
+
+      def key_matcher: (untyped pattern, untyped options) -> untyped
+
+      # Reads an entry from the cache implementation. Subclasses must implement
+      # this method.
+      def read_entry: (untyped key, **untyped options) -> untyped
+
+      # Writes an entry to the cache implementation. Subclasses must implement
+      # this method.
+      def write_entry: (untyped key, untyped entry, **untyped options) -> untyped
+
+      # Reads multiple entries from the cache implementation. Subclasses MAY
+      # implement this method.
+      def read_multi_entries: (untyped names, **untyped options) -> untyped
+
+      # Writes multiple entries to the cache implementation. Subclasses MAY
+      # implement this method.
+      def write_multi_entries: (untyped hash, **untyped options) -> untyped
+
+      # Deletes an entry from the cache implementation. Subclasses must
+      # implement this method.
+      def delete_entry: (untyped key, **untyped options) -> untyped
+
+      # Merges the default options with ones specific to a method call.
+      def merged_options: (untyped call_options) -> untyped
+
+      # Expands and namespaces the cache key. May be overridden by
+      # cache stores to do additional normalization.
+      def normalize_key: (untyped key, ?untyped? options) -> untyped
+
+      # Prefix the key with a namespace string:
+      #
+      #   namespace_key 'foo', namespace: 'cache'
+      #   # => 'cache:foo'
+      #
+      # With a namespace block:
+      #
+      #   namespace_key 'foo', namespace: -> { 'cache' }
+      #   # => 'cache:foo'
+      def namespace_key: (untyped key, ?untyped? options) -> untyped
+
+      # Expands key to be a consistent string value. Invokes +cache_key+ if
+      # object responds to +cache_key+. Otherwise, +to_param+ method will be
+      # called. If the key is a Hash, then keys will be sorted alphabetically.
+      def expanded_key: (untyped key) -> untyped
+
+      def normalize_version: (untyped key, ?untyped? options) -> untyped
+
+      def expanded_version: (untyped key) -> untyped
+
+      def instrument: (untyped operation, untyped key, ?untyped? options) { (untyped) -> untyped } -> untyped
+
+      def log: () { () -> untyped } -> (nil | untyped)
+
+      def handle_expired_entry: (untyped entry, untyped key, untyped options) -> untyped
+
+      def get_entry_value: (untyped entry, untyped name, untyped options) -> untyped
+
+      def save_block_result_to_cache: (untyped name, **untyped options) { (untyped) -> untyped } -> untyped
+    end
+
+    class Entry
+      # This class is used to represent cache entries. Cache entries have a value, an optional
+      # expiration time, and an optional version. The expiration time is used to support the :race_condition_ttl option
+      # on the cache. The version is used to support the :version option on the cache for rejecting
+      # mismatches.
+      #
+      # Since cache entries in most instances will be serialized, the internals of this class are highly optimized
+      # using short instance variable names that are lazily defined.
+      # :nodoc:
+      attr_reader version: untyped
+
+      DEFAULT_COMPRESS_LIMIT: untyped
+
+      # Creates a new cache entry for the specified value. Options supported are
+      # +:compress+, +:compress_threshold+, +:version+ and +:expires_in+.
+      def initialize: (untyped value, ?expires_in: untyped? expires_in, ?version: untyped? version, ?compress_threshold: untyped compress_threshold, ?compress: bool compress) -> untyped
+
+      def value: () -> untyped
+
+      def mismatched?: (untyped version) -> untyped
+
+      # Checks if the entry is expired. The +expires_in+ parameter can override
+      # the value set when the entry was created.
+      def expired?: () -> untyped
+
+      def expires_at: () -> untyped
+
+      def expires_at=: (untyped value) -> untyped
+
+      # Returns the size of the cached value. This could be less than
+      # <tt>value.size</tt> if the data is compressed.
+      def size: () -> untyped
+
+      # Duplicates the value in a class. This is used by cache implementations that don't natively
+      # serialize entries to protect against accidental cache modifications.
+      def dup_value!: () -> untyped
+
+      def compress!: (untyped compress_threshold) -> untyped
+
+      def compressed?: () -> untyped
+
+      def uncompress: (untyped value) -> untyped
+    end
+  end
+end
+
+module ActiveSupport
+  # Callbacks are code hooks that are run at key points in an object's life cycle.
+  # The typical use case is to have a base class define a set of callbacks
+  # relevant to the other functionality it supplies, so that subclasses can
+  # install callbacks that enhance or modify the base functionality without
+  # needing to override or redefine methods of the base class.
+  #
+  # Mixing in this module allows you to define the events in the object's
+  # life cycle that will support callbacks (via +ClassMethods.define_callbacks+),
+  # set the instance methods, procs, or callback objects to be called (via
+  # +ClassMethods.set_callback+), and run the installed callbacks at the
+  # appropriate times (via +run_callbacks+).
+  #
+  # By default callbacks are halted by throwing +:abort+.
+  # See +ClassMethods.define_callbacks+ for details.
+  #
+  # Three kinds of callbacks are supported: before callbacks, run before a
+  # certain event; after callbacks, run after the event; and around callbacks,
+  # blocks that surround the event, triggering it when they yield. Callback code
+  # can be contained in instance methods, procs or lambdas, or callback objects
+  # that respond to certain predetermined methods. See +ClassMethods.set_callback+
+  # for details.
+  #
+  #   class Record
+  #     include ActiveSupport::Callbacks
+  #     define_callbacks :save
+  #
+  #     def save
+  #       run_callbacks :save do
+  #         puts "- save"
+  #       end
+  #     end
+  #   end
+  #
+  #   class PersonRecord < Record
+  #     set_callback :save, :before, :saving_message
+  #     def saving_message
+  #       puts "saving..."
+  #     end
+  #
+  #     set_callback :save, :after do |object|
+  #       puts "saved"
+  #     end
+  #   end
+  #
+  #   person = PersonRecord.new
+  #   person.save
+  #
+  # Output:
+  #   saving...
+  #   - save
+  #   saved
+  module Callbacks
+    extend Concern
+
+    extend ActiveSupport::DescendantsTracker
+
+    CALLBACK_FILTER_TYPES: ::Array[untyped]
+
+    # Runs the callbacks for the given event.
+    #
+    # Calls the before and around callbacks in the order they were set, yields
+    # the block (if given one), and then runs the after callbacks in reverse
+    # order.
+    #
+    # If the callback chain was halted, returns +false+. Otherwise returns the
+    # result of the block, +nil+ if no callbacks have been set, or +true+
+    # if callbacks have been set but no block is given.
+    #
+    #   run_callbacks :save do
+    #     save
+    #   end
+    #
+    # -
+    #
+    # As this method is used in many places, and often wraps large portions of
+    # user code, it has an additional design goal of minimizing its impact on
+    # the visible call stack. An exception from inside a :before or :after
+    # callback can be as noisy as it likes -- but when control has passed
+    # smoothly through and into the supplied block, we want as little evidence
+    # as possible that we were here.
+    def run_callbacks: (untyped kind) { () -> untyped } -> untyped
+
+    # A hook invoked every time a before callback is halted.
+    # This can be overridden in ActiveSupport::Callbacks implementors in order
+    # to provide better debugging/logging.
+    def halted_callback_hook: (untyped filter) -> nil
+
+    module Conditionals
+      # :nodoc:
+      class Value
+        def initialize: () { () -> untyped } -> untyped
+
+        def call: (untyped target, untyped value) -> untyped
+      end
+    end
+
+    module Filters
+      class Environment[T] < ::Struct[T]
+        attr_accessor target(): untyped
+
+        attr_accessor halted(): untyped
+
+        attr_accessor value(): untyped
+      end
+
+      class Before
+        def self.build: (untyped callback_sequence, untyped user_callback, untyped user_conditions, untyped chain_config, untyped filter) -> untyped
+
+        def self.halting_and_conditional: (untyped callback_sequence, untyped user_callback, untyped user_conditions, untyped halted_lambda, untyped filter) -> untyped
+
+        def self.halting: (untyped callback_sequence, untyped user_callback, untyped halted_lambda, untyped filter) -> untyped
+      end
+
+      class After
+        def self.build: (untyped callback_sequence, untyped user_callback, untyped user_conditions, untyped chain_config) -> untyped
+
+        def self.halting_and_conditional: (untyped callback_sequence, untyped user_callback, untyped user_conditions) -> untyped
+
+        def self.halting: (untyped callback_sequence, untyped user_callback) -> untyped
+
+        def self.conditional: (untyped callback_sequence, untyped user_callback, untyped user_conditions) -> untyped
+
+        def self.simple: (untyped callback_sequence, untyped user_callback) -> untyped
+      end
+    end
+
+    class Callback
+      # nodoc:#
+      def self.build: (untyped chain, untyped filter, untyped kind, untyped options) -> untyped
+
+      attr_accessor kind: untyped
+
+      attr_accessor name: untyped
+
+      attr_reader chain_config: untyped
+
+      def initialize: (untyped name, untyped filter, untyped kind, untyped options, untyped chain_config) -> untyped
+
+      def filter: () -> untyped
+
+      def raw_filter: () -> untyped
+
+      def merge_conditional_options: (untyped chain, unless_option: untyped unless_option, if_option: untyped if_option) -> untyped
+
+      def matches?: (untyped _kind, untyped _filter) -> untyped
+
+      def duplicates?: (untyped other) -> untyped
+
+      # Wraps code with filter
+      def apply: (untyped callback_sequence) -> untyped
+
+      def current_scopes: () -> untyped
+
+      def check_conditionals: (untyped conditionals) -> untyped
+
+      def compute_identifier: (untyped filter) -> untyped
+
+      def conditions_lambdas: () -> untyped
+    end
+
+    class CallTemplate
+      # A future invocation of user-supplied code (either as a callback,
+      # or a condition filter).
+      # :nodoc:
+      def initialize: (untyped target, untyped method, untyped arguments, untyped block) -> untyped
+
+      # Return the parts needed to make this call, with the given
+      # input values.
+      #
+      # Returns an array of the form:
+      #
+      #   [target, block, method, *arguments]
+      #
+      # This array can be used as such:
+      #
+      #   target.send(method, *arguments, &block)
+      #
+      # The actual invocation is left up to the caller to minimize
+      # call stack pollution.
+      def expand: (untyped target, untyped value, untyped block) -> untyped
+
+      # Return a lambda that will make this call when given the input
+      # values.
+      def make_lambda: () -> untyped
+
+      # Return a lambda that will make this call when given the input
+      # values, but then return the boolean inverse of that result.
+      def inverted_lambda: () -> untyped
+
+      # Filters support:
+      #
+      #   Symbols:: A method to call.
+      #   Procs::   A proc to call with the object.
+      #   Objects:: An object with a <tt>before_foo</tt> method on it to call.
+      #
+      # All of these objects are converted into a CallTemplate and handled
+      # the same after this point.
+      def self.build: (untyped filter, untyped callback) -> untyped
+    end
+
+    class CallbackSequence
+      # Execute before and after filters in a sequence instead of
+      # chaining them with nested lambda calls, see:
+      # https://github.com/rails/rails/issues/18011
+      # :nodoc:
+      def initialize: (?untyped? nested, ?untyped? call_template, ?untyped? user_conditions) -> untyped
+
+      def before: () { () -> untyped } -> untyped
+
+      def after: () { () -> untyped } -> untyped
+
+      def around: (untyped call_template, untyped user_conditions) -> CallbackSequence
+
+      def skip?: (untyped arg) -> untyped
+
+      attr_reader nested: untyped
+
+      def final?: () -> untyped
+
+      def expand_call_template: (untyped arg, untyped block) -> untyped
+
+      def invoke_before: (untyped arg) -> untyped
+
+      def invoke_after: (untyped arg) -> untyped
+    end
+
+    class CallbackChain
+      # nodoc:#
+      include Enumerable[untyped]
+
+      attr_reader name: untyped
+
+      attr_reader config: untyped
+
+      def initialize: (untyped name, untyped config) -> untyped
+
+      def each: () { () -> untyped } -> untyped
+
+      def index: (untyped o) -> untyped
+
+      def empty?: () -> untyped
+
+      def insert: (untyped index, untyped o) -> untyped
+
+      def delete: (untyped o) -> untyped
+
+      def clear: () -> untyped
+
+      def initialize_copy: (untyped other) -> untyped
+
+      def compile: () -> untyped
+
+      def append: (*untyped callbacks) -> untyped
+
+      def `prepend`: (*untyped callbacks) -> untyped
+
+      attr_reader chain: untyped
+
+      def append_one: (untyped callback) -> untyped
+
+      def prepend_one: (untyped callback) -> untyped
+
+      def remove_duplicates: (untyped callback) -> untyped
+
+      def default_terminator: () -> untyped
+    end
+
+    module ClassMethods
+      def normalize_callback_params: (untyped filters, untyped block) -> ::Array[untyped]
+
+      def __update_callbacks: (untyped name) { (untyped, untyped) -> untyped } -> untyped
+
+      # Install a callback for the given event.
+      #
+      #   set_callback :save, :before, :before_method
+      #   set_callback :save, :after,  :after_method, if: :condition
+      #   set_callback :save, :around, ->(r, block) { stuff; result = block.call; stuff }
+      #
+      # The second argument indicates whether the callback is to be run +:before+,
+      # +:after+, or +:around+ the event. If omitted, +:before+ is assumed. This
+      # means the first example above can also be written as:
+      #
+      #   set_callback :save, :before_method
+      #
+      # The callback can be specified as a symbol naming an instance method; as a
+      # proc, lambda, or block; or as an object that responds to a certain method
+      # determined by the <tt>:scope</tt> argument to +define_callbacks+.
+      #
+      # If a proc, lambda, or block is given, its body is evaluated in the context
+      # of the current object. It can also optionally accept the current object as
+      # an argument.
+      #
+      # Before and around callbacks are called in the order that they are set;
+      # after callbacks are called in the reverse order.
+      #
+      # Around callbacks can access the return value from the event, if it
+      # wasn't halted, from the +yield+ call.
+      #
+      # ===== Options
+      #
+      # * <tt>:if</tt> - A symbol or an array of symbols, each naming an instance
+      #   method or a proc; the callback will be called only when they all return
+      #   a true value.
+      #
+      #   If a proc is given, its body is evaluated in the context of the
+      #   current object. It can also optionally accept the current object as
+      #   an argument.
+      # * <tt>:unless</tt> - A symbol or an array of symbols, each naming an
+      #   instance method or a proc; the callback will be called only when they
+      #   all return a false value.
+      #
+      #   If a proc is given, its body is evaluated in the context of the
+      #   current object. It can also optionally accept the current object as
+      #   an argument.
+      # * <tt>:prepend</tt> - If +true+, the callback will be prepended to the
+      #   existing chain rather than appended.
+      def set_callback: (untyped name, *untyped filter_list) { () -> untyped } -> untyped
+
+      # Skip a previously set callback. Like +set_callback+, <tt>:if</tt> or
+      # <tt>:unless</tt> options may be passed in order to control when the
+      # callback is skipped.
+      #
+      #   class Writer < Person
+      #      skip_callback :validate, :before, :check_membership, if: -> { age > 18 }
+      #   end
+      #
+      # An <tt>ArgumentError</tt> will be raised if the callback has not
+      # already been set (unless the <tt>:raise</tt> option is set to <tt>false</tt>).
+      def skip_callback: (untyped name, *untyped filter_list) { () -> untyped } -> untyped
+
+      # Remove all set callbacks for the given event.
+      def reset_callbacks: (untyped name) -> untyped
+
+      # Define sets of events in the object life cycle that support callbacks.
+      #
+      #   define_callbacks :validate
+      #   define_callbacks :initialize, :save, :destroy
+      #
+      # ===== Options
+      #
+      # * <tt>:terminator</tt> - Determines when a before filter will halt the
+      #   callback chain, preventing following before and around callbacks from
+      #   being called and the event from being triggered.
+      #   This should be a lambda to be executed.
+      #   The current object and the result lambda of the callback will be provided
+      #   to the terminator lambda.
+      #
+      #     define_callbacks :validate, terminator: ->(target, result_lambda) { result_lambda.call == false }
+      #
+      #   In this example, if any before validate callbacks returns +false+,
+      #   any successive before and around callback is not executed.
+      #
+      #   The default terminator halts the chain when a callback throws +:abort+.
+      #
+      # * <tt>:skip_after_callbacks_if_terminated</tt> - Determines if after
+      #   callbacks should be terminated by the <tt>:terminator</tt> option. By
+      #   default after callbacks are executed no matter if callback chain was
+      #   terminated or not. This option has no effect if <tt>:terminator</tt>
+      #   option is set to +nil+.
+      #
+      # * <tt>:scope</tt> - Indicates which methods should be executed when an
+      #   object is used as a callback.
+      #
+      #     class Audit
+      #       def before(caller)
+      #         puts 'Audit: before is called'
+      #       end
+      #
+      #       def before_save(caller)
+      #         puts 'Audit: before_save is called'
+      #       end
+      #     end
+      #
+      #     class Account
+      #       include ActiveSupport::Callbacks
+      #
+      #       define_callbacks :save
+      #       set_callback :save, :before, Audit.new
+      #
+      #       def save
+      #         run_callbacks :save do
+      #           puts 'save in main'
+      #         end
+      #       end
+      #     end
+      #
+      #   In the above case whenever you save an account the method
+      #   <tt>Audit#before</tt> will be called. On the other hand
+      #
+      #     define_callbacks :save, scope: [:kind, :name]
+      #
+      #   would trigger <tt>Audit#before_save</tt> instead. That's constructed
+      #   by calling <tt>#{kind}_#{name}</tt> on the given instance. In this
+      #   case "kind" is "before" and "name" is "save". In this context +:kind+
+      #   and +:name+ have special meanings: +:kind+ refers to the kind of
+      #   callback (before/after/around) and +:name+ refers to the method on
+      #   which callbacks are being defined.
+      #
+      #   A declaration like
+      #
+      #     define_callbacks :save, scope: [:name]
+      #
+      #   would call <tt>Audit#save</tt>.
+      #
+      # ===== Notes
+      #
+      # +names+ passed to +define_callbacks+ must not end with
+      # <tt>!</tt>, <tt>?</tt> or <tt>=</tt>.
+      #
+      # Calling +define_callbacks+ multiple times with the same +names+ will
+      # overwrite previous callbacks registered with +set_callback+.
+      def define_callbacks: (*untyped names) -> untyped
+
+      def get_callbacks: (untyped name) -> untyped
+
+      def set_callbacks: (untyped name, untyped callbacks) -> untyped
+    end
+  end
+end
+
+module ActiveSupport
+  # A typical module looks like this:
+  #
+  #   module M
+  #     def self.included(base)
+  #       base.extend ClassMethods
+  #       base.class_eval do
+  #         scope :disabled, -> { where(disabled: true) }
+  #       end
+  #     end
+  #
+  #     module ClassMethods
+  #       ...
+  #     end
+  #   end
+  #
+  # By using <tt>ActiveSupport::Concern</tt> the above module could instead be
+  # written as:
+  #
+  #   require 'active_support/concern'
+  #
+  #   module M
+  #     extend ActiveSupport::Concern
+  #
+  #     included do
+  #       scope :disabled, -> { where(disabled: true) }
+  #     end
+  #
+  #     class_methods do
+  #       ...
+  #     end
+  #   end
+  #
+  # Moreover, it gracefully handles module dependencies. Given a +Foo+ module
+  # and a +Bar+ module which depends on the former, we would typically write the
+  # following:
+  #
+  #   module Foo
+  #     def self.included(base)
+  #       base.class_eval do
+  #         def self.method_injected_by_foo
+  #           ...
+  #         end
+  #       end
+  #     end
+  #   end
+  #
+  #   module Bar
+  #     def self.included(base)
+  #       base.method_injected_by_foo
+  #     end
+  #   end
+  #
+  #   class Host
+  #     include Foo # We need to include this dependency for Bar
+  #     include Bar # Bar is the module that Host really needs
+  #   end
+  #
+  # But why should +Host+ care about +Bar+'s dependencies, namely +Foo+? We
+  # could try to hide these from +Host+ directly including +Foo+ in +Bar+:
+  #
+  #   module Bar
+  #     include Foo
+  #     def self.included(base)
+  #       base.method_injected_by_foo
+  #     end
+  #   end
+  #
+  #   class Host
+  #     include Bar
+  #   end
+  #
+  # Unfortunately this won't work, since when +Foo+ is included, its <tt>base</tt>
+  # is the +Bar+ module, not the +Host+ class. With <tt>ActiveSupport::Concern</tt>,
+  # module dependencies are properly resolved:
+  #
+  #   require 'active_support/concern'
+  #
+  #   module Foo
+  #     extend ActiveSupport::Concern
+  #     included do
+  #       def self.method_injected_by_foo
+  #         ...
+  #       end
+  #     end
+  #   end
+  #
+  #   module Bar
+  #     extend ActiveSupport::Concern
+  #     include Foo
+  #
+  #     included do
+  #       self.method_injected_by_foo
+  #     end
+  #   end
+  #
+  #   class Host
+  #     include Bar # It works, now Bar takes care of its dependencies
+  #   end
+  module Concern
+    class MultipleIncludedBlocks < StandardError
+      # nodoc:
+      def initialize: () -> untyped
+    end
+
+    def self.extended: (untyped base) -> untyped
+
+    def append_features: (untyped base) -> untyped
+
+    # Evaluate given block in context of base class,
+    # so that you can write class macros here.
+    # When you define more than one +included+ block, it raises an exception.
+    def included: (?untyped? base) { () -> untyped } -> untyped
+
+    # Define class methods from given block.
+    # You can define private class methods as well.
+    #
+    #   module Example
+    #     extend ActiveSupport::Concern
+    #
+    #     class_methods do
+    #       def foo; puts 'foo'; end
+    #
+    #       private
+    #         def bar; puts 'bar'; end
+    #     end
+    #   end
+    #
+    #   class Buzz
+    #     include Example
+    #   end
+    #
+    #   Buzz.foo # => "foo"
+    #   Buzz.bar # => private method 'bar' called for Buzz:Class(NoMethodError)
+    def class_methods: () { () -> untyped } -> untyped
+  end
+end
+
+module ActiveSupport
+  module Concurrency
+    # A monitor that will permit dependency loading while blocked waiting for
+    # the lock.
+    class LoadInterlockAwareMonitor < Monitor
+      EXCEPTION_NEVER: untyped
+
+      EXCEPTION_IMMEDIATE: untyped
+
+      # Enters an exclusive section, but allows dependency loading while blocked
+      def mon_enter: () -> untyped
+
+      def synchronize: () { () -> untyped } -> untyped
+    end
+  end
+end
+
+module ActiveSupport
+  module Concurrency
+    # A share/exclusive lock, otherwise known as a read/write lock.
+    #
+    # https://en.wikipedia.org/wiki/Readers%E2%80%93writer_lock
+    class ShareLock
+      include MonitorMixin
+
+      def raw_state: () { (untyped) -> untyped } -> untyped
+
+      def initialize: () -> untyped
+
+      # Returns false if +no_wait+ is set and the lock is not
+      # immediately available. Otherwise, returns true after the lock
+      # has been acquired.
+      #
+      # +purpose+ and +compatible+ work together; while this thread is
+      # waiting for the exclusive lock, it will yield its share (if any)
+      # to any other attempt whose +purpose+ appears in this attempt's
+      # +compatible+ list. This allows a "loose" upgrade, which, being
+      # less strict, prevents some classes of deadlocks.
+      #
+      # For many resources, loose upgrades are sufficient: if a thread
+      # is awaiting a lock, it is not running any other code. With
+      # +purpose+ matching, it is possible to yield only to other
+      # threads whose activity will not interfere.
+      def start_exclusive: (?no_wait: bool no_wait, ?compatible: untyped compatible, ?purpose: untyped? purpose) -> untyped
+
+      # Relinquish the exclusive lock. Must only be called by the thread
+      # that called start_exclusive (and currently holds the lock).
+      def stop_exclusive: (?compatible: untyped compatible) -> untyped
+
+      def start_sharing: () -> untyped
+
+      def stop_sharing: () -> untyped
+
+      # Execute the supplied block while holding the Exclusive lock. If
+      # +no_wait+ is set and the lock is not immediately available,
+      # returns +nil+ without yielding. Otherwise, returns the result of
+      # the block.
+      #
+      # See +start_exclusive+ for other options.
+      def exclusive: (?no_wait: bool no_wait, ?after_compatible: untyped after_compatible, ?compatible: untyped compatible, ?purpose: untyped? purpose) { () -> untyped } -> untyped
+
+      # Execute the supplied block while holding the Share lock.
+      def sharing: () { () -> untyped } -> untyped
+
+      # Temporarily give up all held Share locks while executing the
+      # supplied block, allowing any +compatible+ exclusive lock request
+      # to proceed.
+      def yield_shares: (?block_share: bool block_share, ?compatible: untyped compatible, ?purpose: untyped? purpose) { () -> untyped } -> untyped
+
+      # Must be called within synchronize
+      def busy_for_exclusive?: (untyped purpose) -> untyped
+
+      def busy_for_sharing?: (untyped purpose) -> untyped
+
+      def eligible_waiters?: (untyped compatible) -> untyped
+
+      def wait_for: (untyped method) { () -> untyped } -> untyped
+    end
+  end
+end
+
+module ActiveSupport
+  # Configurable provides a <tt>config</tt> method to store and retrieve
+  # configuration options as an <tt>OrderedHash</tt>.
+  module Configurable
+    extend ActiveSupport::Concern
+
+    class Configuration[T, U] < ActiveSupport::InheritableOptions[T, U]
+      def compile_methods!: () -> untyped
+
+      # Compiles reader methods so we don't have to go through method_missing.
+      def self.compile_methods!: (untyped keys) -> untyped
+    end
+
+    module ClassMethods
+      def config: () -> untyped
+
+      def configure: () { (untyped) -> untyped } -> untyped
+
+      def config_accessor: (*untyped names, ?instance_accessor: bool instance_accessor, ?instance_writer: bool instance_writer, ?instance_reader: bool instance_reader) { () -> untyped } -> untyped
+    end
+
+    # Reads and writes attributes from a configuration <tt>OrderedHash</tt>.
+    #
+    #   require 'active_support/configurable'
+    #
+    #   class User
+    #     include ActiveSupport::Configurable
+    #   end
+    #
+    #   user = User.new
+    #
+    #   user.config.allowed_access = true
+    #   user.config.level = 1
+    #
+    #   user.config.allowed_access # => true
+    #   user.config.level          # => 1
+    def config: () -> untyped
+  end
+end
+
+class Array[unchecked out Elem]
+  # Returns the tail of the array from +position+.
+  #
+  #   %w( a b c d ).from(0)  # => ["a", "b", "c", "d"]
+  #   %w( a b c d ).from(2)  # => ["c", "d"]
+  #   %w( a b c d ).from(10) # => []
+  #   %w().from(0)           # => []
+  #   %w( a b c d ).from(-2) # => ["c", "d"]
+  #   %w( a b c ).from(-10)  # => []
+  def from: (untyped position) -> untyped
+
+  # Returns the beginning of the array up to +position+.
+  #
+  #   %w( a b c d ).to(0)  # => ["a"]
+  #   %w( a b c d ).to(2)  # => ["a", "b", "c"]
+  #   %w( a b c d ).to(10) # => ["a", "b", "c", "d"]
+  #   %w().to(0)           # => []
+  #   %w( a b c d ).to(-2) # => ["a", "b", "c"]
+  #   %w( a b c ).to(-10)  # => []
+  def to: (untyped position) -> untyped
+
+  # Returns a new array that includes the passed elements.
+  #
+  #   [ 1, 2, 3 ].including(4, 5) # => [ 1, 2, 3, 4, 5 ]
+  #   [ [ 0, 1 ] ].including([ [ 1, 0 ] ]) # => [ [ 0, 1 ], [ 1, 0 ] ]
+  def including: (*untyped elements) -> untyped
+
+  # Returns a copy of the Array excluding the specified elements.
+  #
+  #   ["David", "Rafael", "Aaron", "Todd"].excluding("Aaron", "Todd") # => ["David", "Rafael"]
+  #   [ [ 0, 1 ], [ 1, 0 ] ].excluding([ [ 1, 0 ] ]) # => [ [ 0, 1 ] ]
+  #
+  # Note: This is an optimization of <tt>Enumerable#excluding</tt> that uses <tt>Array#-</tt>
+  # instead of <tt>Array#reject</tt> for performance reasons.
+  def excluding: (*untyped elements) -> untyped
+
+  # Alias for #excluding.
+  def without: (*untyped elements) -> untyped
+
+  # Equal to <tt>self[1]</tt>.
+  #
+  #   %w( a b c d e ).second # => "b"
+  def second: () -> untyped
+
+  # Equal to <tt>self[2]</tt>.
+  #
+  #   %w( a b c d e ).third # => "c"
+  def third: () -> untyped
+
+  # Equal to <tt>self[3]</tt>.
+  #
+  #   %w( a b c d e ).fourth # => "d"
+  def fourth: () -> untyped
+
+  # Equal to <tt>self[4]</tt>.
+  #
+  #   %w( a b c d e ).fifth # => "e"
+  def fifth: () -> untyped
+
+  # Equal to <tt>self[41]</tt>. Also known as accessing "the reddit".
+  #
+  #   (1..42).to_a.forty_two # => 42
+  def forty_two: () -> untyped
+
+  # Equal to <tt>self[-3]</tt>.
+  #
+  #   %w( a b c d e ).third_to_last # => "c"
+  def third_to_last: () -> untyped
+
+  # Equal to <tt>self[-2]</tt>.
+  #
+  #   %w( a b c d e ).second_to_last # => "d"
+  def second_to_last: () -> untyped
+end
+
+class Array[unchecked out Elem]
+  # Converts the array to a comma-separated sentence where the last element is
+  # joined by the connector word.
+  #
+  # You can pass the following options to change the default behavior. If you
+  # pass an option key that doesn't exist in the list below, it will raise an
+  # <tt>ArgumentError</tt>.
+  #
+  # ==== Options
+  #
+  # * <tt>:words_connector</tt> - The sign or word used to join the elements
+  #   in arrays with two or more elements (default: ", ").
+  # * <tt>:two_words_connector</tt> - The sign or word used to join the elements
+  #   in arrays with two elements (default: " and ").
+  # * <tt>:last_word_connector</tt> - The sign or word used to join the last element
+  #   in arrays with three or more elements (default: ", and ").
+  # * <tt>:locale</tt> - If +i18n+ is available, you can set a locale and use
+  #   the connector options defined on the 'support.array' namespace in the
+  #   corresponding dictionary file.
+  #
+  # ==== Examples
+  #
+  #   [].to_sentence                      # => ""
+  #   ['one'].to_sentence                 # => "one"
+  #   ['one', 'two'].to_sentence          # => "one and two"
+  #   ['one', 'two', 'three'].to_sentence # => "one, two, and three"
+  #
+  #   ['one', 'two'].to_sentence(passing: 'invalid option')
+  #   # => ArgumentError: Unknown key: :passing. Valid keys are: :words_connector, :two_words_connector, :last_word_connector, :locale
+  #
+  #   ['one', 'two'].to_sentence(two_words_connector: '-')
+  #   # => "one-two"
+  #
+  #   ['one', 'two', 'three'].to_sentence(words_connector: ' or ', last_word_connector: ' or at least ')
+  #   # => "one or two or at least three"
+  #
+  # Using <tt>:locale</tt> option:
+  #
+  #   # Given this locale dictionary:
+  #   #
+  #   #   es:
+  #   #     support:
+  #   #       array:
+  #   #         words_connector: " o "
+  #   #         two_words_connector: " y "
+  #   #         last_word_connector: " o al menos "
+  #
+  #   ['uno', 'dos'].to_sentence(locale: :es)
+  #   # => "uno y dos"
+  #
+  #   ['uno', 'dos', 'tres'].to_sentence(locale: :es)
+  #   # => "uno o dos o al menos tres"
+  def to_sentence: (?::Hash[untyped, untyped] options) -> untyped
+
+  # Extends <tt>Array#to_s</tt> to convert a collection of elements into a
+  # comma separated id list if <tt>:db</tt> argument is given as the format.
+  #
+  #   Blog.all.to_formatted_s(:db)  # => "1,2,3"
+  #   Blog.none.to_formatted_s(:db) # => "null"
+  #   [1,2].to_formatted_s          # => "[1, 2]"
+  def to_formatted_s: (?::Symbol format) -> untyped
+
+  alias to_default_s to_s
+
+  # Returns a string that represents the array in XML by invoking +to_xml+
+  # on each element. Active Record collections delegate their representation
+  # in XML to this method.
+  #
+  # All elements are expected to respond to +to_xml+, if any of them does
+  # not then an exception is raised.
+  #
+  # The root node reflects the class name of the first element in plural
+  # if all elements belong to the same type and that's not Hash:
+  #
+  #   customer.projects.to_xml
+  #
+  #   <?xml version="1.0" encoding="UTF-8"?>
+  #   <projects type="array">
+  #     <project>
+  #       <amount type="decimal">20000.0</amount>
+  #       <customer-id type="integer">1567</customer-id>
+  #       <deal-date type="date">2008-04-09</deal-date>
+  #       ...
+  #     </project>
+  #     <project>
+  #       <amount type="decimal">57230.0</amount>
+  #       <customer-id type="integer">1567</customer-id>
+  #       <deal-date type="date">2008-04-15</deal-date>
+  #       ...
+  #     </project>
+  #   </projects>
+  #
+  # Otherwise the root element is "objects":
+  #
+  #   [{ foo: 1, bar: 2}, { baz: 3}].to_xml
+  #
+  #   <?xml version="1.0" encoding="UTF-8"?>
+  #   <objects type="array">
+  #     <object>
+  #       <bar type="integer">2</bar>
+  #       <foo type="integer">1</foo>
+  #     </object>
+  #     <object>
+  #       <baz type="integer">3</baz>
+  #     </object>
+  #   </objects>
+  #
+  # If the collection is empty the root element is "nil-classes" by default:
+  #
+  #   [].to_xml
+  #
+  #   <?xml version="1.0" encoding="UTF-8"?>
+  #   <nil-classes type="array"/>
+  #
+  # To ensure a meaningful root element use the <tt>:root</tt> option:
+  #
+  #   customer_with_no_projects.projects.to_xml(root: 'projects')
+  #
+  #   <?xml version="1.0" encoding="UTF-8"?>
+  #   <projects type="array"/>
+  #
+  # By default name of the node for the children of root is <tt>root.singularize</tt>.
+  # You can change it with the <tt>:children</tt> option.
+  #
+  # The +options+ hash is passed downwards:
+  #
+  #   Message.all.to_xml(skip_types: true)
+  #
+  #   <?xml version="1.0" encoding="UTF-8"?>
+  #   <messages>
+  #     <message>
+  #       <created-at>2008-03-07T09:58:18+01:00</created-at>
+  #       <id>1</id>
+  #       <name>1</name>
+  #       <updated-at>2008-03-07T09:58:18+01:00</updated-at>
+  #       <user-id>1</user-id>
+  #     </message>
+  #   </messages>
+  #
+  def to_xml: (?::Hash[untyped, untyped] options) { (untyped) -> untyped } -> untyped
+end
+
+class Array[unchecked out Elem]
+  # Removes and returns the elements for which the block returns a true value.
+  # If no block is given, an Enumerator is returned instead.
+  #
+  #   numbers = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+  #   odd_numbers = numbers.extract! { |number| number.odd? } # => [1, 3, 5, 7, 9]
+  #   numbers # => [0, 2, 4, 6, 8]
+  def extract!: () { (untyped) -> untyped } -> untyped
+end
+
+class Hash[unchecked out K, unchecked out V]
+  # By default, only instances of Hash itself are extractable.
+  # Subclasses of Hash may implement this method and return
+  # true to declare themselves as extractable. If a Hash
+  # is extractable, Array#extract_options! pops it from
+  # the Array when it is the last element of the Array.
+  def extractable_options?: () -> untyped
+end
+
+class Array[unchecked out Elem]
+  # Extracts options from a set of arguments. Removes and returns the last
+  # element in the array if it's a hash, otherwise returns a blank hash.
+  #
+  #   def options(*args)
+  #     args.extract_options!
+  #   end
+  #
+  #   options(1, 2)        # => {}
+  #   options(1, 2, a: :b) # => {:a=>:b}
+  def extract_options!: () -> untyped
+end
+
+class Array[unchecked out Elem]
+  # Splits or iterates over the array in groups of size +number+,
+  # padding any remaining slots with +fill_with+ unless it is +false+.
+  #
+  #   %w(1 2 3 4 5 6 7 8 9 10).in_groups_of(3) {|group| p group}
+  #   ["1", "2", "3"]
+  #   ["4", "5", "6"]
+  #   ["7", "8", "9"]
+  #   ["10", nil, nil]
+  #
+  #   %w(1 2 3 4 5).in_groups_of(2, '&nbsp;') {|group| p group}
+  #   ["1", "2"]
+  #   ["3", "4"]
+  #   ["5", "&nbsp;"]
+  #
+  #   %w(1 2 3 4 5).in_groups_of(2, false) {|group| p group}
+  #   ["1", "2"]
+  #   ["3", "4"]
+  #   ["5"]
+  def in_groups_of: (untyped number, ?untyped? fill_with) { (untyped) -> untyped } -> untyped
+
+  # Splits or iterates over the array in +number+ of groups, padding any
+  # remaining slots with +fill_with+ unless it is +false+.
+  #
+  #   %w(1 2 3 4 5 6 7 8 9 10).in_groups(3) {|group| p group}
+  #   ["1", "2", "3", "4"]
+  #   ["5", "6", "7", nil]
+  #   ["8", "9", "10", nil]
+  #
+  #   %w(1 2 3 4 5 6 7 8 9 10).in_groups(3, '&nbsp;') {|group| p group}
+  #   ["1", "2", "3", "4"]
+  #   ["5", "6", "7", "&nbsp;"]
+  #   ["8", "9", "10", "&nbsp;"]
+  #
+  #   %w(1 2 3 4 5 6 7).in_groups(3, false) {|group| p group}
+  #   ["1", "2", "3"]
+  #   ["4", "5"]
+  #   ["6", "7"]
+  def in_groups: (untyped number, ?untyped? fill_with) { (untyped) -> untyped } -> untyped
+
+  # Divides the array into one or more subarrays based on a delimiting +value+
+  # or the result of an optional block.
+  #
+  #   [1, 2, 3, 4, 5].split(3)              # => [[1, 2], [4, 5]]
+  #   (1..10).to_a.split { |i| i % 3 == 0 } # => [[1, 2], [4, 5], [7, 8], [10]]
+  def split: (?untyped? value) { (untyped) -> untyped } -> untyped
+end
+
+class Array[unchecked out Elem]
+  # Wraps the array in an +ArrayInquirer+ object, which gives a friendlier way
+  # to check its string-like contents.
+  #
+  #   pets = [:cat, :dog].inquiry
+  #
+  #   pets.cat?     # => true
+  #   pets.ferret?  # => false
+  #
+  #   pets.any?(:cat, :ferret)  # => true
+  #   pets.any?(:ferret, :alligator)  # => false
+  def inquiry: () -> ActiveSupport::ArrayInquirer[Elem]
+end
+
+class Array[unchecked out Elem]
+  # Wraps its argument in an array unless it is already an array (or array-like).
+  #
+  # Specifically:
+  #
+  # * If the argument is +nil+ an empty array is returned.
+  # * Otherwise, if the argument responds to +to_ary+ it is invoked, and its result returned.
+  # * Otherwise, returns an array with the argument as its single element.
+  #
+  #     Array.wrap(nil)       # => []
+  #     Array.wrap([1, 2, 3]) # => [1, 2, 3]
+  #     Array.wrap(0)         # => [0]
+  #
+  # This method is similar in purpose to <tt>Kernel#Array</tt>, but there are some differences:
+  #
+  # * If the argument responds to +to_ary+ the method is invoked. <tt>Kernel#Array</tt>
+  #   moves on to try +to_a+ if the returned value is +nil+, but <tt>Array.wrap</tt> returns
+  #   an array with the argument as its single element right away.
+  # * If the returned value from +to_ary+ is neither +nil+ nor an +Array+ object, <tt>Kernel#Array</tt>
+  #   raises an exception, while <tt>Array.wrap</tt> does not, it just returns the value.
+  # * It does not call +to_a+ on the argument, if the argument does not respond to +to_ary+
+  #   it returns an array with the argument as its single element.
+  #
+  # The last point is easily explained with some enumerables:
+  #
+  #   Array(foo: :bar)      # => [[:foo, :bar]]
+  #   Array.wrap(foo: :bar) # => [{:foo=>:bar}]
+  #
+  # There's also a related idiom that uses the splat operator:
+  #
+  #   [*object]
+  #
+  # which returns <tt>[]</tt> for +nil+, but calls to <tt>Array(object)</tt> otherwise.
+  #
+  # The differences with <tt>Kernel#Array</tt> explained above
+  # apply to the rest of <tt>object</tt>s.
+  def self.wrap: (untyped object) -> untyped
+end
+
+module ActiveSupport
+  module BigDecimalWithDefaultFormat
+    # nodoc:
+    def to_s: (?::String format) -> untyped
+  end
+end
+
+class Class
+  # Declare a class-level attribute whose value is inheritable by subclasses.
+  # Subclasses can change their own value and it will not impact parent class.
+  #
+  # ==== Options
+  #
+  # * <tt>:instance_reader</tt> - Sets the instance reader method (defaults to true).
+  # * <tt>:instance_writer</tt> - Sets the instance writer method (defaults to true).
+  # * <tt>:instance_accessor</tt> - Sets both instance methods (defaults to true).
+  # * <tt>:instance_predicate</tt> - Sets a predicate method (defaults to true).
+  # * <tt>:default</tt> - Sets a default value for the attribute (defaults to nil).
+  #
+  # ==== Examples
+  #
+  #   class Base
+  #     class_attribute :setting
+  #   end
+  #
+  #   class Subclass < Base
+  #   end
+  #
+  #   Base.setting = true
+  #   Subclass.setting            # => true
+  #   Subclass.setting = false
+  #   Subclass.setting            # => false
+  #   Base.setting                # => true
+  #
+  # In the above case as long as Subclass does not assign a value to setting
+  # by performing <tt>Subclass.setting = _something_</tt>, <tt>Subclass.setting</tt>
+  # would read value assigned to parent class. Once Subclass assigns a value then
+  # the value assigned by Subclass would be returned.
+  #
+  # This matches normal Ruby method inheritance: think of writing an attribute
+  # on a subclass as overriding the reader method. However, you need to be aware
+  # when using +class_attribute+ with mutable structures as +Array+ or +Hash+.
+  # In such cases, you don't want to do changes in place. Instead use setters:
+  #
+  #   Base.setting = []
+  #   Base.setting                # => []
+  #   Subclass.setting            # => []
+  #
+  #   # Appending in child changes both parent and child because it is the same object:
+  #   Subclass.setting << :foo
+  #   Base.setting               # => [:foo]
+  #   Subclass.setting           # => [:foo]
+  #
+  #   # Use setters to not propagate changes:
+  #   Base.setting = []
+  #   Subclass.setting += [:foo]
+  #   Base.setting               # => []
+  #   Subclass.setting           # => [:foo]
+  #
+  # For convenience, an instance predicate method is defined as well.
+  # To skip it, pass <tt>instance_predicate: false</tt>.
+  #
+  #   Subclass.setting?       # => false
+  #
+  # Instances may overwrite the class value in the same way:
+  #
+  #   Base.setting = true
+  #   object = Base.new
+  #   object.setting          # => true
+  #   object.setting = false
+  #   object.setting          # => false
+  #   Base.setting            # => true
+  #
+  # To opt out of the instance reader method, pass <tt>instance_reader: false</tt>.
+  #
+  #   object.setting          # => NoMethodError
+  #   object.setting?         # => NoMethodError
+  #
+  # To opt out of the instance writer method, pass <tt>instance_writer: false</tt>.
+  #
+  #   object.setting = false  # => NoMethodError
+  #
+  # To opt out of both instance methods, pass <tt>instance_accessor: false</tt>.
+  #
+  # To set a default value for the attribute, pass <tt>default:</tt>, like so:
+  #
+  #   class_attribute :settings, default: {}
+  def class_attribute: (*untyped attrs, ?default: untyped? default, ?instance_predicate: bool instance_predicate, ?instance_writer: untyped instance_writer, ?instance_reader: untyped instance_reader, ?instance_accessor: bool instance_accessor) -> untyped
+end
+
+class Class
+  # Returns an array with all classes that are < than its receiver.
+  #
+  #   class C; end
+  #   C.descendants # => []
+  #
+  #   class B < C; end
+  #   C.descendants # => [B]
+  #
+  #   class A < B; end
+  #   C.descendants # => [B, A]
+  #
+  #   class D < C; end
+  #   C.descendants # => [B, A, D]
+  def descendants: () -> untyped
+
+  # Returns an array with the direct children of +self+.
+  #
+  #   class Foo; end
+  #   class Bar < Foo; end
+  #   class Baz < Bar; end
+  #
+  #   Foo.subclasses # => [Bar]
+  def subclasses: () -> untyped
+end
+
+class Date
+  # Duck-types as a Date-like class. See Object#acts_like?.
+  def acts_like_date?: () -> ::TrueClass
+end
+
+class Date
+  # nodoc:
+  # No Date is blank:
+  #
+  #   Date.today.blank? # => false
+  #
+  # @return [false]
+  def blank?: () -> ::FalseClass
+end
+
+class Date
+  include DateAndTime::Calculations
+
+  attr_accessor beginning_of_week_default: untyped
+
+  # Returns the week start (e.g. :monday) for the current request, if this has been set (via Date.beginning_of_week=).
+  # If <tt>Date.beginning_of_week</tt> has not been set for the current request, returns the week start specified in <tt>config.beginning_of_week</tt>.
+  # If no config.beginning_of_week was specified, returns :monday.
+  def self.beginning_of_week: () -> untyped
+
+  # Sets <tt>Date.beginning_of_week</tt> to a week start (e.g. :monday) for current request/thread.
+  #
+  # This method accepts any of the following day symbols:
+  # :monday, :tuesday, :wednesday, :thursday, :friday, :saturday, :sunday
+  def self.beginning_of_week=: (untyped week_start) -> untyped
+
+  # Returns week start day symbol (e.g. :monday), or raises an +ArgumentError+ for invalid day symbol.
+  def self.find_beginning_of_week!: (untyped week_start) -> untyped
+
+  # Returns a new Date representing the date 1 day ago (i.e. yesterday's date).
+  def self.yesterday: () -> untyped
+
+  # Returns a new Date representing the date 1 day after today (i.e. tomorrow's date).
+  def self.tomorrow: () -> untyped
+
+  # Returns Time.zone.today when <tt>Time.zone</tt> or <tt>config.time_zone</tt> are set, otherwise just returns Date.today.
+  def self.current: () -> untyped
+
+  # Converts Date to a Time (or DateTime if necessary) with the time portion set to the beginning of the day (0:00)
+  # and then subtracts the specified number of seconds.
+  def ago: (untyped seconds) -> untyped
+
+  # Converts Date to a Time (or DateTime if necessary) with the time portion set to the beginning of the day (0:00)
+  # and then adds the specified number of seconds
+  def since: (untyped seconds) -> untyped
+
+  alias in since
+
+  # Converts Date to a Time (or DateTime if necessary) with the time portion set to the beginning of the day (0:00)
+  def beginning_of_day: () -> untyped
+
+  alias midnight beginning_of_day
+
+  alias at_midnight beginning_of_day
+
+  alias at_beginning_of_day beginning_of_day
+
+  # Converts Date to a Time (or DateTime if necessary) with the time portion set to the middle of the day (12:00)
+  def middle_of_day: () -> untyped
+
+  alias midday middle_of_day
+
+  alias noon middle_of_day
+
+  alias at_midday middle_of_day
+
+  alias at_noon middle_of_day
+
+  alias at_middle_of_day middle_of_day
+
+  # Converts Date to a Time (or DateTime if necessary) with the time portion set to the end of the day (23:59:59)
+  def end_of_day: () -> untyped
+
+  alias at_end_of_day end_of_day
+
+  def plus_with_duration: (untyped other) -> untyped
+
+  alias plus_without_duration +
+
+  def minus_with_duration: (untyped other) -> untyped
+
+  alias minus_without_duration -
+
+  # Provides precise Date calculations for years, months, and days. The +options+ parameter takes a hash with
+  # any of these keys: <tt>:years</tt>, <tt>:months</tt>, <tt>:weeks</tt>, <tt>:days</tt>.
+  def advance: (untyped options) -> untyped
+
+  # Returns a new Date where one or more of the elements have been changed according to the +options+ parameter.
+  # The +options+ parameter is a hash with a combination of these keys: <tt>:year</tt>, <tt>:month</tt>, <tt>:day</tt>.
+  #
+  #   Date.new(2007, 5, 12).change(day: 1)               # => Date.new(2007, 5, 1)
+  #   Date.new(2007, 5, 12).change(year: 2005, month: 1) # => Date.new(2005, 1, 12)
+  def change: (untyped options) -> untyped
+
+  # Allow Date to be compared with Time by converting to DateTime and relying on the <=> from there.
+  def compare_with_coercion: (untyped other) -> untyped
+
+  alias compare_without_coercion <=>
+end
+
+class Date
+  DATE_FORMATS: ::Hash[untyped, untyped]
+
+  # Convert to a formatted string. See DATE_FORMATS for predefined formats.
+  #
+  # This method is aliased to <tt>to_s</tt>.
+  #
+  #   date = Date.new(2007, 11, 10)       # => Sat, 10 Nov 2007
+  #
+  #   date.to_formatted_s(:db)            # => "2007-11-10"
+  #   date.to_s(:db)                      # => "2007-11-10"
+  #
+  #   date.to_formatted_s(:short)         # => "10 Nov"
+  #   date.to_formatted_s(:number)        # => "20071110"
+  #   date.to_formatted_s(:long)          # => "November 10, 2007"
+  #   date.to_formatted_s(:long_ordinal)  # => "November 10th, 2007"
+  #   date.to_formatted_s(:rfc822)        # => "10 Nov 2007"
+  #   date.to_formatted_s(:iso8601)       # => "2007-11-10"
+  #
+  # == Adding your own date formats to to_formatted_s
+  # You can add your own formats to the Date::DATE_FORMATS hash.
+  # Use the format name as the hash key and either a strftime string
+  # or Proc instance that takes a date argument as the value.
+  #
+  #   # config/initializers/date_formats.rb
+  #   Date::DATE_FORMATS[:month_and_year] = '%B %Y'
+  #   Date::DATE_FORMATS[:short_ordinal] = ->(date) { date.strftime("%B #{date.day.ordinalize}") }
+  def to_formatted_s: (?::Symbol format) -> untyped
+
+  alias to_default_s to_s
+
+  # Overrides the default inspect method with a human readable one, e.g., "Mon, 21 Feb 2005"
+  def readable_inspect: () -> untyped
+
+  # Converts a Date instance to a Time, where the time is set to the beginning of the day.
+  # The timezone can be either :local or :utc (default :local).
+  #
+  #   date = Date.new(2007, 11, 10)  # => Sat, 10 Nov 2007
+  #
+  #   date.to_time                   # => 2007-11-10 00:00:00 0800
+  #   date.to_time(:local)           # => 2007-11-10 00:00:00 0800
+  #
+  #   date.to_time(:utc)             # => 2007-11-10 00:00:00 UTC
+  #
+  # NOTE: The :local timezone is Ruby's *process* timezone, i.e. ENV['TZ'].
+  #       If the *application's* timezone is needed, then use +in_time_zone+ instead.
+  def to_time: (?::Symbol form) -> untyped
+
+  # Returns a string which represents the time in used time zone as DateTime
+  # defined by XML Schema:
+  #
+  #   date = Date.new(2015, 05, 23)  # => Sat, 23 May 2015
+  #   date.xmlschema                 # => "2015-05-23T00:00:00+04:00"
+  def xmlschema: () -> untyped
+end
+
+class Date
+  include DateAndTime::Zones
+end
+
+module DateAndTime
+  module Calculations
+    DAYS_INTO_WEEK: ::Hash[untyped, untyped]
+
+    WEEKEND_DAYS: ::Array[untyped]
+
+    # Returns a new date/time representing yesterday.
+    def yesterday: () -> untyped
+
+    # Returns a new date/time representing tomorrow.
+    def tomorrow: () -> untyped
+
+    # Returns true if the date/time is today.
+    def today?: () -> untyped
+
+    # Returns true if the date/time is in the past.
+    def past?: () -> untyped
+
+    # Returns true if the date/time is in the future.
+    def future?: () -> untyped
+
+    # Returns true if the date/time falls on a Saturday or Sunday.
+    def on_weekend?: () -> untyped
+
+    # Returns true if the date/time does not fall on a Saturday or Sunday.
+    def on_weekday?: () -> untyped
+
+    # Returns true if the date/time falls before <tt>date_or_time</tt>.
+    def before?: (untyped date_or_time) -> untyped
+
+    # Returns true if the date/time falls after <tt>date_or_time</tt>.
+    def after?: (untyped date_or_time) -> untyped
+
+    # Returns a new date/time the specified number of days ago.
+    def days_ago: (untyped days) -> untyped
+
+    # Returns a new date/time the specified number of days in the future.
+    def days_since: (untyped days) -> untyped
+
+    # Returns a new date/time the specified number of weeks ago.
+    def weeks_ago: (untyped weeks) -> untyped
+
+    # Returns a new date/time the specified number of weeks in the future.
+    def weeks_since: (untyped weeks) -> untyped
+
+    # Returns a new date/time the specified number of months ago.
+    def months_ago: (untyped months) -> untyped
+
+    # Returns a new date/time the specified number of months in the future.
+    def months_since: (untyped months) -> untyped
+
+    # Returns a new date/time the specified number of years ago.
+    def years_ago: (untyped years) -> untyped
+
+    # Returns a new date/time the specified number of years in the future.
+    def years_since: (untyped years) -> untyped
+
+    # Returns a new date/time at the start of the month.
+    #
+    #   today = Date.today # => Thu, 18 Jun 2015
+    #   today.beginning_of_month # => Mon, 01 Jun 2015
+    #
+    # +DateTime+ objects will have a time set to 0:00.
+    #
+    #   now = DateTime.current # => Thu, 18 Jun 2015 15:23:13 +0000
+    #   now.beginning_of_month # => Mon, 01 Jun 2015 00:00:00 +0000
+    def beginning_of_month: () -> untyped
+
+    alias at_beginning_of_month beginning_of_month
+
+    # Returns a new date/time at the start of the quarter.
+    #
+    #   today = Date.today # => Fri, 10 Jul 2015
+    #   today.beginning_of_quarter # => Wed, 01 Jul 2015
+    #
+    # +DateTime+ objects will have a time set to 0:00.
+    #
+    #   now = DateTime.current # => Fri, 10 Jul 2015 18:41:29 +0000
+    #   now.beginning_of_quarter # => Wed, 01 Jul 2015 00:00:00 +0000
+    def beginning_of_quarter: () -> untyped
+
+    alias at_beginning_of_quarter beginning_of_quarter
+
+    # Returns a new date/time at the end of the quarter.
+    #
+    #   today = Date.today # => Fri, 10 Jul 2015
+    #   today.end_of_quarter # => Wed, 30 Sep 2015
+    #
+    # +DateTime+ objects will have a time set to 23:59:59.
+    #
+    #   now = DateTime.current # => Fri, 10 Jul 2015 18:41:29 +0000
+    #   now.end_of_quarter # => Wed, 30 Sep 2015 23:59:59 +0000
+    def end_of_quarter: () -> untyped
+
+    alias at_end_of_quarter end_of_quarter
+
+    # Returns a new date/time at the beginning of the year.
+    #
+    #   today = Date.today # => Fri, 10 Jul 2015
+    #   today.beginning_of_year # => Thu, 01 Jan 2015
+    #
+    # +DateTime+ objects will have a time set to 0:00.
+    #
+    #   now = DateTime.current # => Fri, 10 Jul 2015 18:41:29 +0000
+    #   now.beginning_of_year # => Thu, 01 Jan 2015 00:00:00 +0000
+    def beginning_of_year: () -> untyped
+
+    alias at_beginning_of_year beginning_of_year
+
+    # Returns a new date/time representing the given day in the next week.
+    #
+    #   today = Date.today # => Thu, 07 May 2015
+    #   today.next_week    # => Mon, 11 May 2015
+    #
+    # The +given_day_in_next_week+ defaults to the beginning of the week
+    # which is determined by +Date.beginning_of_week+ or +config.beginning_of_week+
+    # when set.
+    #
+    #   today = Date.today       # => Thu, 07 May 2015
+    #   today.next_week(:friday) # => Fri, 15 May 2015
+    #
+    # +DateTime+ objects have their time set to 0:00 unless +same_time+ is true.
+    #
+    #   now = DateTime.current # => Thu, 07 May 2015 13:31:16 +0000
+    #   now.next_week      # => Mon, 11 May 2015 00:00:00 +0000
+    def next_week: (?untyped given_day_in_next_week, ?same_time: bool same_time) -> untyped
+
+    # Returns a new date/time representing the next weekday.
+    def next_weekday: () -> untyped
+
+    # Short-hand for months_since(3)
+    def next_quarter: () -> untyped
+
+    # Returns a new date/time representing the given day in the previous week.
+    # Week is assumed to start on +start_day+, default is
+    # +Date.beginning_of_week+ or +config.beginning_of_week+ when set.
+    # DateTime objects have their time set to 0:00 unless +same_time+ is true.
+    def prev_week: (?untyped start_day, ?same_time: bool same_time) -> untyped
+
+    alias last_week prev_week
+
+    # Returns a new date/time representing the previous weekday.
+    def prev_weekday: () -> untyped
+
+    alias last_weekday prev_weekday
+
+    # Short-hand for months_ago(1).
+    def last_month: () -> untyped
+
+    # Short-hand for months_ago(3).
+    def prev_quarter: () -> untyped
+
+    alias last_quarter prev_quarter
+
+    # Short-hand for years_ago(1).
+    def last_year: () -> untyped
+
+    # Returns the number of days to the start of the week on the given day.
+    # Week is assumed to start on +start_day+, default is
+    # +Date.beginning_of_week+ or +config.beginning_of_week+ when set.
+    def days_to_week_start: (?untyped start_day) -> untyped
+
+    # Returns a new date/time representing the start of this week on the given day.
+    # Week is assumed to start on +start_day+, default is
+    # +Date.beginning_of_week+ or +config.beginning_of_week+ when set.
+    # +DateTime+ objects have their time set to 0:00.
+    def beginning_of_week: (?untyped start_day) -> untyped
+
+    alias at_beginning_of_week beginning_of_week
+
+    # Returns Monday of this week assuming that week starts on Monday.
+    # +DateTime+ objects have their time set to 0:00.
+    def monday: () -> untyped
+
+    # Returns a new date/time representing the end of this week on the given day.
+    # Week is assumed to start on +start_day+, default is
+    # +Date.beginning_of_week+ or +config.beginning_of_week+ when set.
+    # DateTime objects have their time set to 23:59:59.
+    def end_of_week: (?untyped start_day) -> untyped
+
+    alias at_end_of_week end_of_week
+
+    # Returns Sunday of this week assuming that week starts on Monday.
+    # +DateTime+ objects have their time set to 23:59:59.
+    def sunday: () -> untyped
+
+    # Returns a new date/time representing the end of the month.
+    # DateTime objects will have a time set to 23:59:59.
+    def end_of_month: () -> untyped
+
+    alias at_end_of_month end_of_month
+
+    # Returns a new date/time representing the end of the year.
+    # DateTime objects will have a time set to 23:59:59.
+    def end_of_year: () -> untyped
+
+    alias at_end_of_year end_of_year
+
+    # Returns a Range representing the whole day of the current date/time.
+    def all_day: () -> ::Range[untyped]
+
+    # Returns a Range representing the whole week of the current date/time.
+    # Week starts on start_day, default is <tt>Date.beginning_of_week</tt> or <tt>config.beginning_of_week</tt> when set.
+    def all_week: (?untyped start_day) -> ::Range[untyped]
+
+    # Returns a Range representing the whole month of the current date/time.
+    def all_month: () -> ::Range[untyped]
+
+    # Returns a Range representing the whole quarter of the current date/time.
+    def all_quarter: () -> ::Range[untyped]
+
+    # Returns a Range representing the whole year of the current date/time.
+    def all_year: () -> ::Range[untyped]
+
+    # Returns a new date/time representing the next occurrence of the specified day of week.
+    #
+    #   today = Date.today               # => Thu, 14 Dec 2017
+    #   today.next_occurring(:monday)    # => Mon, 18 Dec 2017
+    #   today.next_occurring(:thursday)  # => Thu, 21 Dec 2017
+    def next_occurring: (untyped day_of_week) -> untyped
+
+    # Returns a new date/time representing the previous occurrence of the specified day of week.
+    #
+    #   today = Date.today               # => Thu, 14 Dec 2017
+    #   today.prev_occurring(:monday)    # => Mon, 11 Dec 2017
+    #   today.prev_occurring(:thursday)  # => Thu, 07 Dec 2017
+    def prev_occurring: (untyped day_of_week) -> untyped
+
+    def first_hour: (untyped date_or_time) -> untyped
+
+    def last_hour: (untyped date_or_time) -> untyped
+
+    def days_span: (untyped day) -> untyped
+
+    def copy_time_to: (untyped other) -> untyped
+  end
+end
+
+module DateAndTime
+  module Compatibility
+  end
+end
+
+module DateAndTime
+  module Zones
+    # Returns the simultaneous time in <tt>Time.zone</tt> if a zone is given or
+    # if Time.zone_default is set. Otherwise, it returns the current time.
+    #
+    #   Time.zone = 'Hawaii'        # => 'Hawaii'
+    #   Time.utc(2000).in_time_zone # => Fri, 31 Dec 1999 14:00:00 HST -10:00
+    #   Date.new(2000).in_time_zone # => Sat, 01 Jan 2000 00:00:00 HST -10:00
+    #
+    # This method is similar to Time#localtime, except that it uses <tt>Time.zone</tt> as the local zone
+    # instead of the operating system's time zone.
+    #
+    # You can also pass in a TimeZone instance or string that identifies a TimeZone as an argument,
+    # and the conversion will be based on that zone instead of <tt>Time.zone</tt>.
+    #
+    #   Time.utc(2000).in_time_zone('Alaska') # => Fri, 31 Dec 1999 15:00:00 AKST -09:00
+    #   Date.new(2000).in_time_zone('Alaska') # => Sat, 01 Jan 2000 00:00:00 AKST -09:00
+    def in_time_zone: (?untyped zone) -> untyped
+
+    def time_with_zone: (untyped time, untyped zone) -> untyped
+  end
+end
+
+class DateTime
+  # Duck-types as a Date-like class. See Object#acts_like?.
+  def acts_like_date?: () -> ::TrueClass
+
+  # Duck-types as a Time-like class. See Object#acts_like?.
+  def acts_like_time?: () -> ::TrueClass
+end
+
+class DateTime
+  # nodoc:
+  # No DateTime is ever blank:
+  #
+  #   DateTime.now.blank? # => false
+  #
+  # @return [false]
+  def blank?: () -> ::FalseClass
+end
+
+class DateTime
+  # Returns <tt>Time.zone.now.to_datetime</tt> when <tt>Time.zone</tt> or
+  # <tt>config.time_zone</tt> are set, otherwise returns
+  # <tt>Time.now.to_datetime</tt>.
+  def self.current: () -> untyped
+
+  # Returns the number of seconds since 00:00:00.
+  #
+  #   DateTime.new(2012, 8, 29,  0,  0,  0).seconds_since_midnight # => 0
+  #   DateTime.new(2012, 8, 29, 12, 34, 56).seconds_since_midnight # => 45296
+  #   DateTime.new(2012, 8, 29, 23, 59, 59).seconds_since_midnight # => 86399
+  def seconds_since_midnight: () -> untyped
+
+  # Returns the number of seconds until 23:59:59.
+  #
+  #   DateTime.new(2012, 8, 29,  0,  0,  0).seconds_until_end_of_day # => 86399
+  #   DateTime.new(2012, 8, 29, 12, 34, 56).seconds_until_end_of_day # => 41103
+  #   DateTime.new(2012, 8, 29, 23, 59, 59).seconds_until_end_of_day # => 0
+  def seconds_until_end_of_day: () -> untyped
+
+  # Returns the fraction of a second as a +Rational+
+  #
+  #   DateTime.new(2012, 8, 29, 0, 0, 0.5).subsec # => (1/2)
+  def subsec: () -> untyped
+
+  # Returns a new DateTime where one or more of the elements have been changed
+  # according to the +options+ parameter. The time options (<tt>:hour</tt>,
+  # <tt>:min</tt>, <tt>:sec</tt>) reset cascadingly, so if only the hour is
+  # passed, then minute and sec is set to 0. If the hour and minute is passed,
+  # then sec is set to 0. The +options+ parameter takes a hash with any of these
+  # keys: <tt>:year</tt>, <tt>:month</tt>, <tt>:day</tt>, <tt>:hour</tt>,
+  # <tt>:min</tt>, <tt>:sec</tt>, <tt>:offset</tt>, <tt>:start</tt>.
+  #
+  #   DateTime.new(2012, 8, 29, 22, 35, 0).change(day: 1)              # => DateTime.new(2012, 8, 1, 22, 35, 0)
+  #   DateTime.new(2012, 8, 29, 22, 35, 0).change(year: 1981, day: 1)  # => DateTime.new(1981, 8, 1, 22, 35, 0)
+  #   DateTime.new(2012, 8, 29, 22, 35, 0).change(year: 1981, hour: 0) # => DateTime.new(1981, 8, 29, 0, 0, 0)
+  def change: (untyped options) -> untyped
+
+  # Uses Date to provide precise Time calculations for years, months, and days.
+  # The +options+ parameter takes a hash with any of these keys: <tt>:years</tt>,
+  # <tt>:months</tt>, <tt>:weeks</tt>, <tt>:days</tt>, <tt>:hours</tt>,
+  # <tt>:minutes</tt>, <tt>:seconds</tt>.
+  def advance: (untyped options) -> untyped
+
+  # Returns a new DateTime representing the time a number of seconds ago.
+  # Do not use this method in combination with x.months, use months_ago instead!
+  def ago: (untyped seconds) -> untyped
+
+  # Returns a new DateTime representing the time a number of seconds since the
+  # instance time. Do not use this method in combination with x.months, use
+  # months_since instead!
+  def since: (untyped seconds) -> untyped
+
+  alias in since
+
+  # Returns a new DateTime representing the start of the day (0:00).
+  def beginning_of_day: () -> untyped
+
+  alias midnight beginning_of_day
+
+  alias at_midnight beginning_of_day
+
+  alias at_beginning_of_day beginning_of_day
+
+  # Returns a new DateTime representing the middle of the day (12:00)
+  def middle_of_day: () -> untyped
+
+  alias midday middle_of_day
+
+  alias noon middle_of_day
+
+  alias at_midday middle_of_day
+
+  alias at_noon middle_of_day
+
+  alias at_middle_of_day middle_of_day
+
+  # Returns a new DateTime representing the end of the day (23:59:59).
+  def end_of_day: () -> untyped
+
+  alias at_end_of_day end_of_day
+
+  # Returns a new DateTime representing the start of the hour (hh:00:00).
+  def beginning_of_hour: () -> untyped
+
+  alias at_beginning_of_hour beginning_of_hour
+
+  # Returns a new DateTime representing the end of the hour (hh:59:59).
+  def end_of_hour: () -> untyped
+
+  alias at_end_of_hour end_of_hour
+
+  # Returns a new DateTime representing the start of the minute (hh:mm:00).
+  def beginning_of_minute: () -> untyped
+
+  alias at_beginning_of_minute beginning_of_minute
+
+  # Returns a new DateTime representing the end of the minute (hh:mm:59).
+  def end_of_minute: () -> untyped
+
+  alias at_end_of_minute end_of_minute
+
+  # Returns a <tt>Time</tt> instance of the simultaneous time in the system timezone.
+  def localtime: (?untyped? utc_offset) -> untyped
+
+  alias getlocal localtime
+
+  # Returns a <tt>Time</tt> instance of the simultaneous time in the UTC timezone.
+  #
+  #   DateTime.civil(2005, 2, 21, 10, 11, 12, Rational(-6, 24))     # => Mon, 21 Feb 2005 10:11:12 -0600
+  #   DateTime.civil(2005, 2, 21, 10, 11, 12, Rational(-6, 24)).utc # => Mon, 21 Feb 2005 16:11:12 UTC
+  def utc: () -> untyped
+
+  alias getgm utc
+
+  alias getutc utc
+
+  alias gmtime utc
+
+  # Returns +true+ if <tt>offset == 0</tt>.
+  def utc?: () -> untyped
+
+  # Returns the offset value in seconds.
+  def utc_offset: () -> untyped
+
+  # Layers additional behavior on DateTime#<=> so that Time and
+  # ActiveSupport::TimeWithZone instances can be compared with a DateTime.
+  def <=>: (untyped other) -> untyped
+end
+
+class DateTime
+  include DateAndTime::Compatibility
+
+  # Either return an instance of +Time+ with the same UTC offset
+  # as +self+ or an instance of +Time+ representing the same time
+  # in the local system timezone depending on the setting of
+  # on the setting of +ActiveSupport.to_time_preserves_timezone+.
+  def to_time: () -> untyped
+end
+
+class DateTime
+  # Convert to a formatted string. See Time::DATE_FORMATS for predefined formats.
+  #
+  # This method is aliased to <tt>to_s</tt>.
+  #
+  # === Examples
+  #   datetime = DateTime.civil(2007, 12, 4, 0, 0, 0, 0)   # => Tue, 04 Dec 2007 00:00:00 +0000
+  #
+  #   datetime.to_formatted_s(:db)            # => "2007-12-04 00:00:00"
+  #   datetime.to_s(:db)                      # => "2007-12-04 00:00:00"
+  #   datetime.to_s(:number)                  # => "20071204000000"
+  #   datetime.to_formatted_s(:short)         # => "04 Dec 00:00"
+  #   datetime.to_formatted_s(:long)          # => "December 04, 2007 00:00"
+  #   datetime.to_formatted_s(:long_ordinal)  # => "December 4th, 2007 00:00"
+  #   datetime.to_formatted_s(:rfc822)        # => "Tue, 04 Dec 2007 00:00:00 +0000"
+  #   datetime.to_formatted_s(:iso8601)       # => "2007-12-04T00:00:00+00:00"
+  #
+  # == Adding your own datetime formats to to_formatted_s
+  # DateTime formats are shared with Time. You can add your own to the
+  # Time::DATE_FORMATS hash. Use the format name as the hash key and
+  # either a strftime string or Proc instance that takes a time or
+  # datetime argument as the value.
+  #
+  #   # config/initializers/time_formats.rb
+  #   Time::DATE_FORMATS[:month_and_year] = '%B %Y'
+  #   Time::DATE_FORMATS[:short_ordinal] = lambda { |time| time.strftime("%B #{time.day.ordinalize}") }
+  def to_formatted_s: (?::Symbol format) -> untyped
+
+  alias to_default_s to_s
+
+  # Returns a formatted string of the offset from UTC, or an alternative
+  # string if the time zone is already UTC.
+  #
+  #   datetime = DateTime.civil(2000, 1, 1, 0, 0, 0, Rational(-6, 24))
+  #   datetime.formatted_offset         # => "-06:00"
+  #   datetime.formatted_offset(false)  # => "-0600"
+  def formatted_offset: (?bool colon, ?untyped? alternate_utc_string) -> untyped
+
+  # Overrides the default inspect method with a human readable one, e.g., "Mon, 21 Feb 2005 14:30:00 +0000".
+  def readable_inspect: () -> untyped
+
+  # Returns DateTime with local offset for given year if format is local else
+  # offset is zero.
+  #
+  #   DateTime.civil_from_format :local, 2012
+  #   # => Sun, 01 Jan 2012 00:00:00 +0300
+  #   DateTime.civil_from_format :local, 2012, 12, 17
+  #   # => Mon, 17 Dec 2012 00:00:00 +0000
+  def self.civil_from_format: (untyped utc_or_local, untyped year, ?::Integer month, ?::Integer day, ?::Integer hour, ?::Integer min, ?::Integer sec) -> untyped
+
+  # Converts +self+ to a floating-point number of seconds, including fractional microseconds, since the Unix epoch.
+  def to_f: () -> untyped
+
+  # Converts +self+ to an integer number of seconds since the Unix epoch.
+  def to_i: () -> untyped
+
+  # Returns the fraction of a second as microseconds
+  def usec: () -> untyped
+
+  # Returns the fraction of a second as nanoseconds
+  def nsec: () -> untyped
+
+  def offset_in_seconds: () -> untyped
+
+  def seconds_since_unix_epoch: () -> untyped
+end
+
+module Digest
+  module UUID
+    DNS_NAMESPACE: ::String
+
+    URL_NAMESPACE: ::String
+
+    OID_NAMESPACE: ::String
+
+    X500_NAMESPACE: ::String
+
+    # Generates a v5 non-random UUID (Universally Unique IDentifier).
+    #
+    # Using Digest::MD5 generates version 3 UUIDs; Digest::SHA1 generates version 5 UUIDs.
+    # uuid_from_hash always generates the same UUID for a given name and namespace combination.
+    #
+    # See RFC 4122 for details of UUID at: https://www.ietf.org/rfc/rfc4122.txt
+    def self.uuid_from_hash: (untyped hash_class, untyped uuid_namespace, untyped name) -> untyped
+
+    # Convenience method for uuid_from_hash using Digest::MD5.
+    def self.uuid_v3: (untyped uuid_namespace, untyped name) -> untyped
+
+    # Convenience method for uuid_from_hash using Digest::SHA1.
+    def self.uuid_v5: (untyped uuid_namespace, untyped name) -> untyped
+
+    # Convenience method for SecureRandom.uuid.
+    def self.uuid_v4: () -> untyped
+  end
+end
+
+module Enumerable[unchecked out Elem]
+  INDEX_WITH_DEFAULT: untyped
+
+  # We can't use Refinements here because Refinements with Module which will be prepended
+  # doesn't work well https://bugs.ruby-lang.org/issues/13446
+  alias _original_sum_with_required_identity sum
+
+  # Calculates a sum from the elements.
+  #
+  #  payments.sum { |p| p.price * p.tax_rate }
+  #  payments.sum(&:price)
+  #
+  # The latter is a shortcut for:
+  #
+  #  payments.inject(0) { |sum, p| sum + p.price }
+  #
+  # It can also calculate the sum without the use of a block.
+  #
+  #  [5, 15, 10].sum # => 30
+  #  ['foo', 'bar'].sum # => "foobar"
+  #  [[1, 2], [3, 1, 5]].sum # => [1, 2, 3, 1, 5]
+  #
+  # The default sum of an empty list is zero. You can override this default:
+  #
+  #  [].sum(Payment.new(0)) { |i| i.amount } # => Payment.new(0)
+  def sum: (?untyped? identity) { () -> untyped } -> untyped
+
+  # Convert an enumerable to a hash keying it by the block return value.
+  #
+  #   people.index_by(&:login)
+  #   # => { "nextangle" => <Person ...>, "chade-" => <Person ...>, ...}
+  #
+  #   people.index_by { |person| "#{person.first_name} #{person.last_name}" }
+  #   # => { "Chade- Fowlersburg-e" => <Person ...>, "David Heinemeier Hansson" => <Person ...>, ...}
+  def index_by: () { (untyped) -> untyped } -> untyped
+
+  # Convert an enumerable to a hash keying it with the enumerable items and with the values returned in the block.
+  #
+  #   post = Post.new(title: "hey there", body: "what's up?")
+  #
+  #   %i( title body ).index_with { |attr_name| post.public_send(attr_name) }
+  #   # => { title: "hey there", body: "what's up?" }
+  def index_with: (?untyped default) { (untyped) -> untyped } -> untyped
+
+  # Returns +true+ if the enumerable has more than 1 element. Functionally
+  # equivalent to <tt>enum.to_a.size > 1</tt>. Can be called with a block too,
+  # much like any?, so <tt>people.many? { |p| p.age > 26 }</tt> returns +true+
+  # if more than one person is over 26.
+  def many?: () { (untyped) -> untyped } -> untyped
+
+  # Returns a new array that includes the passed elements.
+  #
+  #   [ 1, 2, 3 ].including(4, 5)
+  #   # => [ 1, 2, 3, 4, 5 ]
+  #
+  #   ["David", "Rafael"].including %w[ Aaron Todd ]
+  #   # => ["David", "Rafael", "Aaron", "Todd"]
+  def including: (*untyped elements) -> untyped
+
+  # The negative of the <tt>Enumerable#include?</tt>. Returns +true+ if the
+  # collection does not include the object.
+  def exclude?: (untyped object) -> untyped
+
+  # Returns a copy of the enumerable excluding the specified elements.
+  #
+  #   ["David", "Rafael", "Aaron", "Todd"].excluding "Aaron", "Todd"
+  #   # => ["David", "Rafael"]
+  #
+  #   ["David", "Rafael", "Aaron", "Todd"].excluding %w[ Aaron Todd ]
+  #   # => ["David", "Rafael"]
+  #
+  #   {foo: 1, bar: 2, baz: 3}.excluding :bar
+  #   # => {foo: 1, baz: 3}
+  def excluding: (*untyped elements) -> untyped
+
+  # Alias for #excluding.
+  def without: (*untyped elements) -> untyped
+
+  # Convert an enumerable to an array based on the given key.
+  #
+  #   [{ name: "David" }, { name: "Rafael" }, { name: "Aaron" }].pluck(:name)
+  #   # => ["David", "Rafael", "Aaron"]
+  #
+  #   [{ id: 1, name: "David" }, { id: 2, name: "Rafael" }].pluck(:id, :name)
+  #   # => [[1, "David"], [2, "Rafael"]]
+  def pluck: (*untyped keys) -> untyped
+end
+
+class Range[out Elem]
+  # nodoc:
+  # Optimize range sum to use arithmetic progression if a block is not given and
+  # we have a range of numeric values.
+  def sum: (?untyped? identity) -> untyped
+end
+
+class Array[unchecked out Elem]
+  # nodoc:
+  # Array#sum was added in Ruby 2.4 but it only works with Numeric elements.
+  def sum: (?untyped? init) { () -> untyped } -> untyped
+end
+
+class File
+  # Write to a file atomically. Useful for situations where you don't
+  # want other processes or threads to see half-written files.
+  #
+  #   File.atomic_write('important.file') do |file|
+  #     file.write('hello')
+  #   end
+  #
+  # This method needs to create a temporary file. By default it will create it
+  # in the same directory as the destination file. If you don't like this
+  # behavior you can provide a different directory but it must be on the
+  # same physical filesystem as the file you're trying to write.
+  #
+  #   File.atomic_write('/data/something.important', '/data/tmp') do |file|
+  #     file.write('hello')
+  #   end
+  def self.atomic_write: (untyped file_name, ?untyped temp_dir) { (untyped) -> untyped } -> untyped
+
+  def self.probe_stat_in: (untyped dir) -> untyped
+end
+
+class Hash[unchecked out K, unchecked out V]
+  # Returns a string containing an XML representation of its receiver:
+  #
+  #   { foo: 1, bar: 2 }.to_xml
+  #   # =>
+  #   # <?xml version="1.0" encoding="UTF-8"?>
+  #   # <hash>
+  #   #   <foo type="integer">1</foo>
+  #   #   <bar type="integer">2</bar>
+  #   # </hash>
+  #
+  # To do so, the method loops over the pairs and builds nodes that depend on
+  # the _values_. Given a pair +key+, +value+:
+  #
+  # * If +value+ is a hash there's a recursive call with +key+ as <tt>:root</tt>.
+  #
+  # * If +value+ is an array there's a recursive call with +key+ as <tt>:root</tt>,
+  #   and +key+ singularized as <tt>:children</tt>.
+  #
+  # * If +value+ is a callable object it must expect one or two arguments. Depending
+  #   on the arity, the callable is invoked with the +options+ hash as first argument
+  #   with +key+ as <tt>:root</tt>, and +key+ singularized as second argument. The
+  #   callable can add nodes by using <tt>options[:builder]</tt>.
+  #
+  #     {foo: lambda { |options, key| options[:builder].b(key) }}.to_xml
+  #     # => "<b>foo</b>"
+  #
+  # * If +value+ responds to +to_xml+ the method is invoked with +key+ as <tt>:root</tt>.
+  #
+  #     class Foo
+  #       def to_xml(options)
+  #         options[:builder].bar 'fooing!'
+  #       end
+  #     end
+  #
+  #     { foo: Foo.new }.to_xml(skip_instruct: true)
+  #     # =>
+  #     # <hash>
+  #     #   <bar>fooing!</bar>
+  #     # </hash>
+  #
+  # * Otherwise, a node with +key+ as tag is created with a string representation of
+  #   +value+ as text node. If +value+ is +nil+ an attribute "nil" set to "true" is added.
+  #   Unless the option <tt>:skip_types</tt> exists and is true, an attribute "type" is
+  #   added as well according to the following mapping:
+  #
+  #     XML_TYPE_NAMES = {
+  #       "Symbol"     => "symbol",
+  #       "Integer"    => "integer",
+  #       "BigDecimal" => "decimal",
+  #       "Float"      => "float",
+  #       "TrueClass"  => "boolean",
+  #       "FalseClass" => "boolean",
+  #       "Date"       => "date",
+  #       "DateTime"   => "dateTime",
+  #       "Time"       => "dateTime"
+  #     }
+  #
+  # By default the root node is "hash", but that's configurable via the <tt>:root</tt> option.
+  #
+  # The default XML builder is a fresh instance of <tt>Builder::XmlMarkup</tt>. You can
+  # configure your own builder with the <tt>:builder</tt> option. The method also accepts
+  # options like <tt>:dasherize</tt> and friends, they are forwarded to the builder.
+  def to_xml: (?::Hash[untyped, untyped] options) { (untyped) -> untyped } -> untyped
+
+  # Returns a Hash containing a collection of pairs when the key is the node name and the value is
+  # its content
+  #
+  #   xml = <<-XML
+  #     <?xml version="1.0" encoding="UTF-8"?>
+  #       <hash>
+  #         <foo type="integer">1</foo>
+  #         <bar type="integer">2</bar>
+  #       </hash>
+  #   XML
+  #
+  #   hash = Hash.from_xml(xml)
+  #   # => {"hash"=>{"foo"=>1, "bar"=>2}}
+  #
+  # +DisallowedType+ is raised if the XML contains attributes with <tt>type="yaml"</tt> or
+  # <tt>type="symbol"</tt>. Use <tt>Hash.from_trusted_xml</tt> to
+  # parse this XML.
+  #
+  # Custom +disallowed_types+ can also be passed in the form of an
+  # array.
+  #
+  #   xml = <<-XML
+  #     <?xml version="1.0" encoding="UTF-8"?>
+  #       <hash>
+  #         <foo type="integer">1</foo>
+  #         <bar type="string">"David"</bar>
+  #       </hash>
+  #   XML
+  #
+  #   hash = Hash.from_xml(xml, ['integer'])
+  #   # => ActiveSupport::XMLConverter::DisallowedType: Disallowed type attribute: "integer"
+  #
+  # Note that passing custom disallowed types will override the default types,
+  # which are Symbol and YAML.
+  def self.from_xml: (untyped xml, ?untyped? disallowed_types) -> untyped
+
+  # Builds a Hash from XML just like <tt>Hash.from_xml</tt>, but also allows Symbol and YAML.
+  def self.from_trusted_xml: (untyped xml) -> untyped
+end
+
+module ActiveSupport
+  class XMLConverter
+    # :nodoc:
+    # Raised if the XML contains attributes with type="yaml" or
+    # type="symbol". Read Hash#from_xml for more details.
+    class DisallowedType < StandardError
+      def initialize: (untyped `type`) -> untyped
+    end
+
+    DISALLOWED_TYPES: ::Array[untyped]
+
+    def initialize: (untyped xml, ?untyped? disallowed_types) -> untyped
+
+    def to_h: () -> untyped
+
+    def normalize_keys: (untyped params) -> untyped
+
+    def deep_to_h: (untyped value) -> untyped
+
+    def process_hash: (untyped value) -> untyped
+
+    def become_content?: (untyped value) -> untyped
+
+    def become_array?: (untyped value) -> untyped
+
+    def become_empty_string?: (untyped value) -> untyped
+
+    def become_hash?: (untyped value) -> untyped
+
+    def nothing?: (untyped value) -> untyped
+
+    def garbage?: (untyped value) -> untyped
+
+    def process_content: (untyped value) -> untyped
+
+    def process_array: (untyped value) -> untyped
+  end
+end
+
+class Hash[unchecked out K, unchecked out V]
+  # Returns a new hash with +self+ and +other_hash+ merged recursively.
+  #
+  #   h1 = { a: true, b: { c: [1, 2, 3] } }
+  #   h2 = { a: false, b: { x: [3, 4, 5] } }
+  #
+  #   h1.deep_merge(h2) # => { a: false, b: { c: [1, 2, 3], x: [3, 4, 5] } }
+  #
+  # Like with Hash#merge in the standard library, a block can be provided
+  # to merge values:
+  #
+  #   h1 = { a: 100, b: 200, c: { c1: 100 } }
+  #   h2 = { b: 250, c: { c1: 200 } }
+  #   h1.deep_merge(h2) { |key, this_val, other_val| this_val + other_val }
+  #   # => { a: 100, b: 450, c: { c1: 300 } }
+  def deep_merge: (untyped other_hash) { () -> untyped } -> untyped
+
+  # Same as +deep_merge+, but modifies +self+.
+  def deep_merge!: (untyped other_hash) { () -> untyped } -> untyped
+end
+
+class Hash[unchecked out K, unchecked out V]
+  # Returns a new hash with all values converted by the block operation.
+  # This includes the values from the root hash and from all
+  # nested hashes and arrays.
+  #
+  #  hash = { person: { name: 'Rob', age: '28' } }
+  #
+  #  hash.deep_transform_values{ |value| value.to_s.upcase }
+  #  # => {person: {name: "ROB", age: "28"}}
+  def deep_transform_values: () { () -> untyped } -> untyped
+
+  # Destructively converts all values by using the block operation.
+  # This includes the values from the root hash and from all
+  # nested hashes and arrays.
+  def deep_transform_values!: () { () -> untyped } -> untyped
+
+  # support methods for deep transforming nested hashes and arrays
+  def _deep_transform_values_in_object: (untyped object) { (untyped) -> untyped } -> untyped
+
+  def _deep_transform_values_in_object!: (untyped object) { (untyped) -> untyped } -> untyped
+end
+
+class Hash[unchecked out K, unchecked out V]
+  # Returns a hash that includes everything except given keys.
+  #   hash = { a: true, b: false, c: nil }
+  #   hash.except(:c)     # => { a: true, b: false }
+  #   hash.except(:a, :b) # => { c: nil }
+  #   hash                # => { a: true, b: false, c: nil }
+  #
+  # This is useful for limiting a set of parameters to everything but a few known toggles:
+  #   @person.update(params[:person].except(:admin))
+  def except: (*untyped keys) -> untyped
+
+  # Removes the given keys from hash and returns it.
+  #   hash = { a: true, b: false, c: nil }
+  #   hash.except!(:c) # => { a: true, b: false }
+  #   hash             # => { a: true, b: false }
+  def except!: (*untyped keys) -> untyped
+end
+
+class Hash[unchecked out K, unchecked out V]
+  # Returns an <tt>ActiveSupport::HashWithIndifferentAccess</tt> out of its receiver:
+  #
+  #   { a: 1 }.with_indifferent_access['a'] # => 1
+  def with_indifferent_access: () -> ActiveSupport::HashWithIndifferentAccess[K, V]
+
+  # Called when object is nested under an object that receives
+  # #with_indifferent_access. This method will be called on the current object
+  # by the enclosing object and is aliased to #with_indifferent_access by
+  # default. Subclasses of Hash may overwrite this method to return +self+ if
+  # converting to an <tt>ActiveSupport::HashWithIndifferentAccess</tt> would not be
+  # desirable.
+  #
+  #   b = { b: 1 }
+  #   { a: b }.with_indifferent_access['a'] # calls b.nested_under_indifferent_access
+  #   # => {"b"=>1}
+  alias nested_under_indifferent_access with_indifferent_access
+end
+
+class Hash[unchecked out K, unchecked out V]
+  # Returns a new hash with all keys converted to strings.
+  #
+  #   hash = { name: 'Rob', age: '28' }
+  #
+  #   hash.stringify_keys
+  #   # => {"name"=>"Rob", "age"=>"28"}
+  def stringify_keys: () -> untyped
+
+  # Destructively converts all keys to strings. Same as
+  # +stringify_keys+, but modifies +self+.
+  def stringify_keys!: () -> untyped
+
+  # Returns a new hash with all keys converted to symbols, as long as
+  # they respond to +to_sym+.
+  #
+  #   hash = { 'name' => 'Rob', 'age' => '28' }
+  #
+  #   hash.symbolize_keys
+  #   # => {:name=>"Rob", :age=>"28"}
+  def symbolize_keys: () -> untyped
+
+  alias to_options symbolize_keys
+
+  # Destructively converts all keys to symbols, as long as they respond
+  # to +to_sym+. Same as +symbolize_keys+, but modifies +self+.
+  def symbolize_keys!: () -> untyped
+
+  alias to_options! symbolize_keys!
+
+  # Validates all keys in a hash match <tt>*valid_keys</tt>, raising
+  # +ArgumentError+ on a mismatch.
+  #
+  # Note that keys are treated differently than HashWithIndifferentAccess,
+  # meaning that string and symbol keys will not match.
+  #
+  #   { name: 'Rob', years: '28' }.assert_valid_keys(:name, :age) # => raises "ArgumentError: Unknown key: :years. Valid keys are: :name, :age"
+  #   { name: 'Rob', age: '28' }.assert_valid_keys('name', 'age') # => raises "ArgumentError: Unknown key: :name. Valid keys are: 'name', 'age'"
+  #   { name: 'Rob', age: '28' }.assert_valid_keys(:name, :age)   # => passes, raises nothing
+  def assert_valid_keys: (*untyped valid_keys) -> untyped
+
+  # Returns a new hash with all keys converted by the block operation.
+  # This includes the keys from the root hash and from all
+  # nested hashes and arrays.
+  #
+  #  hash = { person: { name: 'Rob', age: '28' } }
+  #
+  #  hash.deep_transform_keys{ |key| key.to_s.upcase }
+  #  # => {"PERSON"=>{"NAME"=>"Rob", "AGE"=>"28"}}
+  def deep_transform_keys: () { () -> untyped } -> untyped
+
+  # Destructively converts all keys by using the block operation.
+  # This includes the keys from the root hash and from all
+  # nested hashes and arrays.
+  def deep_transform_keys!: () { () -> untyped } -> untyped
+
+  # Returns a new hash with all keys converted to strings.
+  # This includes the keys from the root hash and from all
+  # nested hashes and arrays.
+  #
+  #   hash = { person: { name: 'Rob', age: '28' } }
+  #
+  #   hash.deep_stringify_keys
+  #   # => {"person"=>{"name"=>"Rob", "age"=>"28"}}
+  def deep_stringify_keys: () -> untyped
+
+  # Destructively converts all keys to strings.
+  # This includes the keys from the root hash and from all
+  # nested hashes and arrays.
+  def deep_stringify_keys!: () -> untyped
+
+  # Returns a new hash with all keys converted to symbols, as long as
+  # they respond to +to_sym+. This includes the keys from the root hash
+  # and from all nested hashes and arrays.
+  #
+  #   hash = { 'person' => { 'name' => 'Rob', 'age' => '28' } }
+  #
+  #   hash.deep_symbolize_keys
+  #   # => {:person=>{:name=>"Rob", :age=>"28"}}
+  def deep_symbolize_keys: () -> untyped
+
+  # Destructively converts all keys to symbols, as long as they respond
+  # to +to_sym+. This includes the keys from the root hash and from all
+  # nested hashes and arrays.
+  def deep_symbolize_keys!: () -> untyped
+
+  # support methods for deep transforming nested hashes and arrays
+  def _deep_transform_keys_in_object: (untyped object) { (untyped) -> untyped } -> untyped
+
+  def _deep_transform_keys_in_object!: (untyped object) { (untyped) -> untyped } -> untyped
+end
+
+class Hash[unchecked out K, unchecked out V]
+  # Merges the caller into +other_hash+. For example,
+  #
+  #   options = options.reverse_merge(size: 25, velocity: 10)
+  #
+  # is equivalent to
+  #
+  #   options = { size: 25, velocity: 10 }.merge(options)
+  #
+  # This is particularly useful for initializing an options hash
+  # with default values.
+  def reverse_merge: (untyped other_hash) -> untyped
+
+  alias with_defaults reverse_merge
+
+  # Destructive +reverse_merge+.
+  def reverse_merge!: (untyped other_hash) -> untyped
+
+  alias reverse_update reverse_merge!
+
+  alias with_defaults! reverse_merge!
+end
+
+class Hash[unchecked out K, unchecked out V]
+  # Replaces the hash with only the given keys.
+  # Returns a hash containing the removed key/value pairs.
+  #
+  #   hash = { a: 1, b: 2, c: 3, d: 4 }
+  #   hash.slice!(:a, :b)  # => {:c=>3, :d=>4}
+  #   hash                 # => {:a=>1, :b=>2}
+  def slice!: (*untyped keys) -> untyped
+
+  # Removes and returns the key/value pairs matching the given keys.
+  #
+  #   { a: 1, b: 2, c: 3, d: 4 }.extract!(:a, :b) # => {:a=>1, :b=>2}
+  #   { a: 1, b: 2 }.extract!(:a, :x)             # => {:a=>1}
+  def extract!: (*untyped keys) -> untyped
+end
+
+class Integer
+  # Ordinalize turns a number into an ordinal string used to denote the
+  # position in an ordered sequence such as 1st, 2nd, 3rd, 4th.
+  #
+  #  1.ordinalize     # => "1st"
+  #  2.ordinalize     # => "2nd"
+  #  1002.ordinalize  # => "1002nd"
+  #  1003.ordinalize  # => "1003rd"
+  #  -11.ordinalize   # => "-11th"
+  #  -1001.ordinalize # => "-1001st"
+  def ordinalize: () -> untyped
+
+  # Ordinal returns the suffix used to denote the position
+  # in an ordered sequence such as 1st, 2nd, 3rd, 4th.
+  #
+  #  1.ordinal     # => "st"
+  #  2.ordinal     # => "nd"
+  #  1002.ordinal  # => "nd"
+  #  1003.ordinal  # => "rd"
+  #  -11.ordinal   # => "th"
+  #  -1001.ordinal # => "st"
+  def ordinal: () -> untyped
+end
+
+class Integer
+  # Check whether the integer is evenly divisible by the argument.
+  #
+  #   0.multiple_of?(0)  # => true
+  #   6.multiple_of?(5)  # => false
+  #   10.multiple_of?(2) # => true
+  def multiple_of?: (untyped number) -> untyped
+end
+
+class Integer
+  # Returns a Duration instance matching the number of months provided.
+  #
+  #   2.months # => 2 months
+  def months: () -> untyped
+
+  alias month months
+
+  # Returns a Duration instance matching the number of years provided.
+  #
+  #   2.years # => 2 years
+  def years: () -> untyped
+
+  alias year years
+end
+
+module Kernel
+  # A shortcut to define a toplevel concern, not within a module.
+  #
+  # See Module::Concerning for more.
+  def concern: (untyped topic) { () -> untyped } -> untyped
+end
+
+module Kernel
+  # Sets $VERBOSE to +nil+ for the duration of the block and back to its original
+  # value afterwards.
+  #
+  #   silence_warnings do
+  #     value = noisy_call # no warning voiced
+  #   end
+  #
+  #   noisy_call # warning voiced
+  def silence_warnings: () { () -> untyped } -> untyped
+
+  # Sets $VERBOSE to +true+ for the duration of the block and back to its
+  # original value afterwards.
+  def enable_warnings: () { () -> untyped } -> untyped
+
+  # Sets $VERBOSE for the duration of the block and back to its original
+  # value afterwards.
+  def with_warnings: (untyped flag) { () -> untyped } -> untyped
+
+  # Blocks and ignores any exception passed as argument if raised within the block.
+  #
+  #   suppress(ZeroDivisionError) do
+  #     1/0
+  #     puts 'This code is NOT reached'
+  #   end
+  #
+  #   puts 'This code gets executed and nothing related to ZeroDivisionError was seen'
+  def suppress: (*untyped exception_classes) { () -> untyped } -> untyped
+end
+
+module Kernel
+  # class_eval on an object acts like singleton_class.class_eval.
+  def class_eval: (*untyped args) { () -> untyped } -> untyped
+end
+
+class LoadError
+  # Returns true if the given path name (except perhaps for the ".rb"
+  # extension) is the missing file which caused the exception to be raised.
+  def is_missing?: (untyped location) -> untyped
+end
+
+module ActiveSupport
+  module MarshalWithAutoloading
+    # :nodoc:
+    def load: (untyped source, ?untyped? proc) -> untyped
+  end
+end
+
+class Module
+  # Allows you to make aliases for attributes, which includes
+  # getter, setter, and a predicate.
+  #
+  #   class Content < ActiveRecord::Base
+  #     # has a title attribute
+  #   end
+  #
+  #   class Email < Content
+  #     alias_attribute :subject, :title
+  #   end
+  #
+  #   e = Email.find(1)
+  #   e.title    # => "Superstars"
+  #   e.subject  # => "Superstars"
+  #   e.subject? # => true
+  #   e.subject = "Megastars"
+  #   e.title    # => "Megastars"
+  def alias_attribute: (untyped new_name, untyped old_name) -> untyped
+end
+
+class Module
+  # A module may or may not have a name.
+  #
+  #   module M; end
+  #   M.name # => "M"
+  #
+  #   m = Module.new
+  #   m.name # => nil
+  #
+  # +anonymous?+ method returns true if module does not have a name, false otherwise:
+  #
+  #   Module.new.anonymous? # => true
+  #
+  #   module M; end
+  #   M.anonymous?          # => false
+  #
+  # A module gets a name when it is first assigned to a constant. Either
+  # via the +module+ or +class+ keyword or by an explicit assignment:
+  #
+  #   m = Module.new # creates an anonymous module
+  #   m.anonymous?   # => true
+  #   M = m          # m gets a name here as a side-effect
+  #   m.name         # => "M"
+  #   m.anonymous?   # => false
+  def anonymous?: () -> untyped
+end
+
+class Module
+  # Declares an attribute reader backed by an internally-named instance variable.
+  def attr_internal_reader: (*untyped attrs) -> untyped
+
+  # Declares an attribute writer backed by an internally-named instance variable.
+  def attr_internal_writer: (*untyped attrs) -> untyped
+
+  # Declares an attribute reader and writer backed by an internally-named instance
+  # variable.
+  def attr_internal_accessor: (*untyped attrs) -> untyped
+
+  alias attr_internal attr_internal_accessor
+
+  attr_accessor attr_internal_naming_format: untyped
+
+  def attr_internal_ivar_name: (untyped attr) -> untyped
+
+  def attr_internal_define: (untyped attr_name, untyped `type`) -> untyped
+end
+
+# Extends the module object with class/module and instance accessors for
+# class/module attributes, just like the native attr* accessors for instance
+# attributes.
+class Module
+  # Defines a class attribute and creates a class and instance reader methods.
+  # The underlying class variable is set to +nil+, if it is not previously
+  # defined. All class and instance methods created will be public, even if
+  # this method is called with a private or protected access modifier.
+  #
+  #   module HairColors
+  #     mattr_reader :hair_colors
+  #   end
+  #
+  #   HairColors.hair_colors # => nil
+  #   HairColors.class_variable_set("@@hair_colors", [:brown, :black])
+  #   HairColors.hair_colors # => [:brown, :black]
+  #
+  # The attribute name must be a valid method name in Ruby.
+  #
+  #   module Foo
+  #     mattr_reader :"1_Badname"
+  #   end
+  #   # => NameError: invalid attribute name: 1_Badname
+  #
+  # To omit the instance reader method, pass
+  # <tt>instance_reader: false</tt> or <tt>instance_accessor: false</tt>.
+  #
+  #   module HairColors
+  #     mattr_reader :hair_colors, instance_reader: false
+  #   end
+  #
+  #   class Person
+  #     include HairColors
+  #   end
+  #
+  #   Person.new.hair_colors # => NoMethodError
+  #
+  # You can set a default value for the attribute.
+  #
+  #   module HairColors
+  #     mattr_reader :hair_colors, default: [:brown, :black, :blonde, :red]
+  #   end
+  #
+  #   class Person
+  #     include HairColors
+  #   end
+  #
+  #   Person.new.hair_colors # => [:brown, :black, :blonde, :red]
+  def mattr_reader: (*untyped syms, ?default: untyped? default, ?instance_accessor: bool instance_accessor, ?instance_reader: bool instance_reader) { () -> untyped } -> untyped
+
+  alias cattr_reader mattr_reader
+
+  # Defines a class attribute and creates a class and instance writer methods to
+  # allow assignment to the attribute. All class and instance methods created
+  # will be public, even if this method is called with a private or protected
+  # access modifier.
+  #
+  #   module HairColors
+  #     mattr_writer :hair_colors
+  #   end
+  #
+  #   class Person
+  #     include HairColors
+  #   end
+  #
+  #   HairColors.hair_colors = [:brown, :black]
+  #   Person.class_variable_get("@@hair_colors") # => [:brown, :black]
+  #   Person.new.hair_colors = [:blonde, :red]
+  #   HairColors.class_variable_get("@@hair_colors") # => [:blonde, :red]
+  #
+  # To omit the instance writer method, pass
+  # <tt>instance_writer: false</tt> or <tt>instance_accessor: false</tt>.
+  #
+  #   module HairColors
+  #     mattr_writer :hair_colors, instance_writer: false
+  #   end
+  #
+  #   class Person
+  #     include HairColors
+  #   end
+  #
+  #   Person.new.hair_colors = [:blonde, :red] # => NoMethodError
+  #
+  # You can set a default value for the attribute.
+  #
+  #   module HairColors
+  #     mattr_writer :hair_colors, default: [:brown, :black, :blonde, :red]
+  #   end
+  #
+  #   class Person
+  #     include HairColors
+  #   end
+  #
+  #   Person.class_variable_get("@@hair_colors") # => [:brown, :black, :blonde, :red]
+  def mattr_writer: (*untyped syms, ?default: untyped? default, ?instance_accessor: bool instance_accessor, ?instance_writer: bool instance_writer) { () -> untyped } -> untyped
+
+  alias cattr_writer mattr_writer
+
+  # Defines both class and instance accessors for class attributes.
+  # All class and instance methods created will be public, even if
+  # this method is called with a private or protected access modifier.
+  #
+  #   module HairColors
+  #     mattr_accessor :hair_colors
+  #   end
+  #
+  #   class Person
+  #     include HairColors
+  #   end
+  #
+  #   HairColors.hair_colors = [:brown, :black, :blonde, :red]
+  #   HairColors.hair_colors # => [:brown, :black, :blonde, :red]
+  #   Person.new.hair_colors # => [:brown, :black, :blonde, :red]
+  #
+  # If a subclass changes the value then that would also change the value for
+  # parent class. Similarly if parent class changes the value then that would
+  # change the value of subclasses too.
+  #
+  #   class Citizen < Person
+  #   end
+  #
+  #   Citizen.new.hair_colors << :blue
+  #   Person.new.hair_colors # => [:brown, :black, :blonde, :red, :blue]
+  #
+  # To omit the instance writer method, pass <tt>instance_writer: false</tt>.
+  # To omit the instance reader method, pass <tt>instance_reader: false</tt>.
+  #
+  #   module HairColors
+  #     mattr_accessor :hair_colors, instance_writer: false, instance_reader: false
+  #   end
+  #
+  #   class Person
+  #     include HairColors
+  #   end
+  #
+  #   Person.new.hair_colors = [:brown]  # => NoMethodError
+  #   Person.new.hair_colors             # => NoMethodError
+  #
+  # Or pass <tt>instance_accessor: false</tt>, to omit both instance methods.
+  #
+  #   module HairColors
+  #     mattr_accessor :hair_colors, instance_accessor: false
+  #   end
+  #
+  #   class Person
+  #     include HairColors
+  #   end
+  #
+  #   Person.new.hair_colors = [:brown]  # => NoMethodError
+  #   Person.new.hair_colors             # => NoMethodError
+  #
+  # You can set a default value for the attribute.
+  #
+  #   module HairColors
+  #     mattr_accessor :hair_colors, default: [:brown, :black, :blonde, :red]
+  #   end
+  #
+  #   class Person
+  #     include HairColors
+  #   end
+  #
+  #   Person.class_variable_get("@@hair_colors") # => [:brown, :black, :blonde, :red]
+  def mattr_accessor: (*untyped syms, ?default: untyped? default, ?instance_accessor: bool instance_accessor, ?instance_writer: bool instance_writer, ?instance_reader: bool instance_reader) { () -> untyped } -> untyped
+
+  alias cattr_accessor mattr_accessor
+end
+
+# Extends the module object with class/module and instance accessors for
+# class/module attributes, just like the native attr* accessors for instance
+# attributes, but does so on a per-thread basis.
+#
+# So the values are scoped within the Thread.current space under the class name
+# of the module.
+class Module
+  def thread_mattr_reader: (*untyped syms, ?instance_accessor: bool instance_accessor, ?instance_reader: bool instance_reader) -> untyped
+
+  alias thread_cattr_reader thread_mattr_reader
+
+  def thread_mattr_writer: (*untyped syms, ?instance_accessor: bool instance_accessor, ?instance_writer: bool instance_writer) -> untyped
+
+  alias thread_cattr_writer thread_mattr_writer
+
+  # Defines both class and instance accessors for class attributes.
+  #
+  #   class Account
+  #     thread_mattr_accessor :user
+  #   end
+  #
+  #   Account.user = "DHH"
+  #   Account.user     # => "DHH"
+  #   Account.new.user # => "DHH"
+  #
+  # If a subclass changes the value, the parent class' value is not changed.
+  # Similarly, if the parent class changes the value, the value of subclasses
+  # is not changed.
+  #
+  #   class Customer < Account
+  #   end
+  #
+  #   Customer.user = "Rafael"
+  #   Customer.user # => "Rafael"
+  #   Account.user  # => "DHH"
+  #
+  # To omit the instance writer method, pass <tt>instance_writer: false</tt>.
+  # To omit the instance reader method, pass <tt>instance_reader: false</tt>.
+  #
+  #   class Current
+  #     thread_mattr_accessor :user, instance_writer: false, instance_reader: false
+  #   end
+  #
+  #   Current.new.user = "DHH"  # => NoMethodError
+  #   Current.new.user          # => NoMethodError
+  #
+  # Or pass <tt>instance_accessor: false</tt>, to omit both instance methods.
+  #
+  #   class Current
+  #     thread_mattr_accessor :user, instance_accessor: false
+  #   end
+  #
+  #   Current.new.user = "DHH"  # => NoMethodError
+  #   Current.new.user          # => NoMethodError
+  def thread_mattr_accessor: (*untyped syms, ?instance_accessor: bool instance_accessor, ?instance_writer: bool instance_writer, ?instance_reader: bool instance_reader) -> untyped
+
+  alias thread_cattr_accessor thread_mattr_accessor
+end
+
+class Module
+  # = Bite-sized separation of concerns
+  #
+  # We often find ourselves with a medium-sized chunk of behavior that we'd
+  # like to extract, but only mix in to a single class.
+  #
+  # Extracting a plain old Ruby object to encapsulate it and collaborate or
+  # delegate to the original object is often a good choice, but when there's
+  # no additional state to encapsulate or we're making DSL-style declarations
+  # about the parent class, introducing new collaborators can obfuscate rather
+  # than simplify.
+  #
+  # The typical route is to just dump everything in a monolithic class, perhaps
+  # with a comment, as a least-bad alternative. Using modules in separate files
+  # means tedious sifting to get a big-picture view.
+  #
+  # = Dissatisfying ways to separate small concerns
+  #
+  # == Using comments:
+  #
+  #   class Todo < ApplicationRecord
+  #     # Other todo implementation
+  #     # ...
+  #
+  #     ## Event tracking
+  #     has_many :events
+  #
+  #     before_create :track_creation
+  #
+  #     private
+  #       def track_creation
+  #         # ...
+  #       end
+  #   end
+  #
+  # == With an inline module:
+  #
+  # Noisy syntax.
+  #
+  #   class Todo < ApplicationRecord
+  #     # Other todo implementation
+  #     # ...
+  #
+  #     module EventTracking
+  #       extend ActiveSupport::Concern
+  #
+  #       included do
+  #         has_many :events
+  #         before_create :track_creation
+  #       end
+  #
+  #       private
+  #         def track_creation
+  #           # ...
+  #         end
+  #     end
+  #     include EventTracking
+  #   end
+  #
+  # == Mix-in noise exiled to its own file:
+  #
+  # Once our chunk of behavior starts pushing the scroll-to-understand-it
+  # boundary, we give in and move it to a separate file. At this size, the
+  # increased overhead can be a reasonable tradeoff even if it reduces our
+  # at-a-glance perception of how things work.
+  #
+  #   class Todo < ApplicationRecord
+  #     # Other todo implementation
+  #     # ...
+  #
+  #     include TodoEventTracking
+  #   end
+  #
+  # = Introducing Module#concerning
+  #
+  # By quieting the mix-in noise, we arrive at a natural, low-ceremony way to
+  # separate bite-sized concerns.
+  #
+  #   class Todo < ApplicationRecord
+  #     # Other todo implementation
+  #     # ...
+  #
+  #     concerning :EventTracking do
+  #       included do
+  #         has_many :events
+  #         before_create :track_creation
+  #       end
+  #
+  #       private
+  #         def track_creation
+  #           # ...
+  #         end
+  #     end
+  #   end
+  #
+  #   Todo.ancestors
+  #   # => [Todo, Todo::EventTracking, ApplicationRecord, Object]
+  #
+  # This small step has some wonderful ripple effects. We can
+  # * grok the behavior of our class in one glance,
+  # * clean up monolithic junk-drawer classes by separating their concerns, and
+  # * stop leaning on protected/private for crude "this is internal stuff" modularity.
+  module Concerning
+    # Define a new concern and mix it in.
+    def concerning: (untyped topic) { () -> untyped } -> untyped
+
+    # A low-cruft shortcut to define a concern.
+    #
+    #   concern :EventTracking do
+    #     ...
+    #   end
+    #
+    # is equivalent to
+    #
+    #   module EventTracking
+    #     extend ActiveSupport::Concern
+    #
+    #     ...
+    #   end
+    def concern: (untyped topic) { () -> untyped } -> untyped
+  end
+
+  include Concerning
+end
+
+class Module
+  # Error generated by +delegate+ when a method is called on +nil+ and +allow_nil+
+  # option is not used.
+  class DelegationError[T] < NoMethodError[T]
+  end
+
+  RUBY_RESERVED_KEYWORDS: ::Array[untyped]
+
+  DELEGATION_RESERVED_KEYWORDS: ::Array[untyped]
+
+  DELEGATION_RESERVED_METHOD_NAMES: untyped
+
+  # Provides a +delegate+ class method to easily expose contained objects'
+  # public methods as your own.
+  #
+  # ==== Options
+  # * <tt>:to</tt> - Specifies the target object name as a symbol or string
+  # * <tt>:prefix</tt> - Prefixes the new method with the target name or a custom prefix
+  # * <tt>:allow_nil</tt> - If set to true, prevents a +Module::DelegationError+
+  #   from being raised
+  # * <tt>:private</tt> - If set to true, changes method visibility to private
+  #
+  # The macro receives one or more method names (specified as symbols or
+  # strings) and the name of the target object via the <tt>:to</tt> option
+  # (also a symbol or string).
+  #
+  # Delegation is particularly useful with Active Record associations:
+  #
+  #   class Greeter < ActiveRecord::Base
+  #     def hello
+  #       'hello'
+  #     end
+  #
+  #     def goodbye
+  #       'goodbye'
+  #     end
+  #   end
+  #
+  #   class Foo < ActiveRecord::Base
+  #     belongs_to :greeter
+  #     delegate :hello, to: :greeter
+  #   end
+  #
+  #   Foo.new.hello   # => "hello"
+  #   Foo.new.goodbye # => NoMethodError: undefined method `goodbye' for #<Foo:0x1af30c>
+  #
+  # Multiple delegates to the same target are allowed:
+  #
+  #   class Foo < ActiveRecord::Base
+  #     belongs_to :greeter
+  #     delegate :hello, :goodbye, to: :greeter
+  #   end
+  #
+  #   Foo.new.goodbye # => "goodbye"
+  #
+  # Methods can be delegated to instance variables, class variables, or constants
+  # by providing them as a symbols:
+  #
+  #   class Foo
+  #     CONSTANT_ARRAY = [0,1,2,3]
+  #     @@class_array  = [4,5,6,7]
+  #
+  #     def initialize
+  #       @instance_array = [8,9,10,11]
+  #     end
+  #     delegate :sum, to: :CONSTANT_ARRAY
+  #     delegate :min, to: :@@class_array
+  #     delegate :max, to: :@instance_array
+  #   end
+  #
+  #   Foo.new.sum # => 6
+  #   Foo.new.min # => 4
+  #   Foo.new.max # => 11
+  #
+  # It's also possible to delegate a method to the class by using +:class+:
+  #
+  #   class Foo
+  #     def self.hello
+  #       "world"
+  #     end
+  #
+  #     delegate :hello, to: :class
+  #   end
+  #
+  #   Foo.new.hello # => "world"
+  #
+  # Delegates can optionally be prefixed using the <tt>:prefix</tt> option. If the value
+  # is <tt>true</tt>, the delegate methods are prefixed with the name of the object being
+  # delegated to.
+  #
+  #   Person = Struct.new(:name, :address)
+  #
+  #   class Invoice < Struct.new(:client)
+  #     delegate :name, :address, to: :client, prefix: true
+  #   end
+  #
+  #   john_doe = Person.new('John Doe', 'Vimmersvej 13')
+  #   invoice = Invoice.new(john_doe)
+  #   invoice.client_name    # => "John Doe"
+  #   invoice.client_address # => "Vimmersvej 13"
+  #
+  # It is also possible to supply a custom prefix.
+  #
+  #   class Invoice < Struct.new(:client)
+  #     delegate :name, :address, to: :client, prefix: :customer
+  #   end
+  #
+  #   invoice = Invoice.new(john_doe)
+  #   invoice.customer_name    # => 'John Doe'
+  #   invoice.customer_address # => 'Vimmersvej 13'
+  #
+  # The delegated methods are public by default.
+  # Pass <tt>private: true</tt> to change that.
+  #
+  #   class User < ActiveRecord::Base
+  #     has_one :profile
+  #     delegate :first_name, to: :profile
+  #     delegate :date_of_birth, to: :profile, private: true
+  #
+  #     def age
+  #       Date.today.year - date_of_birth.year
+  #     end
+  #   end
+  #
+  #   User.new.first_name # => "Tomas"
+  #   User.new.date_of_birth # => NoMethodError: private method `date_of_birth' called for #<User:0x00000008221340>
+  #   User.new.age # => 2
+  #
+  # If the target is +nil+ and does not respond to the delegated method a
+  # +Module::DelegationError+ is raised. If you wish to instead return +nil+,
+  # use the <tt>:allow_nil</tt> option.
+  #
+  #   class User < ActiveRecord::Base
+  #     has_one :profile
+  #     delegate :age, to: :profile
+  #   end
+  #
+  #   User.new.age
+  #   # => Module::DelegationError: User#age delegated to profile.age, but profile is nil
+  #
+  # But if not having a profile yet is fine and should not be an error
+  # condition:
+  #
+  #   class User < ActiveRecord::Base
+  #     has_one :profile
+  #     delegate :age, to: :profile, allow_nil: true
+  #   end
+  #
+  #   User.new.age # nil
+  #
+  # Note that if the target is not +nil+ then the call is attempted regardless of the
+  # <tt>:allow_nil</tt> option, and thus an exception is still raised if said object
+  # does not respond to the method:
+  #
+  #   class Foo
+  #     def initialize(bar)
+  #       @bar = bar
+  #     end
+  #
+  #     delegate :name, to: :@bar, allow_nil: true
+  #   end
+  #
+  #   Foo.new("Bar").name # raises NoMethodError: undefined method `name'
+  #
+  # The target method must be public, otherwise it will raise +NoMethodError+.
+  def delegate: (*untyped methods, ?private: untyped? `private`, ?allow_nil: untyped? allow_nil, ?prefix: untyped? prefix, ?to: untyped? to) -> untyped
+
+  # When building decorators, a common pattern may emerge:
+  #
+  #   class Partition
+  #     def initialize(event)
+  #       @event = event
+  #     end
+  #
+  #     def person
+  #       detail.person || creator
+  #     end
+  #
+  #     private
+  #       def respond_to_missing?(name, include_private = false)
+  #         @event.respond_to?(name, include_private)
+  #       end
+  #
+  #       def method_missing(method, *args, &block)
+  #         @event.send(method, *args, &block)
+  #       end
+  #   end
+  #
+  # With <tt>Module#delegate_missing_to</tt>, the above is condensed to:
+  #
+  #   class Partition
+  #     delegate_missing_to :@event
+  #
+  #     def initialize(event)
+  #       @event = event
+  #     end
+  #
+  #     def person
+  #       detail.person || creator
+  #     end
+  #   end
+  #
+  # The target can be anything callable within the object, e.g. instance
+  # variables, methods, constants, etc.
+  #
+  # The delegated method must be public on the target, otherwise it will
+  # raise +NoMethodError+.
+  #
+  # The <tt>marshal_dump</tt> and <tt>_dump</tt> methods are exempt from
+  # delegation due to possible interference when calling
+  # <tt>Marshal.dump(object)</tt>, should the delegation target method
+  # of <tt>object</tt> add or remove instance variables.
+  def delegate_missing_to: (untyped target) -> untyped
+end
+
+class Module
+  #   deprecate :foo
+  #   deprecate bar: 'message'
+  #   deprecate :foo, :bar, baz: 'warning!', qux: 'gone!'
+  #
+  # You can also use custom deprecator instance:
+  #
+  #   deprecate :foo, deprecator: MyLib::Deprecator.new
+  #   deprecate :foo, bar: "warning!", deprecator: MyLib::Deprecator.new
+  #
+  # \Custom deprecators must respond to <tt>deprecation_warning(deprecated_method_name, message, caller_backtrace)</tt>
+  # method where you can implement your custom warning behavior.
+  #
+  #   class MyLib::Deprecator
+  #     def deprecation_warning(deprecated_method_name, message, caller_backtrace = nil)
+  #       message = "#{deprecated_method_name} is deprecated and will be removed from MyLibrary | #{message}"
+  #       Kernel.warn message
+  #     end
+  #   end
+  def deprecate: (*untyped method_names) -> untyped
+end
+
+class Module
+  # Returns the name of the module containing this one.
+  #
+  #   M::N.module_parent_name # => "M"
+  def module_parent_name: () -> untyped
+
+  def parent_name: () -> untyped
+
+  # Returns the module which contains this one according to its name.
+  #
+  #   module M
+  #     module N
+  #     end
+  #   end
+  #   X = M::N
+  #
+  #   M::N.module_parent # => M
+  #   X.module_parent    # => M
+  #
+  # The parent of top-level and anonymous modules is Object.
+  #
+  #   M.module_parent          # => Object
+  #   Module.new.module_parent # => Object
+  def module_parent: () -> untyped
+
+  def parent: () -> untyped
+
+  # Returns all the parents of this module according to its name, ordered from
+  # nested outwards. The receiver is not contained within the result.
+  #
+  #   module M
+  #     module N
+  #     end
+  #   end
+  #   X = M::N
+  #
+  #   M.module_parents    # => [Object]
+  #   M::N.module_parents # => [M, Object]
+  #   X.module_parents    # => [M, Object]
+  def module_parents: () -> untyped
+
+  def parents: () -> untyped
+end
+
+class Module
+  # Marks the named method as intended to be redefined, if it exists.
+  # Suppresses the Ruby method redefinition warning. Prefer
+  # #redefine_method where possible.
+  def silence_redefinition_of_method: (untyped method) -> untyped
+
+  # Replaces the existing method definition, if there is one, with the passed
+  # block as its body.
+  def redefine_method: (untyped method) { () -> untyped } -> untyped
+
+  # Replaces the existing singleton method definition, if there is one, with
+  # the passed block as its body.
+  def redefine_singleton_method: (untyped method) { () -> untyped } -> untyped
+
+  def method_visibility: (untyped method) -> untyped
+end
+
+class Module
+  # Removes the named method, if it exists.
+  def remove_possible_method: (untyped method) -> untyped
+
+  # Removes the named singleton method, if it exists.
+  def remove_possible_singleton_method: (untyped method) -> untyped
+end
+
+class NameError[T]
+  # Extract the name of the missing constant from the exception message.
+  #
+  #   begin
+  #     HelloWorld
+  #   rescue NameError => e
+  #     e.missing_name
+  #   end
+  #   # => "HelloWorld"
+  def missing_name: () -> untyped
+
+  # Was this exception raised because the given name was missing?
+  #
+  #   begin
+  #     HelloWorld
+  #   rescue NameError => e
+  #     e.missing_name?("HelloWorld")
+  #   end
+  #   # => true
+  def missing_name?: (untyped name) -> untyped
+end
+
+class Numeric
+  KILOBYTE: ::Integer
+
+  MEGABYTE: untyped
+
+  GIGABYTE: untyped
+
+  TERABYTE: untyped
+
+  PETABYTE: untyped
+
+  EXABYTE: untyped
+
+  # Enables the use of byte calculations and declarations, like 45.bytes + 2.6.megabytes
+  #
+  #   2.bytes # => 2
+  def bytes: () -> untyped
+
+  alias byte bytes
+
+  # Returns the number of bytes equivalent to the kilobytes provided.
+  #
+  #   2.kilobytes # => 2048
+  def kilobytes: () -> untyped
+
+  alias kilobyte kilobytes
+
+  # Returns the number of bytes equivalent to the megabytes provided.
+  #
+  #   2.megabytes # => 2_097_152
+  def megabytes: () -> untyped
+
+  alias megabyte megabytes
+
+  # Returns the number of bytes equivalent to the gigabytes provided.
+  #
+  #   2.gigabytes # => 2_147_483_648
+  def gigabytes: () -> untyped
+
+  alias gigabyte gigabytes
+
+  # Returns the number of bytes equivalent to the terabytes provided.
+  #
+  #   2.terabytes # => 2_199_023_255_552
+  def terabytes: () -> untyped
+
+  alias terabyte terabytes
+
+  # Returns the number of bytes equivalent to the petabytes provided.
+  #
+  #   2.petabytes # => 2_251_799_813_685_248
+  def petabytes: () -> untyped
+
+  alias petabyte petabytes
+
+  # Returns the number of bytes equivalent to the exabytes provided.
+  #
+  #   2.exabytes # => 2_305_843_009_213_693_952
+  def exabytes: () -> untyped
+
+  alias exabyte exabytes
+end
+
+module ActiveSupport
+  module NumericWithFormat
+    # Provides options for converting numbers into formatted strings.
+    # Options are provided for phone numbers, currency, percentage,
+    # precision, positional notation, file size and pretty printing.
+    #
+    # ==== Options
+    #
+    # For details on which formats use which options, see ActiveSupport::NumberHelper
+    #
+    # ==== Examples
+    #
+    #  Phone Numbers:
+    #  5551234.to_s(:phone)                                     # => "555-1234"
+    #  1235551234.to_s(:phone)                                  # => "123-555-1234"
+    #  1235551234.to_s(:phone, area_code: true)                 # => "(123) 555-1234"
+    #  1235551234.to_s(:phone, delimiter: ' ')                  # => "123 555 1234"
+    #  1235551234.to_s(:phone, area_code: true, extension: 555) # => "(123) 555-1234 x 555"
+    #  1235551234.to_s(:phone, country_code: 1)                 # => "+1-123-555-1234"
+    #  1235551234.to_s(:phone, country_code: 1, extension: 1343, delimiter: '.')
+    #  # => "+1.123.555.1234 x 1343"
+    #
+    #  Currency:
+    #  1234567890.50.to_s(:currency)                 # => "$1,234,567,890.50"
+    #  1234567890.506.to_s(:currency)                # => "$1,234,567,890.51"
+    #  1234567890.506.to_s(:currency, precision: 3)  # => "$1,234,567,890.506"
+    #  1234567890.506.to_s(:currency, locale: :fr)   # => "1 234 567 890,51 (trim non-ascii characters)"
+    #  -1234567890.50.to_s(:currency, negative_format: '(%u%n)')
+    #  # => "($1,234,567,890.50)"
+    #  1234567890.50.to_s(:currency, unit: '&pound;', separator: ',', delimiter: '')
+    #  # => "&pound;1234567890,50"
+    #  1234567890.50.to_s(:currency, unit: '&pound;', separator: ',', delimiter: '', format: '%n %u')
+    #  # => "1234567890,50 &pound;"
+    #
+    #  Percentage:
+    #  100.to_s(:percentage)                                  # => "100.000%"
+    #  100.to_s(:percentage, precision: 0)                    # => "100%"
+    #  1000.to_s(:percentage, delimiter: '.', separator: ',') # => "1.000,000%"
+    #  302.24398923423.to_s(:percentage, precision: 5)        # => "302.24399%"
+    #  1000.to_s(:percentage, locale: :fr)                    # => "1 000,000%"
+    #  100.to_s(:percentage, format: '%n  %')                 # => "100.000  %"
+    #
+    #  Delimited:
+    #  12345678.to_s(:delimited)                     # => "12,345,678"
+    #  12345678.05.to_s(:delimited)                  # => "12,345,678.05"
+    #  12345678.to_s(:delimited, delimiter: '.')     # => "12.345.678"
+    #  12345678.to_s(:delimited, delimiter: ',')     # => "12,345,678"
+    #  12345678.05.to_s(:delimited, separator: ' ')  # => "12,345,678 05"
+    #  12345678.05.to_s(:delimited, locale: :fr)     # => "12 345 678,05"
+    #  98765432.98.to_s(:delimited, delimiter: ' ', separator: ',')
+    #  # => "98 765 432,98"
+    #
+    #  Rounded:
+    #  111.2345.to_s(:rounded)                                      # => "111.235"
+    #  111.2345.to_s(:rounded, precision: 2)                        # => "111.23"
+    #  13.to_s(:rounded, precision: 5)                              # => "13.00000"
+    #  389.32314.to_s(:rounded, precision: 0)                       # => "389"
+    #  111.2345.to_s(:rounded, significant: true)                   # => "111"
+    #  111.2345.to_s(:rounded, precision: 1, significant: true)     # => "100"
+    #  13.to_s(:rounded, precision: 5, significant: true)           # => "13.000"
+    #  111.234.to_s(:rounded, locale: :fr)                          # => "111,234"
+    #  13.to_s(:rounded, precision: 5, significant: true, strip_insignificant_zeros: true)
+    #  # => "13"
+    #  389.32314.to_s(:rounded, precision: 4, significant: true)    # => "389.3"
+    #  1111.2345.to_s(:rounded, precision: 2, separator: ',', delimiter: '.')
+    #  # => "1.111,23"
+    #
+    #  Human-friendly size in Bytes:
+    #  123.to_s(:human_size)                                   # => "123 Bytes"
+    #  1234.to_s(:human_size)                                  # => "1.21 KB"
+    #  12345.to_s(:human_size)                                 # => "12.1 KB"
+    #  1234567.to_s(:human_size)                               # => "1.18 MB"
+    #  1234567890.to_s(:human_size)                            # => "1.15 GB"
+    #  1234567890123.to_s(:human_size)                         # => "1.12 TB"
+    #  1234567890123456.to_s(:human_size)                      # => "1.1 PB"
+    #  1234567890123456789.to_s(:human_size)                   # => "1.07 EB"
+    #  1234567.to_s(:human_size, precision: 2)                 # => "1.2 MB"
+    #  483989.to_s(:human_size, precision: 2)                  # => "470 KB"
+    #  1234567.to_s(:human_size, precision: 2, separator: ',') # => "1,2 MB"
+    #  1234567890123.to_s(:human_size, precision: 5)           # => "1.1228 TB"
+    #  524288000.to_s(:human_size, precision: 5)               # => "500 MB"
+    #
+    #  Human-friendly format:
+    #  123.to_s(:human)                                       # => "123"
+    #  1234.to_s(:human)                                      # => "1.23 Thousand"
+    #  12345.to_s(:human)                                     # => "12.3 Thousand"
+    #  1234567.to_s(:human)                                   # => "1.23 Million"
+    #  1234567890.to_s(:human)                                # => "1.23 Billion"
+    #  1234567890123.to_s(:human)                             # => "1.23 Trillion"
+    #  1234567890123456.to_s(:human)                          # => "1.23 Quadrillion"
+    #  1234567890123456789.to_s(:human)                       # => "1230 Quadrillion"
+    #  489939.to_s(:human, precision: 2)                      # => "490 Thousand"
+    #  489939.to_s(:human, precision: 4)                      # => "489.9 Thousand"
+    #  1234567.to_s(:human, precision: 4,
+    #                   significant: false)                   # => "1.2346 Million"
+    #  1234567.to_s(:human, precision: 1,
+    #                   separator: ',',
+    #                   significant: false)                   # => "1,2 Million"
+    def to_s: (?untyped? format, ?untyped? options) -> untyped
+  end
+end
+
+class Numeric
+  # Returns a Duration instance matching the number of seconds provided.
+  #
+  #   2.seconds # => 2 seconds
+  def seconds: () -> untyped
+
+  alias second seconds
+
+  # Returns a Duration instance matching the number of minutes provided.
+  #
+  #   2.minutes # => 2 minutes
+  def minutes: () -> untyped
+
+  alias minute minutes
+
+  # Returns a Duration instance matching the number of hours provided.
+  #
+  #   2.hours # => 2 hours
+  def hours: () -> untyped
+
+  alias hour hours
+
+  # Returns a Duration instance matching the number of days provided.
+  #
+  #   2.days # => 2 days
+  def days: () -> untyped
+
+  alias day days
+
+  # Returns a Duration instance matching the number of weeks provided.
+  #
+  #   2.weeks # => 2 weeks
+  def weeks: () -> untyped
+
+  alias week weeks
+
+  # Returns a Duration instance matching the number of fortnights provided.
+  #
+  #   2.fortnights # => 4 weeks
+  def fortnights: () -> untyped
+
+  alias fortnight fortnights
+
+  # Returns the number of milliseconds equivalent to the seconds provided.
+  # Used with the standard time durations.
+  #
+  #   2.in_milliseconds # => 2000
+  #   1.hour.in_milliseconds # => 3600000
+  def in_milliseconds: () -> untyped
+end
+
+class Object
+  # A duck-type assistant method. For example, Active Support extends Date
+  # to define an <tt>acts_like_date?</tt> method, and extends Time to define
+  # <tt>acts_like_time?</tt>. As a result, we can do <tt>x.acts_like?(:time)</tt> and
+  # <tt>x.acts_like?(:date)</tt> to do duck-type-safe comparisons, since classes that
+  # we want to act like Time simply need to define an <tt>acts_like_time?</tt> method.
+  def acts_like?: (untyped duck) -> untyped
+end
+
+class Object
+  # An object is blank if it's false, empty, or a whitespace string.
+  # For example, +nil+, '', '   ', [], {}, and +false+ are all blank.
+  #
+  # This simplifies
+  #
+  #   !address || address.empty?
+  #
+  # to
+  #
+  #   address.blank?
+  #
+  # @return [true, false]
+  def blank?: () -> untyped
+
+  # An object is present if it's not blank.
+  #
+  # @return [true, false]
+  def present?: () -> untyped
+
+  # Returns the receiver if it's present otherwise returns +nil+.
+  # <tt>object.presence</tt> is equivalent to
+  #
+  #    object.present? ? object : nil
+  #
+  # For example, something like
+  #
+  #   state   = params[:state]   if params[:state].present?
+  #   country = params[:country] if params[:country].present?
+  #   region  = state || country || 'US'
+  #
+  # becomes
+  #
+  #   region = params[:state].presence || params[:country].presence || 'US'
+  #
+  # @return [Object]
+  def presence: () -> untyped
+end
+
+class NilClass
+  # +nil+ is blank:
+  #
+  #   nil.blank? # => true
+  #
+  # @return [true]
+  def blank?: () -> ::TrueClass
+end
+
+class FalseClass
+  # +false+ is blank:
+  #
+  #   false.blank? # => true
+  #
+  # @return [true]
+  def blank?: () -> ::TrueClass
+end
+
+class TrueClass
+  # +true+ is not blank:
+  #
+  #   true.blank? # => false
+  #
+  # @return [false]
+  def blank?: () -> ::FalseClass
+end
+
+class Array[unchecked out Elem]
+  # An array is blank if it's empty:
+  #
+  #   [].blank?      # => true
+  #   [1,2,3].blank? # => false
+  #
+  # @return [true, false]
+  alias blank? empty?
+end
+
+class Hash[unchecked out K, unchecked out V]
+  # A hash is blank if it's empty:
+  #
+  #   {}.blank?                # => true
+  #   { key: 'value' }.blank?  # => false
+  #
+  # @return [true, false]
+  alias blank? empty?
+end
+
+class String
+  BLANK_RE: untyped
+
+  ENCODED_BLANKS: untyped
+
+  # A string is blank if it's empty or contains whitespaces only:
+  #
+  #   ''.blank?       # => true
+  #   '   '.blank?    # => true
+  #   "\t\n\r".blank? # => true
+  #   ' blah '.blank? # => false
+  #
+  # Unicode whitespace is supported:
+  #
+  #   "\u00a0".blank? # => true
+  #
+  # @return [true, false]
+  def blank?: () -> untyped
+end
+
+class Numeric
+  # nodoc:
+  # No number is blank:
+  #
+  #   1.blank? # => false
+  #   0.blank? # => false
+  #
+  # @return [false]
+  def blank?: () -> ::FalseClass
+end
+
+class Time
+  # nodoc:
+  # No Time is blank:
+  #
+  #   Time.now.blank? # => false
+  #
+  # @return [false]
+  def blank?: () -> ::FalseClass
+end
+
+class Object
+  # Returns a deep copy of object if it's duplicable. If it's
+  # not duplicable, returns +self+.
+  #
+  #   object = Object.new
+  #   dup    = object.deep_dup
+  #   dup.instance_variable_set(:@a, 1)
+  #
+  #   object.instance_variable_defined?(:@a) # => false
+  #   dup.instance_variable_defined?(:@a)    # => true
+  def deep_dup: () -> untyped
+end
+
+class Array[unchecked out Elem]
+  # Returns a deep copy of array.
+  #
+  #   array = [1, [2, 3]]
+  #   dup   = array.deep_dup
+  #   dup[1][2] = 4
+  #
+  #   array[1][2] # => nil
+  #   dup[1][2]   # => 4
+  def deep_dup: () -> untyped
+end
+
+class Hash[unchecked out K, unchecked out V]
+  # Returns a deep copy of hash.
+  #
+  #   hash = { a: { b: 'b' } }
+  #   dup  = hash.deep_dup
+  #   dup[:a][:c] = 'c'
+  #
+  #   hash[:a][:c] # => nil
+  #   dup[:a][:c]  # => "c"
+  def deep_dup: () -> untyped
+end
+
+# -
+# Most objects are cloneable, but not all. For example you can't dup methods:
+#
+#   method(:puts).dup # => TypeError: allocator undefined for Method
+#
+# Classes may signal their instances are not duplicable removing +dup+/+clone+
+# or raising exceptions from them. So, to dup an arbitrary object you normally
+# use an optimistic approach and are ready to catch an exception, say:
+#
+#   arbitrary_object.dup rescue object
+#
+# Rails dups objects in a few critical spots where they are not that arbitrary.
+# That rescue is very expensive (like 40 times slower than a predicate), and it
+# is often triggered.
+#
+# That's why we hardcode the following cases and check duplicable? instead of
+# using that rescue idiom.
+# +
+class Object
+  # Can you safely dup this object?
+  #
+  # False for method objects;
+  # true otherwise.
+  def duplicable?: () -> ::TrueClass
+end
+
+class Method
+  # Methods are not duplicable:
+  #
+  #  method(:puts).duplicable? # => false
+  #  method(:puts).dup         # => TypeError: allocator undefined for Method
+  def duplicable?: () -> ::FalseClass
+end
+
+class UnboundMethod
+  # Unbound methods are not duplicable:
+  #
+  #  method(:puts).unbind.duplicable? # => false
+  #  method(:puts).unbind.dup         # => TypeError: allocator undefined for UnboundMethod
+  def duplicable?: () -> ::FalseClass
+end
+
+class Object
+  # Returns true if this object is included in the argument. Argument must be
+  # any object which responds to +#include?+. Usage:
+  #
+  #   characters = ["Konata", "Kagami", "Tsukasa"]
+  #   "Konata".in?(characters) # => true
+  #
+  # This will throw an +ArgumentError+ if the argument doesn't respond
+  # to +#include?+.
+  def in?: (untyped another_object) -> untyped
+
+  # Returns the receiver if it's included in the argument otherwise returns +nil+.
+  # Argument must be any object which responds to +#include?+. Usage:
+  #
+  #   params[:bucket_type].presence_in %w( project calendar )
+  #
+  # This will throw an +ArgumentError+ if the argument doesn't respond to +#include?+.
+  #
+  # @return [Object]
+  def presence_in: (untyped another_object) -> untyped
+end
+
+class Object
+  # Returns a hash with string keys that maps instance variable names without "@" to their
+  # corresponding values.
+  #
+  #   class C
+  #     def initialize(x, y)
+  #       @x, @y = x, y
+  #     end
+  #   end
+  #
+  #   C.new(0, 1).instance_values # => {"x" => 0, "y" => 1}
+  def instance_values: () -> untyped
+
+  # Returns an array of instance variable names as strings including "@".
+  #
+  #   class C
+  #     def initialize(x, y)
+  #       @x, @y = x, y
+  #     end
+  #   end
+  #
+  #   C.new(0, 1).instance_variable_names # => ["@y", "@x"]
+  def instance_variable_names: () -> untyped
+end
+
+module ActiveSupport
+  module ToJsonWithActiveSupportEncoder
+    # :nodoc:
+    def to_json: (?untyped? options) -> untyped
+  end
+end
+
+class Object
+  def as_json: (?untyped? options) -> untyped
+end
+
+class Struct[Elem]
+  # nodoc:
+  def as_json: (?untyped? options) -> untyped
+end
+
+class TrueClass
+  def as_json: (?untyped? options) -> untyped
+end
+
+class FalseClass
+  def as_json: (?untyped? options) -> untyped
+end
+
+class NilClass
+  def as_json: (?untyped? options) -> untyped
+end
+
+class String
+  def as_json: (?untyped? options) -> untyped
+end
+
+class Symbol
+  def as_json: (?untyped? options) -> untyped
+end
+
+class Numeric
+  def as_json: (?untyped? options) -> untyped
+end
+
+class Float
+  def as_json: (?untyped? options) -> untyped
+end
+
+class BigDecimal
+  def as_json: (?untyped? options) -> untyped
+end
+
+class Regexp
+  def as_json: (?untyped? options) -> untyped
+end
+
+module Enumerable[unchecked out Elem]
+  def as_json: (?untyped? options) -> untyped
+end
+
+class IO
+  def as_json: (?untyped? options) -> untyped
+end
+
+class Range[out Elem]
+  def as_json: (?untyped? options) -> untyped
+end
+
+class Array[unchecked out Elem]
+  def as_json: (?untyped? options) -> untyped
+end
+
+class Hash[unchecked out K, unchecked out V]
+  def as_json: (?untyped? options) -> untyped
+end
+
+class Time
+  def as_json: (?untyped? options) -> untyped
+end
+
+class Date
+  def as_json: (?untyped? options) -> untyped
+end
+
+class DateTime
+  def as_json: (?untyped? options) -> untyped
+end
+
+class URI::Generic
+  # nodoc:
+  def as_json: (?untyped? options) -> untyped
+end
+
+class Pathname
+  # nodoc:
+  def as_json: (?untyped? options) -> untyped
+end
+
+class Process::Status
+  # nodoc:
+  def as_json: (?untyped? options) -> { exitstatus: untyped, pid: untyped }
+end
+
+class Exception
+  def as_json: (?untyped? options) -> untyped
+end
+
+class Object
+  # Alias of <tt>to_s</tt>.
+  def to_param: () -> untyped
+
+  # Converts an object into a string suitable for use as a URL query string,
+  # using the given <tt>key</tt> as the param name.
+  def to_query: (untyped key) -> ::String
+end
+
+class NilClass
+  # Returns +self+.
+  def to_param: () -> untyped
+end
+
+class TrueClass
+  # Returns +self+.
+  def to_param: () -> untyped
+end
+
+class FalseClass
+  # Returns +self+.
+  def to_param: () -> untyped
+end
+
+class Array[unchecked out Elem]
+  # Calls <tt>to_param</tt> on all its elements and joins the result with
+  # slashes. This is used by <tt>url_for</tt> in Action Pack.
+  def to_param: () -> untyped
+
+  # Converts an array into a string suitable for use as a URL query string,
+  # using the given +key+ as the param name.
+  #
+  #   ['Rails', 'coding'].to_query('hobbies') # => "hobbies%5B%5D=Rails&hobbies%5B%5D=coding"
+  def to_query: (untyped key) -> untyped
+end
+
+class Hash[unchecked out K, unchecked out V]
+  # Returns a string representation of the receiver suitable for use as a URL
+  # query string:
+  #
+  #   {name: 'David', nationality: 'Danish'}.to_query
+  #   # => "name=David&nationality=Danish"
+  #
+  # An optional namespace can be passed to enclose key names:
+  #
+  #   {name: 'David', nationality: 'Danish'}.to_query('user')
+  #   # => "user%5Bname%5D=David&user%5Bnationality%5D=Danish"
+  #
+  # The string pairs "key=value" that conform the query string
+  # are sorted lexicographically in ascending order.
+  #
+  # This method is also aliased as +to_param+.
+  def to_query: (?untyped? namespace) -> untyped
+
+  alias to_param to_query
+end
+
+module ActiveSupport
+  module Tryable
+    # nodoc:
+    def try: (?untyped? method_name, *untyped args) { (untyped) -> untyped } -> untyped
+
+    def try!: (?untyped? method_name, *untyped args) { (untyped) -> untyped } -> untyped
+  end
+end
+
+class Object
+  include ActiveSupport::Tryable
+end
+
+class Delegator
+  include ActiveSupport::Tryable
+end
+
+class NilClass
+  # Calling +try+ on +nil+ always returns +nil+.
+  # It becomes especially helpful when navigating through associations that may return +nil+.
+  #
+  #   nil.try(:name) # => nil
+  #
+  # Without +try+
+  #   @person && @person.children.any? && @person.children.first.name
+  #
+  # With +try+
+  #   @person.try(:children).try(:first).try(:name)
+  def try: (?untyped? method_name, *untyped args) -> nil
+
+  # Calling +try!+ on +nil+ always returns +nil+.
+  #
+  #   nil.try!(:name) # => nil
+  def try!: (?untyped? method_name, *untyped args) -> nil
+end
+
+class Object
+  # An elegant way to factor duplication out of options passed to a series of
+  # method calls. Each method called in the block, with the block variable as
+  # the receiver, will have its options merged with the default +options+ hash
+  # provided. Each method called on the block variable must take an options
+  # hash as its final argument.
+  #
+  # Without <tt>with_options</tt>, this code contains duplication:
+  #
+  #   class Account < ActiveRecord::Base
+  #     has_many :customers, dependent: :destroy
+  #     has_many :products,  dependent: :destroy
+  #     has_many :invoices,  dependent: :destroy
+  #     has_many :expenses,  dependent: :destroy
+  #   end
+  #
+  # Using <tt>with_options</tt>, we can remove the duplication:
+  #
+  #   class Account < ActiveRecord::Base
+  #     with_options dependent: :destroy do |assoc|
+  #       assoc.has_many :customers
+  #       assoc.has_many :products
+  #       assoc.has_many :invoices
+  #       assoc.has_many :expenses
+  #     end
+  #   end
+  #
+  # It can also be used with an explicit receiver:
+  #
+  #   I18n.with_options locale: user.locale, scope: 'newsletter' do |i18n|
+  #     subject i18n.t :subject
+  #     body    i18n.t :body, user_name: user.name
+  #   end
+  #
+  # When you don't pass an explicit receiver, it executes the whole block
+  # in merging options context:
+  #
+  #   class Account < ActiveRecord::Base
+  #     with_options dependent: :destroy do
+  #       has_many :customers
+  #       has_many :products
+  #       has_many :invoices
+  #       has_many :expenses
+  #     end
+  #   end
+  #
+  # <tt>with_options</tt> can also be nested since the call is forwarded to its receiver.
+  #
+  # NOTE: Each nesting level will merge inherited defaults in addition to their own.
+  #
+  #   class Post < ActiveRecord::Base
+  #     with_options if: :persisted?, length: { minimum: 50 } do
+  #       validates :content, if: -> { content.present? }
+  #     end
+  #   end
+  #
+  # The code is equivalent to:
+  #
+  #   validates :content, length: { minimum: 50 }, if: -> { content.present? }
+  #
+  # Hence the inherited default for +if+ key is ignored.
+  #
+  # NOTE: You cannot call class methods implicitly inside of with_options.
+  # You can access these methods using the class name instead:
+  #
+  #   class Phone < ActiveRecord::Base
+  #     enum phone_number_type: { home: 0, office: 1, mobile: 2 }
+  #
+  #     with_options presence: true do
+  #       validates :phone_number_type, inclusion: { in: Phone.phone_number_types.keys }
+  #     end
+  #   end
+  #
+  def with_options: (untyped options) { () -> untyped } -> untyped
+end
+
+module ActiveSupport
+  module CompareWithRange
+    # Extends the default Range#=== to support range comparisons.
+    #  (1..5) === (1..5)  # => true
+    #  (1..5) === (2..3)  # => true
+    #  (1..5) === (1...6) # => true
+    #  (1..5) === (2..6)  # => false
+    #
+    # The native Range#=== behavior is untouched.
+    #  ('a'..'f') === ('c') # => true
+    #  (5..9) === (11) # => false
+    #
+    # The given range must be fully bounded, with both start and end.
+    def ===: (untyped value) -> untyped
+
+    # Extends the default Range#include? to support range comparisons.
+    #  (1..5).include?(1..5)  # => true
+    #  (1..5).include?(2..3)  # => true
+    #  (1..5).include?(1...6) # => true
+    #  (1..5).include?(2..6)  # => false
+    #
+    # The native Range#include? behavior is untouched.
+    #  ('a'..'f').include?('c') # => true
+    #  (5..9).include?(11) # => false
+    #
+    # The given range must be fully bounded, with both start and end.
+    def include?: (untyped value) -> untyped
+
+    # Extends the default Range#cover? to support range comparisons.
+    #  (1..5).cover?(1..5)  # => true
+    #  (1..5).cover?(2..3)  # => true
+    #  (1..5).cover?(1...6) # => true
+    #  (1..5).cover?(2..6)  # => false
+    #
+    # The native Range#cover? behavior is untouched.
+    #  ('a'..'f').cover?('c') # => true
+    #  (5..9).cover?(11) # => false
+    #
+    # The given range must be fully bounded, with both start and end.
+    def cover?: (untyped value) -> untyped
+  end
+end
+
+module ActiveSupport
+  module RangeWithFormat
+    RANGE_FORMATS: ::Hash[untyped, untyped]
+
+    # Convert range to a formatted string. See RANGE_FORMATS for predefined formats.
+    #
+    #   range = (1..100)           # => 1..100
+    #
+    #   range.to_s                 # => "1..100"
+    #   range.to_s(:db)            # => "BETWEEN '1' AND '100'"
+    #
+    # == Adding your own range formats to to_s
+    # You can add your own formats to the Range::RANGE_FORMATS hash.
+    # Use the format name as the hash key and a Proc instance.
+    #
+    #   # config/initializers/range_formats.rb
+    #   Range::RANGE_FORMATS[:short] = ->(start, stop) { "Between #{start.to_s(:db)} and #{stop.to_s(:db)}" }
+    def to_s: (?::Symbol format) -> untyped
+
+    alias to_default_s to_s
+
+    alias to_formatted_s to_s
+  end
+end
+
+module ActiveSupport
+  module EachTimeWithZone
+    # nodoc:
+    def each: () { () -> untyped } -> untyped
+
+    def step: (?::Integer n) { () -> untyped } -> untyped
+
+    def ensure_iteration_allowed: () -> untyped
+  end
+end
+
+module ActiveSupport
+  module IncludeTimeWithZone
+    # nodoc:
+    # Extends the default Range#include? to support ActiveSupport::TimeWithZone.
+    #
+    #   (1.hour.ago..1.hour.from_now).include?(Time.current) # => true
+    #
+    def include?: (untyped value) -> untyped
+  end
+end
+
+class Range[out Elem]
+  # Compare two ranges and see if they overlap each other
+  #  (1..5).overlaps?(4..6) # => true
+  #  (1..5).overlaps?(7..9) # => false
+  def overlaps?: (untyped other) -> untyped
+end
+
+class Regexp
+  # nodoc:
+  def multiline?: () -> untyped
+end
+
+module SecureRandom
+  BASE58_ALPHABET: untyped
+
+  BASE36_ALPHABET: untyped
+
+  # SecureRandom.base58 generates a random base58 string.
+  #
+  # The argument _n_ specifies the length of the random string to be generated.
+  #
+  # If _n_ is not specified or is +nil+, 16 is assumed. It may be larger in the future.
+  #
+  # The result may contain alphanumeric characters except 0, O, I and l.
+  #
+  #   p SecureRandom.base58 # => "4kUgL2pdQMSCQtjE"
+  #   p SecureRandom.base58(24) # => "77TMHrHJFvFDwodq8w7Ev2m7"
+  def self.base58: (?::Integer n) -> untyped
+
+  # SecureRandom.base36 generates a random base36 string in lowercase.
+  #
+  # The argument _n_ specifies the length of the random string to be generated.
+  #
+  # If _n_ is not specified or is +nil+, 16 is assumed. It may be larger in the future.
+  # This method can be used over +base58+ if a deterministic case key is necessary.
+  #
+  # The result will contain alphanumeric characters in lowercase.
+  #
+  #   p SecureRandom.base36 # => "4kugl2pdqmscqtje"
+  #   p SecureRandom.base36(24) # => "77tmhrhjfvfdwodq8w7ev2m7"
+  def self.base36: (?::Integer n) -> untyped
+end
+
+class String
+  # If you pass a single integer, returns a substring of one character at that
+  # position. The first character of the string is at position 0, the next at
+  # position 1, and so on. If a range is supplied, a substring containing
+  # characters at offsets given by the range is returned. In both cases, if an
+  # offset is negative, it is counted from the end of the string. Returns +nil+
+  # if the initial offset falls outside the string. Returns an empty string if
+  # the beginning of the range is greater than the end of the string.
+  #
+  #   str = "hello"
+  #   str.at(0)      # => "h"
+  #   str.at(1..3)   # => "ell"
+  #   str.at(-2)     # => "l"
+  #   str.at(-2..-1) # => "lo"
+  #   str.at(5)      # => nil
+  #   str.at(5..-1)  # => ""
+  #
+  # If a Regexp is given, the matching portion of the string is returned.
+  # If a String is given, that given string is returned if it occurs in
+  # the string. In both cases, +nil+ is returned if there is no match.
+  #
+  #   str = "hello"
+  #   str.at(/lo/) # => "lo"
+  #   str.at(/ol/) # => nil
+  #   str.at("lo") # => "lo"
+  #   str.at("ol") # => nil
+  def at: (untyped position) -> untyped
+
+  # Returns a substring from the given position to the end of the string.
+  # If the position is negative, it is counted from the end of the string.
+  #
+  #   str = "hello"
+  #   str.from(0)  # => "hello"
+  #   str.from(3)  # => "lo"
+  #   str.from(-2) # => "lo"
+  #
+  # You can mix it with +to+ method and do fun things like:
+  #
+  #   str = "hello"
+  #   str.from(0).to(-1) # => "hello"
+  #   str.from(1).to(-2) # => "ell"
+  def from: (untyped position) -> untyped
+
+  # Returns a substring from the beginning of the string to the given position.
+  # If the position is negative, it is counted from the end of the string.
+  #
+  #   str = "hello"
+  #   str.to(0)  # => "h"
+  #   str.to(3)  # => "hell"
+  #   str.to(-2) # => "hell"
+  #
+  # You can mix it with +from+ method and do fun things like:
+  #
+  #   str = "hello"
+  #   str.from(0).to(-1) # => "hello"
+  #   str.from(1).to(-2) # => "ell"
+  def to: (untyped position) -> untyped
+
+  # Returns the first character. If a limit is supplied, returns a substring
+  # from the beginning of the string until it reaches the limit value. If the
+  # given limit is greater than or equal to the string length, returns a copy of self.
+  #
+  #   str = "hello"
+  #   str.first    # => "h"
+  #   str.first(1) # => "h"
+  #   str.first(2) # => "he"
+  #   str.first(0) # => ""
+  #   str.first(6) # => "hello"
+  def first: (?::Integer limit) -> untyped
+
+  # Returns the last character of the string. If a limit is supplied, returns a substring
+  # from the end of the string until it reaches the limit value (counting backwards). If
+  # the given limit is greater than or equal to the string length, returns a copy of self.
+  #
+  #   str = "hello"
+  #   str.last    # => "o"
+  #   str.last(1) # => "o"
+  #   str.last(2) # => "lo"
+  #   str.last(0) # => ""
+  #   str.last(6) # => "hello"
+  def last: (?::Integer limit) -> untyped
+end
+
+class String
+  # Enables more predictable duck-typing on String-like classes. See <tt>Object#acts_like?</tt>.
+  def acts_like_string?: () -> ::TrueClass
+end
+
+class String
+  # Converts a string to a Time value.
+  # The +form+ can be either :utc or :local (default :local).
+  #
+  # The time is parsed using Time.parse method.
+  # If +form+ is :local, then the time is in the system timezone.
+  # If the date part is missing then the current date is used and if
+  # the time part is missing then it is assumed to be 00:00:00.
+  #
+  #   "13-12-2012".to_time               # => 2012-12-13 00:00:00 +0100
+  #   "06:12".to_time                    # => 2012-12-13 06:12:00 +0100
+  #   "2012-12-13 06:12".to_time         # => 2012-12-13 06:12:00 +0100
+  #   "2012-12-13T06:12".to_time         # => 2012-12-13 06:12:00 +0100
+  #   "2012-12-13T06:12".to_time(:utc)   # => 2012-12-13 06:12:00 UTC
+  #   "12/13/2012".to_time               # => ArgumentError: argument out of range
+  def to_time: (?::Symbol form) -> (nil | untyped)
+
+  # Converts a string to a Date value.
+  #
+  #   "1-1-2012".to_date   # => Sun, 01 Jan 2012
+  #   "01/01/2012".to_date # => Sun, 01 Jan 2012
+  #   "2012-12-13".to_date # => Thu, 13 Dec 2012
+  #   "12/13/2012".to_date # => ArgumentError: invalid date
+  def to_date: () -> untyped
+
+  # Converts a string to a DateTime value.
+  #
+  #   "1-1-2012".to_datetime            # => Sun, 01 Jan 2012 00:00:00 +0000
+  #   "01/01/2012 23:59:59".to_datetime # => Sun, 01 Jan 2012 23:59:59 +0000
+  #   "2012-12-13 12:50".to_datetime    # => Thu, 13 Dec 2012 12:50:00 +0000
+  #   "12/13/2012".to_datetime          # => ArgumentError: invalid date
+  def to_datetime: () -> untyped
+end
+
+class String
+  # The inverse of <tt>String#include?</tt>. Returns true if the string
+  # does not include the other string.
+  #
+  #   "hello".exclude? "lo" # => false
+  #   "hello".exclude? "ol" # => true
+  #   "hello".exclude? ?h   # => false
+  def exclude?: (untyped string) -> untyped
+end
+
+class String
+  # Returns the string, first removing all whitespace on both ends of
+  # the string, and then changing remaining consecutive whitespace
+  # groups into one space each.
+  #
+  # Note that it handles both ASCII and Unicode whitespace.
+  #
+  #   %{ Multi-line
+  #      string }.squish                   # => "Multi-line string"
+  #   " foo   bar    \n   \t   boo".squish # => "foo bar boo"
+  def squish: () -> untyped
+
+  # Performs a destructive squish. See String#squish.
+  #   str = " foo   bar    \n   \t   boo"
+  #   str.squish!                         # => "foo bar boo"
+  #   str                                 # => "foo bar boo"
+  def squish!: () -> untyped
+
+  # Returns a new string with all occurrences of the patterns removed.
+  #   str = "foo bar test"
+  #   str.remove(" test")                 # => "foo bar"
+  #   str.remove(" test", /bar/)          # => "foo "
+  #   str                                 # => "foo bar test"
+  def remove: (*untyped patterns) -> untyped
+
+  # Alters the string by removing all occurrences of the patterns.
+  #   str = "foo bar test"
+  #   str.remove!(" test", /bar/)         # => "foo "
+  #   str                                 # => "foo "
+  def remove!: (*untyped patterns) -> untyped
+
+  # Truncates a given +text+ after a given <tt>length</tt> if +text+ is longer than <tt>length</tt>:
+  #
+  #   'Once upon a time in a world far far away'.truncate(27)
+  #   # => "Once upon a time in a wo..."
+  #
+  # Pass a string or regexp <tt>:separator</tt> to truncate +text+ at a natural break:
+  #
+  #   'Once upon a time in a world far far away'.truncate(27, separator: ' ')
+  #   # => "Once upon a time in a..."
+  #
+  #   'Once upon a time in a world far far away'.truncate(27, separator: /\s/)
+  #   # => "Once upon a time in a..."
+  #
+  # The last characters will be replaced with the <tt>:omission</tt> string (defaults to "...")
+  # for a total length not exceeding <tt>length</tt>:
+  #
+  #   'And they found that many people were sleeping better.'.truncate(25, omission: '... (continued)')
+  #   # => "And they f... (continued)"
+  def truncate: (untyped truncate_at, ?::Hash[untyped, untyped] options) -> untyped
+
+  # Truncates +text+ to at most <tt>bytesize</tt> bytes in length without
+  # breaking string encoding by splitting multibyte characters or breaking
+  # grapheme clusters ("perceptual characters") by truncating at combining
+  # characters.
+  #
+  #   >> "(trim non-ascii characters)".size
+  #   => 20
+  #   >> "(trim non-ascii characters)".bytesize
+  #   => 80
+  #   >> "(trim non-ascii characters)".truncate_bytes(20)
+  #   => "(trim non-ascii characters)"
+  #
+  # The truncated text ends with the <tt>:omission</tt> string, defaulting
+  # to "(trim non-ascii characters)", for a total length not exceeding <tt>bytesize</tt>.
+  def truncate_bytes: (untyped truncate_at, ?omission: ::String omission) -> untyped
+
+  # Truncates a given +text+ after a given number of words (<tt>words_count</tt>):
+  #
+  #   'Once upon a time in a world far far away'.truncate_words(4)
+  #   # => "Once upon a time..."
+  #
+  # Pass a string or regexp <tt>:separator</tt> to specify a different separator of words:
+  #
+  #   'Once<br>upon<br>a<br>time<br>in<br>a<br>world'.truncate_words(5, separator: '<br>')
+  #   # => "Once<br>upon<br>a<br>time<br>in..."
+  #
+  # The last characters will be replaced with the <tt>:omission</tt> string (defaults to "..."):
+  #
+  #   'And they found that many people were sleeping better.'.truncate_words(5, omission: '... (continued)')
+  #   # => "And they found that many... (continued)"
+  def truncate_words: (untyped words_count, ?::Hash[untyped, untyped] options) -> untyped
+end
+
+class String
+  # Same as +indent+, except it indents the receiver in-place.
+  #
+  # Returns the indented string, or +nil+ if there was nothing to indent.
+  def indent!: (untyped amount, ?untyped? indent_string, ?bool indent_empty_lines) -> untyped
+
+  # Indents the lines in the receiver:
+  #
+  #   <<EOS.indent(2)
+  #   def some_method
+  #     some_code
+  #   end
+  #   EOS
+  #   # =>
+  #     def some_method
+  #       some_code
+  #     end
+  #
+  # The second argument, +indent_string+, specifies which indent string to
+  # use. The default is +nil+, which tells the method to make a guess by
+  # peeking at the first indented line, and fallback to a space if there is
+  # none.
+  #
+  #   "  foo".indent(2)        # => "    foo"
+  #   "foo\n\t\tbar".indent(2) # => "\t\tfoo\n\t\t\t\tbar"
+  #   "foo".indent(2, "\t")    # => "\t\tfoo"
+  #
+  # While +indent_string+ is typically one space or tab, it may be any string.
+  #
+  # The third argument, +indent_empty_lines+, is a flag that says whether
+  # empty lines should be indented. Default is false.
+  #
+  #   "foo\n\nbar".indent(2)            # => "  foo\n\n  bar"
+  #   "foo\n\nbar".indent(2, nil, true) # => "  foo\n  \n  bar"
+  #
+  def indent: (untyped amount, ?untyped? indent_string, ?bool indent_empty_lines) -> untyped
+end
+
+# String inflections define new methods on the String class to transform names for different purposes.
+# For instance, you can figure out the name of a table from the name of a class.
+#
+#   'ScaleScore'.tableize # => "scale_scores"
+#
+class String
+  # Returns the plural form of the word in the string.
+  #
+  # If the optional parameter +count+ is specified,
+  # the singular form will be returned if <tt>count == 1</tt>.
+  # For any other value of +count+ the plural will be returned.
+  #
+  # If the optional parameter +locale+ is specified,
+  # the word will be pluralized as a word of that language.
+  # By default, this parameter is set to <tt>:en</tt>.
+  # You must define your own inflection rules for languages other than English.
+  #
+  #   'post'.pluralize             # => "posts"
+  #   'octopus'.pluralize          # => "octopi"
+  #   'sheep'.pluralize            # => "sheep"
+  #   'words'.pluralize            # => "words"
+  #   'the blue mailman'.pluralize # => "the blue mailmen"
+  #   'CamelOctopus'.pluralize     # => "CamelOctopi"
+  #   'apple'.pluralize(1)         # => "apple"
+  #   'apple'.pluralize(2)         # => "apples"
+  #   'ley'.pluralize(:es)         # => "leyes"
+  #   'ley'.pluralize(1, :es)      # => "ley"
+  def pluralize: (?untyped? count, ?::Symbol locale) -> untyped
+
+  # The reverse of +pluralize+, returns the singular form of a word in a string.
+  #
+  # If the optional parameter +locale+ is specified,
+  # the word will be singularized as a word of that language.
+  # By default, this parameter is set to <tt>:en</tt>.
+  # You must define your own inflection rules for languages other than English.
+  #
+  #   'posts'.singularize            # => "post"
+  #   'octopi'.singularize           # => "octopus"
+  #   'sheep'.singularize            # => "sheep"
+  #   'word'.singularize             # => "word"
+  #   'the blue mailmen'.singularize # => "the blue mailman"
+  #   'CamelOctopi'.singularize      # => "CamelOctopus"
+  #   'leyes'.singularize(:es)       # => "ley"
+  def singularize: (?::Symbol locale) -> untyped
+
+  # +constantize+ tries to find a declared constant with the name specified
+  # in the string. It raises a NameError when the name is not in CamelCase
+  # or is not initialized.  See ActiveSupport::Inflector.constantize
+  #
+  #   'Module'.constantize  # => Module
+  #   'Class'.constantize   # => Class
+  #   'blargle'.constantize # => NameError: wrong constant name blargle
+  def constantize: () -> untyped
+
+  # +safe_constantize+ tries to find a declared constant with the name specified
+  # in the string. It returns +nil+ when the name is not in CamelCase
+  # or is not initialized.  See ActiveSupport::Inflector.safe_constantize
+  #
+  #   'Module'.safe_constantize  # => Module
+  #   'Class'.safe_constantize   # => Class
+  #   'blargle'.safe_constantize # => nil
+  def safe_constantize: () -> untyped
+
+  # By default, +camelize+ converts strings to UpperCamelCase. If the argument to camelize
+  # is set to <tt>:lower</tt> then camelize produces lowerCamelCase.
+  #
+  # +camelize+ will also convert '/' to '::' which is useful for converting paths to namespaces.
+  #
+  #   'active_record'.camelize                # => "ActiveRecord"
+  #   'active_record'.camelize(:lower)        # => "activeRecord"
+  #   'active_record/errors'.camelize         # => "ActiveRecord::Errors"
+  #   'active_record/errors'.camelize(:lower) # => "activeRecord::Errors"
+  def camelize: (?::Symbol first_letter) -> untyped
+
+  alias camelcase camelize
+
+  # Capitalizes all the words and replaces some characters in the string to create
+  # a nicer looking title. +titleize+ is meant for creating pretty output. It is not
+  # used in the Rails internals.
+  #
+  # The trailing '_id','Id'.. can be kept and capitalized by setting the
+  # optional parameter +keep_id_suffix+ to true.
+  # By default, this parameter is false.
+  #
+  # +titleize+ is also aliased as +titlecase+.
+  #
+  #   'man from the boondocks'.titleize                       # => "Man From The Boondocks"
+  #   'x-men: the last stand'.titleize                        # => "X Men: The Last Stand"
+  #   'string_ending_with_id'.titleize(keep_id_suffix: true)  # => "String Ending With Id"
+  def titleize: (?keep_id_suffix: bool keep_id_suffix) -> untyped
+
+  alias titlecase titleize
+
+  # The reverse of +camelize+. Makes an underscored, lowercase form from the expression in the string.
+  #
+  # +underscore+ will also change '::' to '/' to convert namespaces to paths.
+  #
+  #   'ActiveModel'.underscore         # => "active_model"
+  #   'ActiveModel::Errors'.underscore # => "active_model/errors"
+  def underscore: () -> untyped
+
+  # Replaces underscores with dashes in the string.
+  #
+  #   'puni_puni'.dasherize # => "puni-puni"
+  def dasherize: () -> untyped
+
+  # Removes the module part from the constant expression in the string.
+  #
+  #   'ActiveSupport::Inflector::Inflections'.demodulize # => "Inflections"
+  #   'Inflections'.demodulize                           # => "Inflections"
+  #   '::Inflections'.demodulize                         # => "Inflections"
+  #   ''.demodulize                                      # => ''
+  #
+  # See also +deconstantize+.
+  def demodulize: () -> untyped
+
+  # Removes the rightmost segment from the constant expression in the string.
+  #
+  #   'Net::HTTP'.deconstantize   # => "Net"
+  #   '::Net::HTTP'.deconstantize # => "::Net"
+  #   'String'.deconstantize      # => ""
+  #   '::String'.deconstantize    # => ""
+  #   ''.deconstantize            # => ""
+  #
+  # See also +demodulize+.
+  def deconstantize: () -> untyped
+
+  # Replaces special characters in a string so that it may be used as part of a 'pretty' URL.
+  #
+  # If the optional parameter +locale+ is specified,
+  # the word will be parameterized as a word of that language.
+  # By default, this parameter is set to <tt>nil</tt> and it will use
+  # the configured <tt>I18n.locale</tt>.
+  #
+  #   class Person
+  #     def to_param
+  #       "#{id}-#{name.parameterize}"
+  #     end
+  #   end
+  #
+  #   @person = Person.find(1)
+  #   # => #<Person id: 1, name: "Donald E. Knuth">
+  #
+  #   <%= link_to(@person.name, person_path) %>
+  #   # => <a href="/person/1-donald-e-knuth">Donald E. Knuth</a>
+  #
+  # To preserve the case of the characters in a string, use the +preserve_case+ argument.
+  #
+  #   class Person
+  #     def to_param
+  #       "#{id}-#{name.parameterize(preserve_case: true)}"
+  #     end
+  #   end
+  #
+  #   @person = Person.find(1)
+  #   # => #<Person id: 1, name: "Donald E. Knuth">
+  #
+  #   <%= link_to(@person.name, person_path) %>
+  #   # => <a href="/person/1-Donald-E-Knuth">Donald E. Knuth</a>
+  def parameterize: (?locale: untyped? locale, ?preserve_case: bool preserve_case, ?separator: ::String separator) -> untyped
+
+  # Creates the name of a table like Rails does for models to table names. This method
+  # uses the +pluralize+ method on the last word in the string.
+  #
+  #   'RawScaledScorer'.tableize # => "raw_scaled_scorers"
+  #   'ham_and_egg'.tableize     # => "ham_and_eggs"
+  #   'fancyCategory'.tableize   # => "fancy_categories"
+  def tableize: () -> untyped
+
+  # Creates a class name from a plural table name like Rails does for table names to models.
+  # Note that this returns a string and not a class. (To convert to an actual class
+  # follow +classify+ with +constantize+.)
+  #
+  #   'ham_and_eggs'.classify # => "HamAndEgg"
+  #   'posts'.classify        # => "Post"
+  def classify: () -> untyped
+
+  # Capitalizes the first word, turns underscores into spaces, and (by default)strips a
+  # trailing '_id' if present.
+  # Like +titleize+, this is meant for creating pretty output.
+  #
+  # The capitalization of the first word can be turned off by setting the
+  # optional parameter +capitalize+ to false.
+  # By default, this parameter is true.
+  #
+  # The trailing '_id' can be kept and capitalized by setting the
+  # optional parameter +keep_id_suffix+ to true.
+  # By default, this parameter is false.
+  #
+  #   'employee_salary'.humanize                    # => "Employee salary"
+  #   'author_id'.humanize                          # => "Author"
+  #   'author_id'.humanize(capitalize: false)       # => "author"
+  #   '_id'.humanize                                # => "Id"
+  #   'author_id'.humanize(keep_id_suffix: true)    # => "Author Id"
+  def humanize: (?keep_id_suffix: bool keep_id_suffix, ?capitalize: bool capitalize) -> untyped
+
+  # Converts just the first character to uppercase.
+  #
+  #   'what a Lovely Day'.upcase_first # => "What a Lovely Day"
+  #   'w'.upcase_first                 # => "W"
+  #   ''.upcase_first                  # => ""
+  def upcase_first: () -> untyped
+
+  # Creates a foreign key name from a class name.
+  # +separate_class_name_and_id_with_underscore+ sets whether
+  # the method should put '_' between the name and 'id'.
+  #
+  #   'Message'.foreign_key        # => "message_id"
+  #   'Message'.foreign_key(false) # => "messageid"
+  #   'Admin::Post'.foreign_key    # => "post_id"
+  def foreign_key: (?bool separate_class_name_and_id_with_underscore) -> untyped
+end
+
+class String
+  # Wraps the current string in the <tt>ActiveSupport::StringInquirer</tt> class,
+  # which gives you a prettier way to test for equality.
+  #
+  #   env = 'production'.inquiry
+  #   env.production?  # => true
+  #   env.development? # => false
+  def inquiry: () -> ActiveSupport::StringInquirer
+end
+
+class String
+  # == Multibyte proxy
+  #
+  # +mb_chars+ is a multibyte safe proxy for string methods.
+  #
+  # It creates and returns an instance of the ActiveSupport::Multibyte::Chars class which
+  # encapsulates the original string. A Unicode safe version of all the String methods are defined on this proxy
+  # class. If the proxy class doesn't respond to a certain method, it's forwarded to the encapsulated string.
+  #
+  #   >> "(trim non-ascii characters)".mb_chars.upcase.to_s
+  #   => "(trim non-ascii characters)"
+  #
+  # NOTE: Ruby 2.4 and later support native Unicode case mappings:
+  #
+  #   >> "(trim non-ascii characters)".upcase
+  #   => "(trim non-ascii characters)"
+  #
+  # == Method chaining
+  #
+  # All the methods on the Chars proxy which normally return a string will return a Chars object. This allows
+  # method chaining on the result of any of these methods.
+  #
+  #   name.mb_chars.reverse.length # => 12
+  #
+  # == Interoperability and configuration
+  #
+  # The Chars object tries to be as interchangeable with String objects as possible: sorting and comparing between
+  # String and Char work like expected. The bang! methods change the internal string representation in the Chars
+  # object. Interoperability problems can be resolved easily with a +to_s+ call.
+  #
+  # For more information about the methods defined on the Chars proxy see ActiveSupport::Multibyte::Chars. For
+  # information about how to change the default Multibyte behavior see ActiveSupport::Multibyte.
+  def mb_chars: () -> untyped
+
+  # Returns +true+ if string has utf_8 encoding.
+  #
+  #   utf_8_str = "some string".encode "UTF-8"
+  #   iso_str = "some string".encode "ISO-8859-1"
+  #
+  #   utf_8_str.is_utf8? # => true
+  #   iso_str.is_utf8?   # => false
+  def is_utf8?: () -> untyped
+end
+
+class ERB
+  module Util
+    HTML_ESCAPE: ::Hash[untyped, untyped]
+
+    JSON_ESCAPE: ::Hash[untyped, untyped]
+
+    HTML_ESCAPE_ONCE_REGEXP: untyped
+
+    JSON_ESCAPE_REGEXP: untyped
+
+    # A utility method for escaping HTML tag characters.
+    # This method is also aliased as <tt>h</tt>.
+    #
+    #   puts html_escape('is a > 0 & a < 10?')
+    #   # => is a &gt; 0 &amp; a &lt; 10?
+    def html_escape: (untyped s) -> untyped
+
+    alias h html_escape
+
+    def unwrapped_html_escape: (untyped s) -> untyped
+
+    # A utility method for escaping HTML without affecting existing escaped entities.
+    #
+    #   html_escape_once('1 < 2 &amp; 3')
+    #   # => "1 &lt; 2 &amp; 3"
+    #
+    #   html_escape_once('&lt;&lt; Accept & Checkout')
+    #   # => "&lt;&lt; Accept &amp; Checkout"
+    def html_escape_once: (untyped s) -> untyped
+
+    # A utility method for escaping HTML entities in JSON strings. Specifically, the
+    # &, > and < characters are replaced with their equivalent unicode escaped form -
+    # \u0026, \u003e, and \u003c. The Unicode sequences \u2028 and \u2029 are also
+    # escaped as they are treated as newline characters in some JavaScript engines.
+    # These sequences have identical meaning as the original characters inside the
+    # context of a JSON string, so assuming the input is a valid and well-formed
+    # JSON value, the output will have equivalent meaning when parsed:
+    #
+    #   json = JSON.generate({ name: "</script><script>alert('PWNED!!!')</script>"})
+    #   # => "{\"name\":\"</script><script>alert('PWNED!!!')</script>\"}"
+    #
+    #   json_escape(json)
+    #   # => "{\"name\":\"\\u003C/script\\u003E\\u003Cscript\\u003Ealert('PWNED!!!')\\u003C/script\\u003E\"}"
+    #
+    #   JSON.parse(json) == JSON.parse(json_escape(json))
+    #   # => true
+    #
+    # The intended use case for this method is to escape JSON strings before including
+    # them inside a script tag to avoid XSS vulnerability:
+    #
+    #   <script>
+    #     var currentUser = <%= raw json_escape(current_user.to_json) %>;
+    #   </script>
+    #
+    # It is necessary to +raw+ the result of +json_escape+, so that quotation marks
+    # don't get converted to <tt>&quot;</tt> entities. +json_escape+ doesn't
+    # automatically flag the result as HTML safe, since the raw value is unsafe to
+    # use inside HTML attributes.
+    #
+    # If your JSON is being used downstream for insertion into the DOM, be aware of
+    # whether or not it is being inserted via +html()+. Most jQuery plugins do this.
+    # If that is the case, be sure to +html_escape+ or +sanitize+ any user-generated
+    # content returned by your JSON.
+    #
+    # If you need to output JSON elsewhere in your HTML, you can just do something
+    # like this, as any unsafe characters (including quotation marks) will be
+    # automatically escaped for you:
+    #
+    #   <div data-user-info="<%= current_user.to_json %>">...</div>
+    #
+    # WARNING: this helper only works with valid JSON. Using this on non-JSON values
+    # will open up serious XSS vulnerabilities. For example, if you replace the
+    # +current_user.to_json+ in the example above with user input instead, the browser
+    # will happily eval() that string as JavaScript.
+    #
+    # The escaping performed in this method is identical to those performed in the
+    # Active Support JSON encoder when +ActiveSupport.escape_html_entities_in_json+ is
+    # set to true. Because this transformation is idempotent, this helper can be
+    # applied even if +ActiveSupport.escape_html_entities_in_json+ is already true.
+    #
+    # Therefore, when you are unsure if +ActiveSupport.escape_html_entities_in_json+
+    # is enabled, or if you are unsure where your JSON string originated from, it
+    # is recommended that you always apply this helper (other libraries, such as the
+    # JSON gem, do not provide this kind of protection by default; also some gems
+    # might override +to_json+ to bypass Active Support's encoder).
+    def json_escape: (untyped s) -> untyped
+  end
+end
+
+class Object
+  def html_safe?: () -> ::FalseClass
+end
+
+class Numeric
+  def html_safe?: () -> ::TrueClass
+end
+
+module ActiveSupport
+  # nodoc:
+  class SafeBuffer < String
+    UNSAFE_STRING_METHODS: ::Array[untyped]
+
+    UNSAFE_STRING_METHODS_WITH_BACKREF: ::Array[untyped]
+
+    alias original_concat concat
+
+    # Raised when <tt>ActiveSupport::SafeBuffer#safe_concat</tt> is called on unsafe buffers.
+    class SafeConcatError < StandardError
+      def initialize: () -> untyped
+    end
+
+    def []: (*untyped args) -> untyped
+
+    def safe_concat: (untyped value) -> untyped
+
+    def initialize: (?::String str) -> untyped
+
+    def initialize_copy: (untyped other) -> untyped
+
+    def clone_empty: () -> untyped
+
+    def concat: (untyped value) -> untyped
+
+    alias << concat
+
+    def insert: (untyped index, untyped value) -> untyped
+
+    def `prepend`: (untyped value) -> untyped
+
+    def replace: (untyped value) -> untyped
+
+    def []=: (*untyped args) -> untyped
+
+    def +: (untyped other) -> untyped
+
+    def *: () -> untyped
+
+    def %: (untyped args) -> untyped
+
+    def html_safe?: () -> untyped
+
+    def to_s: () -> untyped
+
+    def to_param: () -> untyped
+
+    def encode_with: (untyped coder) -> untyped
+
+    def html_escape_interpolated_argument: (untyped arg) -> untyped
+
+    def set_block_back_references: (untyped block, untyped match_data) -> untyped
+  end
+end
+
+class String
+  # Marks a string as trusted safe. It will be inserted into HTML with no
+  # additional escaping performed. It is your responsibility to ensure that the
+  # string contains no malicious content. This method is equivalent to the
+  # +raw+ helper in views. It is recommended that you use +sanitize+ instead of
+  # this method. It should never be called on user input.
+  def html_safe: () -> ActiveSupport::SafeBuffer
+end
+
+class String
+  alias starts_with? start_with?
+
+  alias ends_with? end_with?
+end
+
+class String
+  # Strips indentation in heredocs.
+  #
+  # For example in
+  #
+  #   if options[:usage]
+  #     puts <<-USAGE.strip_heredoc
+  #       This command does such and such.
+  #
+  #       Supported options are:
+  #         -h         This message
+  #         ...
+  #     USAGE
+  #   end
+  #
+  # the user would see the usage message aligned against the left margin.
+  #
+  # Technically, it looks for the least indented non-empty line
+  # in the whole string, and removes that amount of leading whitespace.
+  def strip_heredoc: () -> untyped
+end
+
+class String
+  # Converts String to a TimeWithZone in the current zone if Time.zone or Time.zone_default
+  # is set, otherwise converts String to a Time via String#to_time
+  def in_time_zone: (?untyped zone) -> untyped
+end
+
+class Time
+  # Duck-types as a Time-like class. See Object#acts_like?.
+  def acts_like_time?: () -> ::TrueClass
+end
+
+class Time
+  include DateAndTime::Calculations
+
+  COMMON_YEAR_DAYS_IN_MONTH: ::Array[untyped]
+
+  # Overriding case equality method so that it returns true for ActiveSupport::TimeWithZone instances
+  def self.===: (untyped other) -> untyped
+
+  # Returns the number of days in the given month.
+  # If no year is specified, it will use the current year.
+  def self.days_in_month: (untyped month, ?untyped year) -> untyped
+
+  # Returns the number of days in the given year.
+  # If no year is specified, it will use the current year.
+  def self.days_in_year: (?untyped year) -> untyped
+
+  # Returns <tt>Time.zone.now</tt> when <tt>Time.zone</tt> or <tt>config.time_zone</tt> are set, otherwise just returns <tt>Time.now</tt>.
+  def self.current: () -> untyped
+
+  # Layers additional behavior on Time.at so that ActiveSupport::TimeWithZone and DateTime
+  # instances can be used when called with a single argument
+  def self.at_with_coercion: (*untyped args) -> untyped
+
+  alias self.at_without_coercion self.at
+
+  # Creates a +Time+ instance from an RFC 3339 string.
+  #
+  #   Time.rfc3339('1999-12-31T14:00:00-10:00') # => 2000-01-01 00:00:00 -1000
+  #
+  # If the time or offset components are missing then an +ArgumentError+ will be raised.
+  #
+  #   Time.rfc3339('1999-12-31') # => ArgumentError: invalid date
+  def self.rfc3339: (untyped str) -> Time
+
+  # Returns the number of seconds since 00:00:00.
+  #
+  #   Time.new(2012, 8, 29,  0,  0,  0).seconds_since_midnight # => 0.0
+  #   Time.new(2012, 8, 29, 12, 34, 56).seconds_since_midnight # => 45296.0
+  #   Time.new(2012, 8, 29, 23, 59, 59).seconds_since_midnight # => 86399.0
+  def seconds_since_midnight: () -> untyped
+
+  # Returns the number of seconds until 23:59:59.
+  #
+  #   Time.new(2012, 8, 29,  0,  0,  0).seconds_until_end_of_day # => 86399
+  #   Time.new(2012, 8, 29, 12, 34, 56).seconds_until_end_of_day # => 41103
+  #   Time.new(2012, 8, 29, 23, 59, 59).seconds_until_end_of_day # => 0
+  def seconds_until_end_of_day: () -> untyped
+
+  # Returns the fraction of a second as a +Rational+
+  #
+  #   Time.new(2012, 8, 29, 0, 0, 0.5).sec_fraction # => (1/2)
+  def sec_fraction: () -> untyped
+
+  # Returns a new Time where one or more of the elements have been changed according
+  # to the +options+ parameter. The time options (<tt>:hour</tt>, <tt>:min</tt>,
+  # <tt>:sec</tt>, <tt>:usec</tt>, <tt>:nsec</tt>) reset cascadingly, so if only
+  # the hour is passed, then minute, sec, usec and nsec is set to 0. If the hour
+  # and minute is passed, then sec, usec and nsec is set to 0. The +options+ parameter
+  # takes a hash with any of these keys: <tt>:year</tt>, <tt>:month</tt>, <tt>:day</tt>,
+  # <tt>:hour</tt>, <tt>:min</tt>, <tt>:sec</tt>, <tt>:usec</tt>, <tt>:nsec</tt>,
+  # <tt>:offset</tt>. Pass either <tt>:usec</tt> or <tt>:nsec</tt>, not both.
+  #
+  #   Time.new(2012, 8, 29, 22, 35, 0).change(day: 1)              # => Time.new(2012, 8, 1, 22, 35, 0)
+  #   Time.new(2012, 8, 29, 22, 35, 0).change(year: 1981, day: 1)  # => Time.new(1981, 8, 1, 22, 35, 0)
+  #   Time.new(2012, 8, 29, 22, 35, 0).change(year: 1981, hour: 0) # => Time.new(1981, 8, 29, 0, 0, 0)
+  def change: (untyped options) -> untyped
+
+  # Uses Date to provide precise Time calculations for years, months, and days
+  # according to the proleptic Gregorian calendar. The +options+ parameter
+  # takes a hash with any of these keys: <tt>:years</tt>, <tt>:months</tt>,
+  # <tt>:weeks</tt>, <tt>:days</tt>, <tt>:hours</tt>, <tt>:minutes</tt>,
+  # <tt>:seconds</tt>.
+  #
+  #   Time.new(2015, 8, 1, 14, 35, 0).advance(seconds: 1) # => 2015-08-01 14:35:01 -0700
+  #   Time.new(2015, 8, 1, 14, 35, 0).advance(minutes: 1) # => 2015-08-01 14:36:00 -0700
+  #   Time.new(2015, 8, 1, 14, 35, 0).advance(hours: 1)   # => 2015-08-01 15:35:00 -0700
+  #   Time.new(2015, 8, 1, 14, 35, 0).advance(days: 1)    # => 2015-08-02 14:35:00 -0700
+  #   Time.new(2015, 8, 1, 14, 35, 0).advance(weeks: 1)   # => 2015-08-08 14:35:00 -0700
+  def advance: (untyped options) -> untyped
+
+  # Returns a new Time representing the time a number of seconds ago, this is basically a wrapper around the Numeric extension
+  def ago: (untyped seconds) -> untyped
+
+  # Returns a new Time representing the time a number of seconds since the instance time
+  def since: (untyped seconds) -> untyped
+
+  alias in since
+
+  # Returns a new Time representing the start of the day (0:00)
+  def beginning_of_day: () -> untyped
+
+  alias midnight beginning_of_day
+
+  alias at_midnight beginning_of_day
+
+  alias at_beginning_of_day beginning_of_day
+
+  # Returns a new Time representing the middle of the day (12:00)
+  def middle_of_day: () -> untyped
+
+  alias midday middle_of_day
+
+  alias noon middle_of_day
+
+  alias at_midday middle_of_day
+
+  alias at_noon middle_of_day
+
+  alias at_middle_of_day middle_of_day
+
+  # Returns a new Time representing the end of the day, 23:59:59.999999
+  def end_of_day: () -> untyped
+
+  alias at_end_of_day end_of_day
+
+  # Returns a new Time representing the start of the hour (x:00)
+  def beginning_of_hour: () -> untyped
+
+  alias at_beginning_of_hour beginning_of_hour
+
+  # Returns a new Time representing the end of the hour, x:59:59.999999
+  def end_of_hour: () -> untyped
+
+  alias at_end_of_hour end_of_hour
+
+  # Returns a new Time representing the start of the minute (x:xx:00)
+  def beginning_of_minute: () -> untyped
+
+  alias at_beginning_of_minute beginning_of_minute
+
+  # Returns a new Time representing the end of the minute, x:xx:59.999999
+  def end_of_minute: () -> untyped
+
+  alias at_end_of_minute end_of_minute
+
+  def plus_with_duration: (untyped other) -> untyped
+
+  alias plus_without_duration +
+
+  def minus_with_duration: (untyped other) -> untyped
+
+  alias minus_without_duration -
+
+  # Time#- can also be used to determine the number of seconds between two Time instances.
+  # We're layering on additional behavior so that ActiveSupport::TimeWithZone instances
+  # are coerced into values that Time#- will recognize
+  def minus_with_coercion: (untyped other) -> untyped
+
+  alias minus_without_coercion -
+
+  # Layers additional behavior on Time#<=> so that DateTime and ActiveSupport::TimeWithZone instances
+  # can be chronologically compared with a Time
+  def compare_with_coercion: (untyped other) -> untyped
+
+  alias compare_without_coercion <=>
+
+  # Layers additional behavior on Time#eql? so that ActiveSupport::TimeWithZone instances
+  # can be eql? to an equivalent Time
+  def eql_with_coercion: (untyped other) -> untyped
+
+  alias eql_without_coercion eql?
+
+  # Returns a new time the specified number of days ago.
+  def prev_day: (?::Integer days) -> untyped
+
+  # Returns a new time the specified number of days in the future.
+  def next_day: (?::Integer days) -> untyped
+
+  # Returns a new time the specified number of months ago.
+  def prev_month: (?::Integer months) -> untyped
+
+  # Returns a new time the specified number of months in the future.
+  def next_month: (?::Integer months) -> untyped
+
+  # Returns a new time the specified number of years ago.
+  def prev_year: (?::Integer years) -> untyped
+
+  # Returns a new time the specified number of years in the future.
+  def next_year: (?::Integer years) -> untyped
+end
+
+class Time
+  include DateAndTime::Compatibility
+
+  # Either return +self+ or the time in the local system timezone depending
+  # on the setting of +ActiveSupport.to_time_preserves_timezone+.
+  def to_time: () -> untyped
+end
+
+class Time
+  DATE_FORMATS: ::Hash[untyped, untyped]
+
+  # Converts to a formatted string. See DATE_FORMATS for built-in formats.
+  #
+  # This method is aliased to <tt>to_s</tt>.
+  #
+  #   time = Time.now                    # => 2007-01-18 06:10:17 -06:00
+  #
+  #   time.to_formatted_s(:time)         # => "06:10"
+  #   time.to_s(:time)                   # => "06:10"
+  #
+  #   time.to_formatted_s(:db)           # => "2007-01-18 06:10:17"
+  #   time.to_formatted_s(:number)       # => "20070118061017"
+  #   time.to_formatted_s(:short)        # => "18 Jan 06:10"
+  #   time.to_formatted_s(:long)         # => "January 18, 2007 06:10"
+  #   time.to_formatted_s(:long_ordinal) # => "January 18th, 2007 06:10"
+  #   time.to_formatted_s(:rfc822)       # => "Thu, 18 Jan 2007 06:10:17 -0600"
+  #   time.to_formatted_s(:iso8601)      # => "2007-01-18T06:10:17-06:00"
+  #
+  # == Adding your own time formats to +to_formatted_s+
+  # You can add your own formats to the Time::DATE_FORMATS hash.
+  # Use the format name as the hash key and either a strftime string
+  # or Proc instance that takes a time argument as the value.
+  #
+  #   # config/initializers/time_formats.rb
+  #   Time::DATE_FORMATS[:month_and_year] = '%B %Y'
+  #   Time::DATE_FORMATS[:short_ordinal]  = ->(time) { time.strftime("%B #{time.day.ordinalize}") }
+  def to_formatted_s: (?::Symbol format) -> untyped
+
+  alias to_default_s to_s
+
+  # Returns a formatted string of the offset from UTC, or an alternative
+  # string if the time zone is already UTC.
+  #
+  #   Time.local(2000).formatted_offset        # => "-06:00"
+  #   Time.local(2000).formatted_offset(false) # => "-0600"
+  def formatted_offset: (?bool colon, ?untyped? alternate_utc_string) -> untyped
+
+  # Aliased to +xmlschema+ for compatibility with +DateTime+
+  alias rfc3339 xmlschema
+end
+
+class Time
+  include DateAndTime::Zones
+
+  attr_accessor zone_default: untyped
+
+  # Returns the TimeZone for the current request, if this has been set (via Time.zone=).
+  # If <tt>Time.zone</tt> has not been set for the current request, returns the TimeZone specified in <tt>config.time_zone</tt>.
+  def self.zone: () -> untyped
+
+  # Sets <tt>Time.zone</tt> to a TimeZone object for the current request/thread.
+  #
+  # This method accepts any of the following:
+  #
+  # * A Rails TimeZone object.
+  # * An identifier for a Rails TimeZone object (e.g., "Eastern Time (US & Canada)", <tt>-5.hours</tt>).
+  # * A TZInfo::Timezone object.
+  # * An identifier for a TZInfo::Timezone object (e.g., "America/New_York").
+  #
+  # Here's an example of how you might set <tt>Time.zone</tt> on a per request basis and reset it when the request is done.
+  # <tt>current_user.time_zone</tt> just needs to return a string identifying the user's preferred time zone:
+  #
+  #   class ApplicationController < ActionController::Base
+  #     around_action :set_time_zone
+  #
+  #     def set_time_zone
+  #       if logged_in?
+  #         Time.use_zone(current_user.time_zone) { yield }
+  #       else
+  #         yield
+  #       end
+  #     end
+  #   end
+  def self.zone=: (untyped time_zone) -> untyped
+
+  # Allows override of <tt>Time.zone</tt> locally inside supplied block;
+  # resets <tt>Time.zone</tt> to existing value when done.
+  #
+  #   class ApplicationController < ActionController::Base
+  #     around_action :set_time_zone
+  #
+  #     private
+  #
+  #     def set_time_zone
+  #       Time.use_zone(current_user.timezone) { yield }
+  #     end
+  #   end
+  #
+  # NOTE: This won't affect any <tt>ActiveSupport::TimeWithZone</tt>
+  # objects that have already been created, e.g. any model timestamp
+  # attributes that have been read before the block will remain in
+  # the application's default timezone.
+  def self.use_zone: (untyped time_zone) { () -> untyped } -> untyped
+
+  # Returns a TimeZone instance matching the time zone provided.
+  # Accepts the time zone in any format supported by <tt>Time.zone=</tt>.
+  # Raises an +ArgumentError+ for invalid time zones.
+  #
+  #   Time.find_zone! "America/New_York" # => #<ActiveSupport::TimeZone @name="America/New_York" ...>
+  #   Time.find_zone! "EST"              # => #<ActiveSupport::TimeZone @name="EST" ...>
+  #   Time.find_zone! -5.hours           # => #<ActiveSupport::TimeZone @name="Bogota" ...>
+  #   Time.find_zone! nil                # => nil
+  #   Time.find_zone! false              # => false
+  #   Time.find_zone! "NOT-A-TIMEZONE"   # => ArgumentError: Invalid Timezone: NOT-A-TIMEZONE
+  def self.find_zone!: (untyped time_zone) -> untyped
+
+  # Returns a TimeZone instance matching the time zone provided.
+  # Accepts the time zone in any format supported by <tt>Time.zone=</tt>.
+  # Returns +nil+ for invalid time zones.
+  #
+  #   Time.find_zone "America/New_York" # => #<ActiveSupport::TimeZone @name="America/New_York" ...>
+  #   Time.find_zone "NOT-A-TIMEZONE"   # => nil
+  def self.find_zone: (untyped time_zone) -> untyped
+end
+
+module URI
+  def self.parser: () -> untyped
+end
+
+module ActiveSupport
+  # Abstract super class that provides a thread-isolated attributes singleton, which resets automatically
+  # before and after each request. This allows you to keep all the per-request attributes easily
+  # available to the whole system.
+  #
+  # The following full app-like example demonstrates how to use a Current class to
+  # facilitate easy access to the global, per-request attributes without passing them deeply
+  # around everywhere:
+  #
+  #   # app/models/current.rb
+  #   class Current < ActiveSupport::CurrentAttributes
+  #     attribute :account, :user
+  #     attribute :request_id, :user_agent, :ip_address
+  #
+  #     resets { Time.zone = nil }
+  #
+  #     def user=(user)
+  #       super
+  #       self.account = user.account
+  #       Time.zone    = user.time_zone
+  #     end
+  #   end
+  #
+  #   # app/controllers/concerns/authentication.rb
+  #   module Authentication
+  #     extend ActiveSupport::Concern
+  #
+  #     included do
+  #       before_action :authenticate
+  #     end
+  #
+  #     private
+  #       def authenticate
+  #         if authenticated_user = User.find_by(id: cookies.encrypted[:user_id])
+  #           Current.user = authenticated_user
+  #         else
+  #           redirect_to new_session_url
+  #         end
+  #       end
+  #   end
+  #
+  #   # app/controllers/concerns/set_current_request_details.rb
+  #   module SetCurrentRequestDetails
+  #     extend ActiveSupport::Concern
+  #
+  #     included do
+  #       before_action do
+  #         Current.request_id = request.uuid
+  #         Current.user_agent = request.user_agent
+  #         Current.ip_address = request.ip
+  #       end
+  #     end
+  #   end
+  #
+  #   class ApplicationController < ActionController::Base
+  #     include Authentication
+  #     include SetCurrentRequestDetails
+  #   end
+  #
+  #   class MessagesController < ApplicationController
+  #     def create
+  #       Current.account.messages.create(message_params)
+  #     end
+  #   end
+  #
+  #   class Message < ApplicationRecord
+  #     belongs_to :creator, default: -> { Current.user }
+  #     after_create { |message| Event.create(record: message) }
+  #   end
+  #
+  #   class Event < ApplicationRecord
+  #     before_create do
+  #       self.request_id = Current.request_id
+  #       self.user_agent = Current.user_agent
+  #       self.ip_address = Current.ip_address
+  #     end
+  #   end
+  #
+  # A word of caution: It's easy to overdo a global singleton like Current and tangle your model as a result.
+  # Current should only be used for a few, top-level globals, like account, user, and request details.
+  # The attributes stuck in Current should be used by more or less all actions on all requests. If you start
+  # sticking controller-specific attributes in there, you're going to create a mess.
+  class CurrentAttributes
+    include ActiveSupport::Callbacks
+
+    # Returns singleton instance for this class in this thread. If none exists, one is created.
+    def self.`instance`: () -> untyped
+
+    # Declares one or more attributes that will be given both class and instance accessor methods.
+    def self.attribute: (*untyped names) -> untyped
+
+    # Calls this block before #reset is called on the instance. Used for resetting external collaborators that depend on current values.
+    def self.before_reset: () { () -> untyped } -> untyped
+
+    # Calls this block after #reset is called on the instance. Used for resetting external collaborators, like Time.zone.
+    def self.resets: () { () -> untyped } -> untyped
+
+    alias self.after_reset self.resets
+
+    def self.reset_all: () -> untyped
+
+    def self.clear_all: () -> untyped
+
+    def self.generated_attribute_methods: () -> untyped
+
+    def self.current_instances: () -> untyped
+
+    def self.method_missing: (untyped name, *untyped args) { () -> untyped } -> untyped
+
+    attr_accessor attributes: untyped
+
+    def initialize: () -> untyped
+
+    # Expose one or more attributes within a block. Old values are returned after the block concludes.
+    # Example demonstrating the common use of needing to set Current attributes outside the request-cycle:
+    #
+    #   class Chat::PublicationJob < ApplicationJob
+    #     def perform(attributes, room_number, creator)
+    #       Current.set(person: creator) do
+    #         Chat::Publisher.publish(attributes: attributes, room_number: room_number)
+    #       end
+    #     end
+    #   end
+    def set: (untyped set_attributes) { () -> untyped } -> untyped
+
+    # Reset all attributes. Should be called before and after actions, when used as a per-request singleton.
+    def reset: () -> untyped
+
+    def assign_attributes: (untyped new_attributes) -> untyped
+
+    def compute_attributes: (untyped keys) -> untyped
+  end
+end
+
+module ActiveSupport
+  # Autoload and eager load conveniences for your library.
+  #
+  # This module allows you to define autoloads based on
+  # Rails conventions (i.e. no need to define the path
+  # it is automatically guessed based on the filename)
+  # and also define a set of constants that needs to be
+  # eager loaded:
+  #
+  #   module MyLib
+  #     extend ActiveSupport::Autoload
+  #
+  #     autoload :Model
+  #
+  #     eager_autoload do
+  #       autoload :Cache
+  #     end
+  #   end
+  #
+  # Then your library can be eager loaded by simply calling:
+  #
+  #   MyLib.eager_load!
+  module Autoload
+    def self.extended: (untyped base) -> untyped
+
+    def autoload: (untyped const_name, ?untyped path) -> untyped
+
+    def autoload_under: (untyped path) { () -> untyped } -> untyped
+
+    def autoload_at: (untyped path) { () -> untyped } -> untyped
+
+    def eager_autoload: () { () -> untyped } -> untyped
+
+    def eager_load!: () -> untyped
+
+    def autoloads: () -> untyped
+  end
+end
+
+module ActiveSupport
+  module Dependencies
+    # nodoc:
+    # nodoc:
+    class Interlock
+      def initialize: () -> untyped
+
+      def loading: () { () -> untyped } -> untyped
+
+      def unloading: () { () -> untyped } -> untyped
+
+      def start_unloading: () -> untyped
+
+      def done_unloading: () -> untyped
+
+      def start_running: () -> untyped
+
+      def done_running: () -> untyped
+
+      def running: () { () -> untyped } -> untyped
+
+      def permit_concurrent_loads: () { () -> untyped } -> untyped
+
+      def raw_state: () { () -> untyped } -> untyped
+    end
+  end
+end
+
+module ActiveSupport
+  module Dependencies
+    module ZeitwerkIntegration
+      # :nodoc: all
+      module Decorations
+        def clear: () -> untyped
+
+        def constantize: (untyped cpath) -> untyped
+
+        def safe_constantize: (untyped cpath) -> untyped
+
+        def autoloaded_constants: () -> untyped
+
+        def autoloaded?: (untyped object) -> untyped
+
+        def verbose=: (untyped verbose) -> untyped
+
+        def unhook!: () -> :no_op
+      end
+
+      module RequireDependency
+        def require_dependency: (untyped filename) -> untyped
+      end
+
+      module Inflector
+        def self.camelize: (untyped basename, untyped _abspath) -> untyped
+
+        def self.inflect: (untyped overrides) -> untyped
+      end
+
+      def self.take_over: (enable_reloading: untyped enable_reloading) -> untyped
+
+      def self.setup_autoloaders: (untyped enable_reloading) -> untyped
+
+      def self.autoload_once?: (untyped autoload_path) -> untyped
+
+      def self.eager_load?: (untyped autoload_path) -> untyped
+
+      def self.freeze_paths: () -> untyped
+
+      def self.decorate_dependencies: () -> untyped
+    end
+  end
+end
+
+module ActiveSupport
+  module Dependencies
+    UNBOUND_METHOD_MODULE_NAME: untyped
+
+    # Execute the supplied block without interference from any
+    # concurrent loads.
+    def self.run_interlock: () { () -> untyped } -> untyped
+
+    # Execute the supplied block while holding an exclusive lock,
+    # preventing any other thread from being inside a #run_interlock
+    # block at the same time.
+    def self.load_interlock: () { () -> untyped } -> untyped
+
+    # Execute the supplied block while holding an exclusive lock,
+    # preventing any other thread from being inside a #run_interlock
+    # block at the same time.
+    def self.unload_interlock: () { () -> untyped } -> untyped
+
+    # The WatchStack keeps a stack of the modules being watched as files are
+    # loaded. If a file in the process of being loaded (parent.rb) triggers the
+    # load of another file (child.rb) the stack will ensure that child.rb
+    # handles the new constants.
+    #
+    # If child.rb is being autoloaded, its constants will be added to
+    # autoloaded_constants. If it was being required, they will be discarded.
+    #
+    # This is handled by walking back up the watch stack and adding the constants
+    # found by child.rb to the list of original constants in parent.rb.
+    class WatchStack
+      include Enumerable[untyped]
+
+      attr_reader watching: untyped
+
+      def initialize: () -> untyped
+
+      def each: () { () -> untyped } -> untyped
+
+      def watching?: () -> untyped
+
+      # Returns a list of new constants found since the last call to
+      # <tt>watch_namespaces</tt>.
+      def new_constants: () -> untyped
+
+      # Add a set of modules to the watch stack, remembering the initial
+      # constants.
+      def watch_namespaces: (untyped namespaces) -> untyped
+
+      def pop_modules: (untyped modules) -> untyped
+    end
+
+    module ModuleConstMissing
+      # Module includes this module.
+      # nodoc:
+      def self.append_features: (untyped base) -> (nil | untyped)
+
+      def self.exclude_from: (untyped base) -> untyped
+
+      def self.include_into: (untyped base) -> untyped
+
+      def const_missing: (untyped const_name) -> untyped
+
+      # We assume that the name of the module reflects the nesting
+      # (unless it can be proven that is not the case) and the path to the file
+      # that defines the constant. Anonymous modules cannot follow these
+      # conventions and therefore we assume that the user wants to refer to a
+      # top-level constant.
+      def guess_for_anonymous: (untyped const_name) -> untyped
+
+      def unloadable: (?untyped const_desc) -> untyped
+    end
+
+    module Loadable
+      # Object includes this module.
+      # nodoc:
+      def self.exclude_from: (untyped base) -> untyped
+
+      def self.include_into: (untyped base) -> untyped
+
+      def require_or_load: (untyped file_name) -> untyped
+
+      # Interprets a file using <tt>mechanism</tt> and marks its defined
+      # constants as autoloaded. <tt>file_name</tt> can be either a string or
+      # respond to <tt>to_path</tt>.
+      #
+      # Use this method in code that absolutely needs a certain constant to be
+      # defined at that point. A typical use case is to make constant name
+      # resolution deterministic for constants with the same relative name in
+      # different namespaces whose evaluation would depend on load order
+      # otherwise.
+      def require_dependency: (untyped file_name, ?::String message) -> untyped
+
+      def load_dependency: (untyped file) { () -> untyped } -> untyped
+
+      # Mark the given constant as unloadable. Unloadable constants are removed
+      # each time dependencies are cleared.
+      #
+      # Note that marking a constant for unloading need only be done once. Setup
+      # or init scripts may list each unloadable constant that may need unloading;
+      # each constant will be removed for every subsequent clear, as opposed to
+      # for the first clear.
+      #
+      # The provided constant descriptor may be a (non-anonymous) module or class,
+      # or a qualified constant name as a string or symbol.
+      #
+      # Returns +true+ if the constant was not previously marked for unloading,
+      # +false+ otherwise.
+      def unloadable: (untyped const_desc) -> untyped
+
+      def load: (untyped file, ?bool wrap) -> untyped
+
+      def require: (untyped file) -> untyped
+    end
+
+    module Blamable
+      # Exception file-blaming.
+      # nodoc:
+      def blame_file!: (untyped file) -> untyped
+
+      def blamed_files: () -> untyped
+
+      def describe_blame: () -> (nil | ::String)
+
+      def copy_blame!: (untyped exc) -> untyped
+    end
+
+    def hook!: () -> untyped
+
+    def unhook!: () -> untyped
+
+    def load?: () -> untyped
+
+    def depend_on: (untyped file_name, ?::String message) -> untyped
+
+    def clear: () -> untyped
+
+    def require_or_load: (untyped file_name, ?untyped? const_path) -> (nil | untyped)
+
+    # Is the provided constant path defined?
+    def qualified_const_defined?: (untyped path) -> untyped
+
+    # Given +path+, a filesystem path to a ruby file, return an array of
+    # constant paths which would cause Dependencies to attempt to load this
+    # file.
+    def loadable_constants_for_path: (untyped path, ?untyped bases) -> untyped
+
+    # Search for a file in autoload_paths matching the provided suffix.
+    def search_for_file: (untyped path_suffix) -> (untyped | nil)
+
+    # Does the provided path_suffix correspond to an autoloadable module?
+    # Instead of returning a boolean, the autoload base for this module is
+    # returned.
+    def autoloadable_module?: (untyped path_suffix) -> (untyped | nil)
+
+    def load_once_path?: (untyped path) -> untyped
+
+    # Attempt to autoload the provided module name by searching for a directory
+    # matching the expected path suffix. If found, the module is created and
+    # assigned to +into+'s constants with the name +const_name+. Provided that
+    # the directory was loaded from a reloadable base path, it is added to the
+    # set of constants that are to be unloaded.
+    def autoload_module!: (untyped into, untyped const_name, untyped qualified_name, untyped path_suffix) -> (nil | untyped)
+
+    # Load the file at the provided path. +const_paths+ is a set of qualified
+    # constant names. When loading the file, Dependencies will watch for the
+    # addition of these constants. Each that is defined will be marked as
+    # autoloaded, and will be removed when Dependencies.clear is next called.
+    #
+    # If the second parameter is left off, then Dependencies will construct a
+    # set of names that the file at +path+ may define. See
+    # +loadable_constants_for_path+ for more details.
+    def load_file: (untyped path, ?untyped const_paths) -> untyped
+
+    # Returns the constant path for the provided parent and constant name.
+    def qualified_name_for: (untyped mod, untyped name) -> untyped
+
+    # Load the constant named +const_name+ which is missing from +from_mod+. If
+    # it is not possible to load the constant into from_mod, try its parent
+    # module using +const_missing+.
+    def load_missing_constant: (untyped from_mod, untyped const_name) -> untyped
+
+    # Remove the constants that have been autoloaded, and those that have been
+    # marked for unloading. Before each constant is removed a callback is sent
+    # to its class/module if it implements +before_remove_const+.
+    #
+    # The callback implementation should be restricted to cleaning up caches, etc.
+    # as the environment will be in an inconsistent state, e.g. other constants
+    # may have already been unloaded and not accessible.
+    def remove_unloadable_constants!: () -> untyped
+
+    class ClassCache
+      def initialize: () -> untyped
+
+      def empty?: () -> untyped
+
+      def key?: (untyped key) -> untyped
+
+      def get: (untyped key) -> untyped
+
+      alias [] get
+
+      def safe_get: (untyped key) -> untyped
+
+      def store: (untyped klass) -> untyped
+
+      def clear!: () -> untyped
+    end
+
+    Reference: untyped
+
+    # Store a reference to a class +klass+.
+    def reference: (untyped klass) -> untyped
+
+    # Get the reference for class named +name+.
+    # Raises an exception if referenced class does not exist.
+    def constantize: (untyped name) -> untyped
+
+    # Get the reference for class named +name+ if one exists.
+    # Otherwise returns +nil+.
+    def safe_constantize: (untyped name) -> untyped
+
+    # Determine if the given constant has been automatically loaded.
+    def autoloaded?: (untyped desc) -> (::FalseClass | untyped)
+
+    # Will the provided constant descriptor be unloaded?
+    def will_unload?: (untyped const_desc) -> untyped
+
+    # Mark the provided constant name for unloading. This constant will be
+    # unloaded on each request, not just the next one.
+    def mark_for_unload: (untyped const_desc) -> untyped
+
+    # Run the provided block and detect the new constants that were loaded during
+    # its execution. Constants may only be regarded as 'new' once -- so if the
+    # block calls +new_constants_in+ again, then the constants defined within the
+    # inner call will not be reported in this one.
+    #
+    # If the provided block does not run to completion, and instead raises an
+    # exception, any new constants are regarded as being only partially defined
+    # and will be removed immediately.
+    def new_constants_in: (*untyped descs) { () -> untyped } -> untyped
+
+    def to_constant_name: (untyped desc) -> untyped
+
+    def remove_constant: (untyped const) -> (nil | untyped)
+
+    def log: (untyped message) -> untyped
+
+    # Returns the original name of a class or module even if `name` has been
+    # overridden.
+    def real_mod_name: (untyped mod) -> untyped
+  end
+end
+
+module ActiveSupport
+  # Raised when <tt>ActiveSupport::Deprecation::Behavior#behavior</tt> is set with <tt>:raise</tt>.
+  # You would set <tt>:raise</tt>, as a behavior to raise errors and proactively report exceptions from deprecations.
+  class DeprecationException < StandardError
+  end
+
+  class Deprecation
+    # Default warning behaviors per Rails.env.
+    DEFAULT_BEHAVIORS: ::Hash[untyped, untyped]
+
+    # Behavior module allows to determine how to display deprecation messages.
+    # You can create a custom behavior or set any from the +DEFAULT_BEHAVIORS+
+    # constant. Available behaviors are:
+    #
+    # [+raise+]   Raise <tt>ActiveSupport::DeprecationException</tt>.
+    # [+stderr+]  Log all deprecation warnings to +$stderr+.
+    # [+log+]     Log all deprecation warnings to +Rails.logger+.
+    # [+notify+]  Use +ActiveSupport::Notifications+ to notify +deprecation.rails+.
+    # [+silence+] Do nothing.
+    #
+    # Setting behaviors only affects deprecations that happen after boot time.
+    # For more information you can read the documentation of the +behavior=+ method.
+    module Behavior
+      # Whether to print a backtrace along with the warning.
+      attr_accessor debug: untyped
+
+      # Returns the current behavior or if one isn't set, defaults to +:stderr+.
+      def behavior: () -> untyped
+
+      # Sets the behavior to the specified value. Can be a single value, array,
+      # or an object that responds to +call+.
+      #
+      # Available behaviors:
+      #
+      # [+raise+]   Raise <tt>ActiveSupport::DeprecationException</tt>.
+      # [+stderr+]  Log all deprecation warnings to +$stderr+.
+      # [+log+]     Log all deprecation warnings to +Rails.logger+.
+      # [+notify+]  Use +ActiveSupport::Notifications+ to notify +deprecation.rails+.
+      # [+silence+] Do nothing.
+      #
+      # Setting behaviors only affects deprecations that happen after boot time.
+      # Deprecation warnings raised by gems are not affected by this setting
+      # because they happen before Rails boots up.
+      #
+      #   ActiveSupport::Deprecation.behavior = :stderr
+      #   ActiveSupport::Deprecation.behavior = [:stderr, :log]
+      #   ActiveSupport::Deprecation.behavior = MyCustomHandler
+      #   ActiveSupport::Deprecation.behavior = ->(message, callstack, deprecation_horizon, gem_name) {
+      #     # custom stuff
+      #   }
+      def behavior=: (untyped behavior) -> untyped
+
+      def arity_coerce: (untyped behavior) -> untyped
+    end
+  end
+end
+
+module ActiveSupport
+  class Deprecation
+    # DeprecatedConstantAccessor transforms a constant into a deprecated one by
+    # hooking +const_missing+.
+    #
+    # It takes the names of an old (deprecated) constant and of a new constant
+    # (both in string form) and optionally a deprecator. The deprecator defaults
+    # to +ActiveSupport::Deprecator+ if none is specified.
+    #
+    # The deprecated constant now returns the same object as the new one rather
+    # than a proxy object, so it can be used transparently in +rescue+ blocks
+    # etc.
+    #
+    #   PLANETS = %w(mercury venus earth mars jupiter saturn uranus neptune pluto)
+    #
+    #   # (In a later update, the original implementation of `PLANETS` has been removed.)
+    #
+    #   PLANETS_POST_2006 = %w(mercury venus earth mars jupiter saturn uranus neptune)
+    #   include ActiveSupport::Deprecation::DeprecatedConstantAccessor
+    #   deprecate_constant 'PLANETS', 'PLANETS_POST_2006'
+    #
+    #   PLANETS.map { |planet| planet.capitalize }
+    #   # => DEPRECATION WARNING: PLANETS is deprecated! Use PLANETS_POST_2006 instead.
+    #        (Backtrace information(trim non-ascii characters))
+    #        ["Mercury", "Venus", "Earth", "Mars", "Jupiter", "Saturn", "Uranus", "Neptune"]
+    module DeprecatedConstantAccessor
+      def self.included: (untyped base) -> untyped
+    end
+  end
+end
+
+module ActiveSupport
+  class Deprecation
+    module InstanceDelegator
+      # :nodoc:
+      def self.included: (untyped base) -> untyped
+
+      module ClassMethods
+        # :nodoc:
+        def `include`: (untyped included_module) -> untyped
+
+        def method_added: (untyped method_name) -> untyped
+      end
+
+      module OverrideDelegators
+        # :nodoc:
+        def warn: (?untyped? message, ?untyped? callstack) -> untyped
+
+        def deprecation_warning: (untyped deprecated_method_name, ?untyped? message, ?untyped? caller_backtrace) -> untyped
+      end
+    end
+  end
+end
+
+module ActiveSupport
+  class Deprecation
+    module MethodWrapper
+      # Declare that a method has been deprecated.
+      #
+      #   class Fred
+      #     def aaa; end
+      #     def bbb; end
+      #     def ccc; end
+      #     def ddd; end
+      #     def eee; end
+      #   end
+      #
+      # Using the default deprecator:
+      #   ActiveSupport::Deprecation.deprecate_methods(Fred, :aaa, bbb: :zzz, ccc: 'use Bar#ccc instead')
+      #   # => Fred
+      #
+      #   Fred.new.aaa
+      #   # DEPRECATION WARNING: aaa is deprecated and will be removed from Rails 5.1. (called from irb_binding at (irb):10)
+      #   # => nil
+      #
+      #   Fred.new.bbb
+      #   # DEPRECATION WARNING: bbb is deprecated and will be removed from Rails 5.1 (use zzz instead). (called from irb_binding at (irb):11)
+      #   # => nil
+      #
+      #   Fred.new.ccc
+      #   # DEPRECATION WARNING: ccc is deprecated and will be removed from Rails 5.1 (use Bar#ccc instead). (called from irb_binding at (irb):12)
+      #   # => nil
+      #
+      # Passing in a custom deprecator:
+      #   custom_deprecator = ActiveSupport::Deprecation.new('next-release', 'MyGem')
+      #   ActiveSupport::Deprecation.deprecate_methods(Fred, ddd: :zzz, deprecator: custom_deprecator)
+      #   # => [:ddd]
+      #
+      #   Fred.new.ddd
+      #   DEPRECATION WARNING: ddd is deprecated and will be removed from MyGem next-release (use zzz instead). (called from irb_binding at (irb):15)
+      #   # => nil
+      #
+      # Using a custom deprecator directly:
+      #   custom_deprecator = ActiveSupport::Deprecation.new('next-release', 'MyGem')
+      #   custom_deprecator.deprecate_methods(Fred, eee: :zzz)
+      #   # => [:eee]
+      #
+      #   Fred.new.eee
+      #   DEPRECATION WARNING: eee is deprecated and will be removed from MyGem next-release (use zzz instead). (called from irb_binding at (irb):18)
+      #   # => nil
+      def deprecate_methods: (untyped target_module, *untyped method_names) -> untyped
+    end
+  end
+end
+
+module ActiveSupport
+  class Deprecation
+    class DeprecationProxy
+      # nodoc:
+      def self.new: (*untyped args) { () -> untyped } -> untyped
+
+      # Don't give a deprecation warning on inspect since test/unit and error
+      # logs rely on it for diagnostics.
+      def inspect: () -> untyped
+
+      def method_missing: (untyped called, *untyped args) { () -> untyped } -> untyped
+    end
+
+    # DeprecatedObjectProxy transforms an object into a deprecated one. It
+    # takes an object, a deprecation message and optionally a deprecator. The
+    # deprecator defaults to +ActiveSupport::Deprecator+ if none is specified.
+    #
+    #   deprecated_object = ActiveSupport::Deprecation::DeprecatedObjectProxy.new(Object.new, "This object is now deprecated")
+    #   # => #<Object:0x007fb9b34c34b0>
+    #
+    #   deprecated_object.to_s
+    #   DEPRECATION WARNING: This object is now deprecated.
+    #   (Backtrace)
+    #   # => "#<Object:0x007fb9b34c34b0>"
+    class DeprecatedObjectProxy < DeprecationProxy
+      def initialize: (untyped object, untyped message, ?untyped deprecator) -> untyped
+
+      def target: () -> untyped
+
+      def warn: (untyped callstack, untyped called, untyped args) -> untyped
+    end
+
+    # DeprecatedInstanceVariableProxy transforms an instance variable into a
+    # deprecated one. It takes an instance of a class, a method on that class
+    # and an instance variable. It optionally takes a deprecator as the last
+    # argument. The deprecator defaults to +ActiveSupport::Deprecator+ if none
+    # is specified.
+    #
+    #   class Example
+    #     def initialize
+    #       @request = ActiveSupport::Deprecation::DeprecatedInstanceVariableProxy.new(self, :request, :@request)
+    #       @_request = :special_request
+    #     end
+    #
+    #     def request
+    #       @_request
+    #     end
+    #
+    #     def old_request
+    #       @request
+    #     end
+    #   end
+    #
+    #   example = Example.new
+    #   # => #<Example:0x007fb9b31090b8 @_request=:special_request, @request=:special_request>
+    #
+    #   example.old_request.to_s
+    #   # => DEPRECATION WARNING: @request is deprecated! Call request.to_s instead of
+    #      @request.to_s
+    #      (Backtrace information(trim non-ascii characters))
+    #      "special_request"
+    #
+    #   example.request.to_s
+    #   # => "special_request"
+    class DeprecatedInstanceVariableProxy < DeprecationProxy
+      def initialize: (untyped `instance`, untyped method, ?::String var, ?untyped deprecator) -> untyped
+
+      def target: () -> untyped
+
+      def warn: (untyped callstack, untyped called, untyped args) -> untyped
+    end
+
+    # DeprecatedConstantProxy transforms a constant into a deprecated one. It
+    # takes the names of an old (deprecated) constant and of a new constant
+    # (both in string form) and optionally a deprecator. The deprecator defaults
+    # to +ActiveSupport::Deprecator+ if none is specified. The deprecated constant
+    # now returns the value of the new one.
+    #
+    #   PLANETS = %w(mercury venus earth mars jupiter saturn uranus neptune pluto)
+    #
+    #   # (In a later update, the original implementation of `PLANETS` has been removed.)
+    #
+    #   PLANETS_POST_2006 = %w(mercury venus earth mars jupiter saturn uranus neptune)
+    #   PLANETS = ActiveSupport::Deprecation::DeprecatedConstantProxy.new('PLANETS', 'PLANETS_POST_2006')
+    #
+    #   PLANETS.map { |planet| planet.capitalize }
+    #   # => DEPRECATION WARNING: PLANETS is deprecated! Use PLANETS_POST_2006 instead.
+    #        (Backtrace information(trim non-ascii characters))
+    #        ["Mercury", "Venus", "Earth", "Mars", "Jupiter", "Saturn", "Uranus", "Neptune"]
+    class DeprecatedConstantProxy < Module
+      def self.new: (*untyped args, **untyped kwargs) { () -> untyped } -> untyped
+
+      def initialize: (untyped old_const, untyped new_const, ?untyped deprecator, ?message: ::String message) -> untyped
+
+      # Don't give a deprecation warning on inspect since test/unit and error
+      # logs rely on it for diagnostics.
+      def inspect: () -> untyped
+
+      # Returns the class of the new constant.
+      #
+      #   PLANETS_POST_2006 = %w(mercury venus earth mars jupiter saturn uranus neptune)
+      #   PLANETS = ActiveSupport::Deprecation::DeprecatedConstantProxy.new('PLANETS', 'PLANETS_POST_2006')
+      #   PLANETS.class # => Array
+      def `class`: () -> untyped
+
+      def target: () -> untyped
+
+      def const_missing: (untyped name) -> untyped
+
+      def method_missing: (untyped called, *untyped args) { () -> untyped } -> untyped
+    end
+  end
+end
+
+module ActiveSupport
+  class Deprecation
+    module Reporting
+      # Whether to print a message (silent mode)
+      attr_accessor silenced: untyped
+
+      # Name of gem where method is deprecated
+      attr_accessor gem_name: untyped
+
+      # Outputs a deprecation warning to the output configured by
+      # <tt>ActiveSupport::Deprecation.behavior</tt>.
+      #
+      #   ActiveSupport::Deprecation.warn('something broke!')
+      #   # => "DEPRECATION WARNING: something broke! (called from your_code.rb:1)"
+      def warn: (?untyped? message, ?untyped? callstack) -> (nil | untyped)
+
+      # Silence deprecation warnings within the block.
+      #
+      #   ActiveSupport::Deprecation.warn('something broke!')
+      #   # => "DEPRECATION WARNING: something broke! (called from your_code.rb:1)"
+      #
+      #   ActiveSupport::Deprecation.silence do
+      #     ActiveSupport::Deprecation.warn('something broke!')
+      #   end
+      #   # => nil
+      def silence: () { () -> untyped } -> untyped
+
+      def deprecation_warning: (untyped deprecated_method_name, ?untyped? message, ?untyped? caller_backtrace) -> untyped
+
+      # Outputs a deprecation warning message
+      #
+      #   deprecated_method_warning(:method_name)
+      #   # => "method_name is deprecated and will be removed from Rails #{deprecation_horizon}"
+      #   deprecated_method_warning(:method_name, :another_method)
+      #   # => "method_name is deprecated and will be removed from Rails #{deprecation_horizon} (use another_method instead)"
+      #   deprecated_method_warning(:method_name, "Optional message")
+      #   # => "method_name is deprecated and will be removed from Rails #{deprecation_horizon} (Optional message)"
+      def deprecated_method_warning: (untyped method_name, ?untyped? message) -> untyped
+
+      def deprecation_message: (untyped callstack, ?untyped? message) -> ::String
+
+      def deprecation_caller_message: (untyped callstack) -> untyped
+
+      def extract_callstack: (untyped callstack) -> (untyped | ::Array[untyped])
+
+      def _extract_callstack: (untyped callstack) -> untyped
+
+      RAILS_GEM_ROOT: untyped
+
+      def ignored_callstack: (untyped path) -> untyped
+    end
+  end
+end
+
+module ActiveSupport
+  # \Deprecation specifies the API used by Rails to deprecate methods, instance
+  # variables, objects and constants.
+  class Deprecation
+    include Singleton
+
+    include InstanceDelegator
+
+    include Behavior
+
+    include Reporting
+
+    include MethodWrapper
+
+    # The version number in which the deprecated behavior will be removed, by default.
+    attr_accessor deprecation_horizon: untyped
+
+    # It accepts two parameters on initialization. The first is a version of library
+    # and the second is a library name.
+    #
+    #   ActiveSupport::Deprecation.new('2.0', 'MyLibrary')
+    def initialize: (?::String deprecation_horizon, ?::String gem_name) -> untyped
+  end
+end
+
+module ActiveSupport
+  # This module provides an internal implementation to track descendants
+  # which is faster than iterating through ObjectSpace.
+  module DescendantsTracker
+    def self.direct_descendants: (untyped klass) -> untyped
+
+    def self.descendants: (untyped klass) -> untyped
+
+    def self.clear: () -> untyped
+
+    # This is the only method that is not thread safe, but is only ever called
+    # during the eager loading phase.
+    def self.store_inherited: (untyped klass, untyped descendant) -> untyped
+
+    def self.accumulate_descendants: (untyped klass, untyped acc) -> untyped
+
+    def inherited: (untyped base) -> untyped
+
+    def direct_descendants: () -> untyped
+
+    def descendants: () -> untyped
+
+    class DescendantsArray
+      # DescendantsArray is an array that contains weak references to classes.
+      # :nodoc:
+      include Enumerable[untyped]
+
+      def initialize: () -> untyped
+
+      def initialize_copy: (untyped orig) -> untyped
+
+      def <<: (untyped klass) -> untyped
+
+      def each: () { (untyped) -> untyped } -> untyped
+
+      def refs_size: () -> untyped
+
+      def cleanup!: () -> untyped
+
+      def reject!: () { (untyped) -> untyped } -> untyped
+    end
+  end
+end
+
+module ActiveSupport
+  class Digest
+    def self.hash_digest_class: () -> untyped
+
+    def self.hash_digest_class=: (untyped klass) -> untyped
+
+    def self.hexdigest: (untyped arg) -> untyped
+  end
+end
+
+module ActiveSupport
+  class Duration
+    class ISO8601Parser
+      # Parses a string formatted according to ISO 8601 Duration into the hash.
+      #
+      # See {ISO 8601}[https://en.wikipedia.org/wiki/ISO_8601#Durations] for more information.
+      #
+      # This parser allows negative parts to be present in pattern.
+      # :nodoc:
+      class ParsingError < ::ArgumentError
+      end
+
+      PERIOD_OR_COMMA: untyped
+
+      PERIOD: ::String
+
+      COMMA: ::String
+
+      SIGN_MARKER: untyped
+
+      DATE_MARKER: untyped
+
+      TIME_MARKER: untyped
+
+      DATE_COMPONENT: untyped
+
+      TIME_COMPONENT: untyped
+
+      DATE_TO_PART: ::Hash[untyped, untyped]
+
+      TIME_TO_PART: ::Hash[untyped, untyped]
+
+      DATE_COMPONENTS: ::Array[untyped]
+
+      TIME_COMPONENTS: ::Array[untyped]
+
+      attr_reader parts: untyped
+
+      attr_reader scanner: untyped
+
+      attr_accessor mode: untyped
+
+      attr_accessor sign: untyped
+
+      def initialize: (untyped string) -> untyped
+
+      def parse!: () -> untyped
+
+      def finished?: () -> untyped
+
+      # Parses number which can be a float with either comma or period.
+      def number: () -> untyped
+
+      def scan: (untyped pattern) -> untyped
+
+      def raise_parsing_error: (?untyped? reason) -> untyped
+
+      # Checks for various semantic errors as stated in ISO 8601 standard.
+      def validate!: () -> ::TrueClass
+    end
+  end
+end
+
+module ActiveSupport
+  class Duration
+    class ISO8601Serializer
+      # Serializes duration to string according to ISO 8601 Duration format.
+      # :nodoc:
+      def initialize: (untyped duration, ?precision: untyped? precision) -> untyped
+
+      # Builds and returns output string.
+      def serialize: () -> ("PT0S" | ::String)
+
+      # Return pair of duration's parts and whole duration sign.
+      # Parts are summarized (as they can become repetitive due to addition, etc).
+      # Zero parts are removed as not significant.
+      # If all parts are negative it will negate all of them and return minus as a sign.
+      def normalize: () -> ::Array[untyped]
+    end
+  end
+end
+
+module ActiveSupport
+  # Provides accurate date and time measurements using Date#advance and
+  # Time#advance, respectively. It mainly supports the methods on Numeric.
+  #
+  #   1.month.ago       # equivalent to Time.now.advance(months: -1)
+  class Duration
+    class Scalar < Numeric
+      # nodoc:
+      attr_reader value: untyped
+
+      def initialize: (untyped value) -> untyped
+
+      def coerce: (untyped other) -> ::Array[Scalar | untyped]
+
+      def -@: () -> Scalar
+
+      def <=>: (untyped other) -> untyped
+
+      def +: (untyped other) -> untyped
+
+      def -: (untyped other) -> untyped
+
+      def *: (untyped other) -> untyped
+
+      def /: (untyped other) -> untyped
+
+      def %: (untyped other) -> untyped
+
+      def calculate: (untyped op, untyped other) -> untyped
+
+      def raise_type_error: (untyped other) -> untyped
+    end
+
+    SECONDS_PER_MINUTE: ::Integer
+
+    SECONDS_PER_HOUR: ::Integer
+
+    SECONDS_PER_DAY: ::Integer
+
+    SECONDS_PER_WEEK: ::Integer
+
+    SECONDS_PER_MONTH: ::Integer
+
+    SECONDS_PER_YEAR: ::Integer
+
+    PARTS_IN_SECONDS: untyped
+
+    PARTS: untyped
+
+    attr_accessor value: untyped
+
+    attr_accessor parts: untyped
+
+    # Creates a new Duration from string formatted according to ISO 8601 Duration.
+    #
+    # See {ISO 8601}[https://en.wikipedia.org/wiki/ISO_8601#Durations] for more information.
+    # This method allows negative parts to be present in pattern.
+    # If invalid string is provided, it will raise +ActiveSupport::Duration::ISO8601Parser::ParsingError+.
+    def self.parse: (untyped iso8601duration) -> untyped
+
+    def self.===: (untyped other) -> untyped
+
+    def self.seconds: (untyped value) -> untyped
+
+    def self.minutes: (untyped value) -> untyped
+
+    def self.hours: (untyped value) -> untyped
+
+    def self.days: (untyped value) -> untyped
+
+    def self.weeks: (untyped value) -> untyped
+
+    def self.months: (untyped value) -> untyped
+
+    def self.years: (untyped value) -> untyped
+
+    # Creates a new Duration from a seconds value that is converted
+    # to the individual parts:
+    #
+    #   ActiveSupport::Duration.build(31556952).parts # => {:years=>1}
+    #   ActiveSupport::Duration.build(2716146).parts  # => {:months=>1, :days=>1}
+    #
+    def self.build: (untyped value) -> untyped
+
+    def self.calculate_total_seconds: (untyped parts) -> untyped
+
+    def initialize: (untyped value, untyped parts) -> untyped
+
+    def coerce: (untyped other) -> untyped
+
+    # Compares one Duration with another or a Numeric to this Duration.
+    # Numeric values are treated as seconds.
+    def <=>: (untyped other) -> untyped
+
+    # Adds another Duration or a Numeric to this Duration. Numeric values
+    # are treated as seconds.
+    def +: (untyped other) -> untyped
+
+    # Subtracts another Duration or a Numeric from this Duration. Numeric
+    # values are treated as seconds.
+    def -: (untyped other) -> untyped
+
+    # Multiplies this Duration by a Numeric and returns a new Duration.
+    def *: (untyped other) -> untyped
+
+    # Divides this Duration by a Numeric and returns a new Duration.
+    def /: (untyped other) -> untyped
+
+    # Returns the modulo of this Duration by another Duration or Numeric.
+    # Numeric values are treated as seconds.
+    def %: (untyped other) -> untyped
+
+    def -@: () -> Duration
+
+    def is_a?: (untyped klass) -> untyped
+
+    alias kind_of? is_a?
+
+    def instance_of?: (untyped klass) -> untyped
+
+    # Returns +true+ if +other+ is also a Duration instance with the
+    # same +value+, or if <tt>other == value</tt>.
+    def ==: (untyped other) -> untyped
+
+    # Returns the amount of seconds a duration covers as a string.
+    # For more information check to_i method.
+    #
+    #   1.day.to_s # => "86400"
+    def to_s: () -> untyped
+
+    # Returns the number of seconds that this Duration represents.
+    #
+    #   1.minute.to_i   # => 60
+    #   1.hour.to_i     # => 3600
+    #   1.day.to_i      # => 86400
+    #
+    # Note that this conversion makes some assumptions about the
+    # duration of some periods, e.g. months are always 1/12 of year
+    # and years are 365.2425 days:
+    #
+    #   # equivalent to (1.year / 12).to_i
+    #   1.month.to_i    # => 2629746
+    #
+    #   # equivalent to 365.2425.days.to_i
+    #   1.year.to_i     # => 31556952
+    #
+    # In such cases, Ruby's core
+    # Date[https://ruby-doc.org/stdlib/libdoc/date/rdoc/Date.html] and
+    # Time[https://ruby-doc.org/stdlib/libdoc/time/rdoc/Time.html] should be used for precision
+    # date and time arithmetic.
+    def to_i: () -> untyped
+
+    # Returns +true+ if +other+ is also a Duration instance, which has the
+    # same parts as this one.
+    def eql?: (untyped other) -> untyped
+
+    def hash: () -> untyped
+
+    # Calculates a new Time or Date that is as far in the future
+    # as this Duration represents.
+    def since: (?untyped time) -> untyped
+
+    alias from_now since
+
+    alias after since
+
+    # Calculates a new Time or Date that is as far in the past
+    # as this Duration represents.
+    def ago: (?untyped time) -> untyped
+
+    alias until ago
+
+    alias before ago
+
+    def inspect: () -> (::String | untyped)
+
+    def as_json: (?untyped? options) -> untyped
+
+    def init_with: (untyped coder) -> untyped
+
+    def encode_with: (untyped coder) -> untyped
+
+    # Build ISO 8601 Duration string for this duration.
+    # The +precision+ parameter can be used to limit seconds' precision of duration.
+    def iso8601: (?precision: untyped? precision) -> untyped
+
+    def sum: (untyped sign, ?untyped time) -> untyped
+
+    def respond_to_missing?: (untyped method, untyped _) -> untyped
+
+    def method_missing: (untyped method, *untyped args) { () -> untyped } -> untyped
+
+    def raise_type_error: (untyped other) -> untyped
+  end
+end
+
+module ActiveSupport
+  class EncryptedConfiguration < EncryptedFile
+    def initialize: (raise_if_missing_key: untyped raise_if_missing_key, env_key: untyped env_key, key_path: untyped key_path, config_path: untyped config_path) -> untyped
+
+    # Allow a config to be started without a file present
+    def read: () -> untyped
+
+    def write: (untyped contents) -> untyped
+
+    def config: () -> untyped
+
+    def options: () -> untyped
+
+    def deserialize: (untyped config) -> untyped
+  end
+end
+
+module ActiveSupport
+  class EncryptedFile
+    class MissingContentError < RuntimeError
+      def initialize: (untyped content_path) -> untyped
+    end
+
+    class MissingKeyError < RuntimeError
+      def initialize: (env_key: untyped env_key, key_path: untyped key_path) -> untyped
+    end
+
+    CIPHER: ::String
+
+    def self.generate_key: () -> untyped
+
+    attr_reader content_path: untyped
+
+    attr_reader key_path: untyped
+
+    attr_reader env_key: untyped
+
+    attr_reader raise_if_missing_key: untyped
+
+    def initialize: (raise_if_missing_key: untyped raise_if_missing_key, env_key: untyped env_key, key_path: untyped key_path, content_path: untyped content_path) -> untyped
+
+    def key: () -> untyped
+
+    def read: () -> untyped
+
+    def write: (untyped contents) -> untyped
+
+    def change: () { () -> untyped } -> untyped
+
+    def writing: (untyped contents) { (untyped) -> untyped } -> untyped
+
+    def encrypt: (untyped contents) -> untyped
+
+    def decrypt: (untyped contents) -> untyped
+
+    def encryptor: () -> untyped
+
+    def read_env_key: () -> untyped
+
+    def read_key_file: () -> untyped
+
+    def handle_missing_key: () -> untyped
+  end
+end
+
+module ActiveSupport
+  class EventedFileUpdateChecker
+    # Allows you to "listen" to changes in a file system.
+    # The evented file updater does not hit disk when checking for updates
+    # instead it uses platform specific file system events to trigger a change
+    # in state.
+    #
+    # The file checker takes an array of files to watch or a hash specifying directories
+    # and file extensions to watch. It also takes a block that is called when
+    # EventedFileUpdateChecker#execute is run or when EventedFileUpdateChecker#execute_if_updated
+    # is run and there have been changes to the file system.
+    #
+    # Note: Forking will cause the first call to `updated?` to return `true`.
+    #
+    # Example:
+    #
+    #     checker = ActiveSupport::EventedFileUpdateChecker.new(["/tmp/foo"]) { puts "changed" }
+    #     checker.updated?
+    #     # => false
+    #     checker.execute_if_updated
+    #     # => nil
+    #
+    #     FileUtils.touch("/tmp/foo")
+    #
+    #     checker.updated?
+    #     # => true
+    #     checker.execute_if_updated
+    #     # => "changed"
+    #
+    # nodoc: all
+    def initialize: (untyped files, ?::Hash[untyped, untyped] dirs) { () -> untyped } -> untyped
+
+    def updated?: () -> untyped
+
+    def execute: () -> untyped
+
+    def execute_if_updated: () { () -> untyped } -> untyped
+
+    def boot!: () -> untyped
+
+    def shutdown!: () -> untyped
+
+    def normalize_dirs!: () -> untyped
+
+    def changed: (untyped modified, untyped added, untyped removed) -> untyped
+
+    def watching?: (untyped file) -> untyped
+
+    def directories_to_watch: () -> untyped
+
+    class PathHelper
+      def xpath: (untyped path) -> untyped
+
+      def normalize_extension: (untyped ext) -> untyped
+
+      # Given a collection of Pathname objects returns the longest subpath
+      # common to all of them, or +nil+ if there is none.
+      def longest_common_subpath: (untyped paths) -> (nil | untyped)
+
+      # Returns the deepest existing ascendant, which could be the argument itself.
+      def existing_parent: (untyped dir) -> untyped
+
+      # Filters out directories which are descendants of others in the collection (stable).
+      def filter_out_descendants: (untyped dirs) -> untyped
+
+      def ascendant_of?: (untyped base, untyped other) -> untyped
+    end
+  end
+end
+
+module ActiveSupport
+  class ExecutionWrapper
+    include ActiveSupport::Callbacks
+
+    Null: untyped
+
+    def self.complete!: () -> nil
+
+    def self.to_run: (*untyped args) { () -> untyped } -> untyped
+
+    def self.to_complete: (*untyped args) { () -> untyped } -> untyped
+
+    class RunHook[T] < ::Struct[T]
+      attr_accessor hook(): untyped
+
+      # :nodoc:
+      def before: (untyped target) -> untyped
+    end
+
+    class CompleteHook[T] < ::Struct[T]
+      attr_accessor hook(): untyped
+
+      # :nodoc:
+      def before: (untyped target) -> untyped
+
+      alias after before
+    end
+
+    # Register an object to be invoked during both the +run+ and
+    # +complete+ steps.
+    #
+    # +hook.complete+ will be passed the value returned from +hook.run+,
+    # and will only be invoked if +run+ has previously been called.
+    # (Mostly, this means it won't be invoked if an exception occurs in
+    # a preceding +to_run+ block; all ordinary +to_complete+ blocks are
+    # invoked in that situation.)
+    def self.register_hook: (untyped hook, ?outer: bool outer) -> untyped
+
+    # Run this execution.
+    #
+    # Returns an instance, whose +complete!+ method *must* be invoked
+    # after the work has been performed.
+    #
+    # Where possible, prefer +wrap+.
+    def self.run!: () -> untyped
+
+    # Perform the work in the supplied block as an execution.
+    def self.wrap: () { () -> untyped } -> untyped
+
+    # :nodoc:
+    attr_accessor active: untyped
+
+    def self.inherited: (untyped other) -> untyped
+
+    def self.active?: () -> untyped
+
+    def run!: () -> untyped
+
+    # Complete this in-flight execution. This method *must* be called
+    # exactly once on the result of any call to +run!+.
+    #
+    # Where possible, prefer +wrap+.
+    def complete!: () -> untyped
+
+    def hook_state: () -> untyped
+  end
+end
+
+module ActiveSupport
+  class Executor < ExecutionWrapper
+  end
+end
+
+module ActiveSupport
+  # FileUpdateChecker specifies the API used by Rails to watch files
+  # and control reloading. The API depends on four methods:
+  #
+  # * +initialize+ which expects two parameters and one block as
+  #   described below.
+  #
+  # * +updated?+ which returns a boolean if there were updates in
+  #   the filesystem or not.
+  #
+  # * +execute+ which executes the given block on initialization
+  #   and updates the latest watched files and timestamp.
+  #
+  # * +execute_if_updated+ which just executes the block if it was updated.
+  #
+  # After initialization, a call to +execute_if_updated+ must execute
+  # the block only if there was really a change in the filesystem.
+  #
+  # This class is used by Rails to reload the I18n framework whenever
+  # they are changed upon a new request.
+  #
+  #   i18n_reloader = ActiveSupport::FileUpdateChecker.new(paths) do
+  #     I18n.reload!
+  #   end
+  #
+  #   ActiveSupport::Reloader.to_prepare do
+  #     i18n_reloader.execute_if_updated
+  #   end
+  class FileUpdateChecker
+    # It accepts two parameters on initialization. The first is an array
+    # of files and the second is an optional hash of directories. The hash must
+    # have directories as keys and the value is an array of extensions to be
+    # watched under that directory.
+    #
+    # This method must also receive a block that will be called once a path
+    # changes. The array of files and list of directories cannot be changed
+    # after FileUpdateChecker has been initialized.
+    def initialize: (untyped files, ?::Hash[untyped, untyped] dirs) { () -> untyped } -> untyped
+
+    # Check if any of the entries were updated. If so, the watched and/or
+    # updated_at values are cached until the block is executed via +execute+
+    # or +execute_if_updated+.
+    def updated?: () -> untyped
+
+    # Executes the given block and updates the latest watched files and
+    # timestamp.
+    def execute: () -> untyped
+
+    # Execute the block given if updated.
+    def execute_if_updated: () { () -> untyped } -> untyped
+
+    def watched: () -> untyped
+
+    def updated_at: (untyped paths) -> untyped
+
+    # This method returns the maximum mtime of the files in +paths+, or +nil+
+    # if the array is empty.
+    #
+    # Files with a mtime in the future are ignored. Such abnormal situation
+    # can happen for example if the user changes the clock by hand. It is
+    # healthy to consider this edge case because with mtimes in the future
+    # reloading is not triggered.
+    def max_mtime: (untyped paths) -> untyped
+
+    def compile_glob: (untyped hash) -> (nil | ::String)
+
+    def escape: (untyped key) -> untyped
+
+    def compile_ext: (untyped array) -> (nil | ::String)
+  end
+end
+
+module ActiveSupport
+  # Returns the version of the currently loaded Active Support as a <tt>Gem::Version</tt>.
+  def self.gem_version: () -> Gem::Version
+
+  module VERSION
+    MAJOR: ::Integer
+
+    MINOR: ::Integer
+
+    TINY: ::Integer
+
+    PRE: ::String
+
+    STRING: untyped
+  end
+end
+
+module ActiveSupport
+  # A convenient wrapper for the zlib standard library that allows
+  # compression/decompression of strings with gzip.
+  #
+  #   gzip = ActiveSupport::Gzip.compress('compress me!')
+  #   # => "\x1F\x8B\b\x00o\x8D\xCDO\x00\x03K\xCE\xCF-(J-.V\xC8MU\x04\x00R>n\x83\f\x00\x00\x00"
+  #
+  #   ActiveSupport::Gzip.decompress(gzip)
+  #   # => "compress me!"
+  module Gzip
+    class Stream < StringIO
+      def initialize: () -> untyped
+
+      def close: () -> untyped
+    end
+
+    # Decompresses a gzipped string.
+    def self.decompress: (untyped source) -> untyped
+
+    # Compresses a string using gzip.
+    def self.compress: (untyped source, ?untyped level, ?untyped strategy) -> untyped
+  end
+end
+
+module ActiveSupport
+  # Implements a hash where keys <tt>:foo</tt> and <tt>"foo"</tt> are considered
+  # to be the same.
+  #
+  #   rgb = ActiveSupport::HashWithIndifferentAccess.new
+  #
+  #   rgb[:black] = '#000000'
+  #   rgb[:black]  # => '#000000'
+  #   rgb['black'] # => '#000000'
+  #
+  #   rgb['white'] = '#FFFFFF'
+  #   rgb[:white]  # => '#FFFFFF'
+  #   rgb['white'] # => '#FFFFFF'
+  #
+  # Internally symbols are mapped to strings when used as keys in the entire
+  # writing interface (calling <tt>[]=</tt>, <tt>merge</tt>, etc). This
+  # mapping belongs to the public interface. For example, given:
+  #
+  #   hash = ActiveSupport::HashWithIndifferentAccess.new(a: 1)
+  #
+  # You are guaranteed that the key is returned as a string:
+  #
+  #   hash.keys # => ["a"]
+  #
+  # Technically other types of keys are accepted:
+  #
+  #   hash = ActiveSupport::HashWithIndifferentAccess.new(a: 1)
+  #   hash[0] = 0
+  #   hash # => {"a"=>1, 0=>0}
+  #
+  # but this class is intended for use cases where strings or symbols are the
+  # expected keys and it is convenient to understand both as the same. For
+  # example the +params+ hash in Ruby on Rails.
+  #
+  # Note that core extensions define <tt>Hash#with_indifferent_access</tt>:
+  #
+  #   rgb = { black: '#000000', white: '#FFFFFF' }.with_indifferent_access
+  #
+  # which may be handy.
+  #
+  # To access this class outside of Rails, require the core extension with:
+  #
+  #   require "active_support/core_ext/hash/indifferent_access"
+  #
+  # which will, in turn, require this file.
+  class HashWithIndifferentAccess[T, U] < Hash[T, U]
+    # Returns +true+ so that <tt>Array#extract_options!</tt> finds members of
+    # this class.
+    def extractable_options?: () -> ::TrueClass
+
+    def with_indifferent_access: () -> untyped
+
+    def nested_under_indifferent_access: () -> untyped
+
+    def initialize: (?::Hash[untyped, untyped] constructor) -> untyped
+
+    def self.[]: (*untyped args) -> untyped
+
+    alias regular_writer []=
+
+    alias regular_update update
+
+    # Assigns a new value to the hash:
+    #
+    #   hash = ActiveSupport::HashWithIndifferentAccess.new
+    #   hash[:key] = 'value'
+    #
+    # This value can be later fetched using either +:key+ or <tt>'key'</tt>.
+    def []=: (untyped key, untyped value) -> untyped
+
+    alias store []=
+
+    # Updates the receiver in-place, merging in the hash passed as argument:
+    #
+    #   hash_1 = ActiveSupport::HashWithIndifferentAccess.new
+    #   hash_1[:key] = 'value'
+    #
+    #   hash_2 = ActiveSupport::HashWithIndifferentAccess.new
+    #   hash_2[:key] = 'New Value!'
+    #
+    #   hash_1.update(hash_2) # => {"key"=>"New Value!"}
+    #
+    # The argument can be either an
+    # <tt>ActiveSupport::HashWithIndifferentAccess</tt> or a regular +Hash+.
+    # In either case the merge respects the semantics of indifferent access.
+    #
+    # If the argument is a regular hash with keys +:key+ and +"key"+ only one
+    # of the values end up in the receiver, but which one is unspecified.
+    #
+    # When given a block, the value for duplicated keys will be determined
+    # by the result of invoking the block with the duplicated key, the value
+    # in the receiver, and the value in +other_hash+. The rules for duplicated
+    # keys follow the semantics of indifferent access:
+    #
+    #   hash_1[:key] = 10
+    #   hash_2['key'] = 12
+    #   hash_1.update(hash_2) { |key, old, new| old + new } # => {"key"=>22}
+    def update: (untyped other_hash) { (untyped, untyped, untyped) -> untyped } -> untyped
+
+    alias merge! update
+
+    # Checks the hash for a key matching the argument passed in:
+    #
+    #   hash = ActiveSupport::HashWithIndifferentAccess.new
+    #   hash['key'] = 'value'
+    #   hash.key?(:key)  # => true
+    #   hash.key?('key') # => true
+    def key?: (untyped key) -> untyped
+
+    alias include? key?
+
+    alias has_key? key?
+
+    alias member? key?
+
+    # Same as <tt>Hash#[]</tt> where the key passed as argument can be
+    # either a string or a symbol:
+    #
+    #   counters = ActiveSupport::HashWithIndifferentAccess.new
+    #   counters[:foo] = 1
+    #
+    #   counters['foo'] # => 1
+    #   counters[:foo]  # => 1
+    #   counters[:zoo]  # => nil
+    def []: (untyped key) -> untyped
+
+    # Same as <tt>Hash#assoc</tt> where the key passed as argument can be
+    # either a string or a symbol:
+    #
+    #   counters = ActiveSupport::HashWithIndifferentAccess.new
+    #   counters[:foo] = 1
+    #
+    #   counters.assoc('foo') # => ["foo", 1]
+    #   counters.assoc(:foo)  # => ["foo", 1]
+    #   counters.assoc(:zoo)  # => nil
+    def assoc: (untyped key) -> untyped
+
+    # Same as <tt>Hash#fetch</tt> where the key passed as argument can be
+    # either a string or a symbol:
+    #
+    #   counters = ActiveSupport::HashWithIndifferentAccess.new
+    #   counters[:foo] = 1
+    #
+    #   counters.fetch('foo')          # => 1
+    #   counters.fetch(:bar, 0)        # => 0
+    #   counters.fetch(:bar) { |key| 0 } # => 0
+    #   counters.fetch(:zoo)           # => KeyError: key not found: "zoo"
+    def fetch: (untyped key, *untyped extras) -> untyped
+
+    # Same as <tt>Hash#dig</tt> where the key passed as argument can be
+    # either a string or a symbol:
+    #
+    #   counters = ActiveSupport::HashWithIndifferentAccess.new
+    #   counters[:foo] = { bar: 1 }
+    #
+    #   counters.dig('foo', 'bar')     # => 1
+    #   counters.dig(:foo, :bar)       # => 1
+    #   counters.dig(:zoo)             # => nil
+    def dig: (*untyped args) -> untyped
+
+    # Same as <tt>Hash#default</tt> where the key passed as argument can be
+    # either a string or a symbol:
+    #
+    #   hash = ActiveSupport::HashWithIndifferentAccess.new(1)
+    #   hash.default                   # => 1
+    #
+    #   hash = ActiveSupport::HashWithIndifferentAccess.new { |hash, key| key }
+    #   hash.default                   # => nil
+    #   hash.default('foo')            # => 'foo'
+    #   hash.default(:foo)             # => 'foo'
+    def default: (*untyped args) -> untyped
+
+    # Returns an array of the values at the specified indices:
+    #
+    #   hash = ActiveSupport::HashWithIndifferentAccess.new
+    #   hash[:a] = 'x'
+    #   hash[:b] = 'y'
+    #   hash.values_at('a', 'b') # => ["x", "y"]
+    def values_at: (*untyped keys) -> untyped
+
+    # Returns an array of the values at the specified indices, but also
+    # raises an exception when one of the keys can't be found.
+    #
+    #   hash = ActiveSupport::HashWithIndifferentAccess.new
+    #   hash[:a] = 'x'
+    #   hash[:b] = 'y'
+    #   hash.fetch_values('a', 'b') # => ["x", "y"]
+    #   hash.fetch_values('a', 'c') { |key| 'z' } # => ["x", "z"]
+    #   hash.fetch_values('a', 'c') # => KeyError: key not found: "c"
+    def fetch_values: (*untyped indices) { () -> untyped } -> untyped
+
+    # Returns a shallow copy of the hash.
+    #
+    #   hash = ActiveSupport::HashWithIndifferentAccess.new({ a: { b: 'b' } })
+    #   dup  = hash.dup
+    #   dup[:a][:c] = 'c'
+    #
+    #   hash[:a][:c] # => "c"
+    #   dup[:a][:c]  # => "c"
+    def dup: () -> untyped
+
+    # This method has the same semantics of +update+, except it does not
+    # modify the receiver but rather returns a new hash with indifferent
+    # access with the result of the merge.
+    def merge: (untyped hash) { () -> untyped } -> untyped
+
+    # Like +merge+ but the other way around: Merges the receiver into the
+    # argument and returns a new hash with indifferent access as result:
+    #
+    #   hash = ActiveSupport::HashWithIndifferentAccess.new
+    #   hash['a'] = nil
+    #   hash.reverse_merge(a: 0, b: 1) # => {"a"=>nil, "b"=>1}
+    def reverse_merge: (untyped other_hash) -> untyped
+
+    alias with_defaults reverse_merge
+
+    # Same semantics as +reverse_merge+ but modifies the receiver in-place.
+    def reverse_merge!: (untyped other_hash) -> untyped
+
+    alias with_defaults! reverse_merge!
+
+    # Replaces the contents of this hash with other_hash.
+    #
+    #   h = { "a" => 100, "b" => 200 }
+    #   h.replace({ "c" => 300, "d" => 400 }) # => {"c"=>300, "d"=>400}
+    def replace: (untyped other_hash) -> untyped
+
+    # Removes the specified key from the hash.
+    def delete: (untyped key) -> untyped
+
+    def except: (*untyped keys) -> untyped
+
+    alias without except
+
+    def stringify_keys!: () -> untyped
+
+    def deep_stringify_keys!: () -> untyped
+
+    def stringify_keys: () -> untyped
+
+    def deep_stringify_keys: () -> untyped
+
+    def symbolize_keys: () -> untyped
+
+    alias to_options symbolize_keys
+
+    def deep_symbolize_keys: () -> untyped
+
+    def to_options!: () -> untyped
+
+    def select: (*untyped args) { () -> untyped } -> untyped
+
+    def reject: (*untyped args) { () -> untyped } -> untyped
+
+    def transform_values: (*untyped args) { () -> untyped } -> untyped
+
+    def transform_keys: (*untyped args) { () -> untyped } -> untyped
+
+    def transform_keys!: () { (untyped) -> untyped } -> untyped
+
+    def slice: (*untyped keys) -> untyped
+
+    def slice!: (*untyped keys) -> untyped
+
+    def compact: () -> untyped
+
+    # Convert to a regular hash with string keys.
+    def to_hash: () -> untyped
+
+    def convert_key: (untyped key) -> untyped
+
+    def convert_value: (untyped value, ?::Hash[untyped, untyped] options) -> untyped
+
+    def set_defaults: (untyped target) -> untyped
+  end
+end
+
+# NOTE: HashWithIndifferentAccess and ActiveSupport::HashWithIndifferentAccess are the same object
+#       but RBS doesn't have class alias syntax
+class HashWithIndifferentAccess[T, U] < ActiveSupport::HashWithIndifferentAccess[T, U]
+end
+
+module I18n
+  class Railtie < Rails::Railtie
+    # Setup i18n configuration.
+    def self.initialize_i18n: (untyped app) -> (nil | untyped)
+
+    def self.include_fallbacks_module: () -> untyped
+
+    def self.init_fallbacks: (untyped fallbacks) -> untyped
+
+    def self.validate_fallbacks: (untyped fallbacks) -> untyped
+
+    def self.watched_dirs_with_extensions: (untyped paths) -> untyped
+  end
+end
+
+# -
+# Defines the standard inflection rules. These are the starting point for
+# new projects and are not considered complete. The current set of inflection
+# rules is frozen. This means, we do not change them to become more complete.
+# This is a safety measure to keep existing applications from breaking.
+# +
+module ActiveSupport
+end
+
+module ActiveSupport
+  module Inflector
+    # A singleton instance of this class is yielded by Inflector.inflections,
+    # which can then be used to specify additional inflection rules. If passed
+    # an optional locale, rules for other languages can be specified. The
+    # default locale is <tt>:en</tt>. Only rules for English are provided.
+    #
+    #   ActiveSupport::Inflector.inflections(:en) do |inflect|
+    #     inflect.plural /^(ox)$/i, '\1\2en'
+    #     inflect.singular /^(ox)en/i, '\1'
+    #
+    #     inflect.irregular 'octopus', 'octopi'
+    #
+    #     inflect.uncountable 'equipment'
+    #   end
+    #
+    # New rules are added at the top. So in the example above, the irregular
+    # rule for octopus will now be the first of the pluralization and
+    # singularization rules that is runs. This guarantees that your rules run
+    # before any of the rules that may already have been loaded.
+    class Inflections
+      class Uncountables[T] < Array[T]
+        def initialize: () -> untyped
+
+        def delete: (untyped entry) -> untyped
+
+        def <<: (*untyped word) -> untyped
+
+        def add: (untyped words) -> untyped
+
+        def uncountable?: (untyped str) -> untyped
+
+        def to_regex: (untyped string) -> ::Regexp
+      end
+
+      def self.`instance`: (?::Symbol locale) -> untyped
+
+      attr_reader plurals: untyped
+
+      attr_reader singulars: untyped
+
+      attr_reader uncountables: untyped
+
+      attr_reader humans: untyped
+
+      attr_reader acronyms: untyped
+
+      attr_reader acronyms_camelize_regex: untyped
+
+      attr_reader acronyms_underscore_regex: untyped
+
+      def initialize: () -> untyped
+
+      def initialize_dup: (untyped orig) -> untyped
+
+      # Specifies a new acronym. An acronym must be specified as it will appear
+      # in a camelized string. An underscore string that contains the acronym
+      # will retain the acronym when passed to +camelize+, +humanize+, or
+      # +titleize+. A camelized string that contains the acronym will maintain
+      # the acronym when titleized or humanized, and will convert the acronym
+      # into a non-delimited single lowercase word when passed to +underscore+.
+      #
+      #   acronym 'HTML'
+      #   titleize 'html'     # => 'HTML'
+      #   camelize 'html'     # => 'HTML'
+      #   underscore 'MyHTML' # => 'my_html'
+      #
+      # The acronym, however, must occur as a delimited unit and not be part of
+      # another word for conversions to recognize it:
+      #
+      #   acronym 'HTTP'
+      #   camelize 'my_http_delimited' # => 'MyHTTPDelimited'
+      #   camelize 'https'             # => 'Https', not 'HTTPs'
+      #   underscore 'HTTPS'           # => 'http_s', not 'https'
+      #
+      #   acronym 'HTTPS'
+      #   camelize 'https'   # => 'HTTPS'
+      #   underscore 'HTTPS' # => 'https'
+      #
+      # Note: Acronyms that are passed to +pluralize+ will no longer be
+      # recognized, since the acronym will not occur as a delimited unit in the
+      # pluralized result. To work around this, you must specify the pluralized
+      # form as an acronym as well:
+      #
+      #    acronym 'API'
+      #    camelize(pluralize('api')) # => 'Apis'
+      #
+      #    acronym 'APIs'
+      #    camelize(pluralize('api')) # => 'APIs'
+      #
+      # +acronym+ may be used to specify any word that contains an acronym or
+      # otherwise needs to maintain a non-standard capitalization. The only
+      # restriction is that the word must begin with a capital letter.
+      #
+      #   acronym 'RESTful'
+      #   underscore 'RESTful'           # => 'restful'
+      #   underscore 'RESTfulController' # => 'restful_controller'
+      #   titleize 'RESTfulController'   # => 'RESTful Controller'
+      #   camelize 'restful'             # => 'RESTful'
+      #   camelize 'restful_controller'  # => 'RESTfulController'
+      #
+      #   acronym 'McDonald'
+      #   underscore 'McDonald' # => 'mcdonald'
+      #   camelize 'mcdonald'   # => 'McDonald'
+      def acronym: (untyped word) -> untyped
+
+      # Specifies a new pluralization rule and its replacement. The rule can
+      # either be a string or a regular expression. The replacement should
+      # always be a string that may include references to the matched data from
+      # the rule.
+      def plural: (untyped rule, untyped replacement) -> untyped
+
+      # Specifies a new singularization rule and its replacement. The rule can
+      # either be a string or a regular expression. The replacement should
+      # always be a string that may include references to the matched data from
+      # the rule.
+      def singular: (untyped rule, untyped replacement) -> untyped
+
+      # Specifies a new irregular that applies to both pluralization and
+      # singularization at the same time. This can only be used for strings, not
+      # regular expressions. You simply pass the irregular in singular and
+      # plural form.
+      #
+      #   irregular 'octopus', 'octopi'
+      #   irregular 'person', 'people'
+      def irregular: (untyped singular, untyped plural) -> untyped
+
+      # Specifies words that are uncountable and should not be inflected.
+      #
+      #   uncountable 'money'
+      #   uncountable 'money', 'information'
+      #   uncountable %w( money information rice )
+      def uncountable: (*untyped words) -> untyped
+
+      # Specifies a humanized form of a string by a regular expression rule or
+      # by a string mapping. When using a regular expression based replacement,
+      # the normal humanize formatting is called after the replacement. When a
+      # string is used, the human form should be specified as desired (example:
+      # 'The name', not 'the_name').
+      #
+      #   human /_cnt$/i, '\1_count'
+      #   human 'legacy_col_person_name', 'Name'
+      def human: (untyped rule, untyped replacement) -> untyped
+
+      # Clears the loaded inflections within a given scope (default is
+      # <tt>:all</tt>). Give the scope as a symbol of the inflection type, the
+      # options are: <tt>:plurals</tt>, <tt>:singulars</tt>, <tt>:uncountables</tt>,
+      # <tt>:humans</tt>.
+      #
+      #   clear :all
+      #   clear :plurals
+      def clear: (?::Symbol scope) -> untyped
+
+      def define_acronym_regex_patterns: () -> untyped
+    end
+
+    # Yields a singleton instance of Inflector::Inflections so you can specify
+    # additional inflector rules. If passed an optional locale, rules for other
+    # languages can be specified. If not specified, defaults to <tt>:en</tt>.
+    # Only rules for English are provided.
+    #
+    #   ActiveSupport::Inflector.inflections(:en) do |inflect|
+    #     inflect.uncountable 'rails'
+    #   end
+    def inflections: (?::Symbol locale) { (untyped) -> untyped } -> untyped
+  end
+end
+
+module ActiveSupport
+  # The Inflector transforms words from singular to plural, class names to table
+  # names, modularized class names to ones without, and class names to foreign
+  # keys. The default inflections for pluralization, singularization, and
+  # uncountable words are kept in inflections.rb.
+  #
+  # The Rails core team has stated patches for the inflections library will not
+  # be accepted in order to avoid breaking legacy applications which may be
+  # relying on errant inflections. If you discover an incorrect inflection and
+  # require it for your application or wish to define rules for languages other
+  # than English, please correct or add them yourself (explained below).
+  module Inflector
+    # Returns the plural form of the word in the string.
+    #
+    # If passed an optional +locale+ parameter, the word will be
+    # pluralized using rules defined for that language. By default,
+    # this parameter is set to <tt>:en</tt>.
+    #
+    #   pluralize('post')             # => "posts"
+    #   pluralize('octopus')          # => "octopi"
+    #   pluralize('sheep')            # => "sheep"
+    #   pluralize('words')            # => "words"
+    #   pluralize('CamelOctopus')     # => "CamelOctopi"
+    #   pluralize('ley', :es)         # => "leyes"
+    def pluralize: (untyped word, ?::Symbol locale) -> untyped
+
+    # The reverse of #pluralize, returns the singular form of a word in a
+    # string.
+    #
+    # If passed an optional +locale+ parameter, the word will be
+    # singularized using rules defined for that language. By default,
+    # this parameter is set to <tt>:en</tt>.
+    #
+    #   singularize('posts')            # => "post"
+    #   singularize('octopi')           # => "octopus"
+    #   singularize('sheep')            # => "sheep"
+    #   singularize('word')             # => "word"
+    #   singularize('CamelOctopi')      # => "CamelOctopus"
+    #   singularize('leyes', :es)       # => "ley"
+    def singularize: (untyped word, ?::Symbol locale) -> untyped
+
+    # Converts strings to UpperCamelCase.
+    # If the +uppercase_first_letter+ parameter is set to false, then produces
+    # lowerCamelCase.
+    #
+    # Also converts '/' to '::' which is useful for converting
+    # paths to namespaces.
+    #
+    #   camelize('active_model')                # => "ActiveModel"
+    #   camelize('active_model', false)         # => "activeModel"
+    #   camelize('active_model/errors')         # => "ActiveModel::Errors"
+    #   camelize('active_model/errors', false)  # => "activeModel::Errors"
+    #
+    # As a rule of thumb you can think of +camelize+ as the inverse of
+    # #underscore, though there are cases where that does not hold:
+    #
+    #   camelize(underscore('SSLError'))        # => "SslError"
+    def camelize: (untyped term, ?bool uppercase_first_letter) -> untyped
+
+    # Makes an underscored, lowercase form from the expression in the string.
+    #
+    # Changes '::' to '/' to convert namespaces to paths.
+    #
+    #   underscore('ActiveModel')         # => "active_model"
+    #   underscore('ActiveModel::Errors') # => "active_model/errors"
+    #
+    # As a rule of thumb you can think of +underscore+ as the inverse of
+    # #camelize, though there are cases where that does not hold:
+    #
+    #   camelize(underscore('SSLError'))  # => "SslError"
+    def underscore: (untyped camel_cased_word) -> untyped
+
+    # Tweaks an attribute name for display to end users.
+    #
+    # Specifically, performs these transformations:
+    #
+    # * Applies human inflection rules to the argument.
+    # * Deletes leading underscores, if any.
+    # * Removes a "_id" suffix if present.
+    # * Replaces underscores with spaces, if any.
+    # * Downcases all words except acronyms.
+    # * Capitalizes the first word.
+    # The capitalization of the first word can be turned off by setting the
+    # +:capitalize+ option to false (default is true).
+    #
+    # The trailing '_id' can be kept and capitalized by setting the
+    # optional parameter +keep_id_suffix+ to true (default is false).
+    #
+    #   humanize('employee_salary')                  # => "Employee salary"
+    #   humanize('author_id')                        # => "Author"
+    #   humanize('author_id', capitalize: false)     # => "author"
+    #   humanize('_id')                              # => "Id"
+    #   humanize('author_id', keep_id_suffix: true)  # => "Author Id"
+    #
+    # If "SSL" was defined to be an acronym:
+    #
+    #   humanize('ssl_error') # => "SSL error"
+    #
+    def humanize: (untyped lower_case_and_underscored_word, ?keep_id_suffix: bool keep_id_suffix, ?capitalize: bool capitalize) -> untyped
+
+    # Converts just the first character to uppercase.
+    #
+    #   upcase_first('what a Lovely Day') # => "What a Lovely Day"
+    #   upcase_first('w')                 # => "W"
+    #   upcase_first('')                  # => ""
+    def upcase_first: (untyped string) -> untyped
+
+    # Capitalizes all the words and replaces some characters in the string to
+    # create a nicer looking title. +titleize+ is meant for creating pretty
+    # output. It is not used in the Rails internals.
+    #
+    # The trailing '_id','Id'.. can be kept and capitalized by setting the
+    # optional parameter +keep_id_suffix+ to true.
+    # By default, this parameter is false.
+    #
+    # +titleize+ is also aliased as +titlecase+.
+    #
+    #   titleize('man from the boondocks')                       # => "Man From The Boondocks"
+    #   titleize('x-men: the last stand')                        # => "X Men: The Last Stand"
+    #   titleize('TheManWithoutAPast')                           # => "The Man Without A Past"
+    #   titleize('raiders_of_the_lost_ark')                      # => "Raiders Of The Lost Ark"
+    #   titleize('string_ending_with_id', keep_id_suffix: true)  # => "String Ending With Id"
+    def titleize: (untyped word, ?keep_id_suffix: bool keep_id_suffix) -> untyped
+
+    # Creates the name of a table like Rails does for models to table names.
+    # This method uses the #pluralize method on the last word in the string.
+    #
+    #   tableize('RawScaledScorer') # => "raw_scaled_scorers"
+    #   tableize('ham_and_egg')     # => "ham_and_eggs"
+    #   tableize('fancyCategory')   # => "fancy_categories"
+    def tableize: (untyped class_name) -> untyped
+
+    # Creates a class name from a plural table name like Rails does for table
+    # names to models. Note that this returns a string and not a Class (To
+    # convert to an actual class follow +classify+ with #constantize).
+    #
+    #   classify('ham_and_eggs') # => "HamAndEgg"
+    #   classify('posts')        # => "Post"
+    #
+    # Singular names are not handled correctly:
+    #
+    #   classify('calculus')     # => "Calculu"
+    def classify: (untyped table_name) -> untyped
+
+    # Replaces underscores with dashes in the string.
+    #
+    #   dasherize('puni_puni') # => "puni-puni"
+    def dasherize: (untyped underscored_word) -> untyped
+
+    # Removes the module part from the expression in the string.
+    #
+    #   demodulize('ActiveSupport::Inflector::Inflections') # => "Inflections"
+    #   demodulize('Inflections')                           # => "Inflections"
+    #   demodulize('::Inflections')                         # => "Inflections"
+    #   demodulize('')                                      # => ""
+    #
+    # See also #deconstantize.
+    def demodulize: (untyped path) -> untyped
+
+    # Removes the rightmost segment from the constant expression in the string.
+    #
+    #   deconstantize('Net::HTTP')   # => "Net"
+    #   deconstantize('::Net::HTTP') # => "::Net"
+    #   deconstantize('String')      # => ""
+    #   deconstantize('::String')    # => ""
+    #   deconstantize('')            # => ""
+    #
+    # See also #demodulize.
+    def deconstantize: (untyped path) -> untyped
+
+    # Creates a foreign key name from a class name.
+    # +separate_class_name_and_id_with_underscore+ sets whether
+    # the method should put '_' between the name and 'id'.
+    #
+    #   foreign_key('Message')        # => "message_id"
+    #   foreign_key('Message', false) # => "messageid"
+    #   foreign_key('Admin::Post')    # => "post_id"
+    def foreign_key: (untyped class_name, ?bool separate_class_name_and_id_with_underscore) -> untyped
+
+    # Tries to find a constant with the name specified in the argument string.
+    #
+    #   constantize('Module')   # => Module
+    #   constantize('Foo::Bar') # => Foo::Bar
+    #
+    # The name is assumed to be the one of a top-level constant, no matter
+    # whether it starts with "::" or not. No lexical context is taken into
+    # account:
+    #
+    #   C = 'outside'
+    #   module M
+    #     C = 'inside'
+    #     C                # => 'inside'
+    #     constantize('C') # => 'outside', same as ::C
+    #   end
+    #
+    # NameError is raised when the name is not in CamelCase or the constant is
+    # unknown.
+    def constantize: (untyped camel_cased_word) -> untyped
+
+    # Tries to find a constant with the name specified in the argument string.
+    #
+    #   safe_constantize('Module')   # => Module
+    #   safe_constantize('Foo::Bar') # => Foo::Bar
+    #
+    # The name is assumed to be the one of a top-level constant, no matter
+    # whether it starts with "::" or not. No lexical context is taken into
+    # account:
+    #
+    #   C = 'outside'
+    #   module M
+    #     C = 'inside'
+    #     C                     # => 'inside'
+    #     safe_constantize('C') # => 'outside', same as ::C
+    #   end
+    #
+    # +nil+ is returned when the name is not in CamelCase or the constant (or
+    # part of it) is unknown.
+    #
+    #   safe_constantize('blargle')                  # => nil
+    #   safe_constantize('UnknownModule')            # => nil
+    #   safe_constantize('UnknownModule::Foo::Bar')  # => nil
+    def safe_constantize: (untyped camel_cased_word) -> untyped
+
+    # Returns the suffix that should be added to a number to denote the position
+    # in an ordered sequence such as 1st, 2nd, 3rd, 4th.
+    #
+    #   ordinal(1)     # => "st"
+    #   ordinal(2)     # => "nd"
+    #   ordinal(1002)  # => "nd"
+    #   ordinal(1003)  # => "rd"
+    #   ordinal(-11)   # => "th"
+    #   ordinal(-1021) # => "st"
+    def ordinal: (untyped number) -> untyped
+
+    # Turns a number into an ordinal string used to denote the position in an
+    # ordered sequence such as 1st, 2nd, 3rd, 4th.
+    #
+    #   ordinalize(1)     # => "1st"
+    #   ordinalize(2)     # => "2nd"
+    #   ordinalize(1002)  # => "1002nd"
+    #   ordinalize(1003)  # => "1003rd"
+    #   ordinalize(-11)   # => "-11th"
+    #   ordinalize(-1021) # => "-1021st"
+    def ordinalize: (untyped number) -> untyped
+
+    # Mounts a regular expression, returned as a string to ease interpolation,
+    # that will match part by part the given constant.
+    #
+    #   const_regexp("Foo::Bar::Baz") # => "Foo(::Bar(::Baz)?)?"
+    #   const_regexp("::")            # => "::"
+    def const_regexp: (untyped camel_cased_word) -> untyped
+
+    # Applies inflection rules for +singularize+ and +pluralize+.
+    #
+    # If passed an optional +locale+ parameter, the uncountables will be
+    # found for that locale.
+    #
+    #  apply_inflections('post', inflections.plurals, :en)    # => "posts"
+    #  apply_inflections('posts', inflections.singulars, :en) # => "post"
+    def apply_inflections: (untyped word, untyped rules, ?::Symbol locale) -> untyped
+  end
+end
+
+module ActiveSupport
+  module Inflector
+    # Replaces non-ASCII characters with an ASCII approximation, or if none
+    # exists, a replacement character which defaults to "?".
+    #
+    #    transliterate('(trim non-ascii characters)r(trim non-ascii characters)sk(trim non-ascii characters)bing')
+    #    # => "AEroskobing"
+    #
+    # Default approximations are provided for Western/Latin characters,
+    # e.g, "(trim non-ascii characters)", "(trim non-ascii characters)", "(trim non-ascii characters)", "(trim non-ascii characters)", etc.
+    #
+    # This method is I18n aware, so you can set up custom approximations for a
+    # locale. This can be useful, for example, to transliterate German's "(trim non-ascii characters)"
+    # and "(trim non-ascii characters)" to "ue" and "oe", or to add support for transliterating Russian
+    # to ASCII.
+    #
+    # In order to make your custom transliterations available, you must set
+    # them as the <tt>i18n.transliterate.rule</tt> i18n key:
+    #
+    #   # Store the transliterations in locales/de.yml
+    #   i18n:
+    #     transliterate:
+    #       rule:
+    #         (trim non-ascii characters): "ue"
+    #         (trim non-ascii characters): "oe"
+    #
+    #   # Or set them using Ruby
+    #   I18n.backend.store_translations(:de, i18n: {
+    #     transliterate: {
+    #       rule: {
+    #         '(trim non-ascii characters)' => 'ue',
+    #         '(trim non-ascii characters)' => 'oe'
+    #       }
+    #     }
+    #   })
+    #
+    # The value for <tt>i18n.transliterate.rule</tt> can be a simple Hash that
+    # maps characters to ASCII approximations as shown above, or, for more
+    # complex requirements, a Proc:
+    #
+    #   I18n.backend.store_translations(:de, i18n: {
+    #     transliterate: {
+    #       rule: ->(string) { MyTransliterator.transliterate(string) }
+    #     }
+    #   })
+    #
+    # Now you can have different transliterations for each locale:
+    #
+    #   transliterate('J(trim non-ascii characters)rgen', locale: :en)
+    #   # => "Jurgen"
+    #
+    #   transliterate('J(trim non-ascii characters)rgen', locale: :de)
+    #   # => "Juergen"
+    #
+    # Transliteration is restricted to UTF-8, US-ASCII and GB18030 strings
+    # Other encodings will raise an ArgumentError.
+    def transliterate: (untyped string, ?::String replacement, ?locale: untyped? locale) -> untyped
+
+    # Replaces special characters in a string so that it may be used as part of
+    # a 'pretty' URL.
+    #
+    #   parameterize("Donald E. Knuth") # => "donald-e-knuth"
+    #   parameterize("^tr(trim non-ascii characters)s|Jolie-- ")  # => "tres-jolie"
+    #
+    # To use a custom separator, override the +separator+ argument.
+    #
+    #   parameterize("Donald E. Knuth", separator: '_') # => "donald_e_knuth"
+    #   parameterize("^tr(trim non-ascii characters)s|Jolie__ ", separator: '_')  # => "tres_jolie"
+    #
+    # To preserve the case of the characters in a string, use the +preserve_case+ argument.
+    #
+    #   parameterize("Donald E. Knuth", preserve_case: true) # => "Donald-E-Knuth"
+    #   parameterize("^tr(trim non-ascii characters)s|Jolie-- ", preserve_case: true) # => "tres-Jolie"
+    #
+    # It preserves dashes and underscores unless they are used as separators:
+    #
+    #   parameterize("^tr(trim non-ascii characters)s|Jolie__ ")                 # => "tres-jolie__"
+    #   parameterize("^tr(trim non-ascii characters)s|Jolie-- ", separator: "_") # => "tres_jolie--"
+    #   parameterize("^tr(trim non-ascii characters)s_Jolie-- ", separator: ".") # => "tres_jolie--"
+    #
+    # If the optional parameter +locale+ is specified,
+    # the word will be parameterized as a word of that language.
+    # By default, this parameter is set to <tt>nil</tt> and it will use
+    # the configured <tt>I18n.locale<tt>.
+    def parameterize: (untyped string, ?locale: untyped? locale, ?preserve_case: bool preserve_case, ?separator: ::String separator) -> untyped
+  end
+end
+
+module ActiveSupport
+  module JSON
+    # matches YAML-formatted dates
+    DATE_REGEX: untyped
+
+    DATETIME_REGEX: untyped
+
+    # Parses a JSON string (JavaScript Object Notation) into a hash.
+    # See http://www.json.org for more info.
+    #
+    #   ActiveSupport::JSON.decode("{\"team\":\"rails\",\"players\":\"36\"}")
+    #   => {"team" => "rails", "players" => "36"}
+    def self.decode: (untyped json) -> untyped
+
+    # Returns the class of the error that will be raised when there is an
+    # error in decoding JSON. Using this method means you won't directly
+    # depend on the ActiveSupport's JSON implementation, in case it changes
+    # in the future.
+    #
+    #   begin
+    #     obj = ActiveSupport::JSON.decode(some_string)
+    #   rescue ActiveSupport::JSON.parse_error
+    #     Rails.logger.warn("Attempted to decode invalid JSON: #{some_string}")
+    #   end
+    def self.parse_error: () -> untyped
+
+    def self.convert_dates_from: (untyped data) -> untyped
+  end
+end
+
+module ActiveSupport
+  module JSON
+    # Dumps objects in JSON (JavaScript Object Notation).
+    # See http://www.json.org for more info.
+    #
+    #   ActiveSupport::JSON.encode({ team: 'rails', players: '36' })
+    #   # => "{\"team\":\"rails\",\"players\":\"36\"}"
+    def self.encode: (untyped value, ?untyped? options) -> untyped
+
+    module Encoding
+      class JSONGemEncoder
+        # nodoc:
+        # nodoc:
+        attr_reader options: untyped
+
+        def initialize: (?untyped? options) -> untyped
+
+        # Encode the given object into a JSON string
+        def encode: (untyped value) -> untyped
+
+        # Rails does more escaping than the JSON gem natively does (we
+        # escape \u2028 and \u2029 and optionally >, <, & to work around
+        # certain browser problems).
+        ESCAPED_CHARS: ::Hash[untyped, untyped]
+
+        ESCAPE_REGEX_WITH_HTML_ENTITIES: untyped
+
+        ESCAPE_REGEX_WITHOUT_HTML_ENTITIES: untyped
+
+        class EscapedString < String
+          # This class wraps all the strings we see and does the extra escaping
+          # nodoc:
+          def to_json: () -> untyped
+
+          def to_s: () -> untyped
+        end
+
+        # Convert an object into a "JSON-ready" representation composed of
+        # primitives like Hash, Array, String, Numeric,
+        # and +true+/+false+/+nil+.
+        # Recursively calls #as_json to the object to recursively build a
+        # fully JSON-ready object.
+        #
+        # This allows developers to implement #as_json without having to
+        # worry about what base types of objects they are allowed to return
+        # or having to remember to call #as_json recursively.
+        #
+        # Note: the +options+ hash passed to +object.to_json+ is only passed
+        # to +object.as_json+, not any of this method's recursive +#as_json+
+        # calls.
+        def jsonify: (untyped value) -> untyped
+
+        # Encode a "jsonified" Ruby data structure using the JSON gem
+        def stringify: (untyped jsonified) -> untyped
+      end
+
+      # If true, use ISO 8601 format for dates and times. Otherwise, fall back
+      # to the Active Support legacy format.
+      attr_accessor use_standard_json_time_format: untyped
+
+      # If true, encode >, <, & as escaped unicode sequences (e.g. > as \u003e)
+      # as a safety measure.
+      attr_accessor escape_html_entities_in_json: untyped
+
+      # Sets the precision of encoded time values.
+      # Defaults to 3 (equivalent to millisecond precision)
+      attr_accessor time_precision: untyped
+
+      # Sets the encoder used by Rails to encode Ruby objects into JSON strings
+      # in +Object#to_json+ and +ActiveSupport::JSON.encode+.
+      attr_accessor json_encoder: untyped
+    end
+  end
+end
+
+module ActiveSupport
+  # KeyGenerator is a simple wrapper around OpenSSL's implementation of PBKDF2.
+  # It can be used to derive a number of keys for various purposes from a given secret.
+  # This lets Rails applications have a single secure secret, but avoid reusing that
+  # key in multiple incompatible contexts.
+  class KeyGenerator
+    def initialize: (untyped secret, ?::Hash[untyped, untyped] options) -> untyped
+
+    # Returns a derived key suitable for use.  The default key_size is chosen
+    # to be compatible with the default settings of ActiveSupport::MessageVerifier.
+    # i.e. OpenSSL::Digest::SHA1#block_length
+    def generate_key: (untyped salt, ?::Integer key_size) -> untyped
+  end
+
+  # CachingKeyGenerator is a wrapper around KeyGenerator which allows users to avoid
+  # re-executing the key generation process when it's called using the same salt and
+  # key_size.
+  class CachingKeyGenerator
+    def initialize: (untyped key_generator) -> untyped
+
+    # Returns a derived key suitable for use.
+    def generate_key: (*untyped args) -> untyped
+  end
+end
+
+module ActiveSupport
+  # lazy_load_hooks allows Rails to lazily load a lot of components and thus
+  # making the app boot faster. Because of this feature now there is no need to
+  # require <tt>ActiveRecord::Base</tt> at boot time purely to apply
+  # configuration. Instead a hook is registered that applies configuration once
+  # <tt>ActiveRecord::Base</tt> is loaded. Here <tt>ActiveRecord::Base</tt> is
+  # used as example but this feature can be applied elsewhere too.
+  #
+  # Here is an example where +on_load+ method is called to register a hook.
+  #
+  #   initializer 'active_record.initialize_timezone' do
+  #     ActiveSupport.on_load(:active_record) do
+  #       self.time_zone_aware_attributes = true
+  #       self.default_timezone = :utc
+  #     end
+  #   end
+  #
+  # When the entirety of +ActiveRecord::Base+ has been
+  # evaluated then +run_load_hooks+ is invoked. The very last line of
+  # +ActiveRecord::Base+ is:
+  #
+  #   ActiveSupport.run_load_hooks(:active_record, ActiveRecord::Base)
+  module LazyLoadHooks
+    def self.extended: (untyped base) -> untyped
+
+    # Declares a block that will be executed when a Rails component is fully
+    # loaded.
+    #
+    # Options:
+    #
+    # * <tt>:yield</tt> - Yields the object that run_load_hooks to +block+.
+    # * <tt>:run_once</tt> - Given +block+ will run only once.
+    def on_load: (untyped name, ?::Hash[untyped, untyped] options) { () -> untyped } -> untyped
+
+    def run_load_hooks: (untyped name, ?untyped base) -> untyped
+
+    def with_execution_control: (untyped name, untyped block, untyped once) { () -> untyped } -> untyped
+
+    def execute_hook: (untyped name, untyped base, untyped options, untyped block) -> untyped
+  end
+
+  extend LazyLoadHooks
+end
+
+module ActiveSupport
+  class LogSubscriber
+    # Provides some helpers to deal with testing log subscribers by setting up
+    # notifications. Take for instance Active Record subscriber tests:
+    #
+    #   class SyncLogSubscriberTest < ActiveSupport::TestCase
+    #     include ActiveSupport::LogSubscriber::TestHelper
+    #
+    #     setup do
+    #       ActiveRecord::LogSubscriber.attach_to(:active_record)
+    #     end
+    #
+    #     def test_basic_query_logging
+    #       Developer.all.to_a
+    #       wait
+    #       assert_equal 1, @logger.logged(:debug).size
+    #       assert_match(/Developer Load/, @logger.logged(:debug).last)
+    #       assert_match(/SELECT \* FROM "developers"/, @logger.logged(:debug).last)
+    #     end
+    #   end
+    #
+    # All you need to do is to ensure that your log subscriber is added to
+    # Rails::Subscriber, as in the second line of the code above. The test
+    # helpers are responsible for setting up the queue, subscriptions and
+    # turning colors in logs off.
+    #
+    # The messages are available in the @logger instance, which is a logger with
+    # limited powers (it actually does not send anything to your output), and
+    # you can collect them doing @logger.logged(level), where level is the level
+    # used in logging, like info, debug, warn and so on.
+    module TestHelper
+      def setup: () -> untyped
+
+      def teardown: () -> untyped
+
+      class MockLogger
+        include ::Logger::Severity
+
+        attr_reader flush_count: untyped
+
+        attr_accessor level: untyped
+
+        def initialize: (?untyped level) -> untyped
+
+        def method_missing: (untyped level, ?untyped? message) { () -> untyped } -> untyped
+
+        def logged: (untyped level) -> untyped
+
+        def flush: () -> untyped
+      end
+
+      # Wait notifications to be published.
+      def wait: () -> untyped
+
+      # Overwrite if you use another logger in your log subscriber.
+      #
+      #   def logger
+      #     ActiveRecord::Base.logger = @logger
+      #   end
+      def set_logger: (untyped logger) -> untyped
+    end
+  end
+end
+
+module ActiveSupport
+  # <tt>ActiveSupport::LogSubscriber</tt> is an object set to consume
+  # <tt>ActiveSupport::Notifications</tt> with the sole purpose of logging them.
+  # The log subscriber dispatches notifications to a registered object based
+  # on its given namespace.
+  #
+  # An example would be Active Record log subscriber responsible for logging
+  # queries:
+  #
+  #   module ActiveRecord
+  #     class LogSubscriber < ActiveSupport::LogSubscriber
+  #       def sql(event)
+  #         info "#{event.payload[:name]} (#{event.duration}) #{event.payload[:sql]}"
+  #       end
+  #     end
+  #   end
+  #
+  # And it's finally registered as:
+  #
+  #   ActiveRecord::LogSubscriber.attach_to :active_record
+  #
+  # Since we need to know all instance methods before attaching the log
+  # subscriber, the line above should be called after your
+  # <tt>ActiveRecord::LogSubscriber</tt> definition.
+  #
+  # After configured, whenever a <tt>"sql.active_record"</tt> notification is published,
+  # it will properly dispatch the event
+  # (<tt>ActiveSupport::Notifications::Event</tt>) to the sql method.
+  #
+  # Being an <tt>ActiveSupport::Notifications</tt> consumer,
+  # <tt>ActiveSupport::LogSubscriber</tt> exposes a simple interface to check if
+  # instrumented code raises an exception. It is common to log a different
+  # message in case of an error, and this can be achieved by extending
+  # the previous example:
+  #
+  #   module ActiveRecord
+  #     class LogSubscriber < ActiveSupport::LogSubscriber
+  #       def sql(event)
+  #         exception = event.payload[:exception]
+  #
+  #         if exception
+  #           exception_object = event.payload[:exception_object]
+  #
+  #           error "[ERROR] #{event.payload[:name]}: #{exception.join(', ')} " \
+  #                 "(#{exception_object.backtrace.first})"
+  #         else
+  #           # standard logger code
+  #         end
+  #       end
+  #     end
+  #   end
+  #
+  # Log subscriber also has some helpers to deal with logging and automatically
+  # flushes all logs when the request finishes
+  # (via <tt>action_dispatch.callback</tt> notification) in a Rails environment.
+  class LogSubscriber < Subscriber
+    # Embed in a String to clear all previous ANSI sequences.
+    CLEAR: ::String
+
+    BOLD: ::String
+
+    # Colors
+    BLACK: ::String
+
+    RED: ::String
+
+    GREEN: ::String
+
+    YELLOW: ::String
+
+    BLUE: ::String
+
+    MAGENTA: ::String
+
+    CYAN: ::String
+
+    WHITE: ::String
+
+    def self.logger: () -> untyped
+
+    attr_writer logger: untyped
+
+    def self.log_subscribers: () -> untyped
+
+    # Flush all log_subscribers' logger.
+    def self.flush_all!: () -> untyped
+
+    def logger: () -> untyped
+
+    def start: (untyped name, untyped id, untyped payload) -> untyped
+
+    def finish: (untyped name, untyped id, untyped payload) -> untyped
+
+    def color: (untyped text, untyped color, ?bool bold) -> (untyped | ::String)
+  end
+end
+
+module ActiveSupport
+  class Logger < ::Logger
+    include LoggerSilence
+
+    # Returns true if the logger destination matches one of the sources
+    #
+    #   logger = Logger.new(STDOUT)
+    #   ActiveSupport::Logger.logger_outputs_to?(logger, STDOUT)
+    #   # => true
+    def self.logger_outputs_to?: (untyped logger, *untyped sources) -> untyped
+
+    def self.broadcast: (untyped logger) -> untyped
+
+    def initialize: (*untyped args, **untyped kwargs) -> untyped
+
+    # Simple formatter which only displays the message.
+    class SimpleFormatter < ::Logger::Formatter
+      # This method is invoked when a log event occurs
+      def call: (untyped severity, untyped timestamp, untyped progname, untyped msg) -> ::String
+    end
+  end
+end
+
+module LoggerSilence
+  extend ActiveSupport::Concern
+
+  include ActiveSupport::LoggerSilence
+end
+
+module ActiveSupport
+  module LoggerSilence
+    extend ActiveSupport::Concern
+
+    include ActiveSupport::LoggerThreadSafeLevel
+
+    # Silences the logger for the duration of the block.
+    def silence: (?untyped temporary_level) { (untyped) -> untyped } -> untyped
+  end
+end
+
+module ActiveSupport
+  module LoggerThreadSafeLevel
+    # :nodoc:
+    extend ActiveSupport::Concern
+
+    def after_initialize: () -> untyped
+
+    def local_log_id: () -> untyped
+
+    def local_level: () -> untyped
+
+    def local_level=: (untyped level) -> untyped
+
+    def level: () -> untyped
+
+    def add: (untyped severity, ?untyped? message, ?untyped? progname) { () -> untyped } -> (::TrueClass | untyped)
+  end
+end
+
+module ActiveSupport
+  # MessageEncryptor is a simple way to encrypt values which get stored
+  # somewhere you don't trust.
+  #
+  # The cipher text and initialization vector are base64 encoded and returned
+  # to you.
+  #
+  # This can be used in situations similar to the <tt>MessageVerifier</tt>, but
+  # where you don't want users to be able to determine the value of the payload.
+  #
+  #   len   = ActiveSupport::MessageEncryptor.key_len
+  #   salt  = SecureRandom.random_bytes(len)
+  #   key   = ActiveSupport::KeyGenerator.new('password').generate_key(salt, len) # => "\x89\xE0\x156\xAC..."
+  #   crypt = ActiveSupport::MessageEncryptor.new(key)                            # => #<ActiveSupport::MessageEncryptor ...>
+  #   encrypted_data = crypt.encrypt_and_sign('my secret data')                   # => "NlFBTTMwOUV5UlA1QlNEN2xkY2d6eThYWWh..."
+  #   crypt.decrypt_and_verify(encrypted_data)                                    # => "my secret data"
+  #
+  # === Confining messages to a specific purpose
+  #
+  # By default any message can be used throughout your app. But they can also be
+  # confined to a specific +:purpose+.
+  #
+  #   token = crypt.encrypt_and_sign("this is the chair", purpose: :login)
+  #
+  # Then that same purpose must be passed when verifying to get the data back out:
+  #
+  #   crypt.decrypt_and_verify(token, purpose: :login)    # => "this is the chair"
+  #   crypt.decrypt_and_verify(token, purpose: :shipping) # => nil
+  #   crypt.decrypt_and_verify(token)                     # => nil
+  #
+  # Likewise, if a message has no purpose it won't be returned when verifying with
+  # a specific purpose.
+  #
+  #   token = crypt.encrypt_and_sign("the conversation is lively")
+  #   crypt.decrypt_and_verify(token, purpose: :scare_tactics) # => nil
+  #   crypt.decrypt_and_verify(token)                          # => "the conversation is lively"
+  #
+  # === Making messages expire
+  #
+  # By default messages last forever and verifying one year from now will still
+  # return the original value. But messages can be set to expire at a given
+  # time with +:expires_in+ or +:expires_at+.
+  #
+  #   crypt.encrypt_and_sign(parcel, expires_in: 1.month)
+  #   crypt.encrypt_and_sign(doowad, expires_at: Time.now.end_of_year)
+  #
+  # Then the messages can be verified and returned up to the expire time.
+  # Thereafter, verifying returns +nil+.
+  #
+  # === Rotating keys
+  #
+  # MessageEncryptor also supports rotating out old configurations by falling
+  # back to a stack of encryptors. Call +rotate+ to build and add an encryptor
+  # so +decrypt_and_verify+ will also try the fallback.
+  #
+  # By default any rotated encryptors use the values of the primary
+  # encryptor unless specified otherwise.
+  #
+  # You'd give your encryptor the new defaults:
+  #
+  #   crypt = ActiveSupport::MessageEncryptor.new(@secret, cipher: "aes-256-gcm")
+  #
+  # Then gradually rotate the old values out by adding them as fallbacks. Any message
+  # generated with the old values will then work until the rotation is removed.
+  #
+  #   crypt.rotate old_secret            # Fallback to an old secret instead of @secret.
+  #   crypt.rotate cipher: "aes-256-cbc" # Fallback to an old cipher instead of aes-256-gcm.
+  #
+  # Though if both the secret and the cipher was changed at the same time,
+  # the above should be combined into:
+  #
+  #   crypt.rotate old_secret, cipher: "aes-256-cbc"
+  class MessageEncryptor
+    def self.default_cipher: () -> untyped
+
+    module NullSerializer
+      # nodoc:
+      def self.load: (untyped value) -> untyped
+
+      def self.dump: (untyped value) -> untyped
+    end
+
+    module NullVerifier
+      # nodoc:
+      def self.verify: (untyped value) -> untyped
+
+      def self.generate: (untyped value) -> untyped
+    end
+
+    class InvalidMessage < StandardError
+    end
+
+    OpenSSLCipherError: untyped
+
+    # Initialize a new MessageEncryptor. +secret+ must be at least as long as
+    # the cipher key size. For the default 'aes-256-gcm' cipher, this is 256
+    # bits. If you are using a user-entered secret, you can generate a suitable
+    # key by using <tt>ActiveSupport::KeyGenerator</tt> or a similar key
+    # derivation function.
+    #
+    # First additional parameter is used as the signature key for +MessageVerifier+.
+    # This allows you to specify keys to encrypt and sign data.
+    #
+    #    ActiveSupport::MessageEncryptor.new('secret', 'signature_secret')
+    #
+    # Options:
+    # * <tt>:cipher</tt>     - Cipher to use. Can be any cipher returned by
+    #   <tt>OpenSSL::Cipher.ciphers</tt>. Default is 'aes-256-gcm'.
+    # * <tt>:digest</tt> - String of digest to use for signing. Default is
+    #   +SHA1+. Ignored when using an AEAD cipher like 'aes-256-gcm'.
+    # * <tt>:serializer</tt> - Object serializer to use. Default is +Marshal+.
+    def initialize: (untyped secret, *untyped signature_key_or_options) -> untyped
+
+    # Encrypt and sign a message. We need to sign the message in order to avoid
+    # padding attacks. Reference: https://www.limited-entropy.com/padding-oracle-attacks/.
+    def encrypt_and_sign: (untyped value, ?purpose: untyped? purpose, ?expires_in: untyped? expires_in, ?expires_at: untyped? expires_at) -> untyped
+
+    # Decrypt and verify a message. We need to verify the message in order to
+    # avoid padding attacks. Reference: https://www.limited-entropy.com/padding-oracle-attacks/.
+    def decrypt_and_verify: (untyped data, ?purpose: untyped? purpose) -> untyped
+
+    # Given a cipher, returns the key length of the cipher to help generate the key of desired size
+    def self.key_len: (?untyped cipher) -> untyped
+
+    def _encrypt: (untyped value, **untyped metadata_options) -> untyped
+
+    def _decrypt: (untyped encrypted_message, untyped purpose) -> untyped
+
+    def new_cipher: () -> OpenSSL::Cipher
+
+    attr_reader verifier: untyped
+
+    def aead_mode?: () -> untyped
+
+    def resolve_verifier: () -> untyped
+  end
+end
+
+module ActiveSupport
+  # +MessageVerifier+ makes it easy to generate and verify messages which are
+  # signed to prevent tampering.
+  #
+  # This is useful for cases like remember-me tokens and auto-unsubscribe links
+  # where the session store isn't suitable or available.
+  #
+  # Remember Me:
+  #   cookies[:remember_me] = @verifier.generate([@user.id, 2.weeks.from_now])
+  #
+  # In the authentication filter:
+  #
+  #   id, time = @verifier.verify(cookies[:remember_me])
+  #   if Time.now < time
+  #     self.current_user = User.find(id)
+  #   end
+  #
+  # By default it uses Marshal to serialize the message. If you want to use
+  # another serialization method, you can set the serializer in the options
+  # hash upon initialization:
+  #
+  #   @verifier = ActiveSupport::MessageVerifier.new('s3Krit', serializer: YAML)
+  #
+  # +MessageVerifier+ creates HMAC signatures using SHA1 hash algorithm by default.
+  # If you want to use a different hash algorithm, you can change it by providing
+  # +:digest+ key as an option while initializing the verifier:
+  #
+  #   @verifier = ActiveSupport::MessageVerifier.new('s3Krit', digest: 'SHA256')
+  #
+  # === Confining messages to a specific purpose
+  #
+  # By default any message can be used throughout your app. But they can also be
+  # confined to a specific +:purpose+.
+  #
+  #   token = @verifier.generate("this is the chair", purpose: :login)
+  #
+  # Then that same purpose must be passed when verifying to get the data back out:
+  #
+  #   @verifier.verified(token, purpose: :login)    # => "this is the chair"
+  #   @verifier.verified(token, purpose: :shipping) # => nil
+  #   @verifier.verified(token)                     # => nil
+  #
+  #   @verifier.verify(token, purpose: :login)      # => "this is the chair"
+  #   @verifier.verify(token, purpose: :shipping)   # => ActiveSupport::MessageVerifier::InvalidSignature
+  #   @verifier.verify(token)                       # => ActiveSupport::MessageVerifier::InvalidSignature
+  #
+  # Likewise, if a message has no purpose it won't be returned when verifying with
+  # a specific purpose.
+  #
+  #   token = @verifier.generate("the conversation is lively")
+  #   @verifier.verified(token, purpose: :scare_tactics) # => nil
+  #   @verifier.verified(token)                          # => "the conversation is lively"
+  #
+  #   @verifier.verify(token, purpose: :scare_tactics)   # => ActiveSupport::MessageVerifier::InvalidSignature
+  #   @verifier.verify(token)                            # => "the conversation is lively"
+  #
+  # === Making messages expire
+  #
+  # By default messages last forever and verifying one year from now will still
+  # return the original value. But messages can be set to expire at a given
+  # time with +:expires_in+ or +:expires_at+.
+  #
+  #   @verifier.generate(parcel, expires_in: 1.month)
+  #   @verifier.generate(doowad, expires_at: Time.now.end_of_year)
+  #
+  # Then the messages can be verified and returned up to the expire time.
+  # Thereafter, the +verified+ method returns +nil+ while +verify+ raises
+  # <tt>ActiveSupport::MessageVerifier::InvalidSignature</tt>.
+  #
+  # === Rotating keys
+  #
+  # MessageVerifier also supports rotating out old configurations by falling
+  # back to a stack of verifiers. Call +rotate+ to build and add a verifier to
+  # so either +verified+ or +verify+ will also try verifying with the fallback.
+  #
+  # By default any rotated verifiers use the values of the primary
+  # verifier unless specified otherwise.
+  #
+  # You'd give your verifier the new defaults:
+  #
+  #   verifier = ActiveSupport::MessageVerifier.new(@secret, digest: "SHA512", serializer: JSON)
+  #
+  # Then gradually rotate the old values out by adding them as fallbacks. Any message
+  # generated with the old values will then work until the rotation is removed.
+  #
+  #   verifier.rotate old_secret          # Fallback to an old secret instead of @secret.
+  #   verifier.rotate digest: "SHA256"    # Fallback to an old digest instead of SHA512.
+  #   verifier.rotate serializer: Marshal # Fallback to an old serializer instead of JSON.
+  #
+  # Though the above would most likely be combined into one rotation:
+  #
+  #   verifier.rotate old_secret, digest: "SHA256", serializer: Marshal
+  class MessageVerifier
+    class InvalidSignature < StandardError
+    end
+
+    def initialize: (untyped secret, ?::Hash[untyped, untyped] options) -> untyped
+
+    # Checks if a signed message could have been generated by signing an object
+    # with the +MessageVerifier+'s secret.
+    #
+    #   verifier = ActiveSupport::MessageVerifier.new 's3Krit'
+    #   signed_message = verifier.generate 'a private message'
+    #   verifier.valid_message?(signed_message) # => true
+    #
+    #   tampered_message = signed_message.chop # editing the message invalidates the signature
+    #   verifier.valid_message?(tampered_message) # => false
+    def valid_message?: (untyped signed_message) -> (nil | untyped)
+
+    # Decodes the signed message using the +MessageVerifier+'s secret.
+    #
+    #   verifier = ActiveSupport::MessageVerifier.new 's3Krit'
+    #
+    #   signed_message = verifier.generate 'a private message'
+    #   verifier.verified(signed_message) # => 'a private message'
+    #
+    # Returns +nil+ if the message was not signed with the same secret.
+    #
+    #   other_verifier = ActiveSupport::MessageVerifier.new 'd1ff3r3nt-s3Krit'
+    #   other_verifier.verified(signed_message) # => nil
+    #
+    # Returns +nil+ if the message is not Base64-encoded.
+    #
+    #   invalid_message = "f--46a0120593880c733a53b6dad75b42ddc1c8996d"
+    #   verifier.verified(invalid_message) # => nil
+    #
+    # Raises any error raised while decoding the signed message.
+    #
+    #   incompatible_message = "test--dad7b06c94abba8d46a15fafaef56c327665d5ff"
+    #   verifier.verified(incompatible_message) # => TypeError: incompatible marshal file format
+    def verified: (untyped signed_message, ?purpose: untyped? purpose) -> untyped
+
+    # Decodes the signed message using the +MessageVerifier+'s secret.
+    #
+    #   verifier = ActiveSupport::MessageVerifier.new 's3Krit'
+    #   signed_message = verifier.generate 'a private message'
+    #
+    #   verifier.verify(signed_message) # => 'a private message'
+    #
+    # Raises +InvalidSignature+ if the message was not signed with the same
+    # secret or was not Base64-encoded.
+    #
+    #   other_verifier = ActiveSupport::MessageVerifier.new 'd1ff3r3nt-s3Krit'
+    #   other_verifier.verify(signed_message) # => ActiveSupport::MessageVerifier::InvalidSignature
+    def verify: (*untyped args, **untyped options) -> untyped
+
+    # Generates a signed message for the provided value.
+    #
+    # The message is signed with the +MessageVerifier+'s secret. Without knowing
+    # the secret, the original value cannot be extracted from the message.
+    #
+    #   verifier = ActiveSupport::MessageVerifier.new 's3Krit'
+    #   verifier.generate 'a private message' # => "BAhJIhRwcml2YXRlLW1lc3NhZ2UGOgZFVA==--e2d724331ebdee96a10fb99b089508d1c72bd772"
+    def generate: (untyped value, ?purpose: untyped? purpose, ?expires_in: untyped? expires_in, ?expires_at: untyped? expires_at) -> ::String
+
+    def encode: (untyped data) -> untyped
+
+    def decode: (untyped data) -> untyped
+
+    def generate_digest: (untyped data) -> untyped
+  end
+end
+
+module ActiveSupport
+  module Messages
+    class Metadata
+      # nodoc:
+      # nodoc:
+      def initialize: (untyped message, ?untyped? expires_at, ?untyped? purpose) -> untyped
+
+      def as_json: (?::Hash[untyped, untyped] options) -> { _rails: { message: untyped, exp: untyped, pur: untyped } }
+
+      def self.wrap: (untyped message, ?purpose: untyped? purpose, ?expires_in: untyped? expires_in, ?expires_at: untyped? expires_at) -> untyped
+
+      def self.verify: (untyped message, untyped purpose) -> untyped
+
+      def self.pick_expiry: (untyped expires_at, untyped expires_in) -> untyped
+
+      def self.extract_metadata: (untyped message) -> untyped
+
+      def self.encode: (untyped message) -> untyped
+
+      def self.decode: (untyped message) -> untyped
+
+      def verify: (untyped purpose) -> untyped
+
+      def match?: (untyped purpose) -> untyped
+
+      def fresh?: () -> untyped
+    end
+  end
+end
+
+module ActiveSupport
+  module Messages
+    class RotationConfiguration
+      # :nodoc:
+      attr_reader signed: untyped
+
+      # :nodoc:
+      attr_reader encrypted: untyped
+
+      def initialize: () -> untyped
+
+      def rotate: (untyped kind, *untyped args) -> untyped
+    end
+  end
+end
+
+module ActiveSupport
+  module Messages
+    module Rotator
+      # :nodoc:
+      def initialize: (**untyped options) -> untyped
+
+      def rotate: (*untyped secrets, **untyped options) -> untyped
+
+      module Encryptor
+        include Rotator
+
+        def decrypt_and_verify: (*untyped args, ?on_rotation: untyped? on_rotation, **untyped options) -> untyped
+
+        def build_rotation: (?untyped secret, ?untyped sign_secret, untyped options) -> untyped
+      end
+
+      module Verifier
+        include Rotator
+
+        def verified: (*untyped args, ?on_rotation: untyped? on_rotation, **untyped options) -> untyped
+
+        def build_rotation: (?untyped secret, untyped options) -> untyped
+      end
+
+      def run_rotations: (untyped on_rotation) { (untyped) -> untyped } -> untyped
+    end
+  end
+end
+
+module ActiveSupport
+  module Multibyte
+    # nodoc:
+    # nodoc:
+    # Chars enables you to work transparently with UTF-8 encoding in the Ruby
+    # String class without having extensive knowledge about the encoding. A
+    # Chars object accepts a string upon initialization and proxies String
+    # methods in an encoding safe manner. All the normal String methods are also
+    # implemented on the proxy.
+    #
+    # String methods are proxied through the Chars object, and can be accessed
+    # through the +mb_chars+ method. Methods which would normally return a
+    # String object now return a Chars object so methods can be chained.
+    #
+    #   'The Perfect String  '.mb_chars.downcase.strip
+    #   # => #<ActiveSupport::Multibyte::Chars:0x007fdc434ccc10 @wrapped_string="the perfect string">
+    #
+    # Chars objects are perfectly interchangeable with String objects as long as
+    # no explicit class checks are made. If certain methods do explicitly check
+    # the class, call +to_s+ before you pass chars objects to them.
+    #
+    #   bad.explicit_checking_method 'T'.mb_chars.downcase.to_s
+    #
+    # The default Chars implementation assumes that the encoding of the string
+    # is UTF-8, if you want to handle different encodings you can write your own
+    # multibyte string handler and configure it through
+    # ActiveSupport::Multibyte.proxy_class.
+    #
+    #   class CharsForUTF32
+    #     def size
+    #       @wrapped_string.size / 4
+    #     end
+    #
+    #     def self.accepts?(string)
+    #       string.length % 4 == 0
+    #     end
+    #   end
+    #
+    #   ActiveSupport::Multibyte.proxy_class = CharsForUTF32
+    class Chars
+      include Comparable
+
+      attr_reader wrapped_string: untyped
+
+      alias to_s wrapped_string
+
+      alias to_str wrapped_string
+
+      # Creates a new Chars instance by wrapping _string_.
+      def initialize: (untyped string) -> untyped
+
+      # Forward all undefined methods to the wrapped string.
+      def method_missing: (untyped method, *untyped args) { () -> untyped } -> untyped
+
+      # Returns +true+ if _obj_ responds to the given method. Private methods
+      # are included in the search only if the optional second parameter
+      # evaluates to +true+.
+      def respond_to_missing?: (untyped method, untyped include_private) -> untyped
+
+      # Returns +true+ when the proxy class can handle the string. Returns
+      # +false+ otherwise.
+      def self.consumes?: (untyped string) -> untyped
+
+      # Works just like <tt>String#split</tt>, with the exception that the items
+      # in the resulting list are Chars instances instead of String. This makes
+      # chaining methods easier.
+      #
+      #   'Caf(trim non-ascii characters) p(trim non-ascii characters)rifer(trim non-ascii characters)l'.mb_chars.split(/(trim non-ascii characters)/).map { |part| part.upcase.to_s } # => ["CAF", " P", "RIFER(trim non-ascii characters)L"]
+      def split: (*untyped args) -> untyped
+
+      # Works like <tt>String#slice!</tt>, but returns an instance of
+      # Chars, or +nil+ if the string was not modified. The string will not be
+      # modified if the range given is out of bounds
+      #
+      #   string = 'Welcome'
+      #   string.mb_chars.slice!(3)    # => #<ActiveSupport::Multibyte::Chars:0x000000038109b8 @wrapped_string="c">
+      #   string # => 'Welome'
+      #   string.mb_chars.slice!(0..3) # => #<ActiveSupport::Multibyte::Chars:0x00000002eb80a0 @wrapped_string="Welo">
+      #   string # => 'me'
+      def slice!: (*untyped args) -> untyped
+
+      # Reverses all characters in the string.
+      #
+      #   'Caf(trim non-ascii characters)'.mb_chars.reverse.to_s # => '(trim non-ascii characters)faC'
+      def reverse: () -> untyped
+
+      # Limits the byte size of the string to a number of bytes without breaking
+      # characters. Usable when the storage for a string is limited for some
+      # reason.
+      #
+      #   '(trim non-ascii characters)'.mb_chars.limit(7).to_s # => "(trim non-ascii characters)"
+      def limit: (untyped limit) -> untyped
+
+      # Capitalizes the first letter of every word, when possible.
+      #
+      #   "(trim non-ascii characters)L QUE SE ENTER(trim non-ascii characters)".mb_chars.titleize.to_s    # => "(trim non-ascii characters)l Que Se Enter(trim non-ascii characters)"
+      #   "(trim non-ascii characters)".mb_chars.titleize.to_s               # => "(trim non-ascii characters)"
+      def titleize: () -> untyped
+
+      alias titlecase titleize
+
+      # Returns the KC normalization of the string by default. NFKC is
+      # considered the best normalization form for passing strings to databases
+      # and validations.
+      #
+      # * <tt>form</tt> - The form you want to normalize in. Should be one of the following:
+      #   <tt>:c</tt>, <tt>:kc</tt>, <tt>:d</tt>, or <tt>:kd</tt>. Default is
+      #   ActiveSupport::Multibyte::Unicode.default_normalization_form
+      def normalize: (?untyped? form) -> untyped
+
+      # Performs canonical decomposition on all the characters.
+      #
+      #   '(trim non-ascii characters)'.length                         # => 2
+      #   '(trim non-ascii characters)'.mb_chars.decompose.to_s.length # => 3
+      def decompose: () -> untyped
+
+      # Performs composition on all the characters.
+      #
+      #   '(trim non-ascii characters)'.length                       # => 3
+      #   '(trim non-ascii characters)'.mb_chars.compose.to_s.length # => 2
+      def compose: () -> untyped
+
+      # Returns the number of grapheme clusters in the string.
+      #
+      #   '(trim non-ascii characters)'.mb_chars.length   # => 4
+      #   '(trim non-ascii characters)'.mb_chars.grapheme_length # => 3
+      def grapheme_length: () -> untyped
+
+      # Replaces all ISO-8859-1 or CP1252 characters by their UTF-8 equivalent
+      # resulting in a valid UTF-8 string.
+      #
+      # Passing +true+ will forcibly tidy all bytes, assuming that the string's
+      # encoding is entirely CP1252 or ISO-8859-1.
+      def tidy_bytes: (?bool force) -> untyped
+
+      def as_json: (?untyped? options) -> untyped
+
+      def chars: (untyped string) -> untyped
+    end
+  end
+end
+
+module ActiveSupport
+  module Multibyte
+    module Unicode
+      # A list of all available normalization forms.
+      # See https://www.unicode.org/reports/tr15/tr15-29.html for more
+      # information about normalization.
+      NORMALIZATION_FORMS: ::Array[untyped]
+
+      NORMALIZATION_FORM_ALIASES: ::Hash[untyped, untyped]
+
+      # The Unicode version that is supported by the implementation
+      UNICODE_VERSION: untyped
+
+      # The default normalization used for operations that require
+      # normalization. It can be set to any of the normalizations
+      # in NORMALIZATION_FORMS.
+      #
+      #   ActiveSupport::Multibyte::Unicode.default_normalization_form = :c
+      attr_accessor default_normalization_form: untyped
+
+      # Unpack the string at grapheme boundaries. Returns a list of character
+      # lists.
+      #
+      #   Unicode.unpack_graphemes('(trim non-ascii characters)') # => [[2325, 2381], [2359], [2367]]
+      #   Unicode.unpack_graphemes('Caf(trim non-ascii characters)') # => [[67], [97], [102], [233]]
+      def unpack_graphemes: (untyped string) -> untyped
+
+      # Reverse operation of unpack_graphemes.
+      #
+      #   Unicode.pack_graphemes(Unicode.unpack_graphemes('(trim non-ascii characters)')) # => '(trim non-ascii characters)'
+      def pack_graphemes: (untyped unpacked) -> untyped
+
+      # Decompose composed characters to the decomposed form.
+      def decompose: (untyped `type`, untyped codepoints) -> untyped
+
+      # Compose decomposed characters to the composed form.
+      def compose: (untyped codepoints) -> untyped
+
+      # Replaces all ISO-8859-1 or CP1252 characters by their UTF-8 equivalent
+      # resulting in a valid UTF-8 string.
+      #
+      # Passing +true+ will forcibly tidy all bytes, assuming that the string's
+      # encoding is entirely CP1252 or ISO-8859-1.
+      def tidy_bytes: (untyped string, ?bool force) -> untyped
+
+      # Returns the KC normalization of the string by default. NFKC is
+      # considered the best normalization form for passing strings to databases
+      # and validations.
+      #
+      # * <tt>string</tt> - The string to perform normalization on.
+      # * <tt>form</tt> - The form you want to normalize in. Should be one of
+      #   the following: <tt>:c</tt>, <tt>:kc</tt>, <tt>:d</tt>, or <tt>:kd</tt>.
+      #   Default is ActiveSupport::Multibyte::Unicode.default_normalization_form.
+      def normalize: (untyped string, ?untyped? form) -> untyped
+
+      def recode_windows1252_chars: (untyped string) -> untyped
+    end
+  end
+end
+
+module ActiveSupport
+  # nodoc:
+  module Multibyte
+    # The proxy class returned when calling mb_chars. You can use this accessor
+    # to configure your own proxy class so you can support other encodings. See
+    # the ActiveSupport::Multibyte::Chars implementation for an example how to
+    # do this.
+    #
+    #   ActiveSupport::Multibyte.proxy_class = CharsForUTF32
+    def self.proxy_class=: (untyped klass) -> untyped
+
+    # Returns the current proxy class.
+    def self.proxy_class: () -> untyped
+  end
+end
+
+module ActiveSupport
+  module Notifications
+    # This is a default queue implementation that ships with Notifications.
+    # It just pushes events to all registered log subscribers.
+    #
+    # This class is thread safe. All methods are reentrant.
+    class Fanout
+      include Mutex_m
+
+      def initialize: () -> untyped
+
+      def subscribe: (?untyped? pattern, ?untyped? callable) { () -> untyped } -> untyped
+
+      def unsubscribe: (untyped subscriber_or_name) -> untyped
+
+      def start: (untyped name, untyped id, untyped payload) -> untyped
+
+      def finish: (untyped name, untyped id, untyped payload, ?untyped listeners) -> untyped
+
+      def publish: (untyped name, *untyped args) -> untyped
+
+      def listeners_for: (untyped name) -> untyped
+
+      def listening?: (untyped name) -> untyped
+
+      # This is a sync queue, so there is no waiting.
+      def wait: () -> nil
+
+      module Subscribers
+        # :nodoc:
+        def self.new: (untyped pattern, untyped listener) -> untyped
+
+        def self.event_object_subscriber: (untyped pattern, untyped block) -> untyped
+
+        def self.wrap_all: (untyped pattern, untyped subscriber) -> untyped
+
+        class Matcher
+          # nodoc:
+          attr_reader pattern: untyped
+
+          # nodoc:
+          attr_reader exclusions: untyped
+
+          def self.wrap: (untyped pattern) -> untyped
+
+          def initialize: (untyped pattern) -> untyped
+
+          def unsubscribe!: (untyped name) -> untyped
+
+          def ===: (untyped name) -> untyped
+        end
+
+        class Evented
+          # nodoc:
+          attr_reader pattern: untyped
+
+          def initialize: (untyped pattern, untyped delegate) -> untyped
+
+          def publish: (untyped name, *untyped args) -> untyped
+
+          def start: (untyped name, untyped id, untyped payload) -> untyped
+
+          def finish: (untyped name, untyped id, untyped payload) -> untyped
+
+          def subscribed_to?: (untyped name) -> untyped
+
+          def matches?: (untyped name) -> untyped
+
+          def unsubscribe!: (untyped name) -> untyped
+        end
+
+        class Timed < Evented
+          # :nodoc:
+          def publish: (untyped name, *untyped args) -> untyped
+
+          def start: (untyped name, untyped id, untyped payload) -> untyped
+
+          def finish: (untyped name, untyped id, untyped payload) -> untyped
+        end
+
+        class EventObject < Evented
+          def start: (untyped name, untyped id, untyped payload) -> untyped
+
+          def finish: (untyped name, untyped id, untyped payload) -> untyped
+
+          def build_event: (untyped name, untyped id, untyped payload) -> ActiveSupport::Notifications::Event
+        end
+
+        class AllMessages
+          # :nodoc:
+          def initialize: (untyped delegate) -> untyped
+
+          def start: (untyped name, untyped id, untyped payload) -> untyped
+
+          def finish: (untyped name, untyped id, untyped payload) -> untyped
+
+          def publish: (untyped name, *untyped args) -> untyped
+
+          def subscribed_to?: (untyped name) -> ::TrueClass
+
+          def unsubscribe!: () -> ::FalseClass
+
+          alias matches? ===
+        end
+      end
+    end
+  end
+end
+
+module ActiveSupport
+  module Notifications
+    # Instrumenters are stored in a thread local.
+    class Instrumenter
+      attr_reader id: untyped
+
+      def initialize: (untyped notifier) -> untyped
+
+      # Given a block, instrument it by measuring the time taken to execute
+      # and publish it. Without a block, simply send a message via the
+      # notifier. Notice that events get sent even if an error occurs in the
+      # passed-in block.
+      def instrument: (untyped name, ?::Hash[untyped, untyped] payload) { (untyped) -> untyped } -> untyped
+
+      # Send a start notification with +name+ and +payload+.
+      def start: (untyped name, untyped payload) -> untyped
+
+      # Send a finish notification with +name+ and +payload+.
+      def finish: (untyped name, untyped payload) -> untyped
+
+      def finish_with_state: (untyped listeners_state, untyped name, untyped payload) -> untyped
+
+      def unique_id: () -> untyped
+    end
+
+    class Event
+      attr_reader name: untyped
+
+      attr_reader time: untyped
+
+      attr_reader end: untyped
+
+      attr_reader transaction_id: untyped
+
+      attr_reader payload: untyped
+
+      attr_reader children: untyped
+
+      def self.clock_gettime_supported?: () -> untyped
+
+      def initialize: (untyped name, untyped start, untyped ending, untyped transaction_id, untyped payload) -> untyped
+
+      # Record information at the time this event starts
+      def start!: () -> untyped
+
+      # Record information at the time this event finishes
+      def finish!: () -> untyped
+
+      def end=: (untyped ending) -> untyped
+
+      # Returns the CPU time (in milliseconds) passed since the call to
+      # +start!+ and the call to +finish!+
+      def cpu_time: () -> untyped
+
+      # Returns the idle time time (in milliseconds) passed since the call to
+      # +start!+ and the call to +finish!+
+      def idle_time: () -> untyped
+
+      # Returns the number of allocations made since the call to +start!+ and
+      # the call to +finish!+
+      def allocations: () -> untyped
+
+      # Returns the difference in milliseconds between when the execution of the
+      # event started and when it ended.
+      #
+      #   ActiveSupport::Notifications.subscribe('wait') do |*args|
+      #     @event = ActiveSupport::Notifications::Event.new(*args)
+      #   end
+      #
+      #   ActiveSupport::Notifications.instrument('wait') do
+      #     sleep 1
+      #   end
+      #
+      #   @event.duration # => 1000.138
+      def duration: () -> untyped
+
+      def <<: (untyped event) -> untyped
+
+      def parent_of?: (untyped event) -> untyped
+
+      def now: () -> untyped
+
+      def now_cpu: () -> untyped
+
+      def now_cpu: () -> 0
+
+      def now_allocations: () -> 0
+
+      def now_allocations: () -> untyped
+    end
+  end
+end
+
+module ActiveSupport
+  # = Notifications
+  #
+  # <tt>ActiveSupport::Notifications</tt> provides an instrumentation API for
+  # Ruby.
+  #
+  # == Instrumenters
+  #
+  # To instrument an event you just need to do:
+  #
+  #   ActiveSupport::Notifications.instrument('render', extra: :information) do
+  #     render plain: 'Foo'
+  #   end
+  #
+  # That first executes the block and then notifies all subscribers once done.
+  #
+  # In the example above +render+ is the name of the event, and the rest is called
+  # the _payload_. The payload is a mechanism that allows instrumenters to pass
+  # extra information to subscribers. Payloads consist of a hash whose contents
+  # are arbitrary and generally depend on the event.
+  #
+  # == Subscribers
+  #
+  # You can consume those events and the information they provide by registering
+  # a subscriber.
+  #
+  #   ActiveSupport::Notifications.subscribe('render') do |name, start, finish, id, payload|
+  #     name    # => String, name of the event (such as 'render' from above)
+  #     start   # => Time, when the instrumented block started execution
+  #     finish  # => Time, when the instrumented block ended execution
+  #     id      # => String, unique ID for the instrumenter that fired the event
+  #     payload # => Hash, the payload
+  #   end
+  #
+  # For instance, let's store all "render" events in an array:
+  #
+  #   events = []
+  #
+  #   ActiveSupport::Notifications.subscribe('render') do |*args|
+  #     events << ActiveSupport::Notifications::Event.new(*args)
+  #   end
+  #
+  # That code returns right away, you are just subscribing to "render" events.
+  # The block is saved and will be called whenever someone instruments "render":
+  #
+  #   ActiveSupport::Notifications.instrument('render', extra: :information) do
+  #     render plain: 'Foo'
+  #   end
+  #
+  #   event = events.first
+  #   event.name      # => "render"
+  #   event.duration  # => 10 (in milliseconds)
+  #   event.payload   # => { extra: :information }
+  #
+  # The block in the <tt>subscribe</tt> call gets the name of the event, start
+  # timestamp, end timestamp, a string with a unique identifier for that event's instrumenter
+  # (something like "535801666f04d0298cd6"), and a hash with the payload, in
+  # that order.
+  #
+  # If an exception happens during that particular instrumentation the payload will
+  # have a key <tt>:exception</tt> with an array of two elements as value: a string with
+  # the name of the exception class, and the exception message.
+  # The <tt>:exception_object</tt> key of the payload will have the exception
+  # itself as the value:
+  #
+  #   event.payload[:exception]         # => ["ArgumentError", "Invalid value"]
+  #   event.payload[:exception_object]  # => #<ArgumentError: Invalid value>
+  #
+  # As the earlier example depicts, the class <tt>ActiveSupport::Notifications::Event</tt>
+  # is able to take the arguments as they come and provide an object-oriented
+  # interface to that data.
+  #
+  # It is also possible to pass an object which responds to <tt>call</tt> method
+  # as the second parameter to the <tt>subscribe</tt> method instead of a block:
+  #
+  #   module ActionController
+  #     class PageRequest
+  #       def call(name, started, finished, unique_id, payload)
+  #         Rails.logger.debug ['notification:', name, started, finished, unique_id, payload].join(' ')
+  #       end
+  #     end
+  #   end
+  #
+  #   ActiveSupport::Notifications.subscribe('process_action.action_controller', ActionController::PageRequest.new)
+  #
+  # resulting in the following output within the logs including a hash with the payload:
+  #
+  #   notification: process_action.action_controller 2012-04-13 01:08:35 +0300 2012-04-13 01:08:35 +0300 af358ed7fab884532ec7 {
+  #      controller: "Devise::SessionsController",
+  #      action: "new",
+  #      params: {"action"=>"new", "controller"=>"devise/sessions"},
+  #      format: :html,
+  #      method: "GET",
+  #      path: "/login/sign_in",
+  #      status: 200,
+  #      view_runtime: 279.3080806732178,
+  #      db_runtime: 40.053
+  #    }
+  #
+  # You can also subscribe to all events whose name matches a certain regexp:
+  #
+  #   ActiveSupport::Notifications.subscribe(/render/) do |*args|
+  #     ...
+  #   end
+  #
+  # and even pass no argument to <tt>subscribe</tt>, in which case you are subscribing
+  # to all events.
+  #
+  # == Temporary Subscriptions
+  #
+  # Sometimes you do not want to subscribe to an event for the entire life of
+  # the application. There are two ways to unsubscribe.
+  #
+  # WARNING: The instrumentation framework is designed for long-running subscribers,
+  # use this feature sparingly because it wipes some internal caches and that has
+  # a negative impact on performance.
+  #
+  # === Subscribe While a Block Runs
+  #
+  # You can subscribe to some event temporarily while some block runs. For
+  # example, in
+  #
+  #   callback = lambda {|*args| ... }
+  #   ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+  #     ...
+  #   end
+  #
+  # the callback will be called for all "sql.active_record" events instrumented
+  # during the execution of the block. The callback is unsubscribed automatically
+  # after that.
+  #
+  # === Manual Unsubscription
+  #
+  # The +subscribe+ method returns a subscriber object:
+  #
+  #   subscriber = ActiveSupport::Notifications.subscribe("render") do |*args|
+  #     ...
+  #   end
+  #
+  # To prevent that block from being called anymore, just unsubscribe passing
+  # that reference:
+  #
+  #   ActiveSupport::Notifications.unsubscribe(subscriber)
+  #
+  # You can also unsubscribe by passing the name of the subscriber object. Note
+  # that this will unsubscribe all subscriptions with the given name:
+  #
+  #   ActiveSupport::Notifications.unsubscribe("render")
+  #
+  # Subscribers using a regexp or other pattern-matching object will remain subscribed
+  # to all events that match their original pattern, unless those events match a string
+  # passed to `unsubscribe`:
+  #
+  #   subscriber = ActiveSupport::Notifications.subscribe(/render/) { }
+  #   ActiveSupport::Notifications.unsubscribe('render_template.action_view')
+  #   subscriber.matches?('render_template.action_view') # => false
+  #   subscriber.matches?('render_partial.action_view') # => true
+  #
+  # == Default Queue
+  #
+  # Notifications ships with a queue implementation that consumes and publishes events
+  # to all log subscribers. You can use any queue implementation you want.
+  #
+  module Notifications
+    attr_accessor notifier: untyped
+
+    def self.publish: (untyped name, *untyped args) -> untyped
+
+    def self.instrument: (untyped name, ?::Hash[untyped, untyped] payload) { (untyped) -> untyped } -> untyped
+
+    # Subscribe to a given event name with the passed +block+.
+    #
+    # You can subscribe to events by passing a String to match exact event
+    # names, or by passing a Regexp to match all events that match a pattern.
+    #
+    #   ActiveSupport::Notifications.subscribe(/render/) do |*args|
+    #     @event = ActiveSupport::Notifications::Event.new(*args)
+    #   end
+    #
+    # The +block+ will receive five parameters with information about the event:
+    #
+    #   ActiveSupport::Notifications.subscribe('render') do |name, start, finish, id, payload|
+    #     name    # => String, name of the event (such as 'render' from above)
+    #     start   # => Time, when the instrumented block started execution
+    #     finish  # => Time, when the instrumented block ended execution
+    #     id      # => String, unique ID for the instrumenter that fired the event
+    #     payload # => Hash, the payload
+    #   end
+    #
+    # If the block passed to the method only takes one parameter,
+    # it will yield an event object to the block:
+    #
+    #   ActiveSupport::Notifications.subscribe(/render/) do |event|
+    #     @event = event
+    #   end
+    def self.subscribe: (*untyped args) { () -> untyped } -> untyped
+
+    def self.subscribed: (untyped callback, *untyped args) { () -> untyped } -> untyped
+
+    def self.unsubscribe: (untyped subscriber_or_name) -> untyped
+
+    def self.instrumenter: () -> untyped
+
+    class InstrumentationRegistry
+      # This class is a registry which holds all of the +Instrumenter+ objects
+      # in a particular thread local. To access the +Instrumenter+ object for a
+      # particular +notifier+, you can call the following method:
+      #
+      #   InstrumentationRegistry.instrumenter_for(notifier)
+      #
+      # The instrumenters for multiple notifiers are held in a single instance of
+      # this class.
+      # :nodoc:
+      extend ActiveSupport::PerThreadRegistry
+
+      def initialize: () -> untyped
+
+      def instrumenter_for: (untyped notifier) -> untyped
+    end
+  end
+end
+
+module ActiveSupport
+  module NumberHelper
+    class NumberConverter
+      attr_reader number: untyped
+
+      attr_reader opts: untyped
+
+      DEFAULTS: ::Hash[untyped, untyped]
+
+      def self.convert: (untyped number, untyped options) -> untyped
+
+      def initialize: (untyped number, untyped options) -> untyped
+
+      def execute: () -> untyped
+
+      def options: () -> untyped
+
+      def format_options: () -> untyped
+
+      def default_format_options: () -> untyped
+
+      def i18n_format_options: () -> untyped
+
+      def translate_number_value_with_default: (untyped key, **untyped i18n_options) -> untyped
+
+      def translate_in_locale: (untyped key, **untyped i18n_options) -> untyped
+
+      def default_value: (untyped key) -> untyped
+
+      def valid_float?: () -> untyped
+    end
+  end
+end
+
+module ActiveSupport
+  module NumberHelper
+    class NumberToCurrencyConverter < NumberConverter
+      def convert: () -> untyped
+
+      def options: () -> untyped
+
+      def i18n_opts: () -> untyped
+    end
+  end
+end
+
+module ActiveSupport
+  module NumberHelper
+    class NumberToDelimitedConverter < NumberConverter
+      DEFAULT_DELIMITER_REGEX: untyped
+
+      def convert: () -> untyped
+
+      def parts: () -> untyped
+
+      def delimiter_pattern: () -> untyped
+    end
+  end
+end
+
+module ActiveSupport
+  module NumberHelper
+    class NumberToHumanConverter < NumberConverter
+      # :nodoc:
+      DECIMAL_UNITS: ::Hash[untyped, untyped]
+
+      INVERTED_DECIMAL_UNITS: untyped
+
+      def convert: () -> untyped
+
+      def format: () -> untyped
+
+      def determine_unit: (untyped units, untyped exponent) -> untyped
+
+      def calculate_exponent: (untyped units) -> untyped
+
+      def unit_exponents: (untyped units) -> untyped
+    end
+  end
+end
+
+module ActiveSupport
+  module NumberHelper
+    class NumberToHumanSizeConverter < NumberConverter
+      # nodoc:
+      STORAGE_UNITS: ::Array[untyped]
+
+      def convert: () -> untyped
+
+      def conversion_format: () -> untyped
+
+      def unit: () -> untyped
+
+      def storage_unit_key: () -> ::String
+
+      def exponent: () -> untyped
+
+      def smaller_than_base?: () -> untyped
+
+      def base: () -> 1024
+    end
+  end
+end
+
+module ActiveSupport
+  module NumberHelper
+    class NumberToPercentageConverter < NumberConverter
+      def convert: () -> untyped
+    end
+  end
+end
+
+module ActiveSupport
+  module NumberHelper
+    class NumberToPhoneConverter < NumberConverter
+      # nodoc:
+      def convert: () -> untyped
+
+      def convert_to_phone_number: (untyped number) -> untyped
+
+      def convert_with_area_code: (untyped number) -> untyped
+
+      def convert_without_area_code: (untyped number) -> untyped
+
+      def start_with_delimiter?: (untyped number) -> untyped
+
+      def delimiter: () -> untyped
+
+      def country_code: (untyped code) -> untyped
+
+      def phone_ext: (untyped ext) -> untyped
+
+      def regexp_pattern: (untyped default_pattern) -> untyped
+    end
+  end
+end
+
+module ActiveSupport
+  module NumberHelper
+    class NumberToRoundedConverter < NumberConverter
+      def convert: () -> untyped
+
+      def strip_insignificant_zeros: () -> untyped
+
+      def format_number: (untyped number) -> untyped
+    end
+  end
+end
+
+module ActiveSupport
+  module NumberHelper
+    class RoundingHelper
+      # :nodoc:
+      attr_reader options: untyped
+
+      def initialize: (untyped options) -> untyped
+
+      def round: (untyped number) -> untyped
+
+      def digit_count: (untyped number) -> (1 | untyped)
+
+      def round_without_significant: (untyped number) -> untyped
+
+      def round_significant: (untyped number) -> (0 | untyped)
+
+      def convert_to_decimal: (untyped number) -> untyped
+
+      def precision: () -> untyped
+
+      def significant: () -> untyped
+
+      def absolute_number: (untyped number) -> untyped
+    end
+  end
+end
+
+module ActiveSupport
+  module NumberHelper
+    extend ActiveSupport::Autoload
+
+    # Formats a +number+ into a phone number (US by default e.g., (555)
+    # 123-9876). You can customize the format in the +options+ hash.
+    #
+    # ==== Options
+    #
+    # * <tt>:area_code</tt> - Adds parentheses around the area code.
+    # * <tt>:delimiter</tt> - Specifies the delimiter to use
+    #   (defaults to "-").
+    # * <tt>:extension</tt> - Specifies an extension to add to the
+    #   end of the generated number.
+    # * <tt>:country_code</tt> - Sets the country code for the phone
+    #   number.
+    # * <tt>:pattern</tt> - Specifies how the number is divided into three
+    #   groups with the custom regexp to override the default format.
+    # ==== Examples
+    #
+    #   number_to_phone(5551234)                                     # => "555-1234"
+    #   number_to_phone('5551234')                                   # => "555-1234"
+    #   number_to_phone(1235551234)                                  # => "123-555-1234"
+    #   number_to_phone(1235551234, area_code: true)                 # => "(123) 555-1234"
+    #   number_to_phone(1235551234, delimiter: ' ')                  # => "123 555 1234"
+    #   number_to_phone(1235551234, area_code: true, extension: 555) # => "(123) 555-1234 x 555"
+    #   number_to_phone(1235551234, country_code: 1)                 # => "+1-123-555-1234"
+    #   number_to_phone('123a456')                                   # => "123a456"
+    #
+    #   number_to_phone(1235551234, country_code: 1, extension: 1343, delimiter: '.')
+    #   # => "+1.123.555.1234 x 1343"
+    #
+    #   number_to_phone(75561234567, pattern: /(\d{1,4})(\d{4})(\d{4})$/, area_code: true)
+    #   # => "(755) 6123-4567"
+    #   number_to_phone(13312345678, pattern: /(\d{3})(\d{4})(\d{4})$/)
+    #   # => "133-1234-5678"
+    def number_to_phone: (untyped number, ?::Hash[untyped, untyped] options) -> untyped
+
+    # Formats a +number+ into a currency string (e.g., $13.65). You
+    # can customize the format in the +options+ hash.
+    #
+    # The currency unit and number formatting of the current locale will be used
+    # unless otherwise specified in the provided options. No currency conversion
+    # is performed. If the user is given a way to change their locale, they will
+    # also be able to change the relative value of the currency displayed with
+    # this helper. If your application will ever support multiple locales, you
+    # may want to specify a constant <tt>:locale</tt> option or consider
+    # using a library capable of currency conversion.
+    #
+    # ==== Options
+    #
+    # * <tt>:locale</tt> - Sets the locale to be used for formatting
+    #   (defaults to current locale).
+    # * <tt>:precision</tt> - Sets the level of precision (defaults
+    #   to 2).
+    # * <tt>:unit</tt> - Sets the denomination of the currency
+    #   (defaults to "$").
+    # * <tt>:separator</tt> - Sets the separator between the units
+    #   (defaults to ".").
+    # * <tt>:delimiter</tt> - Sets the thousands delimiter (defaults
+    #   to ",").
+    # * <tt>:format</tt> - Sets the format for non-negative numbers
+    #   (defaults to "%u%n").  Fields are <tt>%u</tt> for the
+    #   currency, and <tt>%n</tt> for the number.
+    # * <tt>:negative_format</tt> - Sets the format for negative
+    #   numbers (defaults to prepending a hyphen to the formatted
+    #   number given by <tt>:format</tt>).  Accepts the same fields
+    #   than <tt>:format</tt>, except <tt>%n</tt> is here the
+    #   absolute value of the number.
+    # * <tt>:strip_insignificant_zeros</tt> - If +true+ removes
+    #   insignificant zeros after the decimal separator (defaults to
+    #   +false+).
+    #
+    # ==== Examples
+    #
+    #   number_to_currency(1234567890.50)                # => "$1,234,567,890.50"
+    #   number_to_currency(1234567890.506)               # => "$1,234,567,890.51"
+    #   number_to_currency(1234567890.506, precision: 3) # => "$1,234,567,890.506"
+    #   number_to_currency(1234567890.506, locale: :fr)  # => "1 234 567 890,51 (trim non-ascii characters)"
+    #   number_to_currency('123a456')                    # => "$123a456"
+    #
+    #   number_to_currency("123a456", raise: true)       # => InvalidNumberError
+    #
+    #   number_to_currency(-0.456789, precision: 0)
+    #   # => "$0"
+    #   number_to_currency(-1234567890.50, negative_format: '(%u%n)')
+    #   # => "($1,234,567,890.50)"
+    #   number_to_currency(1234567890.50, unit: '&pound;', separator: ',', delimiter: '')
+    #   # => "&pound;1234567890,50"
+    #   number_to_currency(1234567890.50, unit: '&pound;', separator: ',', delimiter: '', format: '%n %u')
+    #   # => "1234567890,50 &pound;"
+    #   number_to_currency(1234567890.50, strip_insignificant_zeros: true)
+    #   # => "$1,234,567,890.5"
+    def number_to_currency: (untyped number, ?::Hash[untyped, untyped] options) -> untyped
+
+    # Formats a +number+ as a percentage string (e.g., 65%). You can
+    # customize the format in the +options+ hash.
+    #
+    # ==== Options
+    #
+    # * <tt>:locale</tt> - Sets the locale to be used for formatting
+    #   (defaults to current locale).
+    # * <tt>:precision</tt> - Sets the precision of the number
+    #   (defaults to 3). Keeps the number's precision if +nil+.
+    # * <tt>:significant</tt> - If +true+, precision will be the number
+    #   of significant_digits. If +false+, the number of fractional
+    #   digits (defaults to +false+).
+    # * <tt>:separator</tt> - Sets the separator between the
+    #   fractional and integer digits (defaults to ".").
+    # * <tt>:delimiter</tt> - Sets the thousands delimiter (defaults
+    #   to "").
+    # * <tt>:strip_insignificant_zeros</tt> - If +true+ removes
+    #   insignificant zeros after the decimal separator (defaults to
+    #   +false+).
+    # * <tt>:format</tt> - Specifies the format of the percentage
+    #   string The number field is <tt>%n</tt> (defaults to "%n%").
+    #
+    # ==== Examples
+    #
+    #   number_to_percentage(100)                                  # => "100.000%"
+    #   number_to_percentage('98')                                 # => "98.000%"
+    #   number_to_percentage(100, precision: 0)                    # => "100%"
+    #   number_to_percentage(1000, delimiter: '.', separator: ',') # => "1.000,000%"
+    #   number_to_percentage(302.24398923423, precision: 5)        # => "302.24399%"
+    #   number_to_percentage(1000, locale: :fr)                    # => "1000,000%"
+    #   number_to_percentage(1000, precision: nil)                 # => "1000%"
+    #   number_to_percentage('98a')                                # => "98a%"
+    #   number_to_percentage(100, format: '%n  %')                 # => "100.000  %"
+    def number_to_percentage: (untyped number, ?::Hash[untyped, untyped] options) -> untyped
+
+    # Formats a +number+ with grouped thousands using +delimiter+
+    # (e.g., 12,324). You can customize the format in the +options+
+    # hash.
+    #
+    # ==== Options
+    #
+    # * <tt>:locale</tt> - Sets the locale to be used for formatting
+    #   (defaults to current locale).
+    # * <tt>:delimiter</tt> - Sets the thousands delimiter (defaults
+    #   to ",").
+    # * <tt>:separator</tt> - Sets the separator between the
+    #   fractional and integer digits (defaults to ".").
+    # * <tt>:delimiter_pattern</tt> - Sets a custom regular expression used for
+    #   deriving the placement of delimiter. Helpful when using currency formats
+    #   like INR.
+    #
+    # ==== Examples
+    #
+    #   number_to_delimited(12345678)                    # => "12,345,678"
+    #   number_to_delimited('123456')                    # => "123,456"
+    #   number_to_delimited(12345678.05)                 # => "12,345,678.05"
+    #   number_to_delimited(12345678, delimiter: '.')    # => "12.345.678"
+    #   number_to_delimited(12345678, delimiter: ',')    # => "12,345,678"
+    #   number_to_delimited(12345678.05, separator: ' ') # => "12,345,678 05"
+    #   number_to_delimited(12345678.05, locale: :fr)    # => "12 345 678,05"
+    #   number_to_delimited('112a')                      # => "112a"
+    #   number_to_delimited(98765432.98, delimiter: ' ', separator: ',')
+    #                                                    # => "98 765 432,98"
+    #   number_to_delimited("123456.78",
+    #     delimiter_pattern: /(\d+?)(?=(\d\d)+(\d)(?!\d))/)
+    #                                                    # => "1,23,456.78"
+    def number_to_delimited: (untyped number, ?::Hash[untyped, untyped] options) -> untyped
+
+    # Formats a +number+ with the specified level of
+    # <tt>:precision</tt> (e.g., 112.32 has a precision of 2 if
+    # +:significant+ is +false+, and 5 if +:significant+ is +true+).
+    # You can customize the format in the +options+ hash.
+    #
+    # ==== Options
+    #
+    # * <tt>:locale</tt> - Sets the locale to be used for formatting
+    #   (defaults to current locale).
+    # * <tt>:precision</tt> - Sets the precision of the number
+    #   (defaults to 3). Keeps the number's precision if +nil+.
+    # * <tt>:significant</tt> - If +true+, precision will be the number
+    #   of significant_digits. If +false+, the number of fractional
+    #   digits (defaults to +false+).
+    # * <tt>:separator</tt> - Sets the separator between the
+    #   fractional and integer digits (defaults to ".").
+    # * <tt>:delimiter</tt> - Sets the thousands delimiter (defaults
+    #   to "").
+    # * <tt>:strip_insignificant_zeros</tt> - If +true+ removes
+    #   insignificant zeros after the decimal separator (defaults to
+    #   +false+).
+    #
+    # ==== Examples
+    #
+    #   number_to_rounded(111.2345)                                  # => "111.235"
+    #   number_to_rounded(111.2345, precision: 2)                    # => "111.23"
+    #   number_to_rounded(13, precision: 5)                          # => "13.00000"
+    #   number_to_rounded(389.32314, precision: 0)                   # => "389"
+    #   number_to_rounded(111.2345, significant: true)               # => "111"
+    #   number_to_rounded(111.2345, precision: 1, significant: true) # => "100"
+    #   number_to_rounded(13, precision: 5, significant: true)       # => "13.000"
+    #   number_to_rounded(13, precision: nil)                        # => "13"
+    #   number_to_rounded(111.234, locale: :fr)                      # => "111,234"
+    #
+    #   number_to_rounded(13, precision: 5, significant: true, strip_insignificant_zeros: true)
+    #   # => "13"
+    #
+    #   number_to_rounded(389.32314, precision: 4, significant: true) # => "389.3"
+    #   number_to_rounded(1111.2345, precision: 2, separator: ',', delimiter: '.')
+    #   # => "1.111,23"
+    def number_to_rounded: (untyped number, ?::Hash[untyped, untyped] options) -> untyped
+
+    # Formats the bytes in +number+ into a more understandable
+    # representation (e.g., giving it 1500 yields 1.5 KB). This
+    # method is useful for reporting file sizes to users. You can
+    # customize the format in the +options+ hash.
+    #
+    # See <tt>number_to_human</tt> if you want to pretty-print a
+    # generic number.
+    #
+    # ==== Options
+    #
+    # * <tt>:locale</tt> - Sets the locale to be used for formatting
+    #   (defaults to current locale).
+    # * <tt>:precision</tt> - Sets the precision of the number
+    #   (defaults to 3).
+    # * <tt>:significant</tt> - If +true+, precision will be the number
+    #   of significant_digits. If +false+, the number of fractional
+    #   digits (defaults to +true+)
+    # * <tt>:separator</tt> - Sets the separator between the
+    #   fractional and integer digits (defaults to ".").
+    # * <tt>:delimiter</tt> - Sets the thousands delimiter (defaults
+    #   to "").
+    # * <tt>:strip_insignificant_zeros</tt> - If +true+ removes
+    #   insignificant zeros after the decimal separator (defaults to
+    #   +true+)
+    #
+    # ==== Examples
+    #
+    #   number_to_human_size(123)                                    # => "123 Bytes"
+    #   number_to_human_size(1234)                                   # => "1.21 KB"
+    #   number_to_human_size(12345)                                  # => "12.1 KB"
+    #   number_to_human_size(1234567)                                # => "1.18 MB"
+    #   number_to_human_size(1234567890)                             # => "1.15 GB"
+    #   number_to_human_size(1234567890123)                          # => "1.12 TB"
+    #   number_to_human_size(1234567890123456)                       # => "1.1 PB"
+    #   number_to_human_size(1234567890123456789)                    # => "1.07 EB"
+    #   number_to_human_size(1234567, precision: 2)                  # => "1.2 MB"
+    #   number_to_human_size(483989, precision: 2)                   # => "470 KB"
+    #   number_to_human_size(1234567, precision: 2, separator: ',')  # => "1,2 MB"
+    #   number_to_human_size(1234567890123, precision: 5)            # => "1.1228 TB"
+    #   number_to_human_size(524288000, precision: 5)                # => "500 MB"
+    def number_to_human_size: (untyped number, ?::Hash[untyped, untyped] options) -> untyped
+
+    # Pretty prints (formats and approximates) a number in a way it
+    # is more readable by humans (eg.: 1200000000 becomes "1.2
+    # Billion"). This is useful for numbers that can get very large
+    # (and too hard to read).
+    #
+    # See <tt>number_to_human_size</tt> if you want to print a file
+    # size.
+    #
+    # You can also define your own unit-quantifier names if you want
+    # to use other decimal units (eg.: 1500 becomes "1.5
+    # kilometers", 0.150 becomes "150 milliliters", etc). You may
+    # define a wide range of unit quantifiers, even fractional ones
+    # (centi, deci, mili, etc).
+    #
+    # ==== Options
+    #
+    # * <tt>:locale</tt> - Sets the locale to be used for formatting
+    #   (defaults to current locale).
+    # * <tt>:precision</tt> - Sets the precision of the number
+    #   (defaults to 3).
+    # * <tt>:significant</tt> - If +true+, precision will be the number
+    #   of significant_digits. If +false+, the number of fractional
+    #   digits (defaults to +true+)
+    # * <tt>:separator</tt> - Sets the separator between the
+    #   fractional and integer digits (defaults to ".").
+    # * <tt>:delimiter</tt> - Sets the thousands delimiter (defaults
+    #   to "").
+    # * <tt>:strip_insignificant_zeros</tt> - If +true+ removes
+    #   insignificant zeros after the decimal separator (defaults to
+    #   +true+)
+    # * <tt>:units</tt> - A Hash of unit quantifier names. Or a
+    #   string containing an i18n scope where to find this hash. It
+    #   might have the following keys:
+    #   * *integers*: <tt>:unit</tt>, <tt>:ten</tt>,
+    #     <tt>:hundred</tt>, <tt>:thousand</tt>, <tt>:million</tt>,
+    #     <tt>:billion</tt>, <tt>:trillion</tt>,
+    #     <tt>:quadrillion</tt>
+    #   * *fractionals*: <tt>:deci</tt>, <tt>:centi</tt>,
+    #     <tt>:mili</tt>, <tt>:micro</tt>, <tt>:nano</tt>,
+    #     <tt>:pico</tt>, <tt>:femto</tt>
+    # * <tt>:format</tt> - Sets the format of the output string
+    #   (defaults to "%n %u"). The field types are:
+    #   * %u - The quantifier (ex.: 'thousand')
+    #   * %n - The number
+    #
+    # ==== Examples
+    #
+    #   number_to_human(123)                         # => "123"
+    #   number_to_human(1234)                        # => "1.23 Thousand"
+    #   number_to_human(12345)                       # => "12.3 Thousand"
+    #   number_to_human(1234567)                     # => "1.23 Million"
+    #   number_to_human(1234567890)                  # => "1.23 Billion"
+    #   number_to_human(1234567890123)               # => "1.23 Trillion"
+    #   number_to_human(1234567890123456)            # => "1.23 Quadrillion"
+    #   number_to_human(1234567890123456789)         # => "1230 Quadrillion"
+    #   number_to_human(489939, precision: 2)        # => "490 Thousand"
+    #   number_to_human(489939, precision: 4)        # => "489.9 Thousand"
+    #   number_to_human(1234567, precision: 4,
+    #                            significant: false) # => "1.2346 Million"
+    #   number_to_human(1234567, precision: 1,
+    #                            separator: ',',
+    #                            significant: false) # => "1,2 Million"
+    #
+    #   number_to_human(500000000, precision: 5)           # => "500 Million"
+    #   number_to_human(12345012345, significant: false)   # => "12.345 Billion"
+    #
+    # Non-significant zeros after the decimal separator are stripped
+    # out by default (set <tt>:strip_insignificant_zeros</tt> to
+    # +false+ to change that):
+    #
+    # number_to_human(12.00001)                                       # => "12"
+    # number_to_human(12.00001, strip_insignificant_zeros: false)     # => "12.0"
+    #
+    # ==== Custom Unit Quantifiers
+    #
+    # You can also use your own custom unit quantifiers:
+    #  number_to_human(500000, units: { unit: 'ml', thousand: 'lt' })  # => "500 lt"
+    #
+    # If in your I18n locale you have:
+    #
+    #   distance:
+    #     centi:
+    #       one: "centimeter"
+    #       other: "centimeters"
+    #     unit:
+    #       one: "meter"
+    #       other: "meters"
+    #     thousand:
+    #       one: "kilometer"
+    #       other: "kilometers"
+    #     billion: "gazillion-distance"
+    #
+    # Then you could do:
+    #
+    #   number_to_human(543934, units: :distance)            # => "544 kilometers"
+    #   number_to_human(54393498, units: :distance)          # => "54400 kilometers"
+    #   number_to_human(54393498000, units: :distance)       # => "54.4 gazillion-distance"
+    #   number_to_human(343, units: :distance, precision: 1) # => "300 meters"
+    #   number_to_human(1, units: :distance)                 # => "1 meter"
+    #   number_to_human(0.34, units: :distance)              # => "34 centimeters"
+    def number_to_human: (untyped number, ?::Hash[untyped, untyped] options) -> untyped
+  end
+end
+
+module ActiveSupport
+  class OptionMerger
+    def initialize: (untyped context, untyped options) -> untyped
+
+    def method_missing: (untyped method, *untyped arguments) { () -> untyped } -> untyped
+
+    def invoke_method: (untyped method, untyped arguments, untyped options) { () -> untyped } -> untyped
+  end
+end
+
+module ActiveSupport
+  # DEPRECATED: <tt>ActiveSupport::OrderedHash</tt> implements a hash that preserves
+  # insertion order.
+  #
+  #   oh = ActiveSupport::OrderedHash.new
+  #   oh[:a] = 1
+  #   oh[:b] = 2
+  #   oh.keys # => [:a, :b], this order is guaranteed
+  #
+  # Also, maps the +omap+ feature for YAML files
+  # (See https://yaml.org/type/omap.html) to support ordered items
+  # when loading from yaml.
+  #
+  # <tt>ActiveSupport::OrderedHash</tt> is namespaced to prevent conflicts
+  # with other implementations.
+  class OrderedHash[T, U] < ::Hash[T, U]
+    def to_yaml_type: () -> "!tag:yaml.org,2002:omap"
+
+    def encode_with: (untyped coder) -> untyped
+
+    def select: (*untyped args) { () -> untyped } -> untyped
+
+    def reject: (*untyped args) { () -> untyped } -> untyped
+
+    def nested_under_indifferent_access: () -> untyped
+
+    # Returns true to make sure that this hash is extractable via <tt>Array#extract_options!</tt>
+    def extractable_options?: () -> ::TrueClass
+  end
+end
+
+module ActiveSupport
+  # Usually key value pairs are handled something like this:
+  #
+  #   h = {}
+  #   h[:boy] = 'John'
+  #   h[:girl] = 'Mary'
+  #   h[:boy]  # => 'John'
+  #   h[:girl] # => 'Mary'
+  #   h[:dog]  # => nil
+  #
+  # Using +OrderedOptions+, the above code could be reduced to:
+  #
+  #   h = ActiveSupport::OrderedOptions.new
+  #   h.boy = 'John'
+  #   h.girl = 'Mary'
+  #   h.boy  # => 'John'
+  #   h.girl # => 'Mary'
+  #   h.dog  # => nil
+  #
+  # To raise an exception when the value is blank, append a
+  # bang to the key name, like:
+  #
+  #   h.dog! # => raises KeyError: :dog is blank
+  #
+  class OrderedOptions[T, U] < Hash[T, U]
+    alias _get []
+
+    def []=: (untyped key, untyped value) -> untyped
+
+    def []: (untyped key) -> untyped
+
+    def method_missing: (untyped name, *untyped args) -> untyped
+
+    def respond_to_missing?: (untyped name, untyped include_private) -> ::TrueClass
+
+    def extractable_options?: () -> ::TrueClass
+  end
+
+  # +InheritableOptions+ provides a constructor to build an +OrderedOptions+
+  # hash inherited from another hash.
+  #
+  # Use this if you already have some hash and you want to create a new one based on it.
+  #
+  #   h = ActiveSupport::InheritableOptions.new({ girl: 'Mary', boy: 'John' })
+  #   h.girl # => 'Mary'
+  #   h.boy  # => 'John'
+  class InheritableOptions[T, U] < OrderedOptions[T, U]
+    def initialize: (?untyped? parent) -> untyped
+
+    def inheritable_copy: () -> untyped
+  end
+end
+
+module ActiveSupport
+  # +ParameterFilter+ allows you to specify keys for sensitive data from
+  # hash-like object and replace corresponding value. Filtering only certain
+  # sub-keys from a hash is possible by using the dot notation:
+  # 'credit_card.number'. If a proc is given, each key and value of a hash and
+  # all sub-hashes are passed to it, where the value or the key can be replaced
+  # using String#replace or similar methods.
+  #
+  #   ActiveSupport::ParameterFilter.new([:password])
+  #   => replaces the value to all keys matching /password/i with "[FILTERED]"
+  #
+  #   ActiveSupport::ParameterFilter.new([:foo, "bar"])
+  #   => replaces the value to all keys matching /foo|bar/i with "[FILTERED]"
+  #
+  #   ActiveSupport::ParameterFilter.new(["credit_card.code"])
+  #   => replaces { credit_card: {code: "xxxx"} } with "[FILTERED]", does not
+  #   change { file: { code: "xxxx"} }
+  #
+  #   ActiveSupport::ParameterFilter.new([-> (k, v) do
+  #     v.reverse! if k =~ /secret/i
+  #   end])
+  #   => reverses the value to all keys matching /secret/i
+  class ParameterFilter
+    FILTERED: ::String
+
+    # Create instance with given filters. Supported type of filters are +String+, +Regexp+, and +Proc+.
+    # Other types of filters are treated as +String+ using +to_s+.
+    # For +Proc+ filters, key, value, and optional original hash is passed to block arguments.
+    #
+    # ==== Options
+    #
+    # * <tt>:mask</tt> - A replaced object when filtered. Defaults to +"[FILTERED]"+
+    def initialize: (?untyped filters, ?mask: untyped mask) -> untyped
+
+    # Mask value of +params+ if key matches one of filters.
+    def filter: (untyped params) -> untyped
+
+    # Returns filtered value for given key. For +Proc+ filters, third block argument is not populated.
+    def filter_param: (untyped key, untyped value) -> untyped
+
+    def compiled_filter: () -> untyped
+
+    class CompiledFilter
+      # :nodoc:
+      def self.compile: (untyped filters, mask: untyped mask) -> untyped
+
+      attr_reader regexps: untyped
+
+      attr_reader deep_regexps: untyped
+
+      attr_reader blocks: untyped
+
+      def initialize: (untyped regexps, untyped deep_regexps, untyped blocks, mask: untyped mask) -> untyped
+
+      def call: (untyped params, ?untyped parents, ?untyped original_params) -> untyped
+
+      def value_for_key: (untyped key, untyped value, ?untyped parents, ?untyped? original_params) -> untyped
+    end
+  end
+end
+
+module ActiveSupport
+  # NOTE: This approach has been deprecated for end-user code in favor of {thread_mattr_accessor}[rdoc-ref:Module#thread_mattr_accessor] and friends.
+  # Please use that approach instead.
+  #
+  # This module is used to encapsulate access to thread local variables.
+  #
+  # Instead of polluting the thread locals namespace:
+  #
+  #   Thread.current[:connection_handler]
+  #
+  # you define a class that extends this module:
+  #
+  #   module ActiveRecord
+  #     class RuntimeRegistry
+  #       extend ActiveSupport::PerThreadRegistry
+  #
+  #       attr_accessor :connection_handler
+  #     end
+  #   end
+  #
+  # and invoke the declared instance accessors as class methods. So
+  #
+  #   ActiveRecord::RuntimeRegistry.connection_handler = connection_handler
+  #
+  # sets a connection handler local to the current thread, and
+  #
+  #   ActiveRecord::RuntimeRegistry.connection_handler
+  #
+  # returns a connection handler local to the current thread.
+  #
+  # This feature is accomplished by instantiating the class and storing the
+  # instance as a thread local keyed by the class name. In the example above
+  # a key "ActiveRecord::RuntimeRegistry" is stored in <tt>Thread.current</tt>.
+  # The class methods proxy to said thread local instance.
+  #
+  # If the class has an initializer, it must accept no arguments.
+  module PerThreadRegistry
+    def self.extended: (untyped object) -> untyped
+
+    def `instance`: () -> untyped
+
+    def method_missing: (untyped name, *untyped args) { () -> untyped } -> untyped
+  end
+end
+
+module ActiveSupport
+  # A class with no predefined methods that behaves similarly to Builder's
+  # BlankSlate. Used for proxy classes.
+  class ProxyObject < ::BasicObject
+    # Let ActiveSupport::ProxyObject at least raise exceptions.
+    def raise: (*untyped args) -> untyped
+  end
+end
+
+module ActiveSupport
+  class Railtie < Rails::Railtie
+  end
+end
+
+module ActiveSupport
+  # -
+  # This class defines several callbacks:
+  #
+  #   to_prepare -- Run once at application startup, and also from
+  #   +to_run+.
+  #
+  #   to_run -- Run before a work run that is reloading. If
+  #   +reload_classes_only_on_change+ is true (the default), the class
+  #   unload will have already occurred.
+  #
+  #   to_complete -- Run after a work run that has reloaded. If
+  #   +reload_classes_only_on_change+ is false, the class unload will
+  #   have occurred after the work run, but before this callback.
+  #
+  #   before_class_unload -- Run immediately before the classes are
+  #   unloaded.
+  #
+  #   after_class_unload -- Run immediately after the classes are
+  #   unloaded.
+  #
+  class Reloader < ExecutionWrapper
+    # Registers a callback that will run once at application startup and every time the code is reloaded.
+    def self.to_prepare: (*untyped args) { () -> untyped } -> untyped
+
+    # Registers a callback that will run immediately before the classes are unloaded.
+    def self.before_class_unload: (*untyped args) { () -> untyped } -> untyped
+
+    # Registers a callback that will run immediately after the classes are unloaded.
+    def self.after_class_unload: (*untyped args) { () -> untyped } -> untyped
+
+    # Initiate a manual reload
+    def self.reload!: () -> untyped
+
+    def self.run!: () -> untyped
+
+    # Run the supplied block as a work unit, reloading code as needed
+    def self.wrap: () -> untyped
+
+    def self.check!: () -> untyped
+
+    def self.reloaded!: () -> untyped
+
+    def self.prepare!: () -> untyped
+
+    def initialize: () -> untyped
+
+    # Acquire the ActiveSupport::Dependencies::Interlock unload lock,
+    # ensuring it will be released automatically
+    def require_unload_lock!: () -> untyped
+
+    # Release the unload lock if it has been previously obtained
+    def release_unload_lock!: () -> untyped
+
+    def run!: () -> untyped
+
+    def class_unload!: () { () -> untyped } -> untyped
+
+    def complete!: () -> untyped
+  end
+end
+
+module ActiveSupport
+  # Rescuable module adds support for easier exception handling.
+  module Rescuable
+    extend Concern
+
+    module ClassMethods
+      # Rescue exceptions raised in controller actions.
+      #
+      # <tt>rescue_from</tt> receives a series of exception classes or class
+      # names, and a trailing <tt>:with</tt> option with the name of a method
+      # or a Proc object to be called to handle them. Alternatively a block can
+      # be given.
+      #
+      # Handlers that take one argument will be called with the exception, so
+      # that the exception can be inspected when dealing with it.
+      #
+      # Handlers are inherited. They are searched from right to left, from
+      # bottom to top, and up the hierarchy. The handler of the first class for
+      # which <tt>exception.is_a?(klass)</tt> holds true is the one invoked, if
+      # any.
+      #
+      #   class ApplicationController < ActionController::Base
+      #     rescue_from User::NotAuthorized, with: :deny_access # self defined exception
+      #     rescue_from ActiveRecord::RecordInvalid, with: :show_errors
+      #
+      #     rescue_from 'MyAppError::Base' do |exception|
+      #       render xml: exception, status: 500
+      #     end
+      #
+      #     private
+      #       def deny_access
+      #         ...
+      #       end
+      #
+      #       def show_errors(exception)
+      #         exception.record.new_record? ? ...
+      #       end
+      #   end
+      #
+      # Exceptions raised inside exception handlers are not propagated up.
+      def rescue_from: (*untyped klasses, ?with: untyped? with) { () -> untyped } -> untyped
+
+      # Matches an exception to a handler based on the exception class.
+      #
+      # If no handler matches the exception, check for a handler matching the
+      # (optional) exception.cause. If no handler matches the exception or its
+      # cause, this returns +nil+, so you can deal with unhandled exceptions.
+      # Be sure to re-raise unhandled exceptions if this is what you expect.
+      #
+      #     begin
+      #       (trim non-ascii characters)
+      #     rescue => exception
+      #       rescue_with_handler(exception) || raise
+      #     end
+      #
+      # Returns the exception if it was handled and +nil+ if it was not.
+      def rescue_with_handler: (untyped exception, ?visited_exceptions: untyped visited_exceptions, ?object: untyped object) -> untyped
+
+      def handler_for_rescue: (untyped exception, ?object: untyped object) -> untyped
+
+      def find_rescue_handler: (untyped exception) -> untyped
+
+      def constantize_rescue_handler_class: (untyped class_or_name) -> untyped
+    end
+
+    # Delegates to the class method, but uses the instance as the subject for
+    # rescue_from handlers (method calls, instance_exec blocks).
+    def rescue_with_handler: (untyped exception) -> untyped
+
+    def handler_for_rescue: (untyped exception) -> untyped
+  end
+end
+
+module ActiveSupport
+  module SecurityUtils
+    # Constant time string comparison, for fixed length strings.
+    #
+    # The values compared should be of fixed length, such as strings
+    # that have already been processed by HMAC. Raises in case of length mismatch.
+    def fixed_length_secure_compare: (untyped a, untyped b) -> untyped
+
+    # Constant time string comparison, for variable length strings.
+    #
+    # The values are first processed by SHA256, so that we don't leak length info
+    # via timing attacks.
+    def secure_compare: (untyped a, untyped b) -> untyped
+  end
+end
+
+module ActiveSupport
+  # Wrapping a string in this class gives you a prettier way to test
+  # for equality. The value returned by <tt>Rails.env</tt> is wrapped
+  # in a StringInquirer object, so instead of calling this:
+  #
+  #   Rails.env == 'production'
+  #
+  # you can call this:
+  #
+  #   Rails.env.production?
+  #
+  # == Instantiating a new StringInquirer
+  #
+  #   vehicle = ActiveSupport::StringInquirer.new('car')
+  #   vehicle.car?   # => true
+  #   vehicle.bike?  # => false
+  class StringInquirer < String
+    def respond_to_missing?: (untyped method_name, ?bool include_private) -> untyped
+
+    def method_missing: (untyped method_name, *untyped arguments) -> untyped
+  end
+end
+
+module ActiveSupport
+  # ActiveSupport::Subscriber is an object set to consume
+  # ActiveSupport::Notifications. The subscriber dispatches notifications to
+  # a registered object based on its given namespace.
+  #
+  # An example would be an Active Record subscriber responsible for collecting
+  # statistics about queries:
+  #
+  #   module ActiveRecord
+  #     class StatsSubscriber < ActiveSupport::Subscriber
+  #       attach_to :active_record
+  #
+  #       def sql(event)
+  #         Statsd.timing("sql.#{event.payload[:name]}", event.duration)
+  #       end
+  #     end
+  #   end
+  #
+  # After configured, whenever a "sql.active_record" notification is published,
+  # it will properly dispatch the event (ActiveSupport::Notifications::Event) to
+  # the +sql+ method.
+  #
+  # We can detach a subscriber as well:
+  #
+  #   ActiveRecord::StatsSubscriber.detach_from(:active_record)
+  class Subscriber
+    # Attach the subscriber to a namespace.
+    def self.attach_to: (untyped namespace, ?untyped subscriber, ?untyped notifier) -> untyped
+
+    # Detach the subscriber from a namespace.
+    def self.detach_from: (untyped namespace, ?untyped notifier) -> (nil | untyped)
+
+    # Adds event subscribers for all new methods added to the class.
+    def self.method_added: (untyped event) -> untyped
+
+    def self.subscribers: () -> untyped
+
+    attr_reader subscriber: untyped
+
+    attr_reader notifier: untyped
+
+    attr_reader namespace: untyped
+
+    def self.add_event_subscriber: (untyped event) -> (nil | untyped)
+
+    def self.remove_event_subscriber: (untyped event) -> (nil | untyped)
+
+    def self.find_attached_subscriber: () -> untyped
+
+    def self.invalid_event?: (untyped event) -> untyped
+
+    def self.prepare_pattern: (untyped event) -> ::String
+
+    def self.pattern_subscribed?: (untyped pattern) -> untyped
+
+    attr_reader patterns: untyped
+
+    def initialize: () -> untyped
+
+    def start: (untyped name, untyped id, untyped payload) -> untyped
+
+    def finish: (untyped name, untyped id, untyped payload) -> untyped
+
+    def event_stack: () -> untyped
+  end
+
+  class SubscriberQueueRegistry
+    # This is a registry for all the event stacks kept for subscribers.
+    #
+    # See the documentation of <tt>ActiveSupport::PerThreadRegistry</tt>
+    # for further details.
+    # :nodoc:
+    extend PerThreadRegistry
+
+    def initialize: () -> untyped
+
+    def get_queue: (untyped queue_key) -> untyped
+  end
+end
+
+module ActiveSupport
+  # Wraps any standard Logger object to provide tagging capabilities.
+  #
+  #   logger = ActiveSupport::TaggedLogging.new(Logger.new(STDOUT))
+  #   logger.tagged('BCX') { logger.info 'Stuff' }                            # Logs "[BCX] Stuff"
+  #   logger.tagged('BCX', "Jason") { logger.info 'Stuff' }                   # Logs "[BCX] [Jason] Stuff"
+  #   logger.tagged('BCX') { logger.tagged('Jason') { logger.info 'Stuff' } } # Logs "[BCX] [Jason] Stuff"
+  #
+  # This is used by the default Rails.logger as configured by Railties to make
+  # it easy to stamp log lines with subdomains, request ids, and anything else
+  # to aid debugging of multi-user production applications.
+  module TaggedLogging
+    module Formatter
+      # :nodoc:
+      # This method is invoked when a log event occurs.
+      def call: (untyped severity, untyped timestamp, untyped progname, untyped msg) -> untyped
+
+      def tagged: (*untyped tags) { (untyped) -> untyped } -> untyped
+
+      def push_tags: (*untyped tags) -> untyped
+
+      def pop_tags: (?::Integer size) -> untyped
+
+      def clear_tags!: () -> untyped
+
+      def current_tags: () -> untyped
+
+      def tags_text: () -> untyped
+    end
+
+    def self.new: (untyped logger) -> untyped
+
+    def tagged: (*untyped tags) { (untyped) -> untyped } -> untyped
+
+    def flush: () -> untyped
+  end
+end
+
+module ActiveSupport
+  class TestCase < ::Minitest::Test
+    Assertion: untyped
+
+    # Sets the order in which test cases are run.
+    #
+    #   ActiveSupport::TestCase.test_order = :random # => :random
+    #
+    # Valid values are:
+    # * +:random+   (to run tests in random order)
+    # * +:parallel+ (to run tests in parallel)
+    # * +:sorted+   (to run tests alphabetically by method name)
+    # * +:alpha+    (equivalent to +:sorted+)
+    def self.test_order=: (untyped new_order) -> untyped
+
+    # Returns the order in which test cases are run.
+    #
+    #   ActiveSupport::TestCase.test_order # => :random
+    #
+    # Possible values are +:random+, +:parallel+, +:alpha+, +:sorted+.
+    # Defaults to +:random+.
+    def self.test_order: () -> untyped
+
+    # Parallelizes the test suite.
+    #
+    # Takes a +workers+ argument that controls how many times the process
+    # is forked. For each process a new database will be created suffixed
+    # with the worker number.
+    #
+    #   test-database-0
+    #   test-database-1
+    #
+    # If <tt>ENV["PARALLEL_WORKERS"]</tt> is set the workers argument will be ignored
+    # and the environment variable will be used instead. This is useful for CI
+    # environments, or other environments where you may need more workers than
+    # you do for local testing.
+    #
+    # If the number of workers is set to +1+ or fewer, the tests will not be
+    # parallelized.
+    #
+    # If +workers+ is set to +:number_of_processors+, the number of workers will be
+    # set to the actual core count on the machine you are on.
+    #
+    # The default parallelization method is to fork processes. If you'd like to
+    # use threads instead you can pass <tt>with: :threads</tt> to the +parallelize+
+    # method. Note the threaded parallelization does not create multiple
+    # database and will not work with system tests at this time.
+    #
+    #   parallelize(workers: :number_of_processors, with: :threads)
+    #
+    # The threaded parallelization uses minitest's parallel executor directly.
+    # The processes parallelization uses a Ruby DRb server.
+    def self.parallelize: (?with: ::Symbol with, ?workers: ::Symbol workers) -> (nil | untyped)
+
+    # Set up hook for parallel testing. This can be used if you have multiple
+    # databases or any behavior that needs to be run after the process is forked
+    # but before the tests run.
+    #
+    # Note: this feature is not available with the threaded parallelization.
+    #
+    # In your +test_helper.rb+ add the following:
+    #
+    #   class ActiveSupport::TestCase
+    #     parallelize_setup do
+    #       # create databases
+    #     end
+    #   end
+    def self.parallelize_setup: () { (untyped) -> untyped } -> untyped
+
+    # Clean up hook for parallel testing. This can be used to drop databases
+    # if your app uses multiple write/read databases or other clean up before
+    # the tests finish. This runs before the forked process is closed.
+    #
+    # Note: this feature is not available with the threaded parallelization.
+    #
+    # In your +test_helper.rb+ add the following:
+    #
+    #   class ActiveSupport::TestCase
+    #     parallelize_teardown do
+    #       # drop databases
+    #     end
+    #   end
+    def self.parallelize_teardown: () { (untyped) -> untyped } -> untyped
+
+    alias method_name name
+
+    include ActiveSupport::Testing::TaggedLogging
+
+    include ActiveSupport::Testing::Assertions
+
+    include ActiveSupport::Testing::Deprecation
+
+    include ActiveSupport::Testing::TimeHelpers
+
+    include ActiveSupport::Testing::FileFixtures
+
+    extend ActiveSupport::Testing::Declarative
+
+    # test/unit backwards compatibility methods
+    alias assert_raise assert_raises
+
+    alias assert_not_empty refute_empty
+
+    alias assert_not_equal refute_equal
+
+    alias assert_not_in_delta refute_in_delta
+
+    alias assert_not_in_epsilon refute_in_epsilon
+
+    alias assert_not_includes refute_includes
+
+    alias assert_not_instance_of refute_instance_of
+
+    alias assert_not_kind_of refute_kind_of
+
+    alias assert_no_match refute_match
+
+    alias assert_not_nil refute_nil
+
+    alias assert_not_operator refute_operator
+
+    alias assert_not_predicate refute_predicate
+
+    alias assert_not_respond_to refute_respond_to
+
+    alias assert_not_same refute_same
+  end
+end
+
+module ActiveSupport
+  module Testing
+    module Assertions
+      UNTRACKED: untyped
+
+      # Asserts that an expression is not truthy. Passes if <tt>object</tt> is
+      # +nil+ or +false+. "Truthy" means "considered true in a conditional"
+      # like <tt>if foo</tt>.
+      #
+      #   assert_not nil    # => true
+      #   assert_not false  # => true
+      #   assert_not 'foo'  # => Expected "foo" to be nil or false
+      #
+      # An error message can be specified.
+      #
+      #   assert_not foo, 'foo should be false'
+      def assert_not: (untyped object, ?untyped? message) -> untyped
+
+      # Assertion that the block should not raise an exception.
+      #
+      # Passes if evaluated code in the yielded block raises no exception.
+      #
+      #   assert_nothing_raised do
+      #     perform_service(param: 'no_exception')
+      #   end
+      def assert_nothing_raised: () { () -> untyped } -> untyped
+
+      # Test numeric difference between the return value of an expression as a
+      # result of what is evaluated in the yielded block.
+      #
+      #   assert_difference 'Article.count' do
+      #     post :create, params: { article: {...} }
+      #   end
+      #
+      # An arbitrary expression is passed in and evaluated.
+      #
+      #   assert_difference 'Article.last.comments(:reload).size' do
+      #     post :create, params: { comment: {...} }
+      #   end
+      #
+      # An arbitrary positive or negative difference can be specified.
+      # The default is <tt>1</tt>.
+      #
+      #   assert_difference 'Article.count', -1 do
+      #     post :delete, params: { id: ... }
+      #   end
+      #
+      # An array of expressions can also be passed in and evaluated.
+      #
+      #   assert_difference [ 'Article.count', 'Post.count' ], 2 do
+      #     post :create, params: { article: {...} }
+      #   end
+      #
+      # A hash of expressions/numeric differences can also be passed in and evaluated.
+      #
+      #   assert_difference ->{ Article.count } => 1, ->{ Notification.count } => 2 do
+      #     post :create, params: { article: {...} }
+      #   end
+      #
+      # A lambda or a list of lambdas can be passed in and evaluated:
+      #
+      #   assert_difference ->{ Article.count }, 2 do
+      #     post :create, params: { article: {...} }
+      #   end
+      #
+      #   assert_difference [->{ Article.count }, ->{ Post.count }], 2 do
+      #     post :create, params: { article: {...} }
+      #   end
+      #
+      # An error message can be specified.
+      #
+      #   assert_difference 'Article.count', -1, 'An Article should be destroyed' do
+      #     post :delete, params: { id: ... }
+      #   end
+      def assert_difference: (untyped expression, *untyped args) { () -> untyped } -> untyped
+
+      # Assertion that the numeric result of evaluating an expression is not
+      # changed before and after invoking the passed in block.
+      #
+      #   assert_no_difference 'Article.count' do
+      #     post :create, params: { article: invalid_attributes }
+      #   end
+      #
+      # A lambda can be passed in and evaluated.
+      #
+      #   assert_no_difference -> { Article.count } do
+      #     post :create, params: { article: invalid_attributes }
+      #   end
+      #
+      # An error message can be specified.
+      #
+      #   assert_no_difference 'Article.count', 'An Article should not be created' do
+      #     post :create, params: { article: invalid_attributes }
+      #   end
+      #
+      # An array of expressions can also be passed in and evaluated.
+      #
+      #   assert_no_difference [ 'Article.count', -> { Post.count } ] do
+      #     post :create, params: { article: invalid_attributes }
+      #   end
+      def assert_no_difference: (untyped expression, ?untyped? message) { () -> untyped } -> untyped
+
+      # Assertion that the result of evaluating an expression is changed before
+      # and after invoking the passed in block.
+      #
+      #   assert_changes 'Status.all_good?' do
+      #     post :create, params: { status: { ok: false } }
+      #   end
+      #
+      # You can pass the block as a string to be evaluated in the context of
+      # the block. A lambda can be passed for the block as well.
+      #
+      #   assert_changes -> { Status.all_good? } do
+      #     post :create, params: { status: { ok: false } }
+      #   end
+      #
+      # The assertion is useful to test side effects. The passed block can be
+      # anything that can be converted to string with #to_s.
+      #
+      #   assert_changes :@object do
+      #     @object = 42
+      #   end
+      #
+      # The keyword arguments :from and :to can be given to specify the
+      # expected initial value and the expected value after the block was
+      # executed.
+      #
+      #   assert_changes :@object, from: nil, to: :foo do
+      #     @object = :foo
+      #   end
+      #
+      # An error message can be specified.
+      #
+      #   assert_changes -> { Status.all_good? }, 'Expected the status to be bad' do
+      #     post :create, params: { status: { incident: true } }
+      #   end
+      def assert_changes: (untyped expression, ?untyped? message, ?to: untyped to, ?from: untyped from) { () -> untyped } -> untyped
+
+      # Assertion that the result of evaluating an expression is not changed before
+      # and after invoking the passed in block.
+      #
+      #   assert_no_changes 'Status.all_good?' do
+      #     post :create, params: { status: { ok: true } }
+      #   end
+      #
+      # An error message can be specified.
+      #
+      #   assert_no_changes -> { Status.all_good? }, 'Expected the status to be good' do
+      #     post :create, params: { status: { ok: false } }
+      #   end
+      def assert_no_changes: (untyped expression, ?untyped? message) { () -> untyped } -> untyped
+    end
+  end
+end
+
+module ActiveSupport
+  module Testing
+    # Resolves a constant from a minitest spec name.
+    #
+    # Given the following spec-style test:
+    #
+    #   describe WidgetsController, :index do
+    #     describe "authenticated user" do
+    #       describe "returns widgets" do
+    #         it "has a controller that exists" do
+    #           assert_kind_of WidgetsController, @controller
+    #         end
+    #       end
+    #     end
+    #   end
+    #
+    # The test will have the following name:
+    #
+    #   "WidgetsController::index::authenticated user::returns widgets"
+    #
+    # The constant WidgetsController can be resolved from the name.
+    # The following code will resolve the constant:
+    #
+    #   controller = determine_constant_from_test_name(name) do |constant|
+    #     Class === constant && constant < ::ActionController::Metal
+    #   end
+    module ConstantLookup
+      extend ::ActiveSupport::Concern
+
+      module ClassMethods
+        # :nodoc:
+        def determine_constant_from_test_name: (untyped test_name) { (untyped) -> untyped } -> untyped
+      end
+    end
+  end
+end
+
+module ActiveSupport
+  module Testing
+    module Declarative
+      # Helper to define a test method using a String. Under the hood, it replaces
+      # spaces with underscores and defines the test method.
+      #
+      #   test "verify something" do
+      #     ...
+      #   end
+      def test: (untyped name) { () -> untyped } -> untyped
+    end
+  end
+end
+
+module ActiveSupport
+  module Testing
+    module Deprecation
+      # nodoc:
+      def assert_deprecated: (?untyped? match, ?untyped? deprecator) { () -> untyped } -> untyped
+
+      def assert_not_deprecated: (?untyped? deprecator) { () -> untyped } -> untyped
+
+      def collect_deprecations: (?untyped? deprecator) { () -> untyped } -> untyped
+    end
+  end
+end
+
+module ActiveSupport
+  module Testing
+    # Adds simple access to sample files called file fixtures.
+    # File fixtures are normal files stored in
+    # <tt>ActiveSupport::TestCase.file_fixture_path</tt>.
+    #
+    # File fixtures are represented as +Pathname+ objects.
+    # This makes it easy to extract specific information:
+    #
+    #   file_fixture("example.txt").read # get the file's content
+    #   file_fixture("example.mp3").size # get the file size
+    module FileFixtures
+      extend ActiveSupport::Concern
+
+      # Returns a +Pathname+ to the fixture file named +fixture_name+.
+      #
+      # Raises +ArgumentError+ if +fixture_name+ can't be found.
+      def file_fixture: (untyped fixture_name) -> untyped
+    end
+  end
+end
+
+module ActiveSupport
+  module Testing
+    module Isolation
+      def self.included: (untyped klass) -> untyped
+
+      def self.forking_env?: () -> untyped
+
+      def run: () -> untyped
+
+      module Forking
+        def run_in_isolation: () { () -> untyped } -> untyped
+      end
+
+      module Subprocess
+        ORIG_ARGV: untyped
+
+        # Crazy H4X to get this working in windows / jruby with
+        # no forking.
+        def run_in_isolation: () { () -> untyped } -> untyped
+      end
+    end
+  end
+end
+
+module ActiveSupport
+  module Testing
+    module MethodCallAssertions
+      def assert_called: (untyped object, untyped method_name, ?untyped? message, ?returns: untyped? returns, ?times: ::Integer times) { () -> untyped } -> untyped
+
+      def assert_called_with: (untyped object, untyped method_name, untyped args, ?returns: untyped? returns) { () -> untyped } -> untyped
+
+      def assert_not_called: (untyped object, untyped method_name, ?untyped? message) { () -> untyped } -> untyped
+
+      def assert_called_on_instance_of: (untyped klass, untyped method_name, ?untyped? message, ?returns: untyped? returns, ?times: ::Integer times) { () -> untyped } -> untyped
+
+      def assert_not_called_on_instance_of: (untyped klass, untyped method_name, ?untyped? message) { () -> untyped } -> untyped
+
+      def stub_any_instance: (untyped klass, ?instance: untyped `instance`) { (untyped) -> untyped } -> untyped
+    end
+  end
+end
+
+module ActiveSupport
+  module Testing
+    class Parallelization
+      # :nodoc:
+      class Server
+        include DRb::DRbUndumped
+
+        def initialize: () -> untyped
+
+        def record: (untyped reporter, untyped result) -> untyped
+
+        def <<: (untyped o) -> untyped
+
+        def length: () -> untyped
+
+        def pop: () -> untyped
+      end
+
+      def self.after_fork_hook: () { () -> untyped } -> untyped
+
+      def self.run_cleanup_hook: () { () -> untyped } -> untyped
+
+      def initialize: (untyped queue_size) -> untyped
+
+      def after_fork: (untyped worker) -> untyped
+
+      def run_cleanup: (untyped worker) -> untyped
+
+      def start: () -> untyped
+
+      def <<: (untyped work) -> untyped
+
+      def shutdown: () -> untyped
+
+      def add_setup_exception: (untyped result, untyped setup_exception) -> untyped
+    end
+  end
+end
+
+module ActiveSupport
+  module Testing
+    # Adds support for +setup+ and +teardown+ callbacks.
+    # These callbacks serve as a replacement to overwriting the
+    # <tt>#setup</tt> and <tt>#teardown</tt> methods of your TestCase.
+    #
+    #   class ExampleTest < ActiveSupport::TestCase
+    #     setup do
+    #       # ...
+    #     end
+    #
+    #     teardown do
+    #       # ...
+    #     end
+    #   end
+    module SetupAndTeardown
+      def self.prepended: (untyped klass) -> untyped
+
+      module ClassMethods
+        # Add a callback, which runs before <tt>TestCase#setup</tt>.
+        def setup: (*untyped args) { () -> untyped } -> untyped
+
+        # Add a callback, which runs after <tt>TestCase#teardown</tt>.
+        def teardown: (*untyped args) { () -> untyped } -> untyped
+      end
+
+      def before_setup: () -> untyped
+
+      def after_teardown: () -> untyped
+    end
+  end
+end
+
+module ActiveSupport
+  module Testing
+    module Stream
+      def silence_stream: (untyped stream) { () -> untyped } -> untyped
+
+      def quietly: () { () -> untyped } -> untyped
+
+      def capture: (untyped stream) { () -> untyped } -> untyped
+    end
+  end
+end
+
+module ActiveSupport
+  module Testing
+    module TaggedLogging
+      # Logs a "PostsControllerTest: test name" heading before each test to
+      # make test.log easier to search and follow along with.
+      # nodoc:
+      attr_writer tagged_logger: untyped
+
+      def before_setup: () -> untyped
+
+      def tagged_logger: () -> untyped
+    end
+  end
+end
+
+module ActiveSupport
+  module Testing
+    class SimpleStubs
+      # :nodoc:
+      class Stub[T] < ::Struct[T]
+        attr_accessor object(): untyped
+
+        attr_accessor method_name(): untyped
+
+        attr_accessor original_method(): untyped
+      end
+
+      def initialize: () -> untyped
+
+      def stub_object: (untyped object, untyped method_name) { () -> untyped } -> untyped
+
+      def unstub_all!: () -> untyped
+
+      def stubbing: (untyped object, untyped method_name) -> untyped
+
+      def unstub_object: (untyped stub) -> untyped
+    end
+
+    # Contains helpers that help you test passage of time.
+    module TimeHelpers
+      def after_teardown: () -> untyped
+
+      # Changes current time to the time in the future or in the past by a given time difference by
+      # stubbing +Time.now+, +Date.today+, and +DateTime.now+. The stubs are automatically removed
+      # at the end of the test.
+      #
+      #   Time.current     # => Sat, 09 Nov 2013 15:34:49 EST -05:00
+      #   travel 1.day
+      #   Time.current     # => Sun, 10 Nov 2013 15:34:49 EST -05:00
+      #   Date.current     # => Sun, 10 Nov 2013
+      #   DateTime.current # => Sun, 10 Nov 2013 15:34:49 -0500
+      #
+      # This method also accepts a block, which will return the current time back to its original
+      # state at the end of the block:
+      #
+      #   Time.current # => Sat, 09 Nov 2013 15:34:49 EST -05:00
+      #   travel 1.day do
+      #     User.create.created_at # => Sun, 10 Nov 2013 15:34:49 EST -05:00
+      #   end
+      #   Time.current # => Sat, 09 Nov 2013 15:34:49 EST -05:00
+      def travel: (untyped duration) { () -> untyped } -> untyped
+
+      # Changes current time to the given time by stubbing +Time.now+,
+      # +Date.today+, and +DateTime.now+ to return the time or date passed into this method.
+      # The stubs are automatically removed at the end of the test.
+      #
+      #   Time.current     # => Sat, 09 Nov 2013 15:34:49 EST -05:00
+      #   travel_to Time.zone.local(2004, 11, 24, 01, 04, 44)
+      #   Time.current     # => Wed, 24 Nov 2004 01:04:44 EST -05:00
+      #   Date.current     # => Wed, 24 Nov 2004
+      #   DateTime.current # => Wed, 24 Nov 2004 01:04:44 -0500
+      #
+      # Dates are taken as their timestamp at the beginning of the day in the
+      # application time zone. <tt>Time.current</tt> returns said timestamp,
+      # and <tt>Time.now</tt> its equivalent in the system time zone. Similarly,
+      # <tt>Date.current</tt> returns a date equal to the argument, and
+      # <tt>Date.today</tt> the date according to <tt>Time.now</tt>, which may
+      # be different. (Note that you rarely want to deal with <tt>Time.now</tt>,
+      # or <tt>Date.today</tt>, in order to honor the application time zone
+      # please always use <tt>Time.current</tt> and <tt>Date.current</tt>.)
+      #
+      # Note that the usec for the time passed will be set to 0 to prevent rounding
+      # errors with external services, like MySQL (which will round instead of floor,
+      # leading to off-by-one-second errors).
+      #
+      # This method also accepts a block, which will return the current time back to its original
+      # state at the end of the block:
+      #
+      #   Time.current # => Sat, 09 Nov 2013 15:34:49 EST -05:00
+      #   travel_to Time.zone.local(2004, 11, 24, 01, 04, 44) do
+      #     Time.current # => Wed, 24 Nov 2004 01:04:44 EST -05:00
+      #   end
+      #   Time.current # => Sat, 09 Nov 2013 15:34:49 EST -05:00
+      def travel_to: (untyped date_or_time) { () -> untyped } -> untyped
+
+      # Returns the current time back to its original state, by removing the stubs added by
+      # +travel+, +travel_to+, and +freeze_time+.
+      #
+      #   Time.current # => Sat, 09 Nov 2013 15:34:49 EST -05:00
+      #   travel_to Time.zone.local(2004, 11, 24, 01, 04, 44)
+      #   Time.current # => Wed, 24 Nov 2004 01:04:44 EST -05:00
+      #   travel_back
+      #   Time.current # => Sat, 09 Nov 2013 15:34:49 EST -05:00
+      def travel_back: () -> untyped
+
+      alias unfreeze_time travel_back
+
+      # Calls +travel_to+ with +Time.now+.
+      #
+      #   Time.current # => Sun, 09 Jul 2017 15:34:49 EST -05:00
+      #   freeze_time
+      #   sleep(1)
+      #   Time.current # => Sun, 09 Jul 2017 15:34:49 EST -05:00
+      #
+      # This method also accepts a block, which will return the current time back to its original
+      # state at the end of the block:
+      #
+      #   Time.current # => Sun, 09 Jul 2017 15:34:49 EST -05:00
+      #   freeze_time do
+      #     sleep(1)
+      #     User.create.created_at # => Sun, 09 Jul 2017 15:34:49 EST -05:00
+      #   end
+      #   Time.current # => Sun, 09 Jul 2017 15:34:50 EST -05:00
+      def freeze_time: () { () -> untyped } -> untyped
+
+      def simple_stubs: () -> untyped
+    end
+  end
+end
+
+module ActiveSupport
+end
+
+module ActiveSupport
+  # A Time-like class that can represent a time in any time zone. Necessary
+  # because standard Ruby Time instances are limited to UTC and the
+  # system's <tt>ENV['TZ']</tt> zone.
+  #
+  # You shouldn't ever need to create a TimeWithZone instance directly via +new+.
+  # Instead use methods +local+, +parse+, +at+ and +now+ on TimeZone instances,
+  # and +in_time_zone+ on Time and DateTime instances.
+  #
+  #   Time.zone = 'Eastern Time (US & Canada)'        # => 'Eastern Time (US & Canada)'
+  #   Time.zone.local(2007, 2, 10, 15, 30, 45)        # => Sat, 10 Feb 2007 15:30:45 EST -05:00
+  #   Time.zone.parse('2007-02-10 15:30:45')          # => Sat, 10 Feb 2007 15:30:45 EST -05:00
+  #   Time.zone.at(1171139445)                        # => Sat, 10 Feb 2007 15:30:45 EST -05:00
+  #   Time.zone.now                                   # => Sun, 18 May 2008 13:07:55 EDT -04:00
+  #   Time.utc(2007, 2, 10, 20, 30, 45).in_time_zone  # => Sat, 10 Feb 2007 15:30:45 EST -05:00
+  #
+  # See Time and TimeZone for further documentation of these methods.
+  #
+  # TimeWithZone instances implement the same API as Ruby Time instances, so
+  # that Time and TimeWithZone instances are interchangeable.
+  #
+  #   t = Time.zone.now                     # => Sun, 18 May 2008 13:27:25 EDT -04:00
+  #   t.hour                                # => 13
+  #   t.dst?                                # => true
+  #   t.utc_offset                          # => -14400
+  #   t.zone                                # => "EDT"
+  #   t.to_s(:rfc822)                       # => "Sun, 18 May 2008 13:27:25 -0400"
+  #   t + 1.day                             # => Mon, 19 May 2008 13:27:25 EDT -04:00
+  #   t.beginning_of_year                   # => Tue, 01 Jan 2008 00:00:00 EST -05:00
+  #   t > Time.utc(1999)                    # => true
+  #   t.is_a?(Time)                         # => true
+  #   t.is_a?(ActiveSupport::TimeWithZone)  # => true
+  class TimeWithZone
+    # Report class name as 'Time' to thwart type checking.
+    def self.name: () -> "Time"
+
+    PRECISIONS: untyped
+
+    include Comparable
+
+    include DateAndTime::Compatibility
+
+    attr_reader time_zone: untyped
+
+    def initialize: (untyped utc_time, untyped time_zone, ?untyped? local_time, ?untyped? period) -> untyped
+
+    # Returns a <tt>Time</tt> instance that represents the time in +time_zone+.
+    def time: () -> untyped
+
+    # Returns a <tt>Time</tt> instance of the simultaneous time in the UTC timezone.
+    def utc: () -> untyped
+
+    alias comparable_time utc
+
+    alias getgm utc
+
+    alias getutc utc
+
+    alias gmtime utc
+
+    # Returns the underlying TZInfo::TimezonePeriod.
+    def period: () -> untyped
+
+    # Returns the simultaneous time in <tt>Time.zone</tt>, or the specified zone.
+    def in_time_zone: (?untyped new_zone) -> untyped
+
+    # Returns a <tt>Time</tt> instance of the simultaneous time in the system timezone.
+    def localtime: (?untyped? utc_offset) -> untyped
+
+    alias getlocal localtime
+
+    # Returns true if the current time is within Daylight Savings Time for the
+    # specified time zone.
+    #
+    #   Time.zone = 'Eastern Time (US & Canada)'    # => 'Eastern Time (US & Canada)'
+    #   Time.zone.parse("2012-5-30").dst?           # => true
+    #   Time.zone.parse("2012-11-30").dst?          # => false
+    def dst?: () -> untyped
+
+    alias isdst dst?
+
+    # Returns true if the current time zone is set to UTC.
+    #
+    #   Time.zone = 'UTC'                           # => 'UTC'
+    #   Time.zone.now.utc?                          # => true
+    #   Time.zone = 'Eastern Time (US & Canada)'    # => 'Eastern Time (US & Canada)'
+    #   Time.zone.now.utc?                          # => false
+    def utc?: () -> untyped
+
+    alias gmt? utc?
+
+    # Returns the offset from current time to UTC time in seconds.
+    def utc_offset: () -> untyped
+
+    alias gmt_offset utc_offset
+
+    alias gmtoff utc_offset
+
+    # Returns a formatted string of the offset from UTC, or an alternative
+    # string if the time zone is already UTC.
+    #
+    #   Time.zone = 'Eastern Time (US & Canada)'   # => "Eastern Time (US & Canada)"
+    #   Time.zone.now.formatted_offset(true)       # => "-05:00"
+    #   Time.zone.now.formatted_offset(false)      # => "-0500"
+    #   Time.zone = 'UTC'                          # => "UTC"
+    #   Time.zone.now.formatted_offset(true, "0")  # => "0"
+    def formatted_offset: (?bool colon, ?untyped? alternate_utc_string) -> untyped
+
+    # Returns the time zone abbreviation.
+    #
+    #   Time.zone = 'Eastern Time (US & Canada)'   # => "Eastern Time (US & Canada)"
+    #   Time.zone.now.zone # => "EST"
+    def zone: () -> untyped
+
+    # Returns a string of the object's date, time, zone, and offset from UTC.
+    #
+    #   Time.zone.now.inspect # => "Thu, 04 Dec 2014 11:00:25 EST -05:00"
+    def inspect: () -> ::String
+
+    # Returns a string of the object's date and time in the ISO 8601 standard
+    # format.
+    #
+    #   Time.zone.now.xmlschema  # => "2014-12-04T11:02:37-05:00"
+    def xmlschema: (?::Integer fraction_digits) -> ::String
+
+    alias iso8601 xmlschema
+
+    alias rfc3339 xmlschema
+
+    # Coerces time to a string for JSON encoding. The default format is ISO 8601.
+    # You can get %Y/%m/%d %H:%M:%S +offset style by setting
+    # <tt>ActiveSupport::JSON::Encoding.use_standard_json_time_format</tt>
+    # to +false+.
+    #
+    #   # With ActiveSupport::JSON::Encoding.use_standard_json_time_format = true
+    #   Time.utc(2005,2,1,15,15,10).in_time_zone("Hawaii").to_json
+    #   # => "2005-02-01T05:15:10.000-10:00"
+    #
+    #   # With ActiveSupport::JSON::Encoding.use_standard_json_time_format = false
+    #   Time.utc(2005,2,1,15,15,10).in_time_zone("Hawaii").to_json
+    #   # => "2005/02/01 05:15:10 -1000"
+    def as_json: (?untyped? options) -> untyped
+
+    def init_with: (untyped coder) -> untyped
+
+    def encode_with: (untyped coder) -> untyped
+
+    # Returns a string of the object's date and time in the format used by
+    # HTTP requests.
+    #
+    #   Time.zone.now.httpdate  # => "Tue, 01 Jan 2013 04:39:43 GMT"
+    def httpdate: () -> untyped
+
+    # Returns a string of the object's date and time in the RFC 2822 standard
+    # format.
+    #
+    #   Time.zone.now.rfc2822  # => "Tue, 01 Jan 2013 04:51:39 +0000"
+    def rfc2822: () -> untyped
+
+    alias rfc822 rfc2822
+
+    # Returns a string of the object's date and time.
+    # Accepts an optional <tt>format</tt>:
+    # * <tt>:default</tt> - default value, mimics Ruby Time#to_s format.
+    # * <tt>:db</tt> - format outputs time in UTC :db time. See Time#to_formatted_s(:db).
+    # * Any key in <tt>Time::DATE_FORMATS</tt> can be used. See active_support/core_ext/time/conversions.rb.
+    def to_s: (?::Symbol format) -> untyped
+
+    alias to_formatted_s to_s
+
+    # Replaces <tt>%Z</tt> directive with +zone before passing to Time#strftime,
+    # so that zone information is correct.
+    def strftime: (untyped format) -> untyped
+
+    # Use the time in UTC for comparisons.
+    def <=>: (untyped other) -> untyped
+
+    alias before? <
+
+    alias after? >
+
+    # Returns true if the current object's time is within the specified
+    # +min+ and +max+ time.
+    def between?: (untyped min, untyped max) -> untyped
+
+    # Returns true if the current object's time is in the past.
+    def past?: () -> untyped
+
+    # Returns true if the current object's time falls within
+    # the current day.
+    def today?: () -> untyped
+
+    # Returns true if the current object's time is in the future.
+    def future?: () -> untyped
+
+    # Returns +true+ if +other+ is equal to current object.
+    def eql?: (untyped other) -> untyped
+
+    def hash: () -> untyped
+
+    # Adds an interval of time to the current object's time and returns that
+    # value as a new TimeWithZone object.
+    #
+    #   Time.zone = 'Eastern Time (US & Canada)' # => 'Eastern Time (US & Canada)'
+    #   now = Time.zone.now # => Sun, 02 Nov 2014 01:26:28 EDT -04:00
+    #   now + 1000          # => Sun, 02 Nov 2014 01:43:08 EDT -04:00
+    #
+    # If we're adding a Duration of variable length (i.e., years, months, days),
+    # move forward from #time, otherwise move forward from #utc, for accuracy
+    # when moving across DST boundaries.
+    #
+    # For instance, a time + 24.hours will advance exactly 24 hours, while a
+    # time + 1.day will advance 23-25 hours, depending on the day.
+    #
+    #   now + 24.hours      # => Mon, 03 Nov 2014 00:26:28 EST -05:00
+    #   now + 1.day         # => Mon, 03 Nov 2014 01:26:28 EST -05:00
+    def +: (untyped other) -> untyped
+
+    alias since +
+
+    alias in +
+
+    # Subtracts an interval of time and returns a new TimeWithZone object unless
+    # the other value `acts_like?` time. Then it will return a Float of the difference
+    # between the two times that represents the difference between the current
+    # object's time and the +other+ time.
+    #
+    #   Time.zone = 'Eastern Time (US & Canada)' # => 'Eastern Time (US & Canada)'
+    #   now = Time.zone.now # => Mon, 03 Nov 2014 00:26:28 EST -05:00
+    #   now - 1000          # => Mon, 03 Nov 2014 00:09:48 EST -05:00
+    #
+    # If subtracting a Duration of variable length (i.e., years, months, days),
+    # move backward from #time, otherwise move backward from #utc, for accuracy
+    # when moving across DST boundaries.
+    #
+    # For instance, a time - 24.hours will go subtract exactly 24 hours, while a
+    # time - 1.day will subtract 23-25 hours, depending on the day.
+    #
+    #   now - 24.hours      # => Sun, 02 Nov 2014 01:26:28 EDT -04:00
+    #   now - 1.day         # => Sun, 02 Nov 2014 00:26:28 EDT -04:00
+    #
+    # If both the TimeWithZone object and the other value act like Time, a Float
+    # will be returned.
+    #
+    #   Time.zone.now - 1.day.ago # => 86399.999967
+    #
+    def -: (untyped other) -> untyped
+
+    # Subtracts an interval of time from the current object's time and returns
+    # the result as a new TimeWithZone object.
+    #
+    #   Time.zone = 'Eastern Time (US & Canada)' # => 'Eastern Time (US & Canada)'
+    #   now = Time.zone.now # => Mon, 03 Nov 2014 00:26:28 EST -05:00
+    #   now.ago(1000)       # => Mon, 03 Nov 2014 00:09:48 EST -05:00
+    #
+    # If we're subtracting a Duration of variable length (i.e., years, months,
+    # days), move backward from #time, otherwise move backward from #utc, for
+    # accuracy when moving across DST boundaries.
+    #
+    # For instance, <tt>time.ago(24.hours)</tt> will move back exactly 24 hours,
+    # while <tt>time.ago(1.day)</tt> will move back 23-25 hours, depending on
+    # the day.
+    #
+    #   now.ago(24.hours)   # => Sun, 02 Nov 2014 01:26:28 EDT -04:00
+    #   now.ago(1.day)      # => Sun, 02 Nov 2014 00:26:28 EDT -04:00
+    def ago: (untyped other) -> untyped
+
+    # Returns a new +ActiveSupport::TimeWithZone+ where one or more of the elements have
+    # been changed according to the +options+ parameter. The time options (<tt>:hour</tt>,
+    # <tt>:min</tt>, <tt>:sec</tt>, <tt>:usec</tt>, <tt>:nsec</tt>) reset cascadingly,
+    # so if only the hour is passed, then minute, sec, usec and nsec is set to 0. If the
+    # hour and minute is passed, then sec, usec and nsec is set to 0. The +options+
+    # parameter takes a hash with any of these keys: <tt>:year</tt>, <tt>:month</tt>,
+    # <tt>:day</tt>, <tt>:hour</tt>, <tt>:min</tt>, <tt>:sec</tt>, <tt>:usec</tt>,
+    # <tt>:nsec</tt>, <tt>:offset</tt>, <tt>:zone</tt>. Pass either <tt>:usec</tt>
+    # or <tt>:nsec</tt>, not both. Similarly, pass either <tt>:zone</tt> or
+    # <tt>:offset</tt>, not both.
+    #
+    #   t = Time.zone.now          # => Fri, 14 Apr 2017 11:45:15 EST -05:00
+    #   t.change(year: 2020)       # => Tue, 14 Apr 2020 11:45:15 EST -05:00
+    #   t.change(hour: 12)         # => Fri, 14 Apr 2017 12:00:00 EST -05:00
+    #   t.change(min: 30)          # => Fri, 14 Apr 2017 11:30:00 EST -05:00
+    #   t.change(offset: "-10:00") # => Fri, 14 Apr 2017 11:45:15 HST -10:00
+    #   t.change(zone: "Hawaii")   # => Fri, 14 Apr 2017 11:45:15 HST -10:00
+    def change: (untyped options) -> untyped
+
+    # Uses Date to provide precise Time calculations for years, months, and days
+    # according to the proleptic Gregorian calendar. The result is returned as a
+    # new TimeWithZone object.
+    #
+    # The +options+ parameter takes a hash with any of these keys:
+    # <tt>:years</tt>, <tt>:months</tt>, <tt>:weeks</tt>, <tt>:days</tt>,
+    # <tt>:hours</tt>, <tt>:minutes</tt>, <tt>:seconds</tt>.
+    #
+    # If advancing by a value of variable length (i.e., years, weeks, months,
+    # days), move forward from #time, otherwise move forward from #utc, for
+    # accuracy when moving across DST boundaries.
+    #
+    #   Time.zone = 'Eastern Time (US & Canada)' # => 'Eastern Time (US & Canada)'
+    #   now = Time.zone.now # => Sun, 02 Nov 2014 01:26:28 EDT -04:00
+    #   now.advance(seconds: 1) # => Sun, 02 Nov 2014 01:26:29 EDT -04:00
+    #   now.advance(minutes: 1) # => Sun, 02 Nov 2014 01:27:28 EDT -04:00
+    #   now.advance(hours: 1)   # => Sun, 02 Nov 2014 01:26:28 EST -05:00
+    #   now.advance(days: 1)    # => Mon, 03 Nov 2014 01:26:28 EST -05:00
+    #   now.advance(weeks: 1)   # => Sun, 09 Nov 2014 01:26:28 EST -05:00
+    #   now.advance(months: 1)  # => Tue, 02 Dec 2014 01:26:28 EST -05:00
+    #   now.advance(years: 1)   # => Mon, 02 Nov 2015 01:26:28 EST -05:00
+    def advance: (untyped options) -> untyped
+
+    # Returns Array of parts of Time in sequence of
+    # [seconds, minutes, hours, day, month, year, weekday, yearday, dst?, zone].
+    #
+    #   now = Time.zone.now     # => Tue, 18 Aug 2015 02:29:27 UTC +00:00
+    #   now.to_a                # => [27, 29, 2, 18, 8, 2015, 2, 230, false, "UTC"]
+    def to_a: () -> ::Array[untyped]
+
+    # Returns the object's date and time as a floating point number of seconds
+    # since the Epoch (January 1, 1970 00:00 UTC).
+    #
+    #   Time.zone.now.to_f # => 1417709320.285418
+    def to_f: () -> untyped
+
+    # Returns the object's date and time as an integer number of seconds
+    # since the Epoch (January 1, 1970 00:00 UTC).
+    #
+    #   Time.zone.now.to_i # => 1417709320
+    def to_i: () -> untyped
+
+    alias tv_sec to_i
+
+    # Returns the object's date and time as a rational number of seconds
+    # since the Epoch (January 1, 1970 00:00 UTC).
+    #
+    #   Time.zone.now.to_r # => (708854548642709/500000)
+    def to_r: () -> untyped
+
+    # Returns an instance of DateTime with the timezone's UTC offset
+    #
+    #   Time.zone.now.to_datetime                         # => Tue, 18 Aug 2015 02:32:20 +0000
+    #   Time.current.in_time_zone('Hawaii').to_datetime   # => Mon, 17 Aug 2015 16:32:20 -1000
+    def to_datetime: () -> untyped
+
+    # Returns an instance of +Time+, either with the same UTC offset
+    # as +self+ or in the local system timezone depending on the setting
+    # of +ActiveSupport.to_time_preserves_timezone+.
+    def to_time: () -> untyped
+
+    # So that +self+ <tt>acts_like?(:time)</tt>.
+    def acts_like_time?: () -> ::TrueClass
+
+    # Say we're a Time to thwart type checking.
+    def is_a?: (untyped klass) -> untyped
+
+    alias kind_of? is_a?
+
+    # An instance of ActiveSupport::TimeWithZone is never blank
+    def blank?: () -> ::FalseClass
+
+    def freeze: () -> untyped
+
+    def marshal_dump: () -> ::Array[untyped]
+
+    def marshal_load: (untyped variables) -> untyped
+
+    # respond_to_missing? is not called in some cases, such as when type conversion is
+    # performed with Kernel#String
+    def respond_to?: (untyped sym, ?bool include_priv) -> (::FalseClass | untyped)
+
+    # Ensure proxy class responds to all methods that underlying time instance
+    # responds to.
+    def respond_to_missing?: (untyped sym, untyped include_priv) -> (::FalseClass | untyped)
+
+    # Send the missing method to +time+ instance, and wrap result in a new
+    # TimeWithZone with the existing +time_zone+.
+    def method_missing: (untyped sym, *untyped args) { () -> untyped } -> untyped
+
+    def get_period_and_ensure_valid_local_time: (untyped period) -> untyped
+
+    def transfer_time_values_to_utc_constructor: (untyped time) -> untyped
+
+    def duration_of_variable_length?: (untyped obj) -> untyped
+
+    def wrap_with_time_zone: (untyped time) -> untyped
+  end
+end
+
+module ActiveSupport
+  # The TimeZone class serves as a wrapper around TZInfo::Timezone instances.
+  # It allows us to do the following:
+  #
+  # * Limit the set of zones provided by TZInfo to a meaningful subset of 134
+  #   zones.
+  # * Retrieve and display zones with a friendlier name
+  #   (e.g., "Eastern Time (US & Canada)" instead of "America/New_York").
+  # * Lazily load TZInfo::Timezone instances only when they're needed.
+  # * Create ActiveSupport::TimeWithZone instances via TimeZone's +local+,
+  #   +parse+, +at+ and +now+ methods.
+  #
+  # If you set <tt>config.time_zone</tt> in the Rails Application, you can
+  # access this TimeZone object via <tt>Time.zone</tt>:
+  #
+  #   # application.rb:
+  #   class Application < Rails::Application
+  #     config.time_zone = 'Eastern Time (US & Canada)'
+  #   end
+  #
+  #   Time.zone      # => #<ActiveSupport::TimeZone:0x514834...>
+  #   Time.zone.name # => "Eastern Time (US & Canada)"
+  #   Time.zone.now  # => Sun, 18 May 2008 14:30:44 EDT -04:00
+  class TimeZone
+    # Keys are Rails TimeZone names, values are TZInfo identifiers.
+    MAPPING: ::Hash[untyped, untyped]
+
+    UTC_OFFSET_WITH_COLON: ::String
+
+    UTC_OFFSET_WITHOUT_COLON: untyped
+
+    # Assumes self represents an offset from UTC in seconds (as returned from
+    # Time#utc_offset) and turns this into an +HH:MM formatted string.
+    #
+    #   ActiveSupport::TimeZone.seconds_to_utc_offset(-21_600) # => "-06:00"
+    def self.seconds_to_utc_offset: (untyped seconds, ?bool colon) -> untyped
+
+    def self.find_tzinfo: (untyped name) -> TZInfo::Timezone
+
+    alias self.create self.new
+
+    # Returns a TimeZone instance with the given name, or +nil+ if no
+    # such TimeZone instance exists. (This exists to support the use of
+    # this class with the +composed_of+ macro.)
+    def self.new: (untyped name) -> untyped
+
+    # Returns an array of all TimeZone objects. There are multiple
+    # TimeZone objects per time zone, in many cases, to make it easier
+    # for users to find their own time zone.
+    def self.all: () -> untyped
+
+    # Locate a specific time zone object. If the argument is a string, it
+    # is interpreted to mean the name of the timezone to locate. If it is a
+    # numeric value it is either the hour offset, or the second offset, of the
+    # timezone to find. (The first one with that offset will be returned.)
+    # Returns +nil+ if no such time zone is known to the system.
+    def self.[]: (untyped arg) -> untyped
+
+    # A convenience method for returning a collection of TimeZone objects
+    # for time zones in the USA.
+    def self.us_zones: () -> untyped
+
+    # A convenience method for returning a collection of TimeZone objects
+    # for time zones in the country specified by its ISO 3166-1 Alpha2 code.
+    def self.country_zones: (untyped country_code) -> untyped
+
+    def self.clear: () -> untyped
+
+    def self.load_country_zones: (untyped code) -> untyped
+
+    def self.zones_map: () -> untyped
+
+    include Comparable
+
+    attr_reader name: untyped
+
+    attr_reader tzinfo: untyped
+
+    # Create a new TimeZone object with the given name and offset. The
+    # offset is the number of seconds that this time zone is offset from UTC
+    # (GMT). Seconds were chosen as the offset unit because that is the unit
+    # that Ruby uses to represent time zone offsets (see Time#utc_offset).
+    def initialize: (untyped name, ?untyped? utc_offset, ?untyped? tzinfo) -> untyped
+
+    # Returns the offset of this time zone from UTC in seconds.
+    def utc_offset: () -> untyped
+
+    # Returns a formatted string of the offset from UTC, or an alternative
+    # string if the time zone is already UTC.
+    #
+    #   zone = ActiveSupport::TimeZone['Central Time (US & Canada)']
+    #   zone.formatted_offset        # => "-06:00"
+    #   zone.formatted_offset(false) # => "-0600"
+    def formatted_offset: (?bool colon, ?untyped? alternate_utc_string) -> untyped
+
+    # Compare this time zone to the parameter. The two are compared first on
+    # their offsets, and then by name.
+    def <=>: (untyped zone) -> (nil | untyped)
+
+    # Compare #name and TZInfo identifier to a supplied regexp, returning +true+
+    # if a match is found.
+    def =~: (untyped re) -> untyped
+
+    # Returns a textual representation of this time zone.
+    def to_s: () -> ::String
+
+    # Method for creating new ActiveSupport::TimeWithZone instance in time zone
+    # of +self+ from given values.
+    #
+    #   Time.zone = 'Hawaii'                    # => "Hawaii"
+    #   Time.zone.local(2007, 2, 1, 15, 30, 45) # => Thu, 01 Feb 2007 15:30:45 HST -10:00
+    def local: (*untyped args) -> ActiveSupport::TimeWithZone
+
+    # Method for creating new ActiveSupport::TimeWithZone instance in time zone
+    # of +self+ from number of seconds since the Unix epoch.
+    #
+    #   Time.zone = 'Hawaii'        # => "Hawaii"
+    #   Time.utc(2000).to_f         # => 946684800.0
+    #   Time.zone.at(946684800.0)   # => Fri, 31 Dec 1999 14:00:00 HST -10:00
+    #
+    # A second argument can be supplied to specify sub-second precision.
+    #
+    #   Time.zone = 'Hawaii'                # => "Hawaii"
+    #   Time.at(946684800, 123456.789).nsec # => 123456789
+    def at: (*untyped args) -> untyped
+
+    # Method for creating new ActiveSupport::TimeWithZone instance in time zone
+    # of +self+ from an ISO 8601 string.
+    #
+    #   Time.zone = 'Hawaii'                     # => "Hawaii"
+    #   Time.zone.iso8601('1999-12-31T14:00:00') # => Fri, 31 Dec 1999 14:00:00 HST -10:00
+    #
+    # If the time components are missing then they will be set to zero.
+    #
+    #   Time.zone = 'Hawaii'            # => "Hawaii"
+    #   Time.zone.iso8601('1999-12-31') # => Fri, 31 Dec 1999 00:00:00 HST -10:00
+    #
+    # If the string is invalid then an +ArgumentError+ will be raised unlike +parse+
+    # which usually returns +nil+ when given an invalid date string.
+    def iso8601: (untyped str) -> untyped
+
+    # Method for creating new ActiveSupport::TimeWithZone instance in time zone
+    # of +self+ from parsed string.
+    #
+    #   Time.zone = 'Hawaii'                   # => "Hawaii"
+    #   Time.zone.parse('1999-12-31 14:00:00') # => Fri, 31 Dec 1999 14:00:00 HST -10:00
+    #
+    # If upper components are missing from the string, they are supplied from
+    # TimeZone#now:
+    #
+    #   Time.zone.now               # => Fri, 31 Dec 1999 14:00:00 HST -10:00
+    #   Time.zone.parse('22:30:00') # => Fri, 31 Dec 1999 22:30:00 HST -10:00
+    #
+    # However, if the date component is not provided, but any other upper
+    # components are supplied, then the day of the month defaults to 1:
+    #
+    #   Time.zone.parse('Mar 2000') # => Wed, 01 Mar 2000 00:00:00 HST -10:00
+    #
+    # If the string is invalid then an +ArgumentError+ could be raised.
+    def parse: (untyped str, ?untyped now) -> untyped
+
+    # Method for creating new ActiveSupport::TimeWithZone instance in time zone
+    # of +self+ from an RFC 3339 string.
+    #
+    #   Time.zone = 'Hawaii'                     # => "Hawaii"
+    #   Time.zone.rfc3339('2000-01-01T00:00:00Z') # => Fri, 31 Dec 1999 14:00:00 HST -10:00
+    #
+    # If the time or zone components are missing then an +ArgumentError+ will
+    # be raised. This is much stricter than either +parse+ or +iso8601+ which
+    # allow for missing components.
+    #
+    #   Time.zone = 'Hawaii'            # => "Hawaii"
+    #   Time.zone.rfc3339('1999-12-31') # => ArgumentError: invalid date
+    def rfc3339: (untyped str) -> TimeWithZone
+
+    # Parses +str+ according to +format+ and returns an ActiveSupport::TimeWithZone.
+    #
+    # Assumes that +str+ is a time in the time zone +self+,
+    # unless +format+ includes an explicit time zone.
+    # (This is the same behavior as +parse+.)
+    # In either case, the returned TimeWithZone has the timezone of +self+.
+    #
+    #   Time.zone = 'Hawaii'                   # => "Hawaii"
+    #   Time.zone.strptime('1999-12-31 14:00:00', '%Y-%m-%d %H:%M:%S') # => Fri, 31 Dec 1999 14:00:00 HST -10:00
+    #
+    # If upper components are missing from the string, they are supplied from
+    # TimeZone#now:
+    #
+    #   Time.zone.now                              # => Fri, 31 Dec 1999 14:00:00 HST -10:00
+    #   Time.zone.strptime('22:30:00', '%H:%M:%S') # => Fri, 31 Dec 1999 22:30:00 HST -10:00
+    #
+    # However, if the date component is not provided, but any other upper
+    # components are supplied, then the day of the month defaults to 1:
+    #
+    #   Time.zone.strptime('Mar 2000', '%b %Y') # => Wed, 01 Mar 2000 00:00:00 HST -10:00
+    def strptime: (untyped str, untyped format, ?untyped now) -> untyped
+
+    # Returns an ActiveSupport::TimeWithZone instance representing the current
+    # time in the time zone represented by +self+.
+    #
+    #   Time.zone = 'Hawaii'  # => "Hawaii"
+    #   Time.zone.now         # => Wed, 23 Jan 2008 20:24:27 HST -10:00
+    def now: () -> untyped
+
+    # Returns the current date in this time zone.
+    def today: () -> untyped
+
+    # Returns the next date in this time zone.
+    def tomorrow: () -> untyped
+
+    # Returns the previous date in this time zone.
+    def yesterday: () -> untyped
+
+    # Adjust the given time to the simultaneous time in the time zone
+    # represented by +self+. Returns a Time.utc() instance -- if you want an
+    # ActiveSupport::TimeWithZone instance, use Time#in_time_zone() instead.
+    def utc_to_local: (untyped time) -> untyped
+
+    # Adjust the given time to the simultaneous time in UTC. Returns a
+    # Time.utc() instance.
+    def local_to_utc: (untyped time, ?bool dst) -> untyped
+
+    # Available so that TimeZone instances respond like TZInfo::Timezone
+    # instances.
+    def period_for_utc: (untyped time) -> untyped
+
+    # Available so that TimeZone instances respond like TZInfo::Timezone
+    # instances.
+    def period_for_local: (untyped time, ?bool dst) -> untyped
+
+    def periods_for_local: (untyped time) -> untyped
+
+    def init_with: (untyped coder) -> untyped
+
+    def encode_with: (untyped coder) -> untyped
+
+    def parts_to_time: (untyped parts, untyped now) -> (nil | untyped)
+
+    def time_now: () -> untyped
+  end
+end
+
+module ActiveSupport
+  # Returns the version of the currently loaded ActiveSupport as a <tt>Gem::Version</tt>
+  def self.version: () -> untyped
+end
+
+module ActiveSupport
+  module XmlMini_JDOM
+    CONTENT_KEY: ::String
+
+    NODE_TYPE_NAMES: ::Array[untyped]
+
+    # Parse an XML Document string or IO into a simple hash using Java's jdom.
+    # data::
+    #   XML Document string or IO to parse
+    def parse: (untyped data) -> untyped
+
+    # Convert an XML element and merge into the hash
+    #
+    # hash::
+    #   Hash to merge the converted element into.
+    # element::
+    #   XML element to merge into hash
+    def merge_element!: (untyped hash, untyped element, untyped depth) -> untyped
+
+    def delete_empty: (untyped hash) -> untyped
+
+    # Actually converts an XML document element into a data structure.
+    #
+    # element::
+    #   The document element to be collapsed.
+    def collapse: (untyped element, untyped depth) -> untyped
+
+    # Merge all the texts of an element into the hash
+    #
+    # hash::
+    #   Hash to add the converted element to.
+    # element::
+    #   XML element whose texts are to me merged into the hash
+    def merge_texts!: (untyped hash, untyped element) -> untyped
+
+    # Adds a new key/value pair to an existing Hash. If the key to be added
+    # already exists and the existing value associated with key is not
+    # an Array, it will be wrapped in an Array. Then the new value is
+    # appended to that Array.
+    #
+    # hash::
+    #   Hash to add key/value pair to.
+    # key::
+    #   Key to be added.
+    # value::
+    #   Value to be associated with key.
+    def merge!: (untyped hash, untyped key, untyped value) -> untyped
+
+    # Converts the attributes array of an XML element into a hash.
+    # Returns an empty Hash if node has no attributes.
+    #
+    # element::
+    #   XML element to extract attributes from.
+    def get_attributes: (untyped element) -> untyped
+
+    # Determines if a document element has text content
+    #
+    # element::
+    #   XML element to be checked.
+    def texts: (untyped element) -> untyped
+
+    # Determines if a document element has text content
+    #
+    # element::
+    #   XML element to be checked.
+    def empty_content?: (untyped element) -> untyped
+  end
+end
+
+module ActiveSupport
+  module XmlMini_LibXML
+    # Parse an XML Document string or IO into a simple hash using libxml.
+    # data::
+    #   XML Document string or IO to parse
+    def parse: (untyped data) -> untyped
+  end
+end
+
+module LibXML
+  module Conversions
+    module Document
+      # nodoc:
+      # nodoc:
+      # nodoc:
+      def to_hash: () -> untyped
+    end
+
+    module Node
+      # nodoc:
+      CONTENT_ROOT: ::String
+
+      # Convert XML document to hash.
+      #
+      # hash::
+      #   Hash to merge the converted element into.
+      def to_hash: (?::Hash[untyped, untyped] hash) -> untyped
+    end
+  end
+end
+
+module ActiveSupport
+  module XmlMini_LibXMLSAX
+    # Class that will build the hash while the XML document
+    # is being parsed using SAX events.
+    class HashBuilder
+      include LibXML::XML::SaxParser::Callbacks
+
+      CONTENT_KEY: ::String
+
+      HASH_SIZE_KEY: ::String
+
+      attr_reader hash: untyped
+
+      def current_hash: () -> untyped
+
+      def on_start_document: () -> untyped
+
+      def on_end_document: () -> untyped
+
+      def on_start_element: (untyped name, ?::Hash[untyped, untyped] attrs) -> untyped
+
+      def on_end_element: (untyped name) -> untyped
+
+      def on_characters: (untyped string) -> untyped
+
+      alias on_cdata_block on_characters
+    end
+
+    attr_accessor document_class: untyped
+
+    def parse: (untyped data) -> untyped
+  end
+end
+
+module ActiveSupport
+  module XmlMini_Nokogiri
+    # Parse an XML Document string or IO into a simple hash using libxml / nokogiri.
+    # data::
+    #   XML Document string or IO to parse
+    def parse: (untyped data) -> untyped
+
+    module Conversions
+      module Document
+        # nodoc:
+        # nodoc:
+        def to_hash: () -> untyped
+      end
+
+      module Node
+        # nodoc:
+        CONTENT_ROOT: ::String
+
+        # Convert XML document to hash.
+        #
+        # hash::
+        #   Hash to merge the converted element into.
+        def to_hash: (?::Hash[untyped, untyped] hash) -> untyped
+      end
+    end
+  end
+end
+
+module ActiveSupport
+  module XmlMini_NokogiriSAX
+    # Class that will build the hash while the XML document
+    # is being parsed using SAX events.
+    class HashBuilder < Nokogiri::XML::SAX::Document
+      CONTENT_KEY: ::String
+
+      HASH_SIZE_KEY: ::String
+
+      attr_reader hash: untyped
+
+      def current_hash: () -> untyped
+
+      def start_document: () -> untyped
+
+      def end_document: () -> untyped
+
+      def error: (untyped error_message) -> untyped
+
+      def start_element: (untyped name, ?untyped attrs) -> untyped
+
+      def end_element: (untyped name) -> untyped
+
+      def characters: (untyped string) -> untyped
+
+      alias cdata_block characters
+    end
+
+    attr_accessor document_class: untyped
+
+    def parse: (untyped data) -> untyped
+  end
+end
+
+module ActiveSupport
+  module XmlMini_REXML
+    CONTENT_KEY: ::String
+
+    # Parse an XML Document string or IO into a simple hash.
+    #
+    # Same as XmlSimple::xml_in but doesn't shoot itself in the foot,
+    # and uses the defaults from Active Support.
+    #
+    # data::
+    #   XML Document string or IO to parse
+    def parse: (untyped data) -> untyped
+
+    # Convert an XML element and merge into the hash
+    #
+    # hash::
+    #   Hash to merge the converted element into.
+    # element::
+    #   XML element to merge into hash
+    def merge_element!: (untyped hash, untyped element, untyped depth) -> untyped
+
+    # Actually converts an XML document element into a data structure.
+    #
+    # element::
+    #   The document element to be collapsed.
+    def collapse: (untyped element, untyped depth) -> untyped
+
+    # Merge all the texts of an element into the hash
+    #
+    # hash::
+    #   Hash to add the converted element to.
+    # element::
+    #   XML element whose texts are to me merged into the hash
+    def merge_texts!: (untyped hash, untyped element) -> untyped
+
+    # Adds a new key/value pair to an existing Hash. If the key to be added
+    # already exists and the existing value associated with key is not
+    # an Array, it will be wrapped in an Array. Then the new value is
+    # appended to that Array.
+    #
+    # hash::
+    #   Hash to add key/value pair to.
+    # key::
+    #   Key to be added.
+    # value::
+    #   Value to be associated with key.
+    def merge!: (untyped hash, untyped key, untyped value) -> untyped
+
+    # Converts the attributes array of an XML element into a hash.
+    # Returns an empty Hash if node has no attributes.
+    #
+    # element::
+    #   XML element to extract attributes from.
+    def get_attributes: (untyped element) -> untyped
+
+    # Determines if a document element has text content
+    #
+    # element::
+    #   XML element to be checked.
+    def empty_content?: (untyped element) -> untyped
+  end
+end
+
+module ActiveSupport
+  # = XmlMini
+  #
+  # To use the much faster libxml parser:
+  #   gem 'libxml-ruby', '=0.9.7'
+  #   XmlMini.backend = 'LibXML'
+  module XmlMini
+    module FileLike
+      # This module decorates files deserialized using Hash.from_xml with
+      # the <tt>original_filename</tt> and <tt>content_type</tt> methods.
+      # nodoc:
+      attr_writer original_filename: untyped
+
+      # This module decorates files deserialized using Hash.from_xml with
+      # the <tt>original_filename</tt> and <tt>content_type</tt> methods.
+      # nodoc:
+      attr_writer content_type: untyped
+
+      def original_filename: () -> untyped
+
+      def content_type: () -> untyped
+    end
+
+    DEFAULT_ENCODINGS: ::Hash[untyped, untyped]
+
+    TYPE_NAMES: ::Hash[untyped, untyped]
+
+    FORMATTING: ::Hash[untyped, untyped]
+
+    PARSING: ::Hash[untyped, untyped]
+
+    attr_accessor depth: untyped
+
+    def backend: () -> untyped
+
+    def backend=: (untyped name) -> untyped
+
+    def with_backend: (untyped name) { () -> untyped } -> untyped
+
+    def to_tag: (untyped key, untyped value, untyped options) -> untyped
+
+    def rename_key: (untyped key, ?::Hash[untyped, untyped] options) -> untyped
+
+    def _dasherize: (untyped key) -> ::String
+
+    # TODO: Add support for other encodings
+    def _parse_binary: (untyped bin, untyped entity) -> untyped
+
+    def _parse_file: (untyped file, untyped entity) -> untyped
+
+    def current_thread_backend: () -> untyped
+
+    def current_thread_backend=: (untyped name) -> untyped
+
+    def cast_backend_name_to_module: (untyped name) -> untyped
+  end
+end
+
+module ActiveSupport
+  extend ActiveSupport::Autoload
+
+  def self.eager_load!: () -> untyped
+
+  def self.to_time_preserves_timezone: () -> untyped
+
+  def self.to_time_preserves_timezone=: (untyped value) -> untyped
+end
+
+class Object
+  # Benchmark realtime in milliseconds.
+  #
+  #   Benchmark.realtime { User.all }
+  #   # => 8.0e-05
+  #
+  #   Benchmark.ms { User.all }
+  #   # => 0.074
+  def self.ms: () { () -> untyped } -> untyped
+
+  alias orig_sum sum
+
+  def unescape: (untyped str, ?untyped escaped) -> untyped
+end
+

--- a/gems/activesupport/6.0.3.2/patch.rbs
+++ b/gems/activesupport/6.0.3.2/patch.rbs
@@ -1,0 +1,48 @@
+class Object
+  # Object#sum is actually not defined, but rbs prototype rb generates it mistakenly due to `class << Benchmark`.
+  # So we need to define it to suppress the alias error.
+  def sum: () -> untyped
+end
+
+class Time
+  # alias bug: https://github.com/ruby/rbs/issues/458
+  def xmlschema: (?::Integer fraction_digits) -> ::String
+end
+
+module ActiveSupport
+  class TestCase < ::Minitest::Test
+    # alias bug: https://github.com/ruby/rbs/issues/458
+    def name: () -> untyped
+    def assert_raises: (*untyped) -> untyped
+    def refute_empty: (*untyped) -> untyped
+    def refute_equal: (*untyped) -> untyped
+    def refute_in_delta: (*untyped) -> untyped
+    def refute_in_epsilon: (*untyped) -> untyped
+    def refute_includes: (*untyped) -> untyped
+    def refute_instance_of: (*untyped) -> untyped
+    def refute_kind_of: (*untyped) -> untyped
+    def refute_match: (*untyped) -> untyped
+    def refute_nil: (*untyped) -> untyped
+    def refute_operator: (*untyped) -> untyped
+    def refute_predicate: (*untyped) -> untyped
+    def refute_respond_to: (*untyped) -> untyped
+    def refute_same: (*untyped) -> untyped
+  end
+
+  module Notifications
+    class Fanout
+      module Subscribers
+        class AllMessages
+          # alias bug: https://github.com/ruby/rbs/issues/458
+          def ===: (untyped) -> bool
+        end
+      end
+    end
+  end
+
+  class TimeWithZone
+    # alias bug: https://github.com/ruby/rbs/issues/458
+    def <: (untyped) -> bool
+    def >: (untyped) -> bool
+  end
+end

--- a/gems/railties/6.0.3.2/_scripts/generate.rb
+++ b/gems/railties/6.0.3.2/_scripts/generate.rb
@@ -1,0 +1,206 @@
+# Usage
+#
+#   ruby generate.rb all
+#   ruby generate.rb actionpack
+
+require 'bundler/inline'
+
+require 'pathname'
+require 'open3'
+
+RAILS_CODE_DIR = Pathname(__dir__) / '../_src/'
+
+def bin(c)
+  Pathname(__dir__).join('../_rbs_rails/bin/', c).to_s
+end
+
+def sh!(*cmd, **kwargs)
+  puts(cmd.join(' '))
+  Open3.capture2(*cmd, **kwargs).then do |out, status|
+    raise unless status.success?
+
+    out
+  end
+end
+
+def patch!(name, rbs)
+  case name
+  when 'actionpack'
+    rbs.gsub!(/(      def _reduce_\d+: \(untyped val, untyped _values\) -> )([A-Z]\w*)/) do
+      "#{$~[1]}Nodes::#{$~[2]}"
+    end || raise('it looks unnecessary.')
+
+    # XXX: I guess add-type-params.rb resolves this
+    rbs.gsub!('-> Parameter', '-> Parameter[untyped]') || raise('it looks unnecessary')
+  when 'railties'
+    rbs.gsub!(
+      'class NonSymbolAccessDeprecatedHash < HashWithIndifferentAccess',
+      'class NonSymbolAccessDeprecatedHash[T, U] < HashWithIndifferentAccess[T, U]')
+    # XXX: I guess add-type-params.rb resolves this
+    rbs.gsub!(
+      'def middleware: () -> Hash',
+      'def middleware: () -> Hash[untyped, untyped]')
+    # XXX: I guess add-type-params.rb resolves this
+    rbs.gsub!(
+      'def +: (untyped other) -> Collection',
+      'def +: (untyped other) -> Collection[untyped]')
+    # XXX: I guess add-type-params.rb resolves this
+    rbs.gsub!(
+      'def initializers_for: (untyped binding) -> Collection',
+      'def initializers_for: (untyped binding) -> Collection[untyped]')
+  when 'activesupport'
+    rbs.gsub!(
+      /^  include Java$/,
+      '  # include Java # Java module is missing')
+    # XXX: I guess add-type-params.rb resolves this
+    rbs.gsub!(
+      'class Configuration < ActiveSupport::InheritableOptions',
+      'class Configuration[T, U] < ActiveSupport::InheritableOptions[T, U]')
+    # XXX: I guess add-type-params.rb resolves this
+    rbs.gsub!(
+      'class InheritableOptions < OrderedOptions',
+      'class InheritableOptions[T, U] < OrderedOptions[T, U]')
+    rbs.gsub!( # ref: 5c507aaae492ff5b2002fdd3ece2044b283b5d6f
+      'include ActiveSupport::Logger::Severity',
+      'include ::Logger::Severity')
+    # XXX: I guess add-type-params.rb resolves this
+    rbs.gsub!(
+      'def with_indifferent_access: () -> ActiveSupport::HashWithIndifferentAccess',
+      'def with_indifferent_access: () -> ActiveSupport::HashWithIndifferentAccess[K, V]')
+    # XXX: I guess add-type-params.rb resolves this
+    rbs.gsub!(
+      'def inquiry: () -> ActiveSupport::ArrayInquirer',
+      'def inquiry: () -> ActiveSupport::ArrayInquirer[Elem]')
+
+    # These aliases are actually defined, but it causes duplicated method definition
+    rbs.gsub!('alias to_s to_formatted_s', '')
+    rbs.gsub!('alias + plus_with_duration', '')
+    rbs.gsub!('alias - minus_with_duration', '')
+    rbs.gsub!('alias - minus_with_coercion', '')
+    rbs.gsub!('alias <=> compare_with_coercion', '')
+    rbs.gsub!('alias eql? eql_with_coercion', '')
+    rbs.gsub!('alias self.at self.at_with_coercion', '')
+    rbs.gsub!('alias inspect readable_inspect', '')
+    rbs.gsub!('alias default_inspect inspect', '')
+
+    rbs.gsub!('HashWithIndifferentAccess: untyped', <<~RBS)
+      # NOTE: HashWithIndifferentAccess and ActiveSupport::HashWithIndifferentAccess are the same object
+      #       but RBS doesn't have class alias syntax
+      class HashWithIndifferentAccess[T, U] < ActiveSupport::HashWithIndifferentAccess[T, U]
+      end
+    RBS
+  when 'actionview'
+    rbs.gsub!(
+      'class CheckBoxBuilder < Builder',
+      'class CheckBoxBuilder < CollectionHelpers::Builder')
+    rbs.gsub!(
+      'class RadioButtonBuilder < Builder',
+      'class RadioButtonBuilder < CollectionHelpers::Builder')
+    rbs.gsub!('TemplateError: untyped', <<~RBS)
+      # It is actual TemplateError = Template::Error, but we can't write it in RBS
+      class TemplateError < Template::Error
+      end
+    RBS
+  when 'activerecord'
+    rbs.gsub!(':==', 'Symbol') # To avoid syntax error
+
+    rbs.gsub!(
+      '< Type::Value',
+      '< ActiveModel::Type::Value')
+    rbs.gsub!(
+      '< Type::Binary',
+      '< ActiveModel::Type::Binary')
+    rbs.gsub!(
+      '< Type::Decimal',
+      '< ActiveModel::Type::Decimal')
+    rbs.gsub!(
+      '< Type::String',
+      '< ActiveModel::Type::String')
+    rbs.gsub!(
+      '< Type::Integer',
+      '< ActiveModel::Type::Integer')
+
+    rbs.gsub!(
+      'class SchemaDumper < SchemaDumper',
+      'class SchemaDumper < ActiveRecord::SchemaDumper')
+    rbs.gsub!(
+      'def schema_creation: () -> SchemaCreation',
+      'def schema_creation: () -> untyped')
+    rbs.gsub!('V6_0: untyped', <<~RBS)
+      # V6_0 and Current are the same object actually. hack for https://github.com/ruby/rbs/issues/345
+      class V6_0 < Current
+      end
+    RBS
+    rbs.gsub!('alias numeric decimal', '')
+
+    # XXX: I guess add-type-params.rb resolves this
+    rbs.gsub!(
+      '-> ColumnDefinition',
+      '-> ColumnDefinition[untyped]')
+    # XXX: I guess add-type-params.rb resolves this
+    rbs.gsub!(
+      'def build_point: (untyped x, untyped y) -> ActiveRecord::Point',
+      'def build_point: (untyped x, untyped y) -> ActiveRecord::Point[untyped]')
+    # XXX: I guess add-type-params.rb resolves this
+    rbs.gsub!(
+      'class NullMigration < MigrationProxy',
+      'class NullMigration[T] < MigrationProxy[T]')
+    # XXX: I guess add-type-params.rb resolves this
+    rbs.gsub!(
+      '-> JoinKeys',
+      '-> JoinKeys[untyped]')
+    # XXX: I guess add-type-params.rb resolves this
+    rbs.gsub!(
+      'def row_num_literal: (untyped order_by) -> RowNumber',
+      'def row_num_literal: (untyped order_by) -> RowNumber[untyped]')
+
+    rbs.gsub!(
+      'def get_database_version: () -> Version',
+      'def get_database_version: () -> AbstractAdapter::Version')
+    rbs.gsub!(
+      'def get_database_version: () -> SQLite3Adapter::Version',
+      'def get_database_version: () -> AbstractAdapter::Version')
+    rbs.gsub!(
+      'def []: (untyped name) -> Attribute',
+      'def []: (untyped name) -> ::Arel::Attributes::Attribute')
+  end
+end
+
+def generated_rbs_path(name)
+  version = __dir__[%r!/([^/]+)/_scripts$!, 1]
+  Pathname(__dir__) / '../../../' / name / version / "#{name}-generated.rbs"
+end
+
+def generate1!(name)
+  files = Pathname(RAILS_CODE_DIR).join(name, 'lib').glob('**/*.rb').sort.map(&:to_s)
+  generated_rbs_path = generated_rbs_path(name)
+
+  rbs = sh! 'ruby', bin("rbs-prototype-rb.rb"), 'prototype', 'rb', *files
+  rbs.gsub!(/^(?<indent>\s*)class (?<name>\S+) < $/) { "#{$~[:indent]}class #{$~[:name]} # Note: It inherits unnamed class, but omitted" }
+  rbs.gsub!(/[^[:ascii:]]+/, '(trim non-ascii characters)')
+  patch! name, rbs
+  generated_rbs_path.write(rbs)
+
+end
+
+def generate2!(name)
+  generated_rbs_path = generated_rbs_path(name)
+
+  rbs = sh! 'ruby', bin('add-type-params.rb'), generated_rbs_path.to_s
+  generated_rbs_path.write(rbs)
+
+  sh!({ 'ONLY' => name }, 'ruby', bin('postprocess.rb'), '-rlogger', '-rmutex_m', '-Iassets/sig', '-Isig', 'assets/')
+end
+
+def main(name)
+  if name == 'all'
+    gems = %w[activesupport actionpack activejob activemodel actionview activerecord railties]
+    gems.each { |n| generate1!(n) }
+    gems.each { |n| generate2!(n) }
+  else
+    generate1!(name)
+    generate2!(name)
+  end
+end
+
+main(*ARGV)

--- a/gems/railties/6.0.3.2/_scripts/generate.rb
+++ b/gems/railties/6.0.3.2/_scripts/generate.rb
@@ -3,8 +3,6 @@
 #   ruby generate.rb all
 #   ruby generate.rb actionpack
 
-require 'bundler/inline'
-
 require 'pathname'
 require 'open3'
 
@@ -32,6 +30,12 @@ def patch!(name, rbs)
 
     # XXX: I guess add-type-params.rb resolves this
     rbs.gsub!('-> Parameter', '-> Parameter[untyped]') || raise('it looks unnecessary')
+
+    rbs.gsub!(<<~RUBY.gsub(/^/, '  '), '')
+      module Live
+        def new_controller_thread: () { () -> untyped } -> untyped
+      end
+    RUBY
   when 'railties'
     rbs.gsub!(
       'class NonSymbolAccessDeprecatedHash < HashWithIndifferentAccess',

--- a/gems/railties/6.0.3.2/_scripts/generate.rb
+++ b/gems/railties/6.0.3.2/_scripts/generate.rb
@@ -190,6 +190,14 @@ def generate2!(name)
   generated_rbs_path.write(rbs)
 
   sh!({ 'ONLY' => name }, 'ruby', bin('postprocess.rb'), '-rlogger', '-rmutex_m', '-Iassets/sig', '-Isig', 'assets/')
+
+  # Add license of rails/rails
+  # https://github.com/rails/rails/blob/master/MIT-LICENSE
+  generated_rbs_path.write(<<~COMMENT + RAILS_CODE_DIR.join('MIT-LICENSE').read.gsub(/^/, '#') + "\n" + generated_rbs_path.read)
+    # The generated code is based on Ruby on Rails source code
+    # You can find the license of Ruby on Rails from following.
+
+  COMMENT
 end
 
 def main(name)

--- a/gems/railties/6.0.3.2/_scripts/test
+++ b/gems/railties/6.0.3.2/_scripts/test
@@ -1,0 +1,13 @@
+#!ruby
+
+require 'pathname'
+
+def sh!(*args, **kwargs)
+  system(*args, **kwargs, exception: true)
+end
+
+base = Pathname(__dir__) / '../'
+repo = base.join('../../').to_s
+
+sh!('bundle', 'install', chdir: base.join('_rbs_rails'))
+sh!({ 'RAILS_VERSION' => '6.0.3.2', 'RBS_REPO_DIR' => repo }, 'bundle', 'exec', 'rake', chdir: base.join('_rbs_rails'))

--- a/gems/railties/6.0.3.2/patch.rbs
+++ b/gems/railties/6.0.3.2/patch.rbs
@@ -1,0 +1,29 @@
+module Rails
+  class Application < Engine
+    # alias bug: https://github.com/ruby/rbs/issues/458
+    def app: () -> untyped
+  end
+
+  class Engine < Railtie
+    # bug: rbs prototype rb isn't aware of `class << self` for attr_*
+    def self.isolated: () -> untyped
+    def self.isolated=: (untyped) -> untyped
+
+    # alias bug: https://github.com/ruby/rbs/issues/458
+    def self.railtie_name: (?untyped? name) -> untyped
+  end
+
+  module Generators
+    class PluginGenerator < AppBase
+      # alias bug: https://github.com/ruby/rbs/issues/458
+      def app_path: () -> untyped
+    end
+  end
+
+  module Initializable
+    class Collection[T] < Array[T]
+      def each: () -> ::Enumerator[T, self]
+              | () { (T item) -> void } -> self
+    end
+  end
+end

--- a/gems/railties/6.0.3.2/railties-generated.rbs
+++ b/gems/railties/6.0.3.2/railties-generated.rbs
@@ -38,6 +38,8 @@ end
 class RDoc::Generator::API < RDoc::Generator::SDoc
   def generate_class_tree_level: (untyped classes, ?::Hash[untyped, untyped] visited) -> untyped
 
+  private
+
   def build_core_ext_subtree: (untyped classes, untyped visited) -> untyped
 
   def core_extension?: (untyped klass) -> untyped
@@ -84,6 +86,9 @@ end
 
 module Rails
   module AppLoader
+    # :nodoc:
+    extend ::Rails::AppLoader
+
     RUBY: untyped
 
     EXECUTABLES: ::Array[untyped]
@@ -101,6 +106,8 @@ module Rails
     def self.invoke_from_app_generator: (untyped method) -> untyped
 
     def self.app_generator: () -> untyped
+
+    private
 
     def self.generator_options: () -> untyped
   end
@@ -247,6 +254,8 @@ module Rails
         def respond_to_missing?: (untyped symbol) -> ::TrueClass
       end
 
+      private
+
       def default_credentials_content_path: () -> untyped
 
       def default_credentials_key_path: () -> untyped
@@ -268,6 +277,8 @@ module Rails
       def initialize: (untyped app, untyped config, untyped paths) -> untyped
 
       def build_stack: () -> untyped
+
+      private
 
       def load_rack_cache: () -> (nil | untyped)
 
@@ -323,6 +334,8 @@ module Rails
       def initialize: () -> untyped
 
       def reload!: () -> untyped
+
+      private
 
       def updater: () -> untyped
 
@@ -618,6 +631,8 @@ module Rails
 
     def validate_secret_key_base: (untyped secret_key_base) -> untyped
 
+    private
+
     def generate_development_secret: () -> untyped
 
     def build_request: (untyped env) -> untyped
@@ -630,6 +645,8 @@ module Rails
 
       def []=: (untyped key, untyped value) -> untyped
 
+      private
+
       def convert_key: (untyped key) -> untyped
 
       def convert_value: (untyped value, ?::Hash[untyped, untyped] options) -> untyped
@@ -638,6 +655,8 @@ module Rails
 end
 
 class Rails::ApplicationController < ActionController::Base
+  private
+
   def require_local!: () -> untyped
 
   def local_request?: () -> untyped
@@ -689,6 +708,8 @@ class CodeStatistics
 
   def to_s: () -> untyped
 
+  private
+
   def calculate_statistics: () -> untyped
 
   def calculate_directory_statistics: (untyped directory, ?untyped pattern) -> untyped
@@ -732,6 +753,8 @@ class CodeStatisticsCalculator
   def add_by_file_path: (untyped file_path) -> untyped
 
   def add_by_io: (untyped io, untyped file_type) -> untyped
+
+  private
 
   def file_type: (untyped file_path) -> untyped
 end
@@ -814,6 +837,8 @@ module Rails
       # would return <tt>rails/test</tt>.
       def self.default_command_root: () -> untyped
 
+      private
+
       # Allow the command method to be called perform.
       def self.create_command: (untyped meth) -> untyped
 
@@ -841,6 +866,8 @@ module Rails
         # Track all command subclasses.
         def subclasses: () -> untyped
 
+        private
+
         # Prints a list of generators.
         def print_list: (untyped base, untyped namespaces) -> (nil | untyped)
 
@@ -866,6 +893,8 @@ module Rails
       # nodoc:
       extend ActiveSupport::Concern
 
+      private
+
       def extract_environment_option_from_argument: (?default_environment: untyped default_environment) -> untyped
 
       def acceptable_environment: (?untyped? env) -> untyped
@@ -879,6 +908,8 @@ module Rails
   module Command
     module Helpers
       module Editor
+        private
+
         def ensure_editor_available: (command: untyped command) -> untyped
 
         def catch_editing_exceptions: () { () -> untyped } -> untyped
@@ -891,6 +922,8 @@ module Rails
   module Command
     module Spellchecker
       def self.suggest: (untyped word, from: untyped from) -> untyped
+
+      private
 
       def self.levenshtein_distance: (untyped str1, untyped str2) -> untyped
     end
@@ -918,6 +951,8 @@ module Rails
     def self.root: () -> untyped
 
     def self.print_commands: () -> untyped
+
+    private
 
     COMMANDS_IN_USAGE: ::Array[untyped]
 
@@ -1003,6 +1038,8 @@ module Rails
 
       def show: () -> untyped
 
+      private
+
       def credentials: () -> untyped
 
       def ensure_encryption_key_has_been_added: () -> untyped
@@ -1052,6 +1089,8 @@ module Rails
 
     def database: () -> untyped
 
+    private
+
     def configurations: () -> untyped
 
     def find_cmd_and_exec: (untyped commands, *untyped args) -> untyped
@@ -1098,6 +1137,8 @@ module Rails
       def edit: (untyped file_path) -> untyped
 
       def show: (untyped file_path) -> untyped
+
+      private
 
       def ensure_encryption_key_has_been_added: (untyped key_path) -> untyped
 
@@ -1158,6 +1199,8 @@ module Rails
     class NotesCommand < Base
       def perform: () -> untyped
 
+      private
+
       def display_annotations: () -> untyped
 
       def directories: () -> untyped
@@ -1178,6 +1221,8 @@ module Rails
 
       def perform: (?untyped? `type`, *untyped plugin_args) -> untyped
 
+      private
+
       def run_plugin_generator: (untyped plugin_args) -> untyped
     end
   end
@@ -1193,6 +1238,8 @@ module Rails
 
       def self.perform: (untyped task) -> untyped
 
+      private
+
       def self.rake_tasks: () -> untyped
 
       def self.formatted_rake_tasks: () -> untyped
@@ -1206,6 +1253,8 @@ module Rails
   module Command
     class RoutesCommand < Base
       def perform: () -> untyped
+
+      private
 
       def inspector: () -> ActionDispatch::Routing::RoutesInspector
 
@@ -1242,6 +1291,8 @@ module Rails
 
       def show: () -> untyped
 
+      private
+
       def deprecate_in_favor_of_credentials_and_exit: () -> untyped
     end
   end
@@ -1268,6 +1319,8 @@ module Rails
     def default_options: () -> untyped
 
     def served_url: () -> untyped
+
+    private
 
     def setup_dev_caching: () -> untyped
 
@@ -1296,6 +1349,8 @@ module Rails
       def perform: () -> untyped
 
       def server_options: () -> { user_supplied_options: untyped, server: untyped, :log_stdout => untyped, Port: untyped, Host: untyped, DoNotReverseLookup: ::TrueClass, config: untyped, environment: untyped, daemonize: untyped, pid: untyped, caching: untyped, restart_cmd: untyped, early_hints: untyped }
+
+      private
 
       def user_supplied_options: () -> untyped
 
@@ -1468,6 +1523,8 @@ module Rails
     def self.enable_by_file: () -> untyped
 
     def self.enable_by_argument: (untyped caching) -> untyped
+
+    private
 
     def self.create_cache_file: () -> untyped
 
@@ -1963,6 +2020,8 @@ module Rails
 
     def run_tasks_blocks: () -> untyped
 
+    private
+
     def load_config_initializer: (untyped initializer) -> untyped
 
     def with_inline_jobs: () { () -> untyped } -> untyped
@@ -2020,6 +2079,8 @@ module Rails
         def existing_migration: () -> untyped
 
         alias exists? existing_migration
+
+        private
 
         def on_conflict_behavior: () { () -> untyped } -> untyped
 
@@ -2171,6 +2232,8 @@ module Rails
       #   readme "README"
       def readme: (untyped path) -> untyped
 
+      private
+
       def log: (*untyped args) -> untyped
 
       def execute_command: (untyped executor, untyped command, ?::Hash[untyped, untyped] options) -> untyped
@@ -2262,6 +2325,8 @@ module Rails
       def self.add_shared_options_for: (untyped name) -> untyped
 
       def initialize: (*untyped args) -> untyped
+
+      private
 
       def gemfile_entry: (untyped name, *untyped args) -> untyped
 
@@ -2364,6 +2429,8 @@ module Rails
     module AppName
       # :nodoc:
       RESERVED_NAMES: ::Array[untyped]
+
+      private
 
       def app_name: () -> untyped
 
@@ -2543,6 +2610,8 @@ module Rails
 
       def self.inherited: (untyped base) -> untyped
 
+      private
+
       # Check whether the given class names are already taken by user
       # application or Ruby on Rails.
       def class_collisions: (*untyped class_names) -> (nil | untyped)
@@ -2621,6 +2690,8 @@ module Rails
 
       def convert_database_option_for_jruby: () -> untyped
 
+      private
+
       def mysql_socket: () -> untyped
     end
   end
@@ -2638,6 +2709,8 @@ module Erb
   module Generators
     class MailerGenerator < Base
       def copy_view_files: () -> untyped
+
+      private
 
       def formats: () -> ::Array[:text | :html]
 
@@ -2658,6 +2731,8 @@ module Erb
 
       def copy_view_files: () -> untyped
 
+      private
+
       def available_views: () -> ::Array["index" | "edit" | "show" | "new" | "_form"]
     end
   end
@@ -2666,6 +2741,8 @@ end
 module Erb
   module Generators
     class Base < Rails::Generators::NamedBase
+      private
+
       def formats: () -> ::Array[untyped]
 
       def format: () -> :html
@@ -2696,6 +2773,8 @@ module Rails
       def self.parse: (untyped column_definition) -> untyped
 
       def self.reference?: (untyped `type`) -> untyped
+
+      private
 
       # parse possible attribute options like :limit for string/text/binary/integer, :precision/:scale for decimals or :polymorphic for references/belongs_to
       # when declaring options curly brackets should be used
@@ -2816,6 +2895,8 @@ module Rails
 
       def js_template: (untyped source, untyped destination) -> untyped
 
+      private
+
       attr_reader file_name: untyped
 
       def singular_name: () -> untyped
@@ -2896,6 +2977,8 @@ module Rails
     attr_reader options: untyped
 
     def initialize: (untyped generator) -> untyped
+
+    private
 
     def method_missing: (untyped meth, *untyped args) { () -> untyped } -> untyped
   end
@@ -3054,6 +3137,8 @@ module Rails
 
       def self.banner: () -> ::String
 
+      private
+
       # Define file as an alias to create_file for backwards compatibility.
       def file: (*untyped args) { () -> untyped } -> untyped
 
@@ -3076,6 +3161,8 @@ module Rails
       def prepare!: () -> untyped
 
       def self.default_rc_file: () -> untyped
+
+      private
 
       def handle_version_request!: (untyped argument) -> untyped
 
@@ -3102,6 +3189,8 @@ end
 module Rails
   module Generators
     class AssetsGenerator < NamedBase
+      private
+
       def asset_name: () -> untyped
     end
   end
@@ -3113,6 +3202,8 @@ module Rails
       def create_controller_files: () -> untyped
 
       def add_routes: () -> (nil | untyped)
+
+      private
 
       def file_name: () -> untyped
 
@@ -3140,6 +3231,8 @@ module Rails
 
       def add_credentials_file_silently: (?untyped? template) -> untyped
 
+      private
+
       def credentials: () -> ActiveSupport::EncryptedConfiguration
 
       def credentials_template: () -> ::String
@@ -3165,6 +3258,8 @@ module Rails
 
           def edit_gemfile: () -> untyped
 
+          private
+
           def all_database_gems: () -> untyped
 
           def all_database_gems_regex: () -> ::Regexp
@@ -3184,6 +3279,8 @@ module Rails
       # :nodoc:
       def add_encrypted_file_silently: (untyped file_path, untyped key_path, ?untyped template) -> untyped
 
+      private
+
       def encrypted_file_template: () -> ::String
     end
   end
@@ -3201,6 +3298,8 @@ module Rails
 
       def ignore_key_file_silently: (untyped key_path, ?ignore: untyped ignore) -> untyped
 
+      private
+
       def key_ignore: (untyped key_path) -> untyped
     end
   end
@@ -3211,6 +3310,8 @@ module Rails
     class GeneratorGenerator < NamedBase
       def create_generator_files: () -> untyped
 
+      private
+
       def generator_dir: () -> untyped
     end
   end
@@ -3220,6 +3321,8 @@ module Rails
   module Generators
     class HelperGenerator < NamedBase
       def create_helper_files: () -> untyped
+
+      private
 
       def file_name: () -> untyped
     end
@@ -3246,6 +3349,8 @@ module Rails
       def ignore_master_key_file: () -> untyped
 
       def ignore_master_key_file_silently: () -> untyped
+
+      private
 
       def key_file_generator: () -> EncryptionKeyFileGenerator
 
@@ -3352,6 +3457,8 @@ module Rails
 
       def namespaced_name: () -> untyped
 
+      private
+
       def create_dummy_app: (?untyped? path) -> untyped
 
       def engine?: () -> untyped
@@ -3452,6 +3559,8 @@ module Rails
 
       def create_controller_files: () -> untyped
 
+      private
+
       def permitted_params: () -> untyped
 
       def attachments?: (untyped name) -> untyped
@@ -3480,6 +3589,8 @@ module Rails
       def self.included: (untyped base) -> untyped
 
       def initialize: (*untyped args) -> untyped
+
+      private
 
       attr_reader controller_name: untyped
 
@@ -3549,6 +3660,8 @@ module TestUnit
     class GeneratorGenerator < Base
       def create_generator_files: () -> untyped
 
+      private
+
       def generator_path: () -> untyped
     end
   end
@@ -3566,6 +3679,8 @@ module TestUnit
     class IntegrationGenerator < Base
       def create_test_files: () -> untyped
 
+      private
+
       def file_name: () -> untyped
     end
   end
@@ -3575,6 +3690,8 @@ module TestUnit
   module Generators
     class JobGenerator < Base
       def create_test_file: () -> untyped
+
+      private
 
       def file_name: () -> untyped
     end
@@ -3589,6 +3706,8 @@ module TestUnit
       def create_test_files: () -> untyped
 
       def create_preview_files: () -> untyped
+
+      private
 
       def file_name: () -> untyped
     end
@@ -3606,6 +3725,8 @@ module TestUnit
       def create_test_file: () -> untyped
 
       def create_fixture_file: () -> untyped
+
+      private
 
       def yaml_key_value: (untyped key, untyped value) -> untyped
     end
@@ -3632,6 +3753,8 @@ module TestUnit
 
       def fixture_name: () -> untyped
 
+      private
+
       def attributes_string: () -> untyped
 
       def attributes_hash: () -> (::Hash[untyped, untyped] | untyped)
@@ -3647,6 +3770,8 @@ module TestUnit
   module Generators
     class SystemGenerator < Base
       def create_test_files: () -> untyped
+
+      private
 
       def file_name: () -> untyped
     end
@@ -3804,6 +3929,8 @@ module Rails
         #   create_generated_attribute(:string, 'name')
         def create_generated_attribute: (untyped attribute_type, ?::String name, ?untyped? index) -> untyped
 
+        private
+
         def destination_root_is_set?: () -> untyped
 
         def ensure_current_path: () -> untyped
@@ -3894,6 +4021,8 @@ module Rails
     # commands.
     def self.invoke: (untyped namespace, ?untyped args, ?::Hash[untyped, untyped] config) -> untyped
 
+    private
+
     def self.print_list: (untyped base, untyped namespaces) -> untyped
 
     # Try fallbacks for the given base.
@@ -3933,6 +4062,8 @@ class Rails::InfoController < Rails::ApplicationController
   def properties: () -> untyped
 
   def routes: () -> untyped
+
+  private
 
   def match_route: () { (untyped) -> untyped } -> untyped
 
@@ -3993,6 +4124,8 @@ class Rails::MailersController < Rails::ApplicationController
   def index: () -> untyped
 
   def preview: () -> untyped
+
+  private
 
   def show_previews?: () -> untyped
 
@@ -4079,6 +4212,8 @@ module Rails
 
       def load_paths: () -> untyped
 
+      private
+
       def filter_by: () { (untyped) -> untyped } -> untyped
     end
 
@@ -4121,6 +4256,8 @@ module Rails
 
       alias to_a expanded
 
+      private
+
       def files_in: (untyped path) -> untyped
     end
   end
@@ -4137,6 +4274,8 @@ module Rails
       def initialize: (untyped app, ?untyped? taggers) -> untyped
 
       def call: (untyped env) -> untyped
+
+      private
 
       def call_app: (untyped request, untyped env) -> untyped
 
@@ -4169,6 +4308,8 @@ module Rails
         def respond_to?: (*untyped args) -> untyped
 
         def configure: () { () -> untyped } -> untyped
+
+        private
 
         def method_missing: (*untyped args) { () -> untyped } -> untyped
       end
@@ -4228,6 +4369,8 @@ module Rails
       def to_prepare: () { () -> untyped } -> untyped
 
       def respond_to?: (untyped name, ?bool include_private) -> untyped
+
+      private
 
       def method_missing: (untyped name, *untyped args) { () -> untyped } -> untyped
     end
@@ -4374,6 +4517,8 @@ module Rails
     # subclasses of Railtie so we provide the class method here.
     def self.configure: () { () -> untyped } -> untyped
 
+    private
+
     def self.generate_railtie_name: (untyped string) -> untyped
 
     def self.respond_to_missing?: (untyped name, untyped _) -> untyped
@@ -4434,6 +4579,8 @@ module Rails
     def self.write: (untyped contents) -> untyped
 
     def self.read_for_editing: () { () -> untyped } -> untyped
+
+    private
 
     def self.handle_missing_key: () -> untyped
 
@@ -4564,6 +4711,8 @@ module Rails
 
     def relative_path_for: (untyped file) -> untyped
 
+    private
+
     def output_inline?: () -> untyped
 
     def fail_fast?: () -> untyped
@@ -4597,6 +4746,8 @@ module Rails
 
       def self.compose_filter: (untyped runnable, untyped filter) -> untyped
 
+      private
+
       def self.extract_filters: (untyped argv) -> untyped
     end
 
@@ -4609,6 +4760,8 @@ module Rails
       # minitest uses === to find matching filters.
       def ===: (untyped method) -> untyped
 
+      private
+
       def derive_named_filter: (untyped filter) -> untyped
 
       def derive_line_filters: (untyped patterns) -> untyped
@@ -4619,6 +4772,8 @@ module Rails
       def initialize: (untyped runnable, untyped file, untyped line) -> untyped
 
       def ===: (untyped method) -> (nil | untyped)
+
+      private
 
       def definition_for: (untyped method) -> untyped
     end

--- a/gems/railties/6.0.3.2/railties-generated.rbs
+++ b/gems/railties/6.0.3.2/railties-generated.rbs
@@ -1,3 +1,27 @@
+# The generated code is based on Ruby on Rails source code
+# You can find the license of Ruby on Rails from following.
+
+#Copyright (c) 2005-2019 David Heinemeier Hansson
+#
+#Permission is hereby granted, free of charge, to any person obtaining
+#a copy of this software and associated documentation files (the
+#"Software"), to deal in the Software without restriction, including
+#without limitation the rights to use, copy, modify, merge, publish,
+#distribute, sublicense, and/or sell copies of the Software, and to
+#permit persons to whom the Software is furnished to do so, subject to
+#the following conditions:
+#
+#The above copyright notice and this permission notice shall be
+#included in all copies or substantial portions of the Software.
+#
+#THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+#EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+#MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+#LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+#OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+#WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 module Minitest
   class SuppressedSummaryReporter < SummaryReporter
     # Disable extra failure output after a run if output is inline.

--- a/gems/railties/6.0.3.2/railties-generated.rbs
+++ b/gems/railties/6.0.3.2/railties-generated.rbs
@@ -1,0 +1,4680 @@
+module Minitest
+  class SuppressedSummaryReporter < SummaryReporter
+    # Disable extra failure output after a run if output is inline.
+    def aggregated_results: () -> untyped
+  end
+
+  def self.plugin_rails_options: (untyped opts, untyped options) -> untyped
+
+  # Owes great inspiration to test runner trailblazers like RSpec,
+  # minitest-reporters, maxitest and others.
+  def self.plugin_rails_init: (untyped options) -> untyped
+end
+
+class RDoc::Generator::API < RDoc::Generator::SDoc
+  def generate_class_tree_level: (untyped classes, ?::Hash[untyped, untyped] visited) -> untyped
+
+  def build_core_ext_subtree: (untyped classes, untyped visited) -> untyped
+
+  def core_extension?: (untyped klass) -> untyped
+
+  def active_storage?: (untyped klass) -> untyped
+end
+
+module Rails
+  module API
+    class Task < RDoc::Task
+      RDOC_FILES: ::Hash[untyped, untyped]
+
+      def initialize: (untyped name) -> untyped
+
+      # Hack, ignore the desc calls performed by the original initializer.
+      def desc: (untyped description) -> nil
+
+      def configure_sdoc: () -> untyped
+
+      def configure_rdoc_files: () -> untyped
+
+      def setup_horo_variables: () -> untyped
+
+      def api_main: () -> untyped
+    end
+
+    class RepoTask < Task
+      def configure_sdoc: () -> untyped
+
+      def component_root_dir: (untyped component) -> untyped
+
+      def api_dir: () -> "doc/rdoc"
+    end
+
+    class EdgeTask < RepoTask
+      def rails_version: () -> ::String
+    end
+
+    class StableTask < RepoTask
+      def rails_version: () -> untyped
+    end
+  end
+end
+
+module Rails
+  module AppLoader
+    RUBY: untyped
+
+    EXECUTABLES: ::Array[untyped]
+
+    BUNDLER_WARNING: ::String
+
+    def exec_app: () -> (nil | untyped)
+
+    def find_executable: () -> untyped
+  end
+end
+
+module Rails
+  class AppUpdater
+    def self.invoke_from_app_generator: (untyped method) -> untyped
+
+    def self.app_generator: () -> untyped
+
+    def self.generator_options: () -> untyped
+  end
+end
+
+module Rails
+  class Application
+    module Bootstrap
+      include Initializable
+    end
+  end
+end
+
+module Rails
+  class Application
+    class Configuration < ::Rails::Engine::Configuration
+      attr_accessor allow_concurrency: untyped
+
+      attr_accessor asset_host: untyped
+
+      attr_accessor autoflush_log: untyped
+
+      attr_accessor cache_classes: untyped
+
+      attr_accessor cache_store: untyped
+
+      attr_accessor consider_all_requests_local: untyped
+
+      attr_accessor console: untyped
+
+      attr_accessor eager_load: untyped
+
+      attr_accessor exceptions_app: untyped
+
+      attr_accessor file_watcher: untyped
+
+      attr_accessor filter_parameters: untyped
+
+      attr_accessor force_ssl: untyped
+
+      attr_accessor helpers_paths: untyped
+
+      attr_accessor hosts: untyped
+
+      attr_accessor logger: untyped
+
+      attr_accessor log_formatter: untyped
+
+      attr_accessor log_tags: untyped
+
+      attr_accessor railties_order: untyped
+
+      attr_accessor relative_url_root: untyped
+
+      attr_accessor secret_key_base: untyped
+
+      attr_accessor ssl_options: untyped
+
+      attr_accessor public_file_server: untyped
+
+      attr_accessor session_options: untyped
+
+      attr_accessor time_zone: untyped
+
+      attr_accessor reload_classes_only_on_change: untyped
+
+      attr_accessor beginning_of_week: untyped
+
+      attr_accessor filter_redirect: untyped
+
+      attr_accessor x: untyped
+
+      attr_accessor enable_dependency_loading: untyped
+
+      attr_accessor read_encrypted_secrets: untyped
+
+      attr_accessor log_level: untyped
+
+      attr_accessor content_security_policy_report_only: untyped
+
+      attr_accessor content_security_policy_nonce_generator: untyped
+
+      attr_accessor content_security_policy_nonce_directives: untyped
+
+      attr_accessor require_master_key: untyped
+
+      attr_accessor credentials: untyped
+
+      attr_accessor disable_sandbox: untyped
+
+      attr_accessor add_autoload_paths_to_load_path: untyped
+
+      attr_reader encoding: untyped
+
+      attr_reader api_only: untyped
+
+      attr_reader loaded_config_version: untyped
+
+      attr_reader autoloader: untyped
+
+      def initialize: () -> untyped
+
+      # Loads default configurations. See {the result of the method for each version}[https://guides.rubyonrails.org/configuring.html#results-of-config-load-defaults].
+      def load_defaults: (untyped target_version) -> untyped
+
+      def encoding=: (untyped value) -> untyped
+
+      def api_only=: (untyped value) -> untyped
+
+      def debug_exception_response_format: () -> untyped
+
+      attr_writer debug_exception_response_format: untyped
+
+      def paths: () -> untyped
+
+      def load_database_yaml: () -> untyped
+
+      # Loads and returns the entire raw configuration of database from
+      # values stored in <tt>config/database.yml</tt>.
+      def database_configuration: () -> untyped
+
+      def colorize_logging: () -> untyped
+
+      def colorize_logging=: (untyped val) -> untyped
+
+      def session_store: (?untyped? new_session_store, **untyped options) -> untyped
+
+      def session_store?: () -> untyped
+
+      def annotations: () -> untyped
+
+      def content_security_policy: () { () -> untyped } -> untyped
+
+      def autoloader=: (untyped autoloader) -> untyped
+
+      def default_log_file: () -> untyped
+
+      class Custom
+        # nodoc:
+        def initialize: () -> untyped
+
+        def method_missing: (untyped method, *untyped args) -> untyped
+
+        def respond_to_missing?: (untyped symbol) -> ::TrueClass
+      end
+
+      def default_credentials_content_path: () -> untyped
+
+      def default_credentials_key_path: () -> untyped
+
+      def credentials_available_for_current_env?: () -> untyped
+    end
+  end
+end
+
+module Rails
+  class Application
+    class DefaultMiddlewareStack
+      attr_reader config: untyped
+
+      attr_reader paths: untyped
+
+      attr_reader app: untyped
+
+      def initialize: (untyped app, untyped config, untyped paths) -> untyped
+
+      def build_stack: () -> untyped
+
+      def load_rack_cache: () -> (nil | untyped)
+
+      def show_exceptions_app: () -> untyped
+    end
+  end
+end
+
+class DummyERB < ERB
+  # These classes are used to strip out the ERB configuration
+  # values so we can evaluate the database.yml without evaluating
+  # the ERB values.
+  # :nodoc:
+  def make_compiler: (untyped trim_mode) -> DummyCompiler
+end
+
+class DummyCompiler < ERB::Compiler
+  # :nodoc:
+  def compile_content: (untyped stag, untyped `out`) -> untyped
+end
+
+module Rails
+  class Application
+    module Finisher
+      include Initializable
+
+      class MutexHook
+        def initialize: (?untyped mutex) -> untyped
+
+        def run: () -> untyped
+
+        def complete: (untyped _state) -> untyped
+      end
+
+      module InterlockHook
+        def self.run: () -> untyped
+
+        def self.complete: (untyped _state) -> untyped
+      end
+    end
+  end
+end
+
+module Rails
+  class Application
+    class RoutesReloader
+      attr_reader route_sets: untyped
+
+      attr_reader paths: untyped
+
+      attr_accessor eager_load: untyped
+
+      def initialize: () -> untyped
+
+      def reload!: () -> untyped
+
+      def updater: () -> untyped
+
+      def clear!: () -> untyped
+
+      def load_paths: () -> untyped
+
+      def finalize!: () -> untyped
+
+      def revert: () -> untyped
+    end
+  end
+end
+
+module Rails
+  # An Engine with the responsibility of coordinating the whole boot process.
+  #
+  # == Initialization
+  #
+  # Rails::Application is responsible for executing all railties and engines
+  # initializers. It also executes some bootstrap initializers (check
+  # Rails::Application::Bootstrap) and finishing initializers, after all the others
+  # are executed (check Rails::Application::Finisher).
+  #
+  # == Configuration
+  #
+  # Besides providing the same configuration as Rails::Engine and Rails::Railtie,
+  # the application object has several specific configurations, for example
+  # "cache_classes", "consider_all_requests_local", "filter_parameters",
+  # "logger" and so forth.
+  #
+  # Check Rails::Application::Configuration to see them all.
+  #
+  # == Routes
+  #
+  # The application object is also responsible for holding the routes and reloading routes
+  # whenever the files change in development.
+  #
+  # == Middlewares
+  #
+  # The Application is also responsible for building the middleware stack.
+  #
+  # == Booting process
+  #
+  # The application is also responsible for setting up and executing the booting
+  # process. From the moment you require "config/application.rb" in your app,
+  # the booting process goes like this:
+  #
+  #   1)  require "config/boot.rb" to setup load paths
+  #   2)  require railties and engines
+  #   3)  Define Rails.application as "class MyApp::Application < Rails::Application"
+  #   4)  Run config.before_configuration callbacks
+  #   5)  Load config/environments/ENV.rb
+  #   6)  Run config.before_initialize callbacks
+  #   7)  Run Railtie#initializer defined by railties, engines and application.
+  #       One by one, each engine sets up its load paths, routes and runs its config/initializers/* files.
+  #   8)  Custom Railtie#initializers added by railties, engines and applications are executed
+  #   9)  Build the middleware stack and run to_prepare callbacks
+  #   10) Run config.before_eager_load and eager_load! if eager_load is true
+  #   11) Run config.after_initialize callbacks
+  #
+  # == Multiple Applications
+  #
+  # If you decide to define multiple applications, then the first application
+  # that is initialized will be set to +Rails.application+, unless you override
+  # it with a different application.
+  #
+  # To create a new application, you can instantiate a new instance of a class
+  # that has already been created:
+  #
+  #   class Application < Rails::Application
+  #   end
+  #
+  #   first_application  = Application.new
+  #   second_application = Application.new(config: first_application.config)
+  #
+  # In the above example, the configuration from the first application was used
+  # to initialize the second application. You can also use the +initialize_copy+
+  # on one of the applications to create a copy of the application which shares
+  # the configuration.
+  #
+  # If you decide to define Rake tasks, runners, or initializers in an
+  # application other than +Rails.application+, then you must run them manually.
+  class Application < Engine
+    def self.inherited: (untyped base) -> untyped
+
+    def self.`instance`: () -> untyped
+
+    def self.create: (?::Hash[untyped, untyped] initial_variable_values) { () -> untyped } -> untyped
+
+    def self.find_root: (untyped from) -> untyped
+
+    attr_accessor assets: untyped
+
+    attr_accessor sandbox: untyped
+
+    alias sandbox? sandbox
+
+    attr_reader reloaders: untyped
+
+    attr_reader reloader: untyped
+
+    attr_reader executor: untyped
+
+    INITIAL_VARIABLES: ::Array[untyped]
+
+    def initialize: (?::Hash[untyped, untyped] initial_variable_values) { () -> untyped } -> untyped
+
+    # Returns true if the application is initialized.
+    def initialized?: () -> untyped
+
+    def run_load_hooks!: () -> untyped
+
+    # Reload application routes regardless if they changed or not.
+    def reload_routes!: () -> untyped
+
+    # Returns the application's KeyGenerator
+    def key_generator: () -> untyped
+
+    # Returns a message verifier object.
+    #
+    # This verifier can be used to generate and verify signed messages in the application.
+    #
+    # It is recommended not to use the same verifier for different things, so you can get different
+    # verifiers passing the +verifier_name+ argument.
+    #
+    # ==== Parameters
+    #
+    # * +verifier_name+ - the name of the message verifier.
+    #
+    # ==== Examples
+    #
+    #     message = Rails.application.message_verifier('sensitive_data').generate('my sensible data')
+    #     Rails.application.message_verifier('sensitive_data').verify(message)
+    #     # => 'my sensible data'
+    #
+    # See the +ActiveSupport::MessageVerifier+ documentation for more information.
+    def message_verifier: (untyped verifier_name) -> untyped
+
+    # Convenience for loading config/foo.yml for the current Rails env.
+    #
+    # Example:
+    #
+    #     # config/exception_notification.yml:
+    #     production:
+    #       url: http://127.0.0.1:8080
+    #       namespace: my_app_production
+    #     development:
+    #       url: http://localhost:3001
+    #       namespace: my_app_development
+    #
+    #     # config/environments/production.rb
+    #     Rails.application.configure do
+    #       config.middleware.use ExceptionNotifier, config_for(:exception_notification)
+    #     end
+    def config_for: (untyped name, ?env: untyped env) -> untyped
+
+    # Stores some of the Rails initial environment parameters which
+    # will be used by middlewares and engines to configure themselves.
+    def env_config: () -> untyped
+
+    # If you try to define a set of Rake tasks on the instance, these will get
+    # passed up to the Rake tasks defined on the application's class.
+    def rake_tasks: () { () -> untyped } -> untyped
+
+    # Sends the initializers to the +initializer+ method defined in the
+    # Rails::Initializable module. Each Rails::Application class has its own
+    # set of initializers, as defined by the Initializable module.
+    def initializer: (untyped name, ?::Hash[untyped, untyped] opts) { () -> untyped } -> untyped
+
+    # Sends any runner called in the instance of a new application up
+    # to the +runner+ method defined in Rails::Railtie.
+    def runner: () { () -> untyped } -> untyped
+
+    # Sends any console called in the instance of a new application up
+    # to the +console+ method defined in Rails::Railtie.
+    def console: () { () -> untyped } -> untyped
+
+    # Sends any generators called in the instance of a new application up
+    # to the +generators+ method defined in Rails::Railtie.
+    def generators: () { () -> untyped } -> untyped
+
+    # Sends the +isolate_namespace+ method up to the class method.
+    def isolate_namespace: (untyped mod) -> untyped
+
+    def self.add_lib_to_load_path!: (untyped root) -> untyped
+
+    def require_environment!: () -> untyped
+
+    def routes_reloader: () -> untyped
+
+    def watchable_args: () -> ::Array[untyped]
+
+    def initialize!: (?::Symbol group) -> untyped
+
+    def initializers: () -> untyped
+
+    def config: () -> untyped
+
+    attr_writer config: untyped
+
+    # Returns secrets added to config/secrets.yml.
+    #
+    # Example:
+    #
+    #     development:
+    #       secret_key_base: 836fa3665997a860728bcb9e9a1e704d427cfc920e79d847d79c8a9a907b9e965defa4154b2b86bdec6930adbe33f21364523a6f6ce363865724549fdfc08553
+    #     test:
+    #       secret_key_base: 5a37811464e7d378488b0f073e2193b093682e4e21f5d6f3ae0a4e1781e61a351fdc878a843424e81c73fb484a40d23f92c8dafac4870e74ede6e5e174423010
+    #     production:
+    #       secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+    #       namespace: my_app_production
+    #
+    # +Rails.application.secrets.namespace+ returns +my_app_production+ in the
+    # production environment.
+    def secrets: () -> untyped
+
+    attr_writer secrets: untyped
+
+    # The secret_key_base is used as the input secret to the application's key generator, which in turn
+    # is used to create all MessageVerifiers/MessageEncryptors, including the ones that sign and encrypt cookies.
+    #
+    # In development and test, this is randomly generated and stored in a
+    # temporary file in <tt>tmp/development_secret.txt</tt>.
+    #
+    # In all other environments, we look for it first in ENV["SECRET_KEY_BASE"],
+    # then credentials.secret_key_base, and finally secrets.secret_key_base. For most applications,
+    # the correct place to store it is in the encrypted credentials file.
+    def secret_key_base: () -> untyped
+
+    # Decrypts the credentials hash as kept in +config/credentials.yml.enc+. This file is encrypted with
+    # the Rails master key, which is either taken from <tt>ENV["RAILS_MASTER_KEY"]</tt> or from loading
+    # +config/master.key+.
+    # If specific credentials file exists for current environment, it takes precedence, thus for +production+
+    # environment look first for +config/credentials/production.yml.enc+ with master key taken
+    # from <tt>ENV["RAILS_MASTER_KEY"]</tt> or from loading +config/credentials/production.key+.
+    # Default behavior can be overwritten by setting +config.credentials.content_path+ and +config.credentials.key_path+.
+    def credentials: () -> untyped
+
+    # Shorthand to decrypt any encrypted configurations or files.
+    #
+    # For any file added with <tt>rails encrypted:edit</tt> call +read+ to decrypt
+    # the file with the master key.
+    # The master key is either stored in +config/master.key+ or <tt>ENV["RAILS_MASTER_KEY"]</tt>.
+    #
+    #   Rails.application.encrypted("config/mystery_man.txt.enc").read
+    #   # => "We've met before, haven't we?"
+    #
+    # It's also possible to interpret encrypted YAML files with +config+.
+    #
+    #   Rails.application.encrypted("config/credentials.yml.enc").config
+    #   # => { next_guys_line: "I don't think so. Where was it you think we met?" }
+    #
+    # Any top-level configs are also accessible directly on the return value:
+    #
+    #   Rails.application.encrypted("config/credentials.yml.enc").next_guys_line
+    #   # => "I don't think so. Where was it you think we met?"
+    #
+    # The files or configs can also be encrypted with a custom key. To decrypt with
+    # a key in the +ENV+, use:
+    #
+    #   Rails.application.encrypted("config/special_tokens.yml.enc", env_key: "SPECIAL_TOKENS")
+    #
+    # Or to decrypt with a file, that should be version control ignored, relative to +Rails.root+:
+    #
+    #   Rails.application.encrypted("config/special_tokens.yml.enc", key_path: "config/special_tokens.key")
+    def encrypted: (untyped path, ?env_key: ::String env_key, ?key_path: ::String key_path) -> ActiveSupport::EncryptedConfiguration
+
+    def to_app: () -> untyped
+
+    def helpers_paths: () -> untyped
+
+    def migration_railties: () -> untyped
+
+    # Eager loads the application code.
+    def eager_load!: () -> untyped
+
+    alias build_middleware_stack app
+
+    def run_tasks_blocks: (untyped app) -> untyped
+
+    def run_generators_blocks: (untyped app) -> untyped
+
+    def run_runner_blocks: (untyped app) -> untyped
+
+    def run_console_blocks: (untyped app) -> untyped
+
+    def ordered_railties: () -> untyped
+
+    def railties_initializers: (untyped current) -> untyped
+
+    def default_middleware_stack: () -> untyped
+
+    def validate_secret_key_base: (untyped secret_key_base) -> untyped
+
+    def generate_development_secret: () -> untyped
+
+    def build_request: (untyped env) -> untyped
+
+    def build_middleware: () -> untyped
+
+    class NonSymbolAccessDeprecatedHash[T, U] < HashWithIndifferentAccess[T, U]
+      # :nodoc:
+      def initialize: (?untyped? value) -> untyped
+
+      def []=: (untyped key, untyped value) -> untyped
+
+      def convert_key: (untyped key) -> untyped
+
+      def convert_value: (untyped value, ?::Hash[untyped, untyped] options) -> untyped
+    end
+  end
+end
+
+class Rails::ApplicationController < ActionController::Base
+  def require_local!: () -> untyped
+
+  def local_request?: () -> untyped
+
+  def disable_content_security_policy_nonce!: () -> untyped
+end
+
+module Rails
+  module Autoloaders
+    include Enumerable[untyped]
+
+    def self.main: () -> untyped
+
+    def self.once: () -> untyped
+
+    def self.each: () { (untyped) -> untyped } -> untyped
+
+    def self.logger=: (untyped logger) -> untyped
+
+    def self.log!: () -> untyped
+
+    def self.zeitwerk_enabled?: () -> untyped
+  end
+end
+
+module Rails
+  class BacktraceCleaner < ActiveSupport::BacktraceCleaner
+    APP_DIRS_PATTERN: untyped
+
+    RENDER_TEMPLATE_PATTERN: untyped
+
+    EMPTY_STRING: ::String
+
+    SLASH: ::String
+
+    DOT_SLASH: ::String
+
+    def initialize: () -> untyped
+  end
+end
+
+class CodeStatistics
+  # nodoc:
+  TEST_TYPES: ::Array[untyped]
+
+  HEADERS: ::Hash[untyped, untyped]
+
+  def initialize: (*untyped pairs) -> untyped
+
+  def to_s: () -> untyped
+
+  def calculate_statistics: () -> untyped
+
+  def calculate_directory_statistics: (untyped directory, ?untyped pattern) -> untyped
+
+  def calculate_total: () -> untyped
+
+  def calculate_code: () -> untyped
+
+  def calculate_tests: () -> untyped
+
+  def width_for: (untyped label) -> untyped
+
+  def print_header: () -> untyped
+
+  def print_splitter: () -> untyped
+
+  def print_line: (untyped name, untyped statistics) -> untyped
+
+  def print_code_test_stats: () -> untyped
+end
+
+class CodeStatisticsCalculator
+  # nodoc:
+  attr_reader lines: untyped
+
+  # nodoc:
+  attr_reader code_lines: untyped
+
+  # nodoc:
+  attr_reader classes: untyped
+
+  # nodoc:
+  attr_reader methods: untyped
+
+  PATTERNS: ::Hash[untyped, untyped]
+
+  def initialize: (?::Integer lines, ?::Integer code_lines, ?::Integer classes, ?::Integer methods) -> untyped
+
+  def add: (untyped code_statistics_calculator) -> untyped
+
+  def add_by_file_path: (untyped file_path) -> untyped
+
+  def add_by_io: (untyped io, untyped file_type) -> untyped
+
+  def file_type: (untyped file_path) -> untyped
+end
+
+module Rails
+  module Command
+    module Actions
+      # Change to the application's path if there is no <tt>config.ru</tt> file in current directory.
+      # This allows us to run <tt>rails server</tt> from other directories, but still get
+      # the main <tt>config.ru</tt> and properly set the <tt>tmp</tt> directory.
+      def set_application_directory!: () -> untyped
+
+      def require_application_and_environment!: () -> untyped
+
+      def require_application!: () -> untyped
+
+      def require_environment!: () -> untyped
+
+      def load_tasks: () -> untyped
+
+      def load_generators: () -> untyped
+    end
+  end
+end
+
+module Rails
+  module Command
+    class Base < Thor
+      class Error < Thor::Error
+      end
+
+      include Actions
+
+      def self.exit_on_failure?: () -> ::FalseClass
+
+      # Returns true when the app is a Rails engine.
+      def self.engine?: () -> untyped
+
+      # Tries to get the description from a USAGE file one folder above the command
+      # root.
+      def self.desc: (?untyped? usage, ?untyped? description, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Convenience method to get the namespace from the class name. It's the
+      # same as Thor default except that the Command at the end of the class
+      # is removed.
+      def self.namespace: (?untyped? name) -> untyped
+
+      # Convenience method to hide this command from the available ones when
+      # running rails command.
+      def self.hide_command!: () -> untyped
+
+      def self.inherited: (untyped base) -> untyped
+
+      def self.perform: (untyped command, untyped args, untyped config) -> untyped
+
+      def self.printing_commands: () -> untyped
+
+      def self.executable: () -> ::String
+
+      # Use Rails' default banner.
+      def self.banner: () -> untyped
+
+      # Sets the base_name taking into account the current class namespace.
+      #
+      #   Rails::Command::TestCommand.base_name # => 'rails'
+      def self.base_name: () -> untyped
+
+      # Return command name without namespaces.
+      #
+      #   Rails::Command::TestCommand.command_name # => 'test'
+      def self.command_name: () -> untyped
+
+      # Path to lookup a USAGE description in a file.
+      def self.usage_path: () -> untyped
+
+      # Default file root to place extra files a command might need, placed
+      # one folder above the command file.
+      #
+      # For a Rails::Command::TestCommand placed in <tt>rails/command/test_command.rb</tt>
+      # would return <tt>rails/test</tt>.
+      def self.default_command_root: () -> untyped
+
+      # Allow the command method to be called perform.
+      def self.create_command: (untyped meth) -> untyped
+
+      def self.command_root_namespace: () -> untyped
+
+      def self.relative_command_path: () -> untyped
+
+      def self.namespaced_commands: () -> untyped
+
+      def help: () -> untyped
+    end
+  end
+end
+
+module Rails
+  module Command
+    module Behavior
+      # nodoc:
+      extend ActiveSupport::Concern
+
+      module ClassMethods
+        # Remove the color from output.
+        def no_color!: () -> untyped
+
+        # Track all command subclasses.
+        def subclasses: () -> untyped
+
+        # Prints a list of generators.
+        def print_list: (untyped base, untyped namespaces) -> (nil | untyped)
+
+        # Receives namespaces in an array and tries to find matching generators
+        # in the load path.
+        def lookup: (untyped namespaces) -> (nil | untyped)
+
+        # This will try to load any command in the load path to show in help.
+        def lookup!: () -> untyped
+
+        # Convert namespaces to paths by replacing ":" for "/" and adding
+        # an extra lookup. For example, "rails:model" should be searched
+        # in both: "rails/model/model_generator" and "rails/model_generator".
+        def namespaces_to_paths: (untyped namespaces) -> untyped
+      end
+    end
+  end
+end
+
+module Rails
+  module Command
+    module EnvironmentArgument
+      # nodoc:
+      extend ActiveSupport::Concern
+
+      def extract_environment_option_from_argument: (?default_environment: untyped default_environment) -> untyped
+
+      def acceptable_environment: (?untyped? env) -> untyped
+
+      def available_environments: () -> untyped
+    end
+  end
+end
+
+module Rails
+  module Command
+    module Helpers
+      module Editor
+        def ensure_editor_available: (command: untyped command) -> untyped
+
+        def catch_editing_exceptions: () { () -> untyped } -> untyped
+      end
+    end
+  end
+end
+
+module Rails
+  module Command
+    module Spellchecker
+      def self.suggest: (untyped word, from: untyped from) -> untyped
+
+      def self.levenshtein_distance: (untyped str1, untyped str2) -> untyped
+    end
+  end
+end
+
+module Rails
+  module Command
+    extend ActiveSupport::Autoload
+
+    include Behavior
+
+    HELP_MAPPINGS: ::Array[untyped]
+
+    def self.hidden_commands: () -> untyped
+
+    def self.environment: () -> untyped
+
+    # Receives a namespace, arguments and the behavior to invoke the command.
+    def self.invoke: (untyped full_namespace, ?untyped args, **untyped config) -> untyped
+
+    def self.find_by_namespace: (untyped namespace, ?untyped? command_name) -> untyped
+
+    # Returns the root of the Rails engine or app running the command.
+    def self.root: () -> untyped
+
+    def self.print_commands: () -> untyped
+
+    COMMANDS_IN_USAGE: ::Array[untyped]
+
+    def self.commands: () -> untyped
+
+    def self.command_type: () -> untyped
+
+    def self.lookup_paths: () -> untyped
+
+    def self.file_lookup_paths: () -> untyped
+  end
+end
+
+module Rails
+  module Generators
+    class AppGenerator
+      # :nodoc:
+      # We want to exit on failure to be kind to other libraries
+      # This is only when accessing via CLI
+      def self.exit_on_failure?: () -> ::TrueClass
+    end
+  end
+
+  module Command
+    class ApplicationCommand < Base
+      def help: () -> untyped
+
+      def perform: (*untyped args) -> untyped
+    end
+  end
+end
+
+module Rails
+  class Console
+    module BacktraceCleaner
+      def filter_backtrace: (untyped bt) -> untyped
+    end
+
+    def self.start: (*untyped args) -> untyped
+
+    attr_reader options: untyped
+
+    attr_reader app: untyped
+
+    attr_reader console: untyped
+
+    def initialize: (untyped app, ?::Hash[untyped, untyped] options) -> untyped
+
+    def sandbox?: () -> untyped
+
+    def environment: () -> untyped
+
+    alias environment? environment
+
+    def set_environment!: () -> untyped
+
+    def start: () -> untyped
+  end
+
+  module Command
+    class ConsoleCommand < Base
+      # :nodoc:
+      include EnvironmentArgument
+
+      def initialize: (?untyped args, ?::Hash[untyped, untyped] local_options, ?::Hash[untyped, untyped] config) -> untyped
+
+      def perform: () -> untyped
+    end
+  end
+end
+
+module Rails
+  module Command
+    class CredentialsCommand < Rails::Command::Base
+      # :nodoc:
+      include Helpers::Editor
+
+      include EnvironmentArgument
+
+      def help: () -> untyped
+
+      def edit: () -> untyped
+
+      def show: () -> untyped
+
+      def credentials: () -> untyped
+
+      def ensure_encryption_key_has_been_added: () -> untyped
+
+      def ensure_credentials_have_been_added: () -> untyped
+
+      def change_credentials_in_system_editor: () -> untyped
+
+      def missing_credentials_message: () -> untyped
+
+      def content_path: () -> untyped
+
+      def key_path: () -> untyped
+
+      def encryption_key_file_generator: () -> Rails::Generators::EncryptionKeyFileGenerator
+
+      def encrypted_file_generator: () -> Rails::Generators::EncryptedFileGenerator
+
+      def credentials_generator: () -> Rails::Generators::CredentialsGenerator
+    end
+  end
+end
+
+module Rails
+  module Command
+    module Db
+      module System
+        class ChangeCommand < Base
+          def perform: () -> untyped
+        end
+      end
+    end
+  end
+end
+
+module Rails
+  class DBConsole
+    def self.start: (*untyped args) -> untyped
+
+    def initialize: (?::Hash[untyped, untyped] options) -> untyped
+
+    def start: () -> untyped
+
+    def config: () -> untyped
+
+    def environment: () -> untyped
+
+    def database: () -> untyped
+
+    def configurations: () -> untyped
+
+    def find_cmd_and_exec: (untyped commands, *untyped args) -> untyped
+  end
+
+  module Command
+    class DbconsoleCommand < Base
+      # :nodoc:
+      include EnvironmentArgument
+
+      def perform: () -> untyped
+    end
+  end
+end
+
+module Rails
+  module Command
+    class DestroyCommand < Base
+      def help: () -> untyped
+
+      def perform: () -> untyped
+    end
+  end
+end
+
+module Rails
+  module Command
+    class DevCommand < Base
+      def help: () -> untyped
+
+      def cache: () -> untyped
+    end
+  end
+end
+
+module Rails
+  module Command
+    class EncryptedCommand < Rails::Command::Base
+      # :nodoc:
+      include Helpers::Editor
+
+      def help: () -> untyped
+
+      def edit: (untyped file_path) -> untyped
+
+      def show: (untyped file_path) -> untyped
+
+      def ensure_encryption_key_has_been_added: (untyped key_path) -> untyped
+
+      def ensure_encrypted_file_has_been_added: (untyped file_path, untyped key_path) -> untyped
+
+      def change_encrypted_file_in_system_editor: (untyped file_path, untyped key_path) -> untyped
+
+      def encryption_key_file_generator: () -> Rails::Generators::EncryptionKeyFileGenerator
+
+      def encrypted_file_generator: () -> Rails::Generators::EncryptedFileGenerator
+
+      def missing_encrypted_message: (file_path: untyped file_path, key_path: untyped key_path, key: untyped key) -> untyped
+    end
+  end
+end
+
+module Rails
+  module Command
+    class GenerateCommand < Base
+      def help: () -> untyped
+
+      def perform: () -> untyped
+    end
+  end
+end
+
+module Rails
+  module Command
+    class HelpCommand < Base
+      def help: () -> untyped
+    end
+  end
+end
+
+module Rails
+  module Command
+    class InitializersCommand < Base
+      # :nodoc:
+      include EnvironmentArgument
+
+      def perform: () -> untyped
+    end
+  end
+end
+
+module Rails
+  module Command
+    class NewCommand < Base
+      def help: () -> untyped
+
+      def perform: () -> untyped
+    end
+  end
+end
+
+module Rails
+  module Command
+    class NotesCommand < Base
+      def perform: () -> untyped
+
+      def display_annotations: () -> untyped
+
+      def directories: () -> untyped
+
+      def deprecation_warning: () -> (nil | untyped)
+
+      def source_annotation_directories: () -> untyped
+    end
+  end
+end
+
+module Rails
+  module Command
+    class PluginCommand < Base
+      def help: () -> untyped
+
+      def self.banner: () -> ::String
+
+      def perform: (?untyped? `type`, *untyped plugin_args) -> untyped
+
+      def run_plugin_generator: (untyped plugin_args) -> untyped
+    end
+  end
+end
+
+module Rails
+  module Command
+    class RakeCommand < Base
+      # :nodoc:
+      extend Rails::Command::Actions
+
+      def self.printing_commands: () -> untyped
+
+      def self.perform: (untyped task) -> untyped
+
+      def self.rake_tasks: () -> untyped
+
+      def self.formatted_rake_tasks: () -> untyped
+
+      def self.require_rake: () -> untyped
+    end
+  end
+end
+
+module Rails
+  module Command
+    class RoutesCommand < Base
+      def perform: () -> untyped
+
+      def inspector: () -> ActionDispatch::Routing::RoutesInspector
+
+      def formatter: () -> untyped
+
+      def routes_filter: () -> untyped
+    end
+  end
+end
+
+module Rails
+  module Command
+    class RunnerCommand < Base
+      # :nodoc:
+      include EnvironmentArgument
+
+      def help: () -> untyped
+
+      def self.banner: () -> ::String
+
+      def perform: (?untyped? code_or_file, *untyped command_argv) -> untyped
+    end
+  end
+end
+
+module Rails
+  module Command
+    class SecretsCommand < Rails::Command::Base
+      def help: () -> untyped
+
+      def setup: () -> untyped
+
+      def edit: () -> untyped
+
+      def show: () -> untyped
+
+      def deprecate_in_favor_of_credentials_and_exit: () -> untyped
+    end
+  end
+end
+
+module Rails
+  class Server < ::Rack::Server
+    class Options
+      def parse!: (untyped args) -> untyped
+    end
+
+    def initialize: (?untyped? options) -> untyped
+
+    def opt_parser: () -> Options
+
+    def set_environment: () -> untyped
+
+    def start: (?untyped? after_stop_callback) -> untyped
+
+    def serveable?: () -> untyped
+
+    def middleware: () -> Hash[untyped, untyped]
+
+    def default_options: () -> untyped
+
+    def served_url: () -> untyped
+
+    def setup_dev_caching: () -> untyped
+
+    def create_tmp_directories: () -> untyped
+
+    def log_to_stdout: () -> untyped
+
+    def use_puma?: () -> untyped
+  end
+
+  module Command
+    class ServerCommand < Base
+      # :nodoc:
+      include EnvironmentArgument
+
+      # Hard-coding a bunch of handlers here as we don't have a public way of
+      # querying them from the Rack::Handler registry.
+      RACK_SERVERS: ::Array[untyped]
+
+      DEFAULT_PORT: ::Integer
+
+      DEFAULT_PID_PATH: ::String
+
+      def initialize: (untyped args, untyped local_options) -> untyped
+
+      def perform: () -> untyped
+
+      def server_options: () -> { user_supplied_options: untyped, server: untyped, :log_stdout => untyped, Port: untyped, Host: untyped, DoNotReverseLookup: ::TrueClass, config: untyped, environment: untyped, daemonize: untyped, pid: untyped, caching: untyped, restart_cmd: untyped, early_hints: untyped }
+
+      def user_supplied_options: () -> untyped
+
+      def port: () -> untyped
+
+      def host: () -> untyped
+
+      def environment: () -> untyped
+
+      def restart_command: () -> ::String
+
+      def early_hints: () -> untyped
+
+      def log_to_stdout?: () -> untyped
+
+      def pid: () -> untyped
+
+      def self.banner: () -> "rails server -u [thin/puma/webrick] [options]"
+
+      def prepare_restart: () -> untyped
+
+      def deprecate_positional_rack_server_and_rewrite_to_option: (untyped original_options) -> untyped
+
+      def rack_server_suggestion: (untyped server) -> untyped
+
+      def print_boot_information: (untyped server, untyped url) -> untyped
+    end
+  end
+end
+
+module Rails
+  module Command
+    class TestCommand < Base
+      def help: () -> untyped
+
+      def perform: () -> untyped
+    end
+  end
+end
+
+module Rails
+  module Command
+    class VersionCommand < Base
+      # :nodoc:
+      def perform: () -> untyped
+    end
+  end
+end
+
+module Rails
+  module Configuration
+    # MiddlewareStackProxy is a proxy for the Rails middleware stack that allows
+    # you to configure middlewares in your application. It works basically as a
+    # command recorder, saving each command to be applied after initialization
+    # over the default middleware stack, so you can add, swap, or remove any
+    # middleware in Rails.
+    #
+    # You can add your own middlewares by using the +config.middleware.use+ method:
+    #
+    #     config.middleware.use Magical::Unicorns
+    #
+    # This will put the <tt>Magical::Unicorns</tt> middleware on the end of the stack.
+    # You can use +insert_before+ if you wish to add a middleware before another:
+    #
+    #     config.middleware.insert_before Rack::Head, Magical::Unicorns
+    #
+    # There's also +insert_after+ which will insert a middleware after another:
+    #
+    #     config.middleware.insert_after Rack::Head, Magical::Unicorns
+    #
+    # Middlewares can also be completely swapped out and replaced with others:
+    #
+    #     config.middleware.swap ActionDispatch::Flash, Magical::Unicorns
+    #
+    # And finally they can also be removed from the stack completely:
+    #
+    #     config.middleware.delete ActionDispatch::Flash
+    #
+    class MiddlewareStackProxy
+      def initialize: (?untyped operations, ?untyped delete_operations) -> untyped
+
+      def insert_before: (*untyped args) { () -> untyped } -> untyped
+
+      alias insert insert_before
+
+      def insert_after: (*untyped args) { () -> untyped } -> untyped
+
+      def swap: (*untyped args) { () -> untyped } -> untyped
+
+      def use: (*untyped args) { () -> untyped } -> untyped
+
+      def delete: (*untyped args) { () -> untyped } -> untyped
+
+      def unshift: (*untyped args) { () -> untyped } -> untyped
+
+      def merge_into: (untyped other) -> untyped
+
+      def +: (untyped other) -> MiddlewareStackProxy
+
+      attr_reader operations: untyped
+
+      attr_reader delete_operations: untyped
+    end
+
+    class Generators
+      # nodoc:
+      attr_accessor aliases: untyped
+
+      # nodoc:
+      attr_accessor options: untyped
+
+      # nodoc:
+      attr_accessor templates: untyped
+
+      # nodoc:
+      attr_accessor fallbacks: untyped
+
+      # nodoc:
+      attr_accessor colorize_logging: untyped
+
+      # nodoc:
+      attr_accessor api_only: untyped
+
+      attr_reader hidden_namespaces: untyped
+
+      def initialize: () -> untyped
+
+      def initialize_copy: (untyped source) -> untyped
+
+      def hide_namespace: (untyped namespace) -> untyped
+
+      def method_missing: (untyped method, *untyped args) -> untyped
+    end
+  end
+end
+
+module Rails
+  module ConsoleMethods
+    # reference the global "app" instance, created on demand. To recreate the
+    # instance, pass a non-false value as the parameter.
+    def app: (?bool create) -> untyped
+
+    # create a new session. If a block is given, the new session will be yielded
+    # to the block before being returned.
+    def new_session: () { (untyped) -> untyped } -> untyped
+
+    # reloads the environment
+    def reload!: (?bool print) -> ::TrueClass
+  end
+end
+
+module Rails
+  module ConsoleMethods
+    # Gets the helper methods available to the controller.
+    #
+    # This method assumes an +ApplicationController+ exists, and it extends +ActionController::Base+
+    def helper: () -> untyped
+
+    # Gets a new instance of a controller object.
+    #
+    # This method assumes an +ApplicationController+ exists, and it extends +ActionController::Base+
+    def controller: () -> untyped
+  end
+end
+
+module Rails
+  module DevCaching
+    FILE: ::String
+
+    def self.enable_by_file: () -> untyped
+
+    def self.enable_by_argument: (untyped caching) -> untyped
+
+    def self.create_cache_file: () -> untyped
+
+    def self.delete_cache_file: () -> untyped
+  end
+end
+
+APP_PATH: untyped
+
+module Rails
+  class Engine
+    class Configuration < ::Rails::Railtie::Configuration
+      attr_reader root: untyped
+
+      attr_accessor middleware: untyped
+
+      attr_accessor javascript_path: untyped
+
+      attr_writer eager_load_paths: untyped
+
+      attr_writer autoload_once_paths: untyped
+
+      attr_writer autoload_paths: untyped
+
+      def initialize: (?untyped? root) -> untyped
+
+      # Holds generators configuration:
+      #
+      #   config.generators do |g|
+      #     g.orm             :data_mapper, migration: true
+      #     g.template_engine :haml
+      #     g.test_framework  :rspec
+      #   end
+      #
+      # If you want to disable color in console, do:
+      #
+      #   config.generators.colorize_logging = false
+      #
+      def generators: () { (untyped) -> untyped } -> untyped
+
+      def paths: () -> untyped
+
+      def root=: (untyped value) -> untyped
+
+      def eager_load_paths: () -> untyped
+
+      def autoload_once_paths: () -> untyped
+
+      def autoload_paths: () -> untyped
+    end
+  end
+end
+
+module Rails
+  class Engine < Railtie
+    class Railties
+      include Enumerable[untyped]
+
+      attr_reader _all: untyped
+
+      def initialize: () -> untyped
+
+      def each: (*untyped args) { () -> untyped } -> untyped
+
+      def -: (untyped others) -> untyped
+    end
+  end
+end
+
+module Rails
+  class Engine
+    class Updater
+      def self.generator: () -> untyped
+
+      def self.run: (untyped action) -> untyped
+    end
+  end
+end
+
+module Rails
+  # <tt>Rails::Engine</tt> allows you to wrap a specific Rails application or subset of
+  # functionality and share it with other applications or within a larger packaged application.
+  # Every <tt>Rails::Application</tt> is just an engine, which allows for simple
+  # feature and application sharing.
+  #
+  # Any <tt>Rails::Engine</tt> is also a <tt>Rails::Railtie</tt>, so the same
+  # methods (like <tt>rake_tasks</tt> and +generators+) and configuration
+  # options that are available in railties can also be used in engines.
+  #
+  # == Creating an Engine
+  #
+  # If you want a gem to behave as an engine, you have to specify an +Engine+
+  # for it somewhere inside your plugin's +lib+ folder (similar to how we
+  # specify a +Railtie+):
+  #
+  #   # lib/my_engine.rb
+  #   module MyEngine
+  #     class Engine < Rails::Engine
+  #     end
+  #   end
+  #
+  # Then ensure that this file is loaded at the top of your <tt>config/application.rb</tt>
+  # (or in your +Gemfile+) and it will automatically load models, controllers and helpers
+  # inside +app+, load routes at <tt>config/routes.rb</tt>, load locales at
+  # <tt>config/locales/*</tt>, and load tasks at <tt>lib/tasks/*</tt>.
+  #
+  # == Configuration
+  #
+  # Besides the +Railtie+ configuration which is shared across the application, in a
+  # <tt>Rails::Engine</tt> you can access <tt>autoload_paths</tt>, <tt>eager_load_paths</tt>
+  # and <tt>autoload_once_paths</tt>, which, differently from a <tt>Railtie</tt>, are scoped to
+  # the current engine.
+  #
+  #   class MyEngine < Rails::Engine
+  #     # Add a load path for this specific Engine
+  #     config.autoload_paths << File.expand_path("lib/some/path", __dir__)
+  #
+  #     initializer "my_engine.add_middleware" do |app|
+  #       app.middleware.use MyEngine::Middleware
+  #     end
+  #   end
+  #
+  # == Generators
+  #
+  # You can set up generators for engines with <tt>config.generators</tt> method:
+  #
+  #   class MyEngine < Rails::Engine
+  #     config.generators do |g|
+  #       g.orm             :active_record
+  #       g.template_engine :erb
+  #       g.test_framework  :test_unit
+  #     end
+  #   end
+  #
+  # You can also set generators for an application by using <tt>config.app_generators</tt>:
+  #
+  #   class MyEngine < Rails::Engine
+  #     # note that you can also pass block to app_generators in the same way you
+  #     # can pass it to generators method
+  #     config.app_generators.orm :datamapper
+  #   end
+  #
+  # == Paths
+  #
+  # Applications and engines have flexible path configuration, meaning that you
+  # are not required to place your controllers at <tt>app/controllers</tt>, but
+  # in any place which you find convenient.
+  #
+  # For example, let's suppose you want to place your controllers in <tt>lib/controllers</tt>.
+  # You can set that as an option:
+  #
+  #   class MyEngine < Rails::Engine
+  #     paths["app/controllers"] = "lib/controllers"
+  #   end
+  #
+  # You can also have your controllers loaded from both <tt>app/controllers</tt> and
+  # <tt>lib/controllers</tt>:
+  #
+  #   class MyEngine < Rails::Engine
+  #     paths["app/controllers"] << "lib/controllers"
+  #   end
+  #
+  # The available paths in an engine are:
+  #
+  #   class MyEngine < Rails::Engine
+  #     paths["app"]                 # => ["app"]
+  #     paths["app/controllers"]     # => ["app/controllers"]
+  #     paths["app/helpers"]         # => ["app/helpers"]
+  #     paths["app/models"]          # => ["app/models"]
+  #     paths["app/views"]           # => ["app/views"]
+  #     paths["lib"]                 # => ["lib"]
+  #     paths["lib/tasks"]           # => ["lib/tasks"]
+  #     paths["config"]              # => ["config"]
+  #     paths["config/initializers"] # => ["config/initializers"]
+  #     paths["config/locales"]      # => ["config/locales"]
+  #     paths["config/routes.rb"]    # => ["config/routes.rb"]
+  #   end
+  #
+  # The <tt>Application</tt> class adds a couple more paths to this set. And as in your
+  # <tt>Application</tt>, all folders under +app+ are automatically added to the load path.
+  # If you have an <tt>app/services</tt> folder for example, it will be added by default.
+  #
+  # == Endpoint
+  #
+  # An engine can also be a Rack application. It can be useful if you have a Rack application that
+  # you would like to wrap with +Engine+ and provide with some of the +Engine+'s features.
+  #
+  # To do that, use the +endpoint+ method:
+  #
+  #   module MyEngine
+  #     class Engine < Rails::Engine
+  #       endpoint MyRackApplication
+  #     end
+  #   end
+  #
+  # Now you can mount your engine in application's routes just like that:
+  #
+  #   Rails.application.routes.draw do
+  #     mount MyEngine::Engine => "/engine"
+  #   end
+  #
+  # == Middleware stack
+  #
+  # As an engine can now be a Rack endpoint, it can also have a middleware
+  # stack. The usage is exactly the same as in <tt>Application</tt>:
+  #
+  #   module MyEngine
+  #     class Engine < Rails::Engine
+  #       middleware.use SomeMiddleware
+  #     end
+  #   end
+  #
+  # == Routes
+  #
+  # If you don't specify an endpoint, routes will be used as the default
+  # endpoint. You can use them just like you use an application's routes:
+  #
+  #   # ENGINE/config/routes.rb
+  #   MyEngine::Engine.routes.draw do
+  #     get "/" => "posts#index"
+  #   end
+  #
+  # == Mount priority
+  #
+  # Note that now there can be more than one router in your application, and it's better to avoid
+  # passing requests through many routers. Consider this situation:
+  #
+  #   Rails.application.routes.draw do
+  #     mount MyEngine::Engine => "/blog"
+  #     get "/blog/omg" => "main#omg"
+  #   end
+  #
+  # +MyEngine+ is mounted at <tt>/blog</tt>, and <tt>/blog/omg</tt> points to application's
+  # controller. In such a situation, requests to <tt>/blog/omg</tt> will go through +MyEngine+,
+  # and if there is no such route in +Engine+'s routes, it will be dispatched to <tt>main#omg</tt>.
+  # It's much better to swap that:
+  #
+  #   Rails.application.routes.draw do
+  #     get "/blog/omg" => "main#omg"
+  #     mount MyEngine::Engine => "/blog"
+  #   end
+  #
+  # Now, +Engine+ will get only requests that were not handled by +Application+.
+  #
+  # == Engine name
+  #
+  # There are some places where an Engine's name is used:
+  #
+  # * routes: when you mount an Engine with <tt>mount(MyEngine::Engine => '/my_engine')</tt>,
+  #   it's used as default <tt>:as</tt> option
+  # * rake task for installing migrations <tt>my_engine:install:migrations</tt>
+  #
+  # Engine name is set by default based on class name. For <tt>MyEngine::Engine</tt> it will be
+  # <tt>my_engine_engine</tt>. You can change it manually using the <tt>engine_name</tt> method:
+  #
+  #   module MyEngine
+  #     class Engine < Rails::Engine
+  #       engine_name "my_engine"
+  #     end
+  #   end
+  #
+  # == Isolated Engine
+  #
+  # Normally when you create controllers, helpers and models inside an engine, they are treated
+  # as if they were created inside the application itself. This means that all helpers and
+  # named routes from the application will be available to your engine's controllers as well.
+  #
+  # However, sometimes you want to isolate your engine from the application, especially if your engine
+  # has its own router. To do that, you simply need to call +isolate_namespace+. This method requires
+  # you to pass a module where all your controllers, helpers and models should be nested to:
+  #
+  #   module MyEngine
+  #     class Engine < Rails::Engine
+  #       isolate_namespace MyEngine
+  #     end
+  #   end
+  #
+  # With such an engine, everything that is inside the +MyEngine+ module will be isolated from
+  # the application.
+  #
+  # Consider this controller:
+  #
+  #   module MyEngine
+  #     class FooController < ActionController::Base
+  #     end
+  #   end
+  #
+  # If the +MyEngine+ engine is marked as isolated, +FooController+ only has
+  # access to helpers from +MyEngine+, and <tt>url_helpers</tt> from
+  # <tt>MyEngine::Engine.routes</tt>.
+  #
+  # The next thing that changes in isolated engines is the behavior of routes.
+  # Normally, when you namespace your controllers, you also need to namespace
+  # the related routes. With an isolated engine, the engine's namespace is
+  # automatically applied, so you don't need to specify it explicitly in your
+  # routes:
+  #
+  #   MyEngine::Engine.routes.draw do
+  #     resources :articles
+  #   end
+  #
+  # If +MyEngine+ is isolated, The routes above will point to
+  # <tt>MyEngine::ArticlesController</tt>. You also don't need to use longer
+  # URL helpers like +my_engine_articles_path+. Instead, you should simply use
+  # +articles_path+, like you would do with your main application.
+  #
+  # To make this behavior consistent with other parts of the framework,
+  # isolated engines also have an effect on <tt>ActiveModel::Naming</tt>. In a
+  # normal Rails app, when you use a namespaced model such as
+  # <tt>Namespace::Article</tt>, <tt>ActiveModel::Naming</tt> will generate
+  # names with the prefix "namespace". In an isolated engine, the prefix will
+  # be omitted in URL helpers and form fields, for convenience.
+  #
+  #   polymorphic_url(MyEngine::Article.new)
+  #   # => "articles_path" # not "my_engine_articles_path"
+  #
+  #   form_for(MyEngine::Article.new) do
+  #     text_field :title # => <input type="text" name="article[title]" id="article_title" />
+  #   end
+  #
+  # Additionally, an isolated engine will set its own name according to its
+  # namespace, so <tt>MyEngine::Engine.engine_name</tt> will return
+  # "my_engine". It will also set +MyEngine.table_name_prefix+ to "my_engine_",
+  # meaning for example that <tt>MyEngine::Article</tt> will use the
+  # +my_engine_articles+ database table by default.
+  #
+  # == Using Engine's routes outside Engine
+  #
+  # Since you can now mount an engine inside application's routes, you do not have direct access to +Engine+'s
+  # <tt>url_helpers</tt> inside +Application+. When you mount an engine in an application's routes, a special helper is
+  # created to allow you to do that. Consider such a scenario:
+  #
+  #   # config/routes.rb
+  #   Rails.application.routes.draw do
+  #     mount MyEngine::Engine => "/my_engine", as: "my_engine"
+  #     get "/foo" => "foo#index"
+  #   end
+  #
+  # Now, you can use the <tt>my_engine</tt> helper inside your application:
+  #
+  #   class FooController < ApplicationController
+  #     def index
+  #       my_engine.root_url # => /my_engine/
+  #     end
+  #   end
+  #
+  # There is also a <tt>main_app</tt> helper that gives you access to application's routes inside Engine:
+  #
+  #   module MyEngine
+  #     class BarController
+  #       def index
+  #         main_app.foo_path # => /foo
+  #       end
+  #     end
+  #   end
+  #
+  # Note that the <tt>:as</tt> option given to mount takes the <tt>engine_name</tt> as default, so most of the time
+  # you can simply omit it.
+  #
+  # Finally, if you want to generate a URL to an engine's route using
+  # <tt>polymorphic_url</tt>, you also need to pass the engine helper. Let's
+  # say that you want to create a form pointing to one of the engine's routes.
+  # All you need to do is pass the helper as the first element in array with
+  # attributes for URL:
+  #
+  #   form_for([my_engine, @user])
+  #
+  # This code will use <tt>my_engine.user_path(@user)</tt> to generate the proper route.
+  #
+  # == Isolated engine's helpers
+  #
+  # Sometimes you may want to isolate engine, but use helpers that are defined for it.
+  # If you want to share just a few specific helpers you can add them to application's
+  # helpers in ApplicationController:
+  #
+  #   class ApplicationController < ActionController::Base
+  #     helper MyEngine::SharedEngineHelper
+  #   end
+  #
+  # If you want to include all of the engine's helpers, you can use the #helper method on an engine's
+  # instance:
+  #
+  #   class ApplicationController < ActionController::Base
+  #     helper MyEngine::Engine.helpers
+  #   end
+  #
+  # It will include all of the helpers from engine's directory. Take into account that this does
+  # not include helpers defined in controllers with helper_method or other similar solutions,
+  # only helpers defined in the helpers directory will be included.
+  #
+  # == Migrations & seed data
+  #
+  # Engines can have their own migrations. The default path for migrations is exactly the same
+  # as in application: <tt>db/migrate</tt>
+  #
+  # To use engine's migrations in application you can use the rake task below, which copies them to
+  # application's dir:
+  #
+  #   rake ENGINE_NAME:install:migrations
+  #
+  # Note that some of the migrations may be skipped if a migration with the same name already exists
+  # in application. In such a situation you must decide whether to leave that migration or rename the
+  # migration in the application and rerun copying migrations.
+  #
+  # If your engine has migrations, you may also want to prepare data for the database in
+  # the <tt>db/seeds.rb</tt> file. You can load that data using the <tt>load_seed</tt> method, e.g.
+  #
+  #   MyEngine::Engine.load_seed
+  #
+  # == Loading priority
+  #
+  # In order to change engine's priority you can use +config.railties_order+ in the main application.
+  # It will affect the priority of loading views, helpers, assets, and all the other files
+  # related to engine or application.
+  #
+  #   # load Blog::Engine with highest priority, followed by application and other railties
+  #   config.railties_order = [Blog::Engine, :main_app, :all]
+  class Engine < Railtie
+    attr_accessor called_from: untyped
+
+    attr_accessor isolated: untyped
+
+    alias self.isolated? self.isolated
+
+    alias self.engine_name self.railtie_name
+
+    def self.inherited: (untyped base) -> untyped
+
+    def self.find_root: (untyped from) -> untyped
+
+    def self.endpoint: (?untyped? endpoint) -> untyped
+
+    def self.isolate_namespace: (untyped mod) -> untyped
+
+    # Finds engine with given path.
+    def self.find: (untyped path) -> (untyped | nil)
+
+    def initialize: () -> untyped
+
+    # Load console and invoke the registered hooks.
+    # Check <tt>Rails::Railtie.console</tt> for more info.
+    def load_console: (?untyped app) -> untyped
+
+    # Load Rails runner and invoke the registered hooks.
+    # Check <tt>Rails::Railtie.runner</tt> for more info.
+    def load_runner: (?untyped app) -> untyped
+
+    # Load Rake, railties tasks and invoke the registered hooks.
+    # Check <tt>Rails::Railtie.rake_tasks</tt> for more info.
+    def load_tasks: (?untyped app) -> untyped
+
+    # Load Rails generators and invoke the registered hooks.
+    # Check <tt>Rails::Railtie.generators</tt> for more info.
+    def load_generators: (?untyped app) -> untyped
+
+    def eager_load!: () -> (nil | untyped)
+
+    def railties: () -> untyped
+
+    # Returns a module with all the helpers defined for the engine.
+    def helpers: () -> untyped
+
+    # Returns all registered helpers paths.
+    def helpers_paths: () -> untyped
+
+    # Returns the underlying Rack application for this engine.
+    def app: () -> untyped
+
+    # Returns the endpoint for this engine. If none is registered,
+    # defaults to an ActionDispatch::Routing::RouteSet.
+    def endpoint: () -> untyped
+
+    # Define the Rack API for this engine.
+    def call: (untyped env) -> untyped
+
+    # Defines additional Rack env configuration that is added on each call.
+    def env_config: () -> untyped
+
+    # Defines the routes for this engine. If a block is given to
+    # routes, it is appended to the engine.
+    def routes: () { () -> untyped } -> untyped
+
+    # Define the configuration object for the engine.
+    def config: () -> untyped
+
+    # Load data from db/seeds.rb file. It can be used in to load engines'
+    # seeds, e.g.:
+    #
+    # Blog::Engine.load_seed
+    def load_seed: () -> (nil | untyped)
+
+    def routes?: () -> untyped
+
+    def run_tasks_blocks: () -> untyped
+
+    def load_config_initializer: (untyped initializer) -> untyped
+
+    def with_inline_jobs: () { () -> untyped } -> untyped
+
+    def has_migrations?: () -> untyped
+
+    def self.find_root_with_flag: (untyped flag, untyped root_path, ?untyped? default) -> Pathname
+
+    def default_middleware_stack: () -> ActionDispatch::MiddlewareStack
+
+    def _all_autoload_once_paths: () -> untyped
+
+    def _all_autoload_paths: () -> untyped
+
+    def _all_load_paths: (untyped add_autoload_paths_to_load_path) -> untyped
+
+    def build_request: (untyped env) -> untyped
+
+    def build_middleware: () -> untyped
+  end
+end
+
+module Rails
+  # Returns the version of the currently loaded Rails as a <tt>Gem::Version</tt>
+  def self.gem_version: () -> Gem::Version
+
+  module VERSION
+    MAJOR: ::Integer
+
+    MINOR: ::Integer
+
+    TINY: ::Integer
+
+    PRE: ::String
+
+    STRING: untyped
+  end
+end
+
+module Rails
+  module Generators
+    module Actions
+      class CreateMigration < Thor::Actions::CreateFile
+        # nodoc:
+        def migration_dir: () -> untyped
+
+        def migration_file_name: () -> untyped
+
+        def identical?: () -> untyped
+
+        def revoke!: () -> (nil | untyped)
+
+        def relative_existing_migration: () -> untyped
+
+        def existing_migration: () -> untyped
+
+        alias exists? existing_migration
+
+        def on_conflict_behavior: () { () -> untyped } -> untyped
+
+        def say_status: (untyped status, untyped color, ?untyped message) -> untyped
+      end
+    end
+  end
+end
+
+module Rails
+  module Generators
+    module Actions
+      def initialize: () -> untyped
+
+      # Adds an entry into +Gemfile+ for the supplied gem.
+      #
+      #   gem "rspec", group: :test
+      #   gem "technoweenie-restful-authentication", lib: "restful-authentication", source: "http://gems.github.com/"
+      #   gem "rails", "3.0", git: "https://github.com/rails/rails"
+      #   gem "RedCloth", ">= 4.1.0", "< 4.2.0"
+      def gem: (*untyped args) -> untyped
+
+      # Wraps gem entries inside a group.
+      #
+      #   gem_group :development, :test do
+      #     gem "rspec-rails"
+      #   end
+      def gem_group: (*untyped names) { () -> untyped } -> untyped
+
+      def github: (untyped repo, ?::Hash[untyped, untyped] options) { () -> untyped } -> untyped
+
+      # Add the given source to +Gemfile+
+      #
+      # If block is given, gem entries in block are wrapped into the source group.
+      #
+      #   add_source "http://gems.github.com/"
+      #
+      #   add_source "http://gems.github.com/" do
+      #     gem "rspec-rails"
+      #   end
+      def add_source: (untyped source, ?::Hash[untyped, untyped] options) { () -> untyped } -> untyped
+
+      # Adds a line inside the Application class for <tt>config/application.rb</tt>.
+      #
+      # If options <tt>:env</tt> is specified, the line is appended to the corresponding
+      # file in <tt>config/environments</tt>.
+      #
+      #   environment do
+      #     "config.action_controller.asset_host = 'cdn.provider.com'"
+      #   end
+      #
+      #   environment(nil, env: "development") do
+      #     "config.action_controller.asset_host = 'localhost:3000'"
+      #   end
+      def environment: (?untyped? data, ?::Hash[untyped, untyped] options) { () -> untyped } -> untyped
+
+      alias application environment
+
+      # Run a command in git.
+      #
+      #   git :init
+      #   git add: "this.file that.rb"
+      #   git add: "onefile.rb", rm: "badfile.cxx"
+      def git: (?::Hash[untyped, untyped] commands) -> untyped
+
+      # Create a new file in the <tt>vendor/</tt> directory. Code can be specified
+      # in a block or a data string can be given.
+      #
+      #   vendor("sekrit.rb") do
+      #     sekrit_salt = "#{Time.now}--#{3.years.ago}--#{rand}--"
+      #     "salt = '#{sekrit_salt}'"
+      #   end
+      #
+      #   vendor("foreign.rb", "# Foreign code is fun")
+      def vendor: (untyped filename, ?untyped? data) { () -> untyped } -> untyped
+
+      # Create a new file in the <tt>lib/</tt> directory. Code can be specified
+      # in a block or a data string can be given.
+      #
+      #   lib("crypto.rb") do
+      #     "crypted_special_value = '#{rand}--#{Time.now}--#{rand(1337)}--'"
+      #   end
+      #
+      #   lib("foreign.rb", "# Foreign code is fun")
+      def lib: (untyped filename, ?untyped? data) { () -> untyped } -> untyped
+
+      # Create a new +Rakefile+ with the provided code (either in a block or a string).
+      #
+      #   rakefile("bootstrap.rake") do
+      #     project = ask("What is the UNIX name of your project?")
+      #
+      #     <<-TASK
+      #       namespace :#{project} do
+      #         task :bootstrap do
+      #           puts "I like boots!"
+      #         end
+      #       end
+      #     TASK
+      #   end
+      #
+      #   rakefile('seed.rake', 'puts "Planting seeds"')
+      def rakefile: (untyped filename, ?untyped? data) { () -> untyped } -> untyped
+
+      # Create a new initializer with the provided code (either in a block or a string).
+      #
+      #   initializer("globals.rb") do
+      #     data = ""
+      #
+      #     ['MY_WORK', 'ADMINS', 'BEST_COMPANY_EVAR'].each do |const|
+      #       data << "#{const} = :entp\n"
+      #     end
+      #
+      #     data
+      #   end
+      #
+      #   initializer("api.rb", "API_KEY = '123456'")
+      def initializer: (untyped filename, ?untyped? data) { () -> untyped } -> untyped
+
+      # Generate something using a generator from Rails or a plugin.
+      # The second parameter is the argument string that is passed to
+      # the generator or an Array that is joined.
+      #
+      #   generate(:authenticated, "user session")
+      def generate: (untyped what, *untyped args) -> untyped
+
+      # Runs the supplied rake task (invoked with 'rake ...')
+      #
+      #   rake("db:migrate")
+      #   rake("db:migrate", env: "production")
+      #   rake("gems:install", sudo: true)
+      #   rake("gems:install", capture: true)
+      def rake: (untyped command, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Runs the supplied rake task (invoked with 'rails ...')
+      #
+      #   rails_command("db:migrate")
+      #   rails_command("db:migrate", env: "production")
+      #   rails_command("gems:install", sudo: true)
+      #   rails_command("gems:install", capture: true)
+      def rails_command: (untyped command, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Make an entry in Rails routing file <tt>config/routes.rb</tt>
+      #
+      #   route "root 'welcome#index'"
+      def route: (untyped routing_code) -> untyped
+
+      # Reads the given file at the source root and prints it in the console.
+      #
+      #   readme "README"
+      def readme: (untyped path) -> untyped
+
+      def log: (*untyped args) -> untyped
+
+      def execute_command: (untyped executor, untyped command, ?::Hash[untyped, untyped] options) -> untyped
+
+      def extify: (untyped name) -> untyped
+
+      def quote: (untyped value) -> untyped
+
+      def optimize_indentation: (untyped value, ?::Integer amount) -> (::String | untyped)
+
+      def indentation: () -> untyped
+
+      def with_indentation: () { () -> untyped } -> untyped
+    end
+  end
+end
+
+module Rails
+  module Generators
+    # ActiveModel is a class to be implemented by each ORM to allow Rails to
+    # generate customized controller code.
+    #
+    # The API has the same methods as ActiveRecord, but each method returns a
+    # string that matches the ORM API.
+    #
+    # For example:
+    #
+    #   ActiveRecord::Generators::ActiveModel.find(Foo, "params[:id]")
+    #   # => "Foo.find(params[:id])"
+    #
+    #   DataMapper::Generators::ActiveModel.find(Foo, "params[:id]")
+    #   # => "Foo.get(params[:id])"
+    #
+    # On initialization, the ActiveModel accepts the instance name that will
+    # receive the calls:
+    #
+    #   builder = ActiveRecord::Generators::ActiveModel.new "@foo"
+    #   builder.save # => "@foo.save"
+    #
+    # The only exception in ActiveModel for ActiveRecord is the use of self.build
+    # instead of self.new.
+    #
+    class ActiveModel
+      attr_reader name: untyped
+
+      def initialize: (untyped name) -> untyped
+
+      # GET index
+      def self.all: (untyped klass) -> ::String
+
+      # GET show
+      # GET edit
+      # PATCH/PUT update
+      # DELETE destroy
+      def self.find: (untyped klass, ?untyped? params) -> ::String
+
+      # GET new
+      # POST create
+      def self.build: (untyped klass, ?untyped? params) -> untyped
+
+      # POST create
+      def save: () -> ::String
+
+      # PATCH/PUT update
+      def update: (?untyped? params) -> ::String
+
+      # POST create
+      # PATCH/PUT update
+      def errors: () -> ::String
+
+      # DELETE destroy
+      def destroy: () -> ::String
+    end
+  end
+end
+
+module Rails
+  module Generators
+    class AppBase < Base
+      # :nodoc:
+      include Database
+
+      include AppName
+
+      attr_accessor rails_template: untyped
+
+      def self.strict_args_position: () -> ::FalseClass
+
+      def self.add_shared_options_for: (untyped name) -> untyped
+
+      def initialize: (*untyped args) -> untyped
+
+      def gemfile_entry: (untyped name, *untyped args) -> untyped
+
+      def gemfile_entries: () -> untyped
+
+      def add_gem_entry_filter: () { (untyped) -> untyped } -> untyped
+
+      def builder: () -> untyped
+
+      def build: (untyped meth, *untyped args) -> untyped
+
+      def create_root: () -> untyped
+
+      def apply_rails_template: () -> untyped
+
+      def set_default_accessors!: () -> untyped
+
+      def database_gemfile_entry: () -> (::Array[untyped] | untyped)
+
+      def web_server_gemfile_entry: () -> (::Array[untyped] | GemfileEntry)
+
+      def include_all_railties?: () -> untyped
+
+      def comment_if: (untyped value) -> untyped
+
+      def keeps?: () -> untyped
+
+      def sqlite3?: () -> untyped
+
+      def skip_active_storage?: () -> untyped
+
+      def skip_action_mailbox?: () -> untyped
+
+      def skip_action_text?: () -> untyped
+
+      class GemfileEntry
+        # Note: It inherits unnamed class, but omitted
+        def initialize: (untyped name, untyped version, untyped comment, ?::Hash[untyped, untyped] options, ?bool commented_out) -> untyped
+
+        def self.github: (untyped name, untyped github, ?untyped? branch, ?untyped? comment) -> untyped
+
+        def self.version: (untyped name, untyped version, ?untyped? comment) -> untyped
+
+        def self.path: (untyped name, untyped path, ?untyped? comment) -> untyped
+
+        def version: () -> untyped
+      end
+
+      def rails_gemfile_entry: () -> untyped
+
+      def rails_version_specifier: (?untyped gem_version) -> untyped
+
+      def assets_gemfile_entry: () -> (::Array[untyped] | untyped)
+
+      def webpacker_gemfile_entry: () -> (::Array[untyped] | untyped)
+
+      def jbuilder_gemfile_entry: () -> GemfileEntry
+
+      def javascript_gemfile_entry: () -> untyped
+
+      def psych_gemfile_entry: () -> (::Array[untyped] | GemfileEntry)
+
+      def cable_gemfile_entry: () -> (::Array[untyped] | untyped)
+
+      def bundle_command: (untyped command, ?::Hash[untyped, untyped] env) -> untyped
+
+      def exec_bundle_command: (untyped bundle_command, untyped command, untyped env) -> untyped
+
+      def bundle_install?: () -> untyped
+
+      def spring_install?: () -> untyped
+
+      def webpack_install?: () -> untyped
+
+      def depends_on_system_test?: () -> untyped
+
+      def depend_on_listen?: () -> untyped
+
+      def depend_on_bootsnap?: () -> untyped
+
+      def os_supports_listen_out_of_the_box?: () -> untyped
+
+      def run_bundle: () -> untyped
+
+      def run_webpack: () -> untyped
+
+      def generate_bundler_binstub: () -> untyped
+
+      def generate_spring_binstubs: () -> untyped
+
+      def empty_directory_with_keep_file: (untyped destination, ?::Hash[untyped, untyped] config) -> untyped
+
+      def keep_file: (untyped destination) -> untyped
+    end
+  end
+end
+
+module Rails
+  module Generators
+    module AppName
+      # :nodoc:
+      RESERVED_NAMES: ::Array[untyped]
+
+      def app_name: () -> untyped
+
+      def original_app_name: () -> untyped
+
+      def defined_app_name: () -> untyped
+
+      def defined_app_const_base: () -> untyped
+
+      alias defined_app_const_base? defined_app_const_base
+
+      def app_const_base: () -> untyped
+
+      alias camelized app_const_base
+
+      def app_const: () -> untyped
+
+      def valid_const?: () -> untyped
+    end
+  end
+end
+
+module Rails
+  module Generators
+    class Error < Thor::Error
+    end
+
+    class Base < Thor::Group
+      include Thor::Actions
+
+      include Rails::Generators::Actions
+
+      def self.exit_on_failure?: () -> ::FalseClass
+
+      # Returns the source root for this generator using default_source_root as default.
+      def self.source_root: (?untyped? path) -> untyped
+
+      # Tries to get the description from a USAGE file one folder above the source
+      # root otherwise uses a default description.
+      def self.desc: (?untyped? description) -> untyped
+
+      # Convenience method to get the namespace from the class name. It's the
+      # same as Thor default except that the Generator at the end of the class
+      # is removed.
+      def self.namespace: (?untyped? name) -> untyped
+
+      # Convenience method to hide this generator from the available ones when
+      # running rails generator command.
+      def self.hide!: () -> untyped
+
+      # Invoke a generator based on the value supplied by the user to the
+      # given option named "name". A class option is created when this method
+      # is invoked and you can set a hash to customize it.
+      #
+      # ==== Examples
+      #
+      #   module Rails::Generators
+      #     class ControllerGenerator < Base
+      #       hook_for :test_framework, aliases: "-t"
+      #     end
+      #   end
+      #
+      # The example above will create a test framework option and will invoke
+      # a generator based on the user supplied value.
+      #
+      # For example, if the user invoke the controller generator as:
+      #
+      #   rails generate controller Account --test-framework=test_unit
+      #
+      # The controller generator will then try to invoke the following generators:
+      #
+      #   "rails:test_unit", "test_unit:controller", "test_unit"
+      #
+      # Notice that "rails:generators:test_unit" could be loaded as well, what
+      # Rails looks for is the first and last parts of the namespace. This is what
+      # allows any test framework to hook into Rails as long as it provides any
+      # of the hooks above.
+      #
+      # ==== Options
+      #
+      # The first and last part used to find the generator to be invoked are
+      # guessed based on class invokes hook_for, as noticed in the example above.
+      # This can be customized with two options: :in and :as.
+      #
+      # Let's suppose you are creating a generator that needs to invoke the
+      # controller generator from test unit. Your first attempt is:
+      #
+      #   class AwesomeGenerator < Rails::Generators::Base
+      #     hook_for :test_framework
+      #   end
+      #
+      # The lookup in this case for test_unit as input is:
+      #
+      #   "test_unit:awesome", "test_unit"
+      #
+      # Which is not the desired lookup. You can change it by providing the
+      # :as option:
+      #
+      #   class AwesomeGenerator < Rails::Generators::Base
+      #     hook_for :test_framework, as: :controller
+      #   end
+      #
+      # And now it will look up at:
+      #
+      #   "test_unit:controller", "test_unit"
+      #
+      # Similarly, if you want it to also look up in the rails namespace, you
+      # just need to provide the :in value:
+      #
+      #   class AwesomeGenerator < Rails::Generators::Base
+      #     hook_for :test_framework, in: :rails, as: :controller
+      #   end
+      #
+      # And the lookup is exactly the same as previously:
+      #
+      #   "rails:test_unit", "test_unit:controller", "test_unit"
+      #
+      # ==== Switches
+      #
+      # All hooks come with switches for user interface. If you do not want
+      # to use any test framework, you can do:
+      #
+      #   rails generate controller Account --skip-test-framework
+      #
+      # Or similarly:
+      #
+      #   rails generate controller Account --no-test-framework
+      #
+      # ==== Boolean hooks
+      #
+      # In some cases, you may want to provide a boolean hook. For example, webrat
+      # developers might want to have webrat available on controller generator.
+      # This can be achieved as:
+      #
+      #   Rails::Generators::ControllerGenerator.hook_for :webrat, type: :boolean
+      #
+      # Then, if you want webrat to be invoked, just supply:
+      #
+      #   rails generate controller Account --webrat
+      #
+      # The hooks lookup is similar as above:
+      #
+      #   "rails:generators:webrat", "webrat:generators:controller", "webrat"
+      #
+      # ==== Custom invocations
+      #
+      # You can also supply a block to hook_for to customize how the hook is
+      # going to be invoked. The block receives two arguments, an instance
+      # of the current class and the class to be invoked.
+      #
+      # For example, in the resource generator, the controller should be invoked
+      # with a pluralized class name. But by default it is invoked with the same
+      # name as the resource generator, which is singular. To change this, we
+      # can give a block to customize how the controller can be invoked.
+      #
+      #   hook_for :resource_controller do |instance, controller|
+      #     instance.invoke controller, [ instance.name.pluralize ]
+      #   end
+      #
+      def self.hook_for: (*untyped names) { () -> untyped } -> untyped
+
+      # Remove a previously added hook.
+      #
+      #   remove_hook_for :orm
+      def self.remove_hook_for: (*untyped names) -> untyped
+
+      def self.class_option: (untyped name, ?::Hash[untyped, untyped] options) -> untyped
+
+      # Returns the default source root for a given generator. This is used internally
+      # by rails to set its generators source root. If you want to customize your source
+      # root, you should use source_root.
+      def self.default_source_root: () -> (nil | untyped)
+
+      # Returns the base root for a common set of generators. This is used to dynamically
+      # guess the default source root.
+      def self.base_root: () -> untyped
+
+      def self.inherited: (untyped base) -> untyped
+
+      # Check whether the given class names are already taken by user
+      # application or Ruby on Rails.
+      def class_collisions: (*untyped class_names) -> (nil | untyped)
+
+      def extract_last_module: (untyped nesting) -> untyped
+
+      def module_namespacing: () { () -> untyped } -> untyped
+
+      def indent: (untyped content, ?::Integer multiplier) -> untyped
+
+      def wrap_with_namespace: (untyped content) -> ::String
+
+      def namespace: () -> untyped
+
+      def namespaced?: () -> untyped
+
+      def namespace_dirs: () -> untyped
+
+      def namespaced_path: () -> untyped
+
+      def self.banner: () -> untyped
+
+      def self.base_name: () -> untyped
+
+      def self.generator_name: () -> untyped
+
+      def self.default_value_for_option: (untyped name, untyped options) -> untyped
+
+      def self.default_aliases_for_option: (untyped name, untyped options) -> untyped
+
+      def self.default_for_option: (untyped config, untyped name, untyped options, untyped default) -> untyped
+
+      def self.hooks: () -> untyped
+
+      def self.prepare_for_invocation: (untyped name, untyped value) -> untyped
+
+      def self.add_shebang_option!: () -> untyped
+
+      def self.usage_path: () -> untyped
+
+      def self.default_generator_root: () -> untyped
+    end
+  end
+end
+
+module Css
+  module Generators
+    class AssetsGenerator < Rails::Generators::NamedBase
+      def copy_stylesheet: () -> untyped
+    end
+  end
+end
+
+module Css
+  module Generators
+    class ScaffoldGenerator < Rails::Generators::NamedBase
+      # In order to allow the Sass generators to pick up the default Rails CSS and
+      # transform it, we leave it in a standard location for the CSS stylesheet
+      # generators to handle. For the simple, default case, just copy it over.
+      def copy_stylesheet: () -> untyped
+    end
+  end
+end
+
+module Rails
+  module Generators
+    module Database
+      # :nodoc:
+      JDBC_DATABASES: ::Array[untyped]
+
+      DATABASES: untyped
+
+      def initialize: () -> untyped
+
+      def gem_for_database: (?untyped database) -> untyped
+
+      def convert_database_option_for_jruby: () -> untyped
+
+      def mysql_socket: () -> untyped
+    end
+  end
+end
+
+module Erb
+  module Generators
+    class ControllerGenerator < Base
+      def copy_view_files: () -> untyped
+    end
+  end
+end
+
+module Erb
+  module Generators
+    class MailerGenerator < Base
+      def copy_view_files: () -> untyped
+
+      def formats: () -> ::Array[:text | :html]
+
+      def file_name: () -> untyped
+    end
+  end
+end
+
+module Erb
+  module Generators
+    class ScaffoldGenerator < Base
+      # :nodoc:
+      # :nodoc:
+      # :nodoc:
+      include Rails::Generators::ResourceHelpers
+
+      def create_root_folder: () -> untyped
+
+      def copy_view_files: () -> untyped
+
+      def available_views: () -> ::Array["index" | "edit" | "show" | "new" | "_form"]
+    end
+  end
+end
+
+module Erb
+  module Generators
+    class Base < Rails::Generators::NamedBase
+      def formats: () -> ::Array[untyped]
+
+      def format: () -> :html
+
+      def handler: () -> :erb
+
+      def filename_with_extensions: (untyped name, ?untyped file_format) -> untyped
+    end
+  end
+end
+
+module Rails
+  module Generators
+    class GeneratedAttribute
+      # :nodoc:
+      INDEX_OPTIONS: ::Array[untyped]
+
+      UNIQ_INDEX_OPTIONS: ::Array[untyped]
+
+      attr_accessor name: untyped
+
+      attr_accessor type: untyped
+
+      attr_reader attr_options: untyped
+
+      attr_writer index_name: untyped
+
+      def self.parse: (untyped column_definition) -> untyped
+
+      def self.reference?: (untyped `type`) -> untyped
+
+      # parse possible attribute options like :limit for string/text/binary/integer, :precision/:scale for decimals or :polymorphic for references/belongs_to
+      # when declaring options curly brackets should be used
+      def self.parse_type_and_options: (untyped `type`) -> untyped
+
+      def initialize: (untyped name, ?untyped? `type`, ?bool index_type, ?::Hash[untyped, untyped] attr_options) -> untyped
+
+      def field_type: () -> untyped
+
+      def default: () -> untyped
+
+      def plural_name: () -> untyped
+
+      def singular_name: () -> untyped
+
+      def human_name: () -> untyped
+
+      def index_name: () -> untyped
+
+      def column_name: () -> untyped
+
+      def foreign_key?: () -> untyped
+
+      def reference?: () -> untyped
+
+      def polymorphic?: () -> untyped
+
+      def required?: () -> untyped
+
+      def has_index?: () -> untyped
+
+      def has_uniq_index?: () -> untyped
+
+      def password_digest?: () -> untyped
+
+      def token?: () -> untyped
+
+      def rich_text?: () -> untyped
+
+      def attachment?: () -> untyped
+
+      def attachments?: () -> untyped
+
+      def virtual?: () -> untyped
+
+      def inject_options: () -> untyped
+
+      def inject_index_options: () -> untyped
+
+      def options_for_migration: () -> untyped
+    end
+  end
+end
+
+module Rails
+  module Generators
+    # Holds common methods for migrations. It assumes that migrations have the
+    # [0-9]*_name format and can be used by other frameworks (like Sequel)
+    # just by implementing the next migration version method.
+    module Migration
+      extend ActiveSupport::Concern
+
+      attr_reader migration_number: untyped
+
+      attr_reader migration_file_name: untyped
+
+      attr_reader migration_class_name: untyped
+
+      module ClassMethods
+        # nodoc:
+        def migration_lookup_at: (untyped dirname) -> untyped
+
+        def migration_exists?: (untyped dirname, untyped file_name) -> untyped
+
+        def current_migration_number: (untyped dirname) -> untyped
+
+        def next_migration_number: (untyped dirname) -> untyped
+      end
+
+      def create_migration: (untyped destination, untyped data, ?::Hash[untyped, untyped] config) { () -> untyped } -> untyped
+
+      def set_migration_assigns!: (untyped destination) -> untyped
+
+      # Creates a migration template at the given destination. The difference
+      # to the default template method is that the migration version is appended
+      # to the destination file name.
+      #
+      # The migration version, migration file name, migration class name are
+      # available as instance variables in the template to be rendered.
+      #
+      #   migration_template "migration.rb", "db/migrate/add_foo_to_bar.rb"
+      def migration_template: (untyped source, untyped destination, ?::Hash[untyped, untyped] config) -> untyped
+    end
+  end
+end
+
+module Rails
+  module Generators
+    module ModelHelpers
+      # :nodoc:
+      PLURAL_MODEL_NAME_WARN_MESSAGE: ::String
+
+      IRREGULAR_MODEL_NAME_WARN_MESSAGE: ::String
+
+      def self.included: (untyped base) -> untyped
+
+      def initialize: (untyped args, *untyped _options) -> untyped
+    end
+  end
+end
+
+module Rails
+  module Generators
+    class NamedBase < Base
+      def initialize: (untyped args, *untyped options) -> untyped
+
+      def template: (untyped source, *untyped args) { () -> untyped } -> untyped
+
+      def js_template: (untyped source, untyped destination) -> untyped
+
+      attr_reader file_name: untyped
+
+      def singular_name: () -> untyped
+
+      def inside_template: () { () -> untyped } -> untyped
+
+      def inside_template?: () -> untyped
+
+      def file_path: () -> untyped
+
+      def class_path: () -> untyped
+
+      def regular_class_path: () -> untyped
+
+      def namespaced_class_path: () -> untyped
+
+      def class_name: () -> untyped
+
+      def human_name: () -> untyped
+
+      def plural_name: () -> untyped
+
+      def i18n_scope: () -> untyped
+
+      def table_name: () -> untyped
+
+      def uncountable?: () -> untyped
+
+      def index_helper: () -> untyped
+
+      def show_helper: () -> ::String
+
+      def edit_helper: () -> ::String
+
+      def new_helper: () -> ::String
+
+      def singular_table_name: () -> untyped
+
+      def plural_table_name: () -> untyped
+
+      def plural_file_name: () -> untyped
+
+      def fixture_file_name: () -> untyped
+
+      def route_url: () -> untyped
+
+      def url_helper_prefix: () -> untyped
+
+      def application_name: () -> untyped
+
+      def redirect_resource_name: () -> untyped
+
+      def model_resource_name: (?prefix: ::String prefix) -> untyped
+
+      def singular_route_name: () -> untyped
+
+      def plural_route_name: () -> untyped
+
+      def assign_names!: (untyped name) -> untyped
+
+      # Convert attributes array into GeneratedAttribute objects.
+      def parse_attributes!: () -> untyped
+
+      def attributes_names: () -> untyped
+
+      def pluralize_table_names?: () -> untyped
+
+      def mountable_engine?: () -> untyped
+
+      def self.check_class_collision: (?::Hash[untyped, untyped] options) -> untyped
+    end
+  end
+end
+
+module Rails
+  module ActionMethods
+    # :nodoc:
+    attr_reader options: untyped
+
+    def initialize: (untyped generator) -> untyped
+
+    def method_missing: (untyped meth, *untyped args) { () -> untyped } -> untyped
+  end
+
+  # The application builder allows you to override elements of the application
+  # generator without being forced to reverse the operations of the default
+  # generator.
+  #
+  # This allows you to override entire operations, like the creation of the
+  # Gemfile, README, or JavaScript files, without needing to know exactly
+  # what those operations do so you can create another template action.
+  #
+  #  class CustomAppBuilder < Rails::AppBuilder
+  #    def test
+  #      @generator.gem "rspec-rails", group: [:development, :test]
+  #      run "bundle install"
+  #      generate "rspec:install"
+  #    end
+  #  end
+  class AppBuilder
+    def rakefile: () -> untyped
+
+    def readme: () -> untyped
+
+    def ruby_version: () -> untyped
+
+    def gemfile: () -> untyped
+
+    def configru: () -> untyped
+
+    def gitignore: () -> untyped
+
+    def version_control: () -> untyped
+
+    def package_json: () -> untyped
+
+    def app: () -> untyped
+
+    def bin: () -> untyped
+
+    def bin_when_updating: () -> untyped
+
+    def config: () -> untyped
+
+    def config_when_updating: () -> untyped
+
+    def master_key: () -> (nil | untyped)
+
+    def credentials: () -> (nil | untyped)
+
+    def database_yml: () -> untyped
+
+    def db: () -> untyped
+
+    def lib: () -> untyped
+
+    def log: () -> untyped
+
+    def public_directory: () -> untyped
+
+    def storage: () -> untyped
+
+    def test: () -> untyped
+
+    def system_test: () -> untyped
+
+    def tmp: () -> untyped
+
+    def vendor: () -> untyped
+
+    def config_target_version: () -> untyped
+  end
+
+  module Generators
+    # We need to store the RAILS_DEV_PATH in a constant, otherwise the path
+    # can change in Ruby 1.8.7 when we FileUtils.cd.
+    RAILS_DEV_PATH: untyped
+
+    class AppGenerator < AppBase
+      # :nodoc:
+      WEBPACKS: ::Array[untyped]
+
+      def initialize: (*untyped args) -> untyped
+
+      def create_root_files: () -> untyped
+
+      def create_app_files: () -> untyped
+
+      def create_bin_files: () -> untyped
+
+      def update_bin_files: () -> untyped
+
+      def update_active_storage: () -> untyped
+
+      def create_config_files: () -> untyped
+
+      def update_config_files: () -> untyped
+
+      def create_master_key: () -> untyped
+
+      def create_credentials: () -> untyped
+
+      def display_upgrade_guide_info: () -> untyped
+
+      def create_boot_file: () -> untyped
+
+      def create_active_record_files: () -> (nil | untyped)
+
+      def create_db_files: () -> (nil | untyped)
+
+      def create_lib_files: () -> untyped
+
+      def create_log_files: () -> untyped
+
+      def create_public_files: () -> untyped
+
+      def create_tmp_files: () -> untyped
+
+      def create_vendor_files: () -> untyped
+
+      def create_test_files: () -> untyped
+
+      def create_system_test_files: () -> untyped
+
+      def create_storage_files: () -> untyped
+
+      def delete_app_assets_if_api_option: () -> untyped
+
+      def delete_app_helpers_if_api_option: () -> untyped
+
+      def delete_app_views_if_api_option: () -> untyped
+
+      def delete_public_files_if_api_option: () -> untyped
+
+      def delete_js_folder_skipping_javascript: () -> untyped
+
+      def delete_assets_initializer_skipping_sprockets: () -> untyped
+
+      def delete_application_record_skipping_active_record: () -> untyped
+
+      def delete_action_mailer_files_skipping_action_mailer: () -> untyped
+
+      def delete_action_cable_files_skipping_action_cable: () -> untyped
+
+      def delete_non_api_initializers_if_api_option: () -> untyped
+
+      def delete_api_initializers: () -> untyped
+
+      def delete_new_framework_defaults: () -> untyped
+
+      def delete_bin_yarn: () -> untyped
+
+      def finish_template: () -> untyped
+
+      def run_after_bundle_callbacks: () -> untyped
+
+      def self.banner: () -> ::String
+
+      # Define file as an alias to create_file for backwards compatibility.
+      def file: (*untyped args) { () -> untyped } -> untyped
+
+      def after_bundle: () { () -> untyped } -> untyped
+
+      def get_builder_class: () -> untyped
+    end
+
+    class ARGVScrubber
+      # This class handles preparation of the arguments before the AppGenerator is
+      # called. The class provides version or help information if they were
+      # requested, and also constructs the railsrc file (used for extra configuration
+      # options).
+      #
+      # This class should be called before the AppGenerator is required and started
+      # since it configures and mutates ARGV correctly.
+      # :nodoc:
+      def initialize: (?untyped argv) -> untyped
+
+      def prepare!: () -> untyped
+
+      def self.default_rc_file: () -> untyped
+
+      def handle_version_request!: (untyped argument) -> untyped
+
+      def handle_invalid_command!: (untyped argument, untyped argv) { () -> untyped } -> untyped
+
+      def handle_rails_rc!: (untyped argv) -> untyped
+
+      def railsrc: (untyped argv) { (untyped, untyped) -> untyped } -> untyped
+
+      def read_rc_file: (untyped railsrc) -> untyped
+
+      def insert_railsrc_into_argv!: (untyped argv, untyped railsrc) -> untyped
+    end
+  end
+end
+
+module Rails
+  module Generators
+    class ApplicationRecordGenerator < Base
+    end
+  end
+end
+
+module Rails
+  module Generators
+    class AssetsGenerator < NamedBase
+      def asset_name: () -> untyped
+    end
+  end
+end
+
+module Rails
+  module Generators
+    class ControllerGenerator < NamedBase
+      def create_controller_files: () -> untyped
+
+      def add_routes: () -> (nil | untyped)
+
+      def file_name: () -> untyped
+
+      def remove_possible_suffix: (untyped name) -> untyped
+
+      # This method creates nested route entry for namespaced resources.
+      # For eg. rails g controller foo/bar/baz index show
+      # Will generate -
+      # namespace :foo do
+      #   namespace :bar do
+      #     get 'baz/index'
+      #     get 'baz/show'
+      #   end
+      # end
+      def generate_routing_code: () -> untyped
+    end
+  end
+end
+
+module Rails
+  module Generators
+    class CredentialsGenerator < Base
+      # :nodoc:
+      def add_credentials_file: () -> untyped
+
+      def add_credentials_file_silently: (?untyped? template) -> untyped
+
+      def credentials: () -> ActiveSupport::EncryptedConfiguration
+
+      def credentials_template: () -> ::String
+    end
+  end
+end
+
+module Rails
+  module Generators
+    module Db
+      module System
+        class ChangeGenerator < Base
+          # :nodoc:
+          include Database
+
+          include AppName
+
+          def self.default_generator_root: () -> untyped
+
+          def initialize: () -> untyped
+
+          def edit_database_config: () -> untyped
+
+          def edit_gemfile: () -> untyped
+
+          def all_database_gems: () -> untyped
+
+          def all_database_gems_regex: () -> ::Regexp
+
+          def gem_entry_regex_for: (untyped gem_name) -> ::Regexp
+
+          def gem_entry_for: (*untyped gem_name_and_version) -> ::String
+        end
+      end
+    end
+  end
+end
+
+module Rails
+  module Generators
+    class EncryptedFileGenerator < Base
+      # :nodoc:
+      def add_encrypted_file_silently: (untyped file_path, untyped key_path, ?untyped template) -> untyped
+
+      def encrypted_file_template: () -> ::String
+    end
+  end
+end
+
+module Rails
+  module Generators
+    class EncryptionKeyFileGenerator < Base
+      # :nodoc:
+      def add_key_file: (untyped key_path) -> untyped
+
+      def add_key_file_silently: (untyped key_path, ?untyped? key) -> untyped
+
+      def ignore_key_file: (untyped key_path, ?ignore: untyped ignore) -> untyped
+
+      def ignore_key_file_silently: (untyped key_path, ?ignore: untyped ignore) -> untyped
+
+      def key_ignore: (untyped key_path) -> untyped
+    end
+  end
+end
+
+module Rails
+  module Generators
+    class GeneratorGenerator < NamedBase
+      def create_generator_files: () -> untyped
+
+      def generator_dir: () -> untyped
+    end
+  end
+end
+
+module Rails
+  module Generators
+    class HelperGenerator < NamedBase
+      def create_helper_files: () -> untyped
+
+      def file_name: () -> untyped
+    end
+  end
+end
+
+module Rails
+  module Generators
+    class IntegrationTestGenerator < NamedBase
+    end
+  end
+end
+
+module Rails
+  module Generators
+    class MasterKeyGenerator < Base
+      # :nodoc:
+      MASTER_KEY_PATH: untyped
+
+      def add_master_key_file: () -> untyped
+
+      def add_master_key_file_silently: (?untyped? key) -> untyped
+
+      def ignore_master_key_file: () -> untyped
+
+      def ignore_master_key_file_silently: () -> untyped
+
+      def key_file_generator: () -> EncryptionKeyFileGenerator
+
+      def key_ignore: () -> untyped
+    end
+  end
+end
+
+module Rails
+  module Generators
+    class MigrationGenerator < NamedBase
+    end
+  end
+end
+
+module Rails
+  module Generators
+    class ModelGenerator < NamedBase
+      # :nodoc:
+      include Rails::Generators::ModelHelpers
+    end
+  end
+end
+
+module Rails
+  # The plugin builder allows you to override elements of the plugin
+  # generator without being forced to reverse the operations of the default
+  # generator.
+  #
+  # This allows you to override entire operations, like the creation of the
+  # Gemfile, \README, or JavaScript files, without needing to know exactly
+  # what those operations do so you can create another template action.
+  class PluginBuilder
+    def rakefile: () -> untyped
+
+    def app: () -> untyped
+
+    def readme: () -> untyped
+
+    def gemfile: () -> untyped
+
+    def license: () -> untyped
+
+    def gemspec: () -> untyped
+
+    def gitignore: () -> untyped
+
+    def lib: () -> untyped
+
+    def config: () -> untyped
+
+    def test: () -> untyped
+
+    PASSTHROUGH_OPTIONS: ::Array[untyped]
+
+    def generate_test_dummy: (?bool force) -> untyped
+
+    def test_dummy_config: () -> untyped
+
+    def test_dummy_assets: () -> untyped
+
+    def test_dummy_clean: () -> untyped
+
+    def assets_manifest: () -> untyped
+
+    def stylesheets: () -> untyped
+
+    def bin: (?bool force) -> untyped
+
+    def gemfile_entry: () -> (nil | untyped)
+  end
+
+  module Generators
+    class PluginGenerator < AppBase
+      alias plugin_path app_path
+
+      def initialize: (*untyped args) -> untyped
+
+      def create_root_files: () -> untyped
+
+      def create_app_files: () -> untyped
+
+      def create_config_files: () -> untyped
+
+      def create_lib_files: () -> untyped
+
+      def create_assets_manifest_file: () -> untyped
+
+      def create_public_stylesheets_files: () -> untyped
+
+      def create_bin_files: () -> untyped
+
+      def create_test_files: () -> untyped
+
+      def create_test_dummy_files: () -> (nil | untyped)
+
+      def update_gemfile: () -> untyped
+
+      def finish_template: () -> untyped
+
+      def name: () -> untyped
+
+      def underscored_name: () -> untyped
+
+      def namespaced_name: () -> untyped
+
+      def create_dummy_app: (?untyped? path) -> untyped
+
+      def engine?: () -> untyped
+
+      def full?: () -> untyped
+
+      def mountable?: () -> untyped
+
+      def skip_git?: () -> untyped
+
+      def with_dummy_app?: () -> untyped
+
+      def api?: () -> untyped
+
+      def self.banner: () -> ::String
+
+      def original_name: () -> untyped
+
+      def modules: () -> untyped
+
+      def wrap_in_modules: (untyped unwrapped_code) -> untyped
+
+      def camelized_modules: () -> untyped
+
+      def humanized: () -> untyped
+
+      def camelized: () -> untyped
+
+      def author: () -> untyped
+
+      def email: () -> untyped
+
+      def valid_const?: () -> untyped
+
+      def application_definition: () -> untyped
+
+      alias store_application_definition! application_definition
+
+      def get_builder_class: () -> untyped
+
+      def rakefile_test_tasks: () -> ::String
+
+      def dummy_path: (?untyped? path) -> untyped
+
+      def mute: () { () -> untyped } -> untyped
+
+      def rails_app_path: () -> untyped
+
+      def inside_application?: () -> untyped
+
+      def relative_path: () -> (nil | untyped)
+    end
+  end
+end
+
+module Rails
+  module Generators
+    class ResourceGenerator < ModelGenerator
+      # :nodoc:
+      include ResourceHelpers
+    end
+  end
+end
+
+module Rails
+  module Generators
+    class ResourceRouteGenerator < NamedBase
+      # :nodoc:
+      # Properly nests namespaces passed into a generator
+      #
+      #   $ rails generate resource admin/users/products
+      #
+      # should give you
+      #
+      #   namespace :admin do
+      #     namespace :users do
+      #       resources :products
+      #     end
+      #   end
+      def add_resource_route: () -> (nil | untyped)
+    end
+  end
+end
+
+module Rails
+  module Generators
+    class ScaffoldGenerator < ResourceGenerator
+      def handle_skip: () -> untyped
+    end
+  end
+end
+
+module Rails
+  module Generators
+    class ScaffoldControllerGenerator < NamedBase
+      # :nodoc:
+      include ResourceHelpers
+
+      def create_controller_files: () -> untyped
+
+      def permitted_params: () -> untyped
+
+      def attachments?: (untyped name) -> untyped
+    end
+  end
+end
+
+module Rails
+  module Generators
+    class SystemTestGenerator < NamedBase
+    end
+  end
+end
+
+module Rails
+  module Generators
+    class TaskGenerator < NamedBase
+      def create_task_files: () -> untyped
+    end
+  end
+end
+
+module Rails
+  module Generators
+    module ResourceHelpers
+      def self.included: (untyped base) -> untyped
+
+      def initialize: (*untyped args) -> untyped
+
+      attr_reader controller_name: untyped
+
+      attr_reader controller_file_name: untyped
+
+      def controller_class_path: () -> untyped
+
+      def assign_controller_names!: (untyped name) -> untyped
+
+      def controller_file_path: () -> untyped
+
+      def controller_class_name: () -> untyped
+
+      def controller_i18n_scope: () -> untyped
+
+      # Loads the ORM::Generators::ActiveModel class. This class is responsible
+      # to tell scaffold entities how to generate a specific method for the
+      # ORM. Check Rails::Generators::ActiveModel for more information.
+      def orm_class: () -> untyped
+
+      # Initialize ORM::Generators::ActiveModel to access instance methods.
+      def orm_instance: (?untyped name) -> untyped
+    end
+  end
+end
+
+module Rails
+  module Generators
+    # This class provides a TestCase for testing generators. To setup, you need
+    # just to configure the destination and set which generator is being tested:
+    #
+    #   class AppGeneratorTest < Rails::Generators::TestCase
+    #     tests AppGenerator
+    #     destination File.expand_path("../tmp", __dir__)
+    #   end
+    #
+    # If you want to ensure your destination root is clean before running each test,
+    # you can set a setup callback:
+    #
+    #   class AppGeneratorTest < Rails::Generators::TestCase
+    #     tests AppGenerator
+    #     destination File.expand_path("../tmp", __dir__)
+    #     setup :prepare_destination
+    #   end
+    class TestCase < ActiveSupport::TestCase
+      include Rails::Generators::Testing::Behaviour
+
+      include Rails::Generators::Testing::SetupAndTeardown
+
+      include Rails::Generators::Testing::Assertions
+
+      include FileUtils
+    end
+  end
+end
+
+module TestUnit
+  module Generators
+    class ControllerGenerator < Base
+      def create_test_files: () -> untyped
+    end
+  end
+end
+
+module TestUnit
+  module Generators
+    class GeneratorGenerator < Base
+      def create_generator_files: () -> untyped
+
+      def generator_path: () -> untyped
+    end
+  end
+end
+
+module TestUnit
+  module Generators
+    class HelperGenerator < Base
+    end
+  end
+end
+
+module TestUnit
+  module Generators
+    class IntegrationGenerator < Base
+      def create_test_files: () -> untyped
+
+      def file_name: () -> untyped
+    end
+  end
+end
+
+module TestUnit
+  module Generators
+    class JobGenerator < Base
+      def create_test_file: () -> untyped
+
+      def file_name: () -> untyped
+    end
+  end
+end
+
+module TestUnit
+  module Generators
+    class MailerGenerator < Base
+      def check_class_collision: () -> untyped
+
+      def create_test_files: () -> untyped
+
+      def create_preview_files: () -> untyped
+
+      def file_name: () -> untyped
+    end
+  end
+end
+
+module TestUnit
+  module Generators
+    class ModelGenerator < Base
+      # :nodoc:
+      # :nodoc:
+      # :nodoc:
+      RESERVED_YAML_KEYWORDS: ::Array[untyped]
+
+      def create_test_file: () -> untyped
+
+      def create_fixture_file: () -> untyped
+
+      def yaml_key_value: (untyped key, untyped value) -> untyped
+    end
+  end
+end
+
+module TestUnit
+  module Generators
+    class PluginGenerator < Base
+      def create_test_files: () -> untyped
+    end
+  end
+end
+
+module TestUnit
+  module Generators
+    class ScaffoldGenerator < Base
+      # :nodoc:
+      # :nodoc:
+      # :nodoc:
+      include Rails::Generators::ResourceHelpers
+
+      def create_test_files: () -> untyped
+
+      def fixture_name: () -> untyped
+
+      def attributes_string: () -> untyped
+
+      def attributes_hash: () -> (::Hash[untyped, untyped] | untyped)
+
+      def boolean?: (untyped name) -> untyped
+
+      def virtual?: (untyped name) -> untyped
+    end
+  end
+end
+
+module TestUnit
+  module Generators
+    class SystemGenerator < Base
+      def create_test_files: () -> untyped
+
+      def file_name: () -> untyped
+    end
+  end
+end
+
+module TestUnit
+  module Generators
+    class Base < Rails::Generators::NamedBase
+    end
+  end
+end
+
+module Rails
+  module Generators
+    module Testing
+      module Assertions
+        # Asserts a given file exists. You need to supply an absolute path or a path relative
+        # to the configured destination:
+        #
+        #   assert_file "config/environment.rb"
+        #
+        # You can also give extra arguments. If the argument is a regexp, it will check if the
+        # regular expression matches the given file content. If it's a string, it compares the
+        # file with the given string:
+        #
+        #   assert_file "config/environment.rb", /initialize/
+        #
+        # Finally, when a block is given, it yields the file content:
+        #
+        #   assert_file "app/controllers/products_controller.rb" do |controller|
+        #     assert_instance_method :index, controller do |index|
+        #       assert_match(/Product\.all/, index)
+        #     end
+        #   end
+        def assert_file: (untyped relative, *untyped contents) { (untyped) -> untyped } -> untyped
+
+        alias assert_directory assert_file
+
+        # Asserts a given file does not exist. You need to supply an absolute path or a
+        # path relative to the configured destination:
+        #
+        #   assert_no_file "config/random.rb"
+        def assert_no_file: (untyped relative) -> untyped
+
+        alias assert_no_directory assert_no_file
+
+        # Asserts a given migration exists. You need to supply an absolute path or a
+        # path relative to the configured destination:
+        #
+        #   assert_migration "db/migrate/create_products.rb"
+        #
+        # This method manipulates the given path and tries to find any migration which
+        # matches the migration name. For example, the call above is converted to:
+        #
+        #   assert_file "db/migrate/003_create_products.rb"
+        #
+        # Consequently, assert_migration accepts the same arguments has assert_file.
+        def assert_migration: (untyped relative, *untyped contents) { () -> untyped } -> untyped
+
+        # Asserts a given migration does not exist. You need to supply an absolute path or a
+        # path relative to the configured destination:
+        #
+        #   assert_no_migration "db/migrate/create_products.rb"
+        def assert_no_migration: (untyped relative) -> untyped
+
+        # Asserts the given class method exists in the given content. This method does not detect
+        # class methods inside (class << self), only class methods which starts with "self.".
+        # When a block is given, it yields the content of the method.
+        #
+        #   assert_migration "db/migrate/create_products.rb" do |migration|
+        #     assert_class_method :up, migration do |up|
+        #       assert_match(/create_table/, up)
+        #     end
+        #   end
+        def assert_class_method: (untyped method, untyped content) { () -> untyped } -> untyped
+
+        # Asserts the given method exists in the given content. When a block is given,
+        # it yields the content of the method.
+        #
+        #   assert_file "app/controllers/products_controller.rb" do |controller|
+        #     assert_instance_method :index, controller do |index|
+        #       assert_match(/Product\.all/, index)
+        #     end
+        #   end
+        def assert_instance_method: (untyped method, untyped content) { (untyped) -> untyped } -> untyped
+
+        alias assert_method assert_instance_method
+
+        # Asserts the given attribute type gets translated to a field type
+        # properly:
+        #
+        #   assert_field_type :date, :date_select
+        def assert_field_type: (untyped attribute_type, untyped field_type) -> untyped
+
+        # Asserts the given attribute type gets a proper default value:
+        #
+        #   assert_field_default_value :string, "MyString"
+        def assert_field_default_value: (untyped attribute_type, untyped value) -> untyped
+      end
+    end
+  end
+end
+
+module Rails
+  module Generators
+    module Testing
+      module Behaviour
+        extend ActiveSupport::Concern
+
+        include ActiveSupport::Testing::Stream
+
+        module ClassMethods
+          # Sets which generator should be tested:
+          #
+          #   tests AppGenerator
+          def tests: (untyped klass) -> untyped
+
+          # Sets default arguments on generator invocation. This can be overwritten when
+          # invoking it.
+          #
+          #   arguments %w(app_name --skip-active-record)
+          def arguments: (untyped array) -> untyped
+
+          # Sets the destination of generator files:
+          #
+          #   destination File.expand_path("../tmp", __dir__)
+          def destination: (untyped path) -> untyped
+        end
+
+        # Runs the generator configured for this class. The first argument is an array like
+        # command line arguments:
+        #
+        #   class AppGeneratorTest < Rails::Generators::TestCase
+        #     tests AppGenerator
+        #     destination File.expand_path("../tmp", __dir__)
+        #     setup :prepare_destination
+        #
+        #     test "database.yml is not created when skipping Active Record" do
+        #       run_generator %w(myapp --skip-active-record)
+        #       assert_no_file "config/database.yml"
+        #     end
+        #   end
+        #
+        # You can provide a configuration hash as second argument. This method returns the output
+        # printed by the generator.
+        def run_generator: (?untyped args, ?::Hash[untyped, untyped] config) -> untyped
+
+        # Instantiate the generator.
+        def generator: (?untyped args, ?::Hash[untyped, untyped] options, ?::Hash[untyped, untyped] config) -> untyped
+
+        # Create a Rails::Generators::GeneratedAttribute by supplying the
+        # attribute type and, optionally, the attribute name:
+        #
+        #   create_generated_attribute(:string, 'name')
+        def create_generated_attribute: (untyped attribute_type, ?::String name, ?untyped? index) -> untyped
+
+        def destination_root_is_set?: () -> untyped
+
+        def ensure_current_path: () -> untyped
+
+        def prepare_destination: () -> untyped
+
+        def migration_file_name: (untyped relative) -> untyped
+      end
+    end
+  end
+end
+
+module Rails
+  module Generators
+    module Testing
+      module SetupAndTeardown
+        def setup: () -> untyped
+
+        def teardown: () -> untyped
+      end
+    end
+  end
+end
+
+module Rails
+  module Generators
+    include Rails::Command::Behavior
+
+    DEFAULT_ALIASES: ::Hash[untyped, untyped]
+
+    DEFAULT_OPTIONS: ::Hash[untyped, untyped]
+
+    def self.configure!: (untyped config) -> untyped
+
+    def self.templates_path: () -> untyped
+
+    def self.aliases: () -> untyped
+
+    def self.options: () -> untyped
+
+    # Hold configured generators fallbacks. If a plugin developer wants a
+    # generator group to fallback to another group in case of missing generators,
+    # they can add a fallback.
+    #
+    # For example, shoulda is considered a test_framework and is an extension
+    # of test_unit. However, most part of shoulda generators are similar to
+    # test_unit ones.
+    #
+    # Shoulda then can tell generators to search for test_unit generators when
+    # some of them are not available by adding a fallback:
+    #
+    #   Rails::Generators.fallbacks[:shoulda] = :test_unit
+    def self.fallbacks: () -> untyped
+
+    # Configure generators for API only applications. It basically hides
+    # everything that is usually browser related, such as assets and session
+    # migration generators, and completely disable helpers and assets
+    # so generators such as scaffold won't create them.
+    def self.api_only!: () -> untyped
+
+    # Remove the color from output.
+    def self.no_color!: () -> untyped
+
+    # Returns an array of generator namespaces that are hidden.
+    # Generator namespaces may be hidden for a variety of reasons.
+    # Some are aliased such as "rails:migration" and can be
+    # invoked with the shorter "migration", others are private to other generators
+    # such as "css:scaffold".
+    def self.hidden_namespaces: () -> untyped
+
+    def self.hide_namespaces: (*untyped namespaces) -> untyped
+
+    alias self.hide_namespace self.hide_namespaces
+
+    # Show help message with available generators.
+    def self.help: (?::String command) -> untyped
+
+    def self.public_namespaces: () -> untyped
+
+    def self.print_generators: () -> untyped
+
+    def self.sorted_groups: () -> untyped
+
+    def self.find_by_namespace: (untyped name, ?untyped? base, ?untyped? context) -> untyped
+
+    # Receives a namespace, arguments and the behavior to invoke the generator.
+    # It's used as the default entry point for generate, destroy and update
+    # commands.
+    def self.invoke: (untyped namespace, ?untyped args, ?::Hash[untyped, untyped] config) -> untyped
+
+    def self.print_list: (untyped base, untyped namespaces) -> untyped
+
+    # Try fallbacks for the given base.
+    def self.invoke_fallbacks_for: (untyped name, untyped base) -> (nil | untyped)
+
+    def self.command_type: () -> untyped
+
+    def self.lookup_paths: () -> untyped
+
+    def self.file_lookup_paths: () -> untyped
+  end
+end
+
+module Rails
+  # This module helps build the runtime properties that are displayed in
+  # Rails::InfoController responses. These include the active Rails version,
+  # Ruby version, Rack version, and so on.
+  module Info
+    def self.names: () -> untyped
+
+    def self.value_for: (untyped property_name) -> untyped
+
+    # nodoc:
+    def self.property: (untyped name, ?untyped? value) { () -> untyped } -> untyped
+
+    def self.to_s: () -> untyped
+
+    alias self.inspect self.to_s
+
+    def self.to_html: () -> untyped
+  end
+end
+
+class Rails::InfoController < Rails::ApplicationController
+  def index: () -> untyped
+
+  def properties: () -> untyped
+
+  def routes: () -> untyped
+
+  def match_route: () { (untyped) -> untyped } -> untyped
+
+  def with_leading_slash: (untyped path) -> untyped
+end
+
+module Rails
+  module Initializable
+    def self.included: (untyped base) -> untyped
+
+    class Initializer
+      attr_reader name: untyped
+
+      attr_reader block: untyped
+
+      def initialize: (untyped name, untyped context, untyped options) { () -> untyped } -> untyped
+
+      def before: () -> untyped
+
+      def after: () -> untyped
+
+      def belongs_to?: (untyped group) -> untyped
+
+      def run: (*untyped args) -> untyped
+
+      def bind: (untyped context) -> (untyped | Initializer)
+
+      def context_class: () -> untyped
+    end
+
+    class Collection[T] < Array[T]
+      include TSort
+
+      alias tsort_each_node each
+
+      def tsort_each_child: (untyped initializer) { () -> untyped } -> untyped
+
+      def +: (untyped other) -> Collection[untyped]
+    end
+
+    def run_initializers: (?::Symbol group, *untyped args) -> (nil | untyped)
+
+    def initializers: () -> untyped
+
+    module ClassMethods
+      def initializers: () -> untyped
+
+      def initializers_chain: () -> untyped
+
+      def initializers_for: (untyped binding) -> Collection[untyped]
+
+      def initializer: (untyped name, ?::Hash[untyped, untyped] opts) { () -> untyped } -> untyped
+    end
+  end
+end
+
+class Rails::MailersController < Rails::ApplicationController
+  def index: () -> untyped
+
+  def preview: () -> untyped
+
+  def show_previews?: () -> untyped
+
+  def find_preview: () -> untyped
+
+  def find_preferred_part: (*untyped formats) -> untyped
+
+  def find_part: (untyped format) -> untyped
+
+  def part_query: (untyped mime_type) -> untyped
+
+  def locale_query: (untyped locale) -> untyped
+
+  def set_locale: () { () -> untyped } -> untyped
+end
+
+module Rails
+  module Paths
+    # This object is an extended hash that behaves as root of the <tt>Rails::Paths</tt> system.
+    # It allows you to collect information about how you want to structure your application
+    # paths through a Hash-like API. It requires you to give a physical path on initialization.
+    #
+    #   root = Root.new "/rails"
+    #   root.add "app/controllers", eager_load: true
+    #
+    # The above command creates a new root object and adds "app/controllers" as a path.
+    # This means we can get a <tt>Rails::Paths::Path</tt> object back like below:
+    #
+    #   path = root["app/controllers"]
+    #   path.eager_load?               # => true
+    #   path.is_a?(Rails::Paths::Path) # => true
+    #
+    # The +Path+ object is simply an enumerable and allows you to easily add extra paths:
+    #
+    #   path.is_a?(Enumerable) # => true
+    #   path.to_ary.inspect    # => ["app/controllers"]
+    #
+    #   path << "lib/controllers"
+    #   path.to_ary.inspect    # => ["app/controllers", "lib/controllers"]
+    #
+    # Notice that when you add a path using +add+, the path object created already
+    # contains the path with the same path value given to +add+. In some situations,
+    # you may not want this behavior, so you can give <tt>:with</tt> as option.
+    #
+    #   root.add "config/routes", with: "config/routes.rb"
+    #   root["config/routes"].inspect # => ["config/routes.rb"]
+    #
+    # The +add+ method accepts the following options as arguments:
+    # eager_load, autoload, autoload_once, and glob.
+    #
+    # Finally, the +Path+ object also provides a few helpers:
+    #
+    #   root = Root.new "/rails"
+    #   root.add "app/controllers"
+    #
+    #   root["app/controllers"].expanded # => ["/rails/app/controllers"]
+    #   root["app/controllers"].existent # => ["/rails/app/controllers"]
+    #
+    # Check the <tt>Rails::Paths::Path</tt> documentation for more information.
+    class Root
+      attr_accessor path: untyped
+
+      def initialize: (untyped path) -> untyped
+
+      def []=: (untyped path, untyped value) -> untyped
+
+      def add: (untyped path, ?::Hash[untyped, untyped] options) -> untyped
+
+      def []: (untyped path) -> untyped
+
+      def values: () -> untyped
+
+      def keys: () -> untyped
+
+      def values_at: (*untyped list) -> untyped
+
+      def all_paths: () -> untyped
+
+      def autoload_once: () -> untyped
+
+      def eager_load: () -> untyped
+
+      def autoload_paths: () -> untyped
+
+      def load_paths: () -> untyped
+
+      def filter_by: () { (untyped) -> untyped } -> untyped
+    end
+
+    class Path
+      include Enumerable[untyped]
+
+      attr_accessor glob: untyped
+
+      def initialize: (untyped root, untyped current, untyped paths, ?::Hash[untyped, untyped] options) -> untyped
+
+      def absolute_current: () -> untyped
+
+      def children: () -> untyped
+
+      def first: () -> untyped
+
+      def last: () -> untyped
+
+      def each: () { () -> untyped } -> untyped
+
+      def <<: (untyped path) -> untyped
+
+      alias push <<
+
+      def concat: (untyped paths) -> untyped
+
+      def unshift: (*untyped paths) -> untyped
+
+      def to_ary: () -> untyped
+
+      def extensions: () -> untyped
+
+      # Expands all paths against the root and return all unique values.
+      def expanded: () -> untyped
+
+      # Returns all expanded paths but only if they exist in the filesystem.
+      def existent: () -> untyped
+
+      def existent_directories: () -> untyped
+
+      alias to_a expanded
+
+      def files_in: (untyped path) -> untyped
+    end
+  end
+end
+
+module Rails
+  module Rack
+    # Sets log tags, logs the request, calls the app, and flushes the logs.
+    #
+    # Log tags (+taggers+) can be an Array containing: methods that the +request+
+    # object responds to, objects that respond to +to_s+ or Proc objects that accept
+    # an instance of the +request+ object.
+    class Logger < ActiveSupport::LogSubscriber
+      def initialize: (untyped app, ?untyped? taggers) -> untyped
+
+      def call: (untyped env) -> untyped
+
+      def call_app: (untyped request, untyped env) -> untyped
+
+      def started_request_message: (untyped request) -> untyped
+
+      def compute_tags: (untyped request) -> untyped
+
+      def finish: (untyped request) -> untyped
+
+      def logger: () -> untyped
+    end
+  end
+end
+
+module Rails
+  module Rack
+  end
+end
+
+module Rails
+  class Railtie
+    module Configurable
+      extend ActiveSupport::Concern
+
+      module ClassMethods
+        def inherited: (untyped base) -> untyped
+
+        def `instance`: () -> untyped
+
+        def respond_to?: (*untyped args) -> untyped
+
+        def configure: () { () -> untyped } -> untyped
+
+        def method_missing: (*untyped args) { () -> untyped } -> untyped
+      end
+    end
+  end
+end
+
+module Rails
+  class Railtie
+    class Configuration
+      def initialize: () -> untyped
+
+      def self.eager_load_namespaces: () -> untyped
+
+      # All namespaces that are eager loaded
+      def eager_load_namespaces: () -> untyped
+
+      # Add files that should be watched for change.
+      def watchable_files: () -> untyped
+
+      # Add directories that should be watched for change.
+      # The key of the hashes should be directories and the values should
+      # be an array of extensions to match in each directory.
+      def watchable_dirs: () -> untyped
+
+      # This allows you to modify the application's middlewares from Engines.
+      #
+      # All operations you run on the app_middleware will be replayed on the
+      # application once it is defined and the default_middlewares are
+      # created
+      def app_middleware: () -> untyped
+
+      # This allows you to modify application's generators from Railties.
+      #
+      # Values set on app_generators will become defaults for application, unless
+      # application overwrites them.
+      def app_generators: () { (untyped) -> untyped } -> untyped
+
+      # First configurable block to run. Called before any initializers are run.
+      def before_configuration: () { () -> untyped } -> untyped
+
+      # Third configurable block to run. Does not run if +config.eager_load+
+      # set to false.
+      def before_eager_load: () { () -> untyped } -> untyped
+
+      # Second configurable block to run. Called before frameworks initialize.
+      def before_initialize: () { () -> untyped } -> untyped
+
+      # Last configurable block to run. Called after frameworks initialize.
+      def after_initialize: () { () -> untyped } -> untyped
+
+      # Array of callbacks defined by #to_prepare.
+      def to_prepare_blocks: () -> untyped
+
+      # Defines generic callbacks to run before #after_initialize. Useful for
+      # Rails::Railtie subclasses.
+      def to_prepare: () { () -> untyped } -> untyped
+
+      def respond_to?: (untyped name, ?bool include_private) -> untyped
+
+      def method_missing: (untyped name, *untyped args) { () -> untyped } -> untyped
+    end
+  end
+end
+
+module Rails
+  # <tt>Rails::Railtie</tt> is the core of the Rails framework and provides
+  # several hooks to extend Rails and/or modify the initialization process.
+  #
+  # Every major component of Rails (Action Mailer, Action Controller, Active
+  # Record, etc.) implements a railtie. Each of them is responsible for their
+  # own initialization. This makes Rails itself absent of any component hooks,
+  # allowing other components to be used in place of any of the Rails defaults.
+  #
+  # Developing a Rails extension does _not_ require implementing a railtie, but
+  # if you need to interact with the Rails framework during or after boot, then
+  # a railtie is needed.
+  #
+  # For example, an extension doing any of the following would need a railtie:
+  #
+  # * creating initializers
+  # * configuring a Rails framework for the application, like setting a generator
+  # * adding <tt>config.*</tt> keys to the environment
+  # * setting up a subscriber with <tt>ActiveSupport::Notifications</tt>
+  # * adding Rake tasks
+  #
+  # == Creating a Railtie
+  #
+  # To extend Rails using a railtie, create a subclass of <tt>Rails::Railtie</tt>.
+  # This class must be loaded during the Rails boot process, and is conventionally
+  # called <tt>MyNamespace::Railtie</tt>.
+  #
+  # The following example demonstrates an extension which can be used with or
+  # without Rails.
+  #
+  #   # lib/my_gem/railtie.rb
+  #   module MyGem
+  #     class Railtie < Rails::Railtie
+  #     end
+  #   end
+  #
+  #   # lib/my_gem.rb
+  #   require 'my_gem/railtie' if defined?(Rails)
+  #
+  # == Initializers
+  #
+  # To add an initialization step to the Rails boot process from your railtie, just
+  # define the initialization code with the +initializer+ macro:
+  #
+  #   class MyRailtie < Rails::Railtie
+  #     initializer "my_railtie.configure_rails_initialization" do
+  #       # some initialization behavior
+  #     end
+  #   end
+  #
+  # If specified, the block can also receive the application object, in case you
+  # need to access some application-specific configuration, like middleware:
+  #
+  #   class MyRailtie < Rails::Railtie
+  #     initializer "my_railtie.configure_rails_initialization" do |app|
+  #       app.middleware.use MyRailtie::Middleware
+  #     end
+  #   end
+  #
+  # Finally, you can also pass <tt>:before</tt> and <tt>:after</tt> as options to
+  # +initializer+, in case you want to couple it with a specific step in the
+  # initialization process.
+  #
+  # == Configuration
+  #
+  # Railties can access a config object which contains configuration shared by all
+  # railties and the application:
+  #
+  #   class MyRailtie < Rails::Railtie
+  #     # Customize the ORM
+  #     config.app_generators.orm :my_railtie_orm
+  #
+  #     # Add a to_prepare block which is executed once in production
+  #     # and before each request in development.
+  #     config.to_prepare do
+  #       MyRailtie.setup!
+  #     end
+  #   end
+  #
+  # == Loading Rake Tasks and Generators
+  #
+  # If your railtie has Rake tasks, you can tell Rails to load them through the method
+  # +rake_tasks+:
+  #
+  #   class MyRailtie < Rails::Railtie
+  #     rake_tasks do
+  #       load 'path/to/my_railtie.tasks'
+  #     end
+  #   end
+  #
+  # By default, Rails loads generators from your load path. However, if you want to place
+  # your generators at a different location, you can specify in your railtie a block which
+  # will load them during normal generators lookup:
+  #
+  #   class MyRailtie < Rails::Railtie
+  #     generators do
+  #       require 'path/to/my_railtie_generator'
+  #     end
+  #   end
+  #
+  # Since filenames on the load path are shared across gems, be sure that files you load
+  # through a railtie have unique names.
+  #
+  # == Application and Engine
+  #
+  # An engine is nothing more than a railtie with some initializers already set. And since
+  # <tt>Rails::Application</tt> is an engine, the same configuration described here can be
+  # used in both.
+  #
+  # Be sure to look at the documentation of those specific classes for more information.
+  class Railtie
+    include Initializable
+
+    ABSTRACT_RAILTIES: ::Array[untyped]
+
+    def self.subclasses: () -> untyped
+
+    def self.inherited: (untyped base) -> untyped
+
+    def self.rake_tasks: () { () -> untyped } -> untyped
+
+    def self.console: () { () -> untyped } -> untyped
+
+    def self.runner: () { () -> untyped } -> untyped
+
+    def self.generators: () { () -> untyped } -> untyped
+
+    def self.abstract_railtie?: () -> untyped
+
+    def self.railtie_name: (?untyped? name) -> untyped
+
+    # Since Rails::Railtie cannot be instantiated, any methods that call
+    # +instance+ are intended to be called only on subclasses of a Railtie.
+    def self.`instance`: () -> untyped
+
+    # Allows you to configure the railtie. This is the same method seen in
+    # Railtie::Configurable, but this module is no longer required for all
+    # subclasses of Railtie so we provide the class method here.
+    def self.configure: () { () -> untyped } -> untyped
+
+    def self.generate_railtie_name: (untyped string) -> untyped
+
+    def self.respond_to_missing?: (untyped name, untyped _) -> untyped
+
+    # If the class method does not have a method, then send the method call
+    # to the Railtie instance.
+    def self.method_missing: (untyped name, *untyped args) { () -> untyped } -> untyped
+
+    # receives an instance variable identifier, set the variable value if is
+    # blank and append given block to value, which will be used later in
+    # `#each_registered_block(type, &block)`
+    def self.register_block_for: (untyped `type`) { () -> untyped } -> untyped
+
+    def initialize: () -> untyped
+
+    def configure: () { () -> untyped } -> untyped
+
+    # This is used to create the <tt>config</tt> object on Railties, an instance of
+    # Railtie::Configuration, that is used by Railties and Application to store
+    # related configuration.
+    def config: () -> untyped
+
+    def railtie_namespace: () -> untyped
+
+    def run_console_blocks: (untyped app) -> untyped
+
+    def run_generators_blocks: (untyped app) -> untyped
+
+    def run_runner_blocks: (untyped app) -> untyped
+
+    def run_tasks_blocks: (untyped app) -> untyped
+
+    # run `&block` in every registered block in `#register_block_for`
+    def each_registered_block: (untyped `type`) { () -> untyped } -> untyped
+  end
+end
+
+module Rails
+  class Secrets
+    # Greatly inspired by Ara T. Howard's magnificent sekrets gem. (trim non-ascii characters)
+    # :nodoc:
+    class MissingKeyError < RuntimeError
+      def initialize: () -> untyped
+    end
+
+    attr_writer root: untyped
+
+    def self.parse: (untyped paths, env: untyped env) -> untyped
+
+    def self.key: () -> untyped
+
+    def self.encrypt: (untyped data) -> untyped
+
+    def self.decrypt: (untyped data) -> untyped
+
+    def self.read: () -> untyped
+
+    def self.write: (untyped contents) -> untyped
+
+    def self.read_for_editing: () { () -> untyped } -> untyped
+
+    def self.handle_missing_key: () -> untyped
+
+    def self.read_key_file: () -> untyped
+
+    def self.key_path: () -> untyped
+
+    def self.path: () -> untyped
+
+    def self.preprocess: (untyped path) -> untyped
+
+    def self.writing: (untyped contents) { (untyped) -> untyped } -> untyped
+
+    def self.encryptor: () -> untyped
+  end
+end
+
+module Rails
+  # Implements the logic behind <tt>Rails::Command::NotesCommand</tt>. See <tt>rails notes --help</tt> for usage information.
+  #
+  # Annotation objects are triplets <tt>:line</tt>, <tt>:tag</tt>, <tt>:text</tt> that
+  # represent the line where the annotation lives, its tag, and its text. Note
+  # the filename is not stored.
+  #
+  # Annotations are looked for in comments and modulus whitespace they have to
+  # start with the tag optionally followed by a colon. Everything up to the end
+  # of the line (or closing ERB comment tag) is considered to be their text.
+  class SourceAnnotationExtractor
+    class Annotation
+      # Note: It inherits unnamed class, but omitted
+      def self.directories: () -> untyped
+
+      # Registers additional directories to be included
+      #   Rails::SourceAnnotationExtractor::Annotation.register_directories("spec", "another")
+      def self.register_directories: (*untyped dirs) -> untyped
+
+      def self.tags: () -> untyped
+
+      # Registers additional tags
+      #   Rails::SourceAnnotationExtractor::Annotation.register_tags("TESTME", "DEPRECATEME")
+      def self.register_tags: (*untyped additional_tags) -> untyped
+
+      def self.extensions: () -> untyped
+
+      # Registers new Annotations File Extensions
+      #   Rails::SourceAnnotationExtractor::Annotation.register_extensions("css", "scss", "sass", "less", "js") { |tag| /\/\/\s*(#{tag}):?\s*(.*)$/ }
+      def self.register_extensions: (*untyped exts) { () -> untyped } -> untyped
+
+      # Returns a representation of the annotation that looks like this:
+      #
+      #   [126] [TODO] This algorithm is simple and clearly correct, make it faster.
+      #
+      # If +options+ has a flag <tt>:tag</tt> the tag is shown as in the example above.
+      # Otherwise the string contains just line and text.
+      def to_s: (?::Hash[untyped, untyped] options) -> untyped
+
+      # Used in annotations.rake
+      # nodoc:
+      def self.notes_task_deprecation_warning: () -> untyped
+    end
+
+    # Prints all annotations with tag +tag+ under the root directories +app+,
+    # +config+, +db+, +lib+, and +test+ (recursively).
+    #
+    # If +tag+ is <tt>nil</tt>, annotations with either default or registered tags are printed.
+    #
+    # Specific directories can be explicitly set using the <tt>:dirs</tt> key in +options+.
+    #
+    #   Rails::SourceAnnotationExtractor.enumerate 'TODO|FIXME', dirs: %w(app lib), tag: true
+    #
+    # If +options+ has a <tt>:tag</tt> flag, it will be passed to each annotation's +to_s+.
+    #
+    # See <tt>#find_in</tt> for a list of file extensions that will be taken into account.
+    #
+    # This class method is the single entry point for the `rails notes` command.
+    def self.enumerate: (?untyped? tag, ?::Hash[untyped, untyped] options) -> untyped
+
+    attr_reader tag: untyped
+
+    def initialize: (untyped tag) -> untyped
+
+    # Returns a hash that maps filenames under +dirs+ (recursively) to arrays
+    # with their annotations.
+    def find: (untyped dirs) -> untyped
+
+    # Returns a hash that maps filenames under +dir+ (recursively) to arrays
+    # with their annotations. Files with extensions registered in
+    # <tt>Rails::SourceAnnotationExtractor::Annotation.extensions</tt> are
+    # taken into account. Only files with annotations are included.
+    def find_in: (untyped dir) -> untyped
+
+    # If +file+ is the filename of a file that contains annotations this method returns
+    # a hash with a single entry that maps +file+ to an array of its annotations.
+    # Otherwise it returns an empty hash.
+    def extract_annotations_from: (untyped file, untyped pattern) -> untyped
+
+    # Prints the mapping from filenames to annotations in +results+ ordered by filename.
+    # The +options+ hash is passed to each annotation's +to_s+.
+    def display: (untyped results, ?::Hash[untyped, untyped] options) -> untyped
+  end
+end
+
+# Remove this deprecated class in the next minor version
+# nodoc:
+SourceAnnotationExtractor: untyped
+
+module Rails
+  module LineFiltering
+    # :nodoc:
+    def run: (untyped reporter, ?::Hash[untyped, untyped] options) -> untyped
+  end
+end
+
+module Rails
+  class TestUnitRailtie < Rails::Railtie
+  end
+end
+
+module Rails
+  class TestUnitReporter < Minitest::StatisticsReporter
+    def record: (untyped result) -> untyped
+
+    def report: () -> (nil | untyped)
+
+    def aggregated_results: () -> untyped
+
+    def filtered_results: () -> untyped
+
+    def relative_path_for: (untyped file) -> untyped
+
+    def output_inline?: () -> untyped
+
+    def fail_fast?: () -> untyped
+
+    def format_line: (untyped result) -> untyped
+
+    def format_rerun_snippet: (untyped result) -> ::String
+
+    def app_root: () -> untyped
+
+    def colored_output?: () -> untyped
+
+    COLOR_BY_RESULT_CODE: ::Hash[untyped, untyped]
+
+    def color_output: (untyped string, by: untyped by) -> untyped
+  end
+end
+
+module Rails
+  module TestUnit
+    class Runner
+      def self.attach_before_load_options: (untyped opts) -> untyped
+
+      def self.parse_options: (untyped argv) -> untyped
+
+      def self.rake_run: (?untyped argv) -> untyped
+
+      def self.run: (?untyped argv) -> untyped
+
+      def self.load_tests: (untyped argv) -> untyped
+
+      def self.compose_filter: (untyped runnable, untyped filter) -> untyped
+
+      def self.extract_filters: (untyped argv) -> untyped
+    end
+
+    class CompositeFilter
+      # :nodoc:
+      attr_reader named_filter: untyped
+
+      def initialize: (untyped runnable, untyped filter, untyped patterns) -> untyped
+
+      # minitest uses === to find matching filters.
+      def ===: (untyped method) -> untyped
+
+      def derive_named_filter: (untyped filter) -> untyped
+
+      def derive_line_filters: (untyped patterns) -> untyped
+    end
+
+    class Filter
+      # :nodoc:
+      def initialize: (untyped runnable, untyped file, untyped line) -> untyped
+
+      def ===: (untyped method) -> (nil | untyped)
+
+      def definition_for: (untyped method) -> untyped
+    end
+  end
+end
+
+module Rails
+  # Returns the version of the currently loaded Rails as a string.
+  def self.version: () -> untyped
+end
+
+class Rails::WelcomeController < Rails::ApplicationController
+  def index: () -> nil
+end
+
+module Rails
+  extend ActiveSupport::Autoload
+
+  attr_writer application: untyped
+
+  attr_accessor app_class: untyped
+
+  attr_accessor cache: untyped
+
+  attr_accessor logger: untyped
+
+  def self.application: () -> untyped
+
+  # The Configuration instance used to configure the Rails environment
+  def self.configuration: () -> untyped
+
+  def self.backtrace_cleaner: () -> untyped
+
+  # Returns a Pathname object of the current Rails project,
+  # otherwise it returns +nil+ if there is no project:
+  #
+  #   Rails.root
+  #     # => #<Pathname:/Users/someuser/some/path/project>
+  def self.root: () -> untyped
+
+  # Returns the current Rails environment.
+  #
+  #   Rails.env # => "development"
+  #   Rails.env.development? # => true
+  #   Rails.env.production? # => false
+  def self.env: () -> untyped
+
+  # Sets the Rails environment.
+  #
+  #   Rails.env = "staging" # => "staging"
+  def self.env=: (untyped environment) -> untyped
+
+  # Returns all Rails groups for loading based on:
+  #
+  # * The Rails environment;
+  # * The environment variable RAILS_GROUPS;
+  # * The optional envs given as argument and the hash with group dependencies;
+  #
+  #   groups assets: [:development, :test]
+  #
+  #   # Returns
+  #   # => [:default, "development", :assets] for Rails.env == "development"
+  #   # => [:default, "production"]           for Rails.env == "production"
+  def self.groups: (*untyped groups) -> untyped
+
+  # Returns a Pathname object of the public folder of the current
+  # Rails project, otherwise it returns +nil+ if there is no project:
+  #
+  #   Rails.public_path
+  #     # => #<Pathname:/Users/someuser/some/path/project/public>
+  def self.public_path: () -> untyped
+
+  def self.autoloaders: () -> untyped
+end
+
+class Object
+  include ActiveRecord::TestDatabases
+
+  include ActiveRecord::TestFixtures
+
+  def before_setup: () -> untyped
+end
+


### PR DESCRIPTION
This pull request adds RBS files for Ruby on Rails. They are imported from pocke/rbs_rails.


# Added RBS files


I added three sorts of files. 

First, `-generated` suffixed files, such as `activerecord-generated.rbs`.
They are generated by `generate.rb`, which is based on `rbs prototype rb`, and not modified by hand.

Seocnd, `patch.rbs`.
They include monkey patches to fix errors. I designed them as a place to put RBSs that are temporarily necessary due to bug of RBS. 


Last, other rbs files, such as `activerecord.rbs`.
They have hand-written RBS files. If we want to improve the generated types, we can write types to the files (not `-generated` files).




# Directory structure


Ruby on Rails has several gems, such as activereocrd, actionpack, etc.. But they need the same script to generate/test RBSs for them.
So I put the scripts under Railties directory. Other gems don't have any scripts/tests.


The Railties directory has pocke/rbs_rails as a git submodule. pocke/rbs_rails is necessary to generate RBSs and test them.
ref: https://github.com/pocke/rbs_rails/pull/65 The submoduled rbs_rails refers the commit in this pull request.