### PR TITLE
[rails] Re-generate RBS for rails gems with RBS v1.0.0

### DIFF
--- a/gems/actionpack/6.0.3.2/actionpack-generated.rbs
+++ b/gems/actionpack/6.0.3.2/actionpack-generated.rbs
@@ -55,7 +55,7 @@ module AbstractController
 
     extend ActiveSupport::DescendantsTracker
 
-    attr_reader abstract: untyped
+    attr_reader self.abstract: untyped
 
     alias self.abstract? self.abstract
 
@@ -1624,7 +1624,7 @@ module ActionController
   module Helpers
     extend ActiveSupport::Concern
 
-    attr_accessor helpers_path: untyped
+    attr_accessor self.helpers_path: untyped
 
     include AbstractController::Helpers
 
@@ -5363,7 +5363,7 @@ module ActionDispatch
       end
 
       # Returns the parameter parsers.
-      attr_reader parameter_parsers: untyped
+      attr_reader self.parameter_parsers: untyped
 
       module ClassMethods
         # Configure the parameter parser for a given MIME type.
@@ -11397,7 +11397,7 @@ end
 module ActionDispatch
   module SystemTesting
     class Server
-      attr_accessor silence_puma: untyped
+      attr_accessor self.silence_puma: untyped
 
       def run: () -> untyped
 

--- a/gems/actionpack/6.0.3.2/actionpack-generated.rbs
+++ b/gems/actionpack/6.0.3.2/actionpack-generated.rbs
@@ -5462,8 +5462,6 @@ module ActionDispatch
 
     def initialize: (untyped env) -> untyped
 
-    def commit_cookie_jar!: () -> nil
-
     PASS_NOT_FOUND: untyped
 
     def controller_class: () -> untyped

--- a/gems/actionpack/6.0.3.2/actionpack-generated.rbs
+++ b/gems/actionpack/6.0.3.2/actionpack-generated.rbs
@@ -2489,7 +2489,7 @@ module ActionController
 
       def initialize: (untyped mimes, ?untyped? variant) -> untyped
 
-      def `any`: (*untyped args) { () -> untyped } -> untyped
+      def any: (*untyped args) { () -> untyped } -> untyped
 
       alias all any
 
@@ -2503,7 +2503,7 @@ module ActionController
         # nodoc:
         def initialize: (?untyped? variant) -> untyped
 
-        def `any`: (*untyped args) { () -> untyped } -> untyped
+        def any: (*untyped args) { () -> untyped } -> untyped
 
         alias all any
 
@@ -2638,7 +2638,7 @@ module ActionController
 
       def model: () -> untyped
 
-      def `include`: () -> untyped
+      def include: () -> untyped
 
       def name: () -> untyped
 
@@ -6081,6 +6081,8 @@ module ActionDispatch
 
       def self.normalize_port: (untyped port, untyped protocol) { (untyped) -> untyped } -> (nil | untyped)
 
+      public
+
       def initialize: () -> untyped
 
       # Returns the complete URL used for this request.
@@ -6503,7 +6505,7 @@ module ActionDispatch
 
         def name: () -> untyped
 
-        def `type`: () -> untyped
+        def type: () -> untyped
 
         def symbol?: () -> ::FalseClass
 
@@ -6529,7 +6531,7 @@ module ActionDispatch
         # :nodoc:
         def literal?: () -> ::TrueClass
 
-        def `type`: () -> :LITERAL
+        def type: () -> :LITERAL
       end
 
       class Dummy < Literal
@@ -6541,12 +6543,12 @@ module ActionDispatch
 
       class Slash < Terminal
         # :nodoc:
-        def `type`: () -> :SLASH
+        def type: () -> :SLASH
       end
 
       class Dot < Terminal
         # :nodoc:
-        def `type`: () -> :DOT
+        def type: () -> :DOT
       end
 
       class Symbol < Terminal
@@ -6563,7 +6565,7 @@ module ActionDispatch
 
         def default_regexp?: () -> untyped
 
-        def `type`: () -> :SYMBOL
+        def type: () -> :SYMBOL
 
         def symbol?: () -> ::TrueClass
       end
@@ -6575,7 +6577,7 @@ module ActionDispatch
 
       class Group < Unary
         # :nodoc:
-        def `type`: () -> :GROUP
+        def type: () -> :GROUP
 
         def group?: () -> ::TrueClass
       end
@@ -6584,7 +6586,7 @@ module ActionDispatch
         # :nodoc:
         def star?: () -> ::TrueClass
 
-        def `type`: () -> :STAR
+        def type: () -> :STAR
 
         def name: () -> untyped
       end
@@ -6602,7 +6604,7 @@ module ActionDispatch
         # :nodoc:
         def cat?: () -> ::TrueClass
 
-        def `type`: () -> :CAT
+        def type: () -> :CAT
       end
 
       class Or < Node
@@ -6611,7 +6613,7 @@ module ActionDispatch
 
         def initialize: (untyped children) -> untyped
 
-        def `type`: () -> :OR
+        def type: () -> :OR
       end
     end
   end
@@ -10597,7 +10599,7 @@ module ActionDispatch
 
       def append: () { () -> untyped } -> untyped
 
-      def `prepend`: () { () -> untyped } -> untyped
+      def prepend: () { () -> untyped } -> untyped
 
       private
 
@@ -11342,7 +11344,7 @@ module ActionDispatch
 
       def initialize: (untyped name) -> untyped
 
-      def `type`: () -> untyped
+      def type: () -> untyped
 
       def options: () -> untyped
 

--- a/gems/actionpack/6.0.3.2/patch.rbs
+++ b/gems/actionpack/6.0.3.2/patch.rbs
@@ -2,10 +2,6 @@ module AbstractController
   class Base
     # alias bug: https://github.com/ruby/rbs/issues/458
     def send: (String | Symbol name, *untyped args) ?{ (*untyped) -> untyped } -> untyped
-
-    # bug: rbs prototype rb isn't aware of `class << self` for attr_reader
-    # https://github.com/rails/rails/blob/fbe2433be6e052a1acac63c7faf287c52ed3c5ba/actionpack/lib/abstract_controller/base.rb#L34-L35
-    def self.abstract: () -> untyped
   end
 end
 

--- a/gems/actionpack/6.0.3.2/patch.rbs
+++ b/gems/actionpack/6.0.3.2/patch.rbs
@@ -1,18 +1,13 @@
-module AbstractController
-  class Base
-    # alias bug: https://github.com/ruby/rbs/issues/458
-    def send: (String | Symbol name, *untyped args) ?{ (*untyped) -> untyped } -> untyped
-  end
-end
-
 module ActionController
   class Metal
-    # alias bug?: https://github.com/ruby/rbs/issues/458
+    # It is necessary to satisfy alias target.
+    # TODO: Define this method to correct place.
     def status: -> untyped
   end
 
   class LiveTestResponse < Live::Response
-    # alias bug?: https://github.com/ruby/rbs/issues/458
+    # It is necessary to satisfy alias target.
+    # TODO: Define this method to correct place.
     def successful?: -> untyped
     def not_found?: -> untyped
     def server_error?: -> untyped
@@ -21,49 +16,9 @@ end
 
 module ActionDispatch
   class Response
-    # alias bug: https://github.com/ruby/rbs/issues/458
+    # It is necessary to satisfy alias target.
+    # TODO: Define this method to correct place.
     attr_accessor cache_control: untyped
-
-    # alias bug: https://github.com/ruby/rbs/issues/458
-    def location: () -> untyped
-  end
-
-  class Cookies
-    class CookieJar
-      # alias bug: https://github.com/ruby/rbs/issues/458
-      def to_h: () -> ::Hash[untyped, untyped]
-              | [T, U] () { (untyped) -> [T, U] } -> ::Hash[T, U]
-    end
-  end
-
-  module Journey
-    module Nodes
-      class Terminal < Node
-        # alias bug: https://github.com/ruby/rbs/issues/458
-        def left: () -> untyped
-      end
-    end
-  end
-
-  module Routing
-    class Mapper
-      module Resources
-        class SingletonResource < Resource
-          # alias bug: https://github.com/ruby/rbs/issues/458
-          attr_reader path: untyped
-        end
-      end
-    end
-
-    class OptionRedirect < Redirect
-      # alias bug: https://github.com/ruby/rbs/issues/458
-      attr_reader block: untyped
-    end
-
-    class RouteSet
-      # alias bug: https://github.com/ruby/rbs/issues/458
-      def to_s: () -> String
-    end
   end
 end
 

--- a/gems/actionview/6.0.3.2/actionview-generated.rbs
+++ b/gems/actionview/6.0.3.2/actionview-generated.rbs
@@ -391,6 +391,8 @@ module ActionView
 
     def self.find_template: (untyped finder, untyped name, untyped prefixes, untyped partial, untyped keys) -> untyped
 
+    public
+
     class Node
       attr_reader name: untyped
 
@@ -10438,7 +10440,7 @@ module ActionView
     # consume this in production. This is only slow if it's being listened to.
     def render: (untyped view, untyped locals, ?untyped buffer) { () -> untyped } -> untyped
 
-    def `type`: () -> untyped
+    def type: () -> untyped
 
     def short_identifier: () -> untyped
 

--- a/gems/actionview/6.0.3.2/actionview-generated.rbs
+++ b/gems/actionview/6.0.3.2/actionview-generated.rbs
@@ -10517,7 +10517,7 @@ module ActionView
 
       attr_accessor params: untyped
 
-      attr_writer controller_path: untyped
+      attr_writer self.controller_path: untyped
 
       def controller_path=: (untyped path) -> untyped
 

--- a/gems/actionview/6.0.3.2/patch.rbs
+++ b/gems/actionview/6.0.3.2/patch.rbs
@@ -1,16 +1,4 @@
 module ActionView
-  class OutputBuffer < ActiveSupport::SafeBuffer
-    # alias bug: https://github.com/ruby/rbs/issues/458
-    def safe_concat: (untyped value) -> untyped
-  end
-
-  class LookupContext
-    class DetailsKey
-      # alias bug: https://github.com/ruby/rbs/issues/458
-      def equal?: (untyped other) -> bool
-    end
-  end
-
   class Resolver
     # Defined with meta-programming
     def self.caching: () -> untyped

--- a/gems/activemodel/6.0.3.2/activemodel-generated.rbs
+++ b/gems/activemodel/6.0.3.2/activemodel-generated.rbs
@@ -1359,7 +1359,7 @@ module ActiveModel
 
     MESSAGE_OPTIONS: ::Array[untyped]
 
-    attr_accessor i18n_customize_full_message: untyped
+    attr_accessor self.i18n_customize_full_message: untyped
 
     attr_reader messages: untyped
 
@@ -2079,7 +2079,7 @@ module ActiveModel
     # Hence need to put a restriction on password length.
     MAX_PASSWORD_LENGTH_ALLOWED: ::Integer
 
-    attr_accessor min_cost: untyped
+    attr_accessor self.min_cost: untyped
 
     module ClassMethods
       # Adds methods to set and authenticate against a BCrypt password.
@@ -2901,7 +2901,7 @@ end
 
 module ActiveModel
   module Type
-    attr_accessor registry: untyped
+    attr_accessor self.registry: untyped
 
     # Add a new type to the registry, allowing it to be gotten through ActiveModel::Type#lookup
     def self.register: (untyped type_name, ?untyped? klass, **untyped options) { () -> untyped } -> untyped

--- a/gems/activemodel/6.0.3.2/activemodel-generated.rbs
+++ b/gems/activemodel/6.0.3.2/activemodel-generated.rbs
@@ -2457,7 +2457,7 @@ module ActiveModel
   module Type
     class Binary < Value
       # :nodoc:
-      def `type`: () -> :binary
+      def type: () -> :binary
 
       def binary?: () -> ::TrueClass
 
@@ -2499,7 +2499,7 @@ module ActiveModel
     class Boolean < Value
       FALSE_VALUES: untyped
 
-      def `type`: () -> :boolean
+      def type: () -> :boolean
 
       def serialize: (untyped value) -> untyped
 
@@ -2516,7 +2516,7 @@ module ActiveModel
       # :nodoc:
       include Helpers::Timezone
 
-      def `type`: () -> :date
+      def type: () -> :date
 
       def type_cast_for_schema: (untyped value) -> untyped
 
@@ -2545,7 +2545,7 @@ module ActiveModel
 
       include Helpers::TimeValue
 
-      def `type`: () -> :datetime
+      def type: () -> :datetime
 
       private
 
@@ -2570,7 +2570,7 @@ module ActiveModel
 
       BIGDECIMAL_PRECISION: ::Integer
 
-      def `type`: () -> :decimal
+      def type: () -> :decimal
 
       def type_cast_for_schema: (untyped value) -> untyped
 
@@ -2593,7 +2593,7 @@ module ActiveModel
       # :nodoc:
       include Helpers::Numeric
 
-      def `type`: () -> :float
+      def type: () -> :float
 
       def type_cast_for_schema: (untyped value) -> ("::Float::NAN" | untyped)
 
@@ -2697,7 +2697,7 @@ module ActiveModel
   module Type
     class ImmutableString < Value
       # :nodoc:
-      def `type`: () -> :string
+      def type: () -> :string
 
       def serialize: (untyped value) -> untyped
 
@@ -2720,7 +2720,7 @@ module ActiveModel
 
       def initialize: () -> untyped
 
-      def `type`: () -> :integer
+      def type: () -> :integer
 
       def deserialize: (untyped value) -> (nil | untyped)
 
@@ -2800,7 +2800,7 @@ module ActiveModel
 
       include Helpers::TimeValue
 
-      def `type`: () -> :time
+      def type: () -> :time
 
       def user_input_in_time_zone: (untyped value) -> (nil | untyped)
 
@@ -2822,7 +2822,7 @@ module ActiveModel
 
       def initialize: (?scale: untyped? scale, ?limit: untyped? limit, ?precision: untyped? precision) -> untyped
 
-      def `type`: () -> nil
+      def type: () -> nil
 
       # Converts a value from database input to the appropriate ruby type. The
       # return value of this method will be returned from

--- a/gems/activemodel/6.0.3.2/patch.rbs
+++ b/gems/activemodel/6.0.3.2/patch.rbs
@@ -1,11 +1,13 @@
 module ActiveModel
   module Serialization
-    # alias bug: https://github.com/ruby/rbs/issues/458
+    # It is necessary to satisfy alias target.
+    # TODO: Define this method to correct place.
     def `send`: (String name, *untyped args) ?{ (*untyped) -> untyped } -> untyped
   end
 
   module Validations
-    # alias bug: https://github.com/ruby/rbs/issues/458
+    # It is necessary to satisfy alias target.
+    # TODO: Define this method to correct place.
     def `send`: (String name, *untyped args) ?{ (*untyped) -> untyped } -> untyped
   end
 end

--- a/gems/activerecord/6.0.3.2/activerecord-generated.rbs
+++ b/gems/activerecord/6.0.3.2/activerecord-generated.rbs
@@ -657,7 +657,7 @@ end
 
 module ActiveRecord::Associations::Builder
   class Association
-    attr_accessor extensions: untyped
+    attr_accessor self.extensions: untyped
 
     VALID_OPTIONS: ::Array[untyped]
 
@@ -12551,7 +12551,7 @@ module ActiveRecord
     def method_missing: (untyped name, *untyped arguments) { () -> untyped } -> untyped
 
     class Method
-      attr_reader matchers: untyped
+      attr_reader self.matchers: untyped
 
       def self.match: (untyped model, untyped name) -> untyped
 
@@ -15165,9 +15165,9 @@ module ActiveRecord
       def connection: () -> untyped
     end
 
-    attr_accessor delegate: untyped
+    attr_accessor self.delegate: untyped
 
-    attr_accessor disable_ddl_transaction: untyped
+    attr_accessor self.disable_ddl_transaction: untyped
 
     def self.nearest_delegate: () -> untyped
 
@@ -15427,7 +15427,7 @@ module ActiveRecord
   end
 
   class Migrator
-    attr_accessor migrations_paths: untyped
+    attr_accessor self.migrations_paths: untyped
 
     # For cases where a table doesn't exist like loading from schema cache
     def self.current_version: () -> untyped
@@ -20785,7 +20785,7 @@ module ActiveRecord
   module Store
     extend ActiveSupport::Concern
 
-    attr_accessor local_stored_attributes: untyped
+    attr_accessor self.local_stored_attributes: untyped
 
     module ClassMethods
       def store: (untyped store_attribute, ?::Hash[untyped, untyped] options) -> untyped
@@ -21957,7 +21957,7 @@ end
 
 module ActiveRecord
   module Type
-    attr_accessor registry: untyped
+    attr_accessor self.registry: untyped
 
     # Add a new type to the registry, allowing it to be referenced as a
     # symbol by {ActiveRecord::Base.attribute}[rdoc-ref:Attributes::ClassMethods#attribute].
@@ -23794,7 +23794,7 @@ module Arel
 
     include Arel::FactoryMethods
 
-    attr_accessor engine: untyped
+    attr_accessor self.engine: untyped
 
     attr_accessor name: untyped
 

--- a/gems/activerecord/6.0.3.2/activerecord-generated.rbs
+++ b/gems/activerecord/6.0.3.2/activerecord-generated.rbs
@@ -1641,7 +1641,7 @@ module ActiveRecord
 
       alias concat <<
 
-      def `prepend`: (*untyped args) -> untyped
+      def prepend: (*untyped args) -> untyped
 
       # Equivalent to +delete_all+. The difference is that returns +self+, instead
       # of an array with the deleted objects, so methods can be chained. See
@@ -6182,6 +6182,8 @@ module ActiveRecord
 
         def self.spawn_thread: (untyped frequency) -> untyped
 
+        public
+
         def run: () -> (nil | untyped)
       end
 
@@ -10125,7 +10127,7 @@ module ActiveRecord
         class Bit < ActiveModel::Type::Value
           # :nodoc:
           # :nodoc:
-          def `type`: () -> :bit
+          def type: () -> :bit
 
           def cast_value: (untyped value) -> untyped
 
@@ -10157,7 +10159,7 @@ module ActiveRecord
         class BitVarying < OID::Bit
           # :nodoc:
           # :nodoc:
-          def `type`: () -> :bit_varying
+          def type: () -> :bit_varying
         end
       end
     end
@@ -10185,7 +10187,7 @@ module ActiveRecord
         class Cidr < ActiveModel::Type::Value
           # :nodoc:
           # :nodoc:
-          def `type`: () -> :cidr
+          def type: () -> :cidr
 
           def type_cast_for_schema: (untyped value) -> untyped
 
@@ -10247,7 +10249,7 @@ module ActiveRecord
         class Enum < ActiveModel::Type::Value
           # :nodoc:
           # :nodoc:
-          def `type`: () -> :enum
+          def type: () -> :enum
 
           private
 
@@ -10267,7 +10269,7 @@ module ActiveRecord
           # :nodoc:
           include ActiveModel::Type::Helpers::Mutable
 
-          def `type`: () -> :hstore
+          def type: () -> :hstore
 
           def deserialize: (untyped value) -> untyped
 
@@ -10299,7 +10301,7 @@ module ActiveRecord
         class Inet < Cidr
           # :nodoc:
           # :nodoc:
-          def `type`: () -> :inet
+          def type: () -> :inet
         end
       end
     end
@@ -10313,7 +10315,7 @@ module ActiveRecord
         class Jsonb < Type::Json
           # :nodoc:
           # :nodoc:
-          def `type`: () -> :jsonb
+          def type: () -> :jsonb
         end
       end
     end
@@ -10329,7 +10331,7 @@ module ActiveRecord
           # :nodoc:
           include ActiveModel::Type::Helpers::Mutable
 
-          def `type`: () -> :point
+          def type: () -> :point
 
           def cast: (untyped value) -> untyped
 
@@ -10351,7 +10353,7 @@ module ActiveRecord
         class Money < ActiveModel::Type::Decimal
           # :nodoc:
           # :nodoc:
-          def `type`: () -> :money
+          def type: () -> :money
 
           def scale: () -> 2
 
@@ -10369,7 +10371,7 @@ module ActiveRecord
         class Oid < Type::UnsignedInteger
           # :nodoc:
           # :nodoc:
-          def `type`: () -> :oid
+          def type: () -> :oid
         end
       end
     end
@@ -10391,7 +10393,7 @@ module ActiveRecord
           # :nodoc:
           include ActiveModel::Type::Helpers::Mutable
 
-          def `type`: () -> :point
+          def type: () -> :point
 
           def cast: (untyped value) -> untyped
 
@@ -10526,7 +10528,7 @@ module ActiveRecord
 
           alias serialize deserialize
 
-          def `type`: () -> :uuid
+          def type: () -> :uuid
 
           private
 
@@ -10572,7 +10574,7 @@ module ActiveRecord
         class Xml < ActiveModel::Type::String
           # :nodoc:
           # :nodoc:
-          def `type`: () -> :xml
+          def type: () -> :xml
 
           def serialize: (untyped value) -> (nil | Data)
 
@@ -13642,6 +13644,8 @@ module ActiveRecord
 
     def self.update_all_loaded_fixtures: (untyped fixtures_map) -> untyped
 
+    public
+
     attr_reader table_name: untyped
 
     attr_reader name: untyped
@@ -13665,6 +13669,8 @@ module ActiveRecord
     # Returns a hash of rows to be inserted. The key is the table, the value is
     # a list of rows to insert to that table.
     def table_rows: () -> untyped
+
+    private
 
     def model_class=: (untyped class_name) -> untyped
 
@@ -16183,6 +16189,8 @@ module ActiveRecord
 
     def self.klasses: () -> untyped
 
+    public
+
     # Returns +true+ if the class has +no_touching+ set, +false+ otherwise.
     #
     #   Project.no_touching do
@@ -17027,6 +17035,8 @@ module ActiveRecord
     private
 
     def self.reflection_class_for: (untyped macro) -> untyped
+
+    public
 
     # \Reflection enables the ability to examine the associations and aggregations of
     # Active Record classes and objects. This information, for example,
@@ -20260,7 +20270,11 @@ module ActiveRecord
 
     def self.generate_options: (untyped config) -> { table_name_prefix: untyped, table_name_suffix: untyped }
 
+    public
+
     def dump: (untyped stream) -> untyped
+
+    private
 
     attr_accessor table_name: untyped
 
@@ -20896,7 +20910,7 @@ module ActiveRecord
 
     def arel_attribute: (untyped column_name) -> untyped
 
-    def `type`: (untyped column_name) -> untyped
+    def type: (untyped column_name) -> untyped
 
     def has_column?: (untyped column_name) -> untyped
 
@@ -21809,7 +21823,7 @@ module ActiveRecord
   module Type
     class DecimalWithoutScale < ActiveModel::Type::BigInteger
       # :nodoc:
-      def `type`: () -> :decimal
+      def type: () -> :decimal
 
       def type_cast_for_schema: (untyped value) -> untyped
     end
@@ -21850,7 +21864,7 @@ module ActiveRecord
     class Json < ActiveModel::Type::Value
       include ActiveModel::Type::Helpers::Mutable
 
-      def `type`: () -> :json
+      def type: () -> :json
 
       def deserialize: (untyped value) -> untyped
 
@@ -21902,7 +21916,7 @@ module ActiveRecord
   module Type
     class Text < ActiveModel::Type::String
       # :nodoc:
-      def `type`: () -> :text
+      def type: () -> :text
     end
   end
 end
@@ -21976,6 +21990,8 @@ module ActiveRecord
     private
 
     def self.current_adapter_name: () -> untyped
+
+    public
 
     BigInteger: untyped
 
@@ -23616,7 +23632,7 @@ module Arel
 
     def between: (untyped other) -> untyped
 
-    def `in`: (untyped other) -> untyped
+    def in: (untyped other) -> untyped
 
     def in_any: (untyped others) -> untyped
 
@@ -23805,7 +23821,7 @@ module Arel
 
     def initialize: (untyped name, ?type_caster: untyped? type_caster, ?as: untyped? as) -> untyped
 
-    def `alias`: (?::String name) -> Nodes::TableAlias
+    def alias: (?::String name) -> Nodes::TableAlias
 
     def from: () -> SelectManager
 

--- a/gems/activerecord/6.0.3.2/activerecord-generated.rbs
+++ b/gems/activerecord/6.0.3.2/activerecord-generated.rbs
@@ -21218,13 +21218,13 @@ module ActiveRecord
 end
 
 module ActiveRecord
-  module TestDatabases
+  module TestDatabases : BasicObject
     def self.create_and_load_schema: (untyped i, env_name: untyped env_name) -> untyped
   end
 end
 
 module ActiveRecord
-  module TestFixtures
+  module TestFixtures : BasicObject
     extend ActiveSupport::Concern
 
     def before_setup: () -> untyped

--- a/gems/activerecord/6.0.3.2/patch.rbs
+++ b/gems/activerecord/6.0.3.2/patch.rbs
@@ -1,29 +1,13 @@
 module ActiveRecord
   class Relation
-    # alias bug: https://github.com/ruby/rbs/issues/458
+    # It is necessary to satisfy alias target.
+    # TODO: Define this method to correct place.
     def lock_value: () -> untyped
   end
 
   module QueryMethods
     # It is defined with meta programming
     def extending_values: () -> untyped
-  end
-
-  module ConnectionAdapters
-    module PostgreSQL
-      module OID
-        class Uuid < ActiveModel::Type::Value
-          # alias bug: https://github.com/ruby/rbs/issues/458
-          def deserialize: (*untyped) -> untyped
-        end
-      end
-    end
-  end
-
-  module ConnectionAdapters
-    class PostgreSQLAdapter < AbstractAdapter
-      def database_version: (*untyped) -> untyped
-    end
   end
 
   class Migration
@@ -33,52 +17,6 @@ module ActiveRecord
       def remove_reference: (*untyped) -> untyped
       def invert_add_reference: (*untyped) -> untyped
       def invert_remove_reference: (*untyped) -> untyped
-    end
-  end
-
-  class Result
-    # alias bug: https://github.com/ruby/rbs/issues/458
-    def map: [U] () { (untyped arg0) -> U } -> ::Array[U]
-           | () -> ::Enumerator[untyped, ::Array[untyped]]
-  end
-end
-
-module Arel
-  module Nodes
-    class Quoted < Arel::Nodes::Unary
-      # alias bug: https://github.com/ruby/rbs/issues/458
-      def value: () -> untyped
-    end
-
-    class Equality < Arel::Nodes::Binary
-      # alias bug: https://github.com/ruby/rbs/issues/458
-      def left: () -> untyped
-      # alias bug: https://github.com/ruby/rbs/issues/458
-      def right: () -> untyped
-    end
-
-    class TableAlias < Arel::Nodes::Binary
-      # alias bug: https://github.com/ruby/rbs/issues/458
-      def left: () -> untyped
-      # alias bug: https://github.com/ruby/rbs/issues/458
-      def right: () -> untyped
-    end
-
-    class UnqualifiedColumn < Arel::Nodes::Unary
-      # alias bug: https://github.com/ruby/rbs/issues/458
-      def expr: () -> untyped
-      # alias bug: https://github.com/ruby/rbs/issues/458
-      def expr=: (untyped) -> untyped
-    end
-
-    class ValuesList < Unary
-      # alias bug: https://github.com/ruby/rbs/issues/458
-      def expr: () -> untyped
-    end
-
-    class With < Arel::Nodes::Unary
-      # alias bug: https://github.com/ruby/rbs/issues/458
-      def expr: () -> untyped
     end
   end
 end

--- a/gems/activesupport/6.0.3.2/activesupport-generated.rbs
+++ b/gems/activesupport/6.0.3.2/activesupport-generated.rbs
@@ -4976,7 +4976,7 @@ class Hash[unchecked out K, unchecked out V]
 end
 
 module ActiveSupport
-  module Tryable
+  module Tryable : BasicObject
     # nodoc:
     def try: (?untyped? method_name, *untyped args) { (untyped) -> untyped } -> untyped
 

--- a/gems/activesupport/6.0.3.2/activesupport-generated.rbs
+++ b/gems/activesupport/6.0.3.2/activesupport-generated.rbs
@@ -2378,7 +2378,7 @@ end
 class Date
   include DateAndTime::Calculations
 
-  attr_accessor beginning_of_week_default: untyped
+  attr_accessor self.beginning_of_week_default: untyped
 
   # Returns the week start (e.g. :monday) for the current request, if this has been set (via Date.beginning_of_week=).
   # If <tt>Date.beginning_of_week</tt> has not been set for the current request, returns the week start specified in <tt>config.beginning_of_week</tt>.
@@ -3699,7 +3699,7 @@ class Module
 
   alias attr_internal attr_internal_accessor
 
-  attr_accessor attr_internal_naming_format: untyped
+  attr_accessor self.attr_internal_naming_format: untyped
 
   private
 
@@ -6231,7 +6231,7 @@ end
 class Time
   include DateAndTime::Zones
 
-  attr_accessor zone_default: untyped
+  attr_accessor self.zone_default: untyped
 
   # Returns the TimeZone for the current request, if this has been set (via Time.zone=).
   # If <tt>Time.zone</tt> has not been set for the current request, returns the TimeZone specified in <tt>config.time_zone</tt>.
@@ -7720,7 +7720,7 @@ module ActiveSupport
     def self.wrap: () { () -> untyped } -> untyped
 
     # :nodoc:
-    attr_accessor active: untyped
+    attr_accessor self.active: untyped
 
     def self.inherited: (untyped other) -> untyped
 
@@ -8789,19 +8789,19 @@ module ActiveSupport
 
       # If true, use ISO 8601 format for dates and times. Otherwise, fall back
       # to the Active Support legacy format.
-      attr_accessor use_standard_json_time_format: untyped
+      attr_accessor self.use_standard_json_time_format: untyped
 
       # If true, encode >, <, & as escaped unicode sequences (e.g. > as \u003e)
       # as a safety measure.
-      attr_accessor escape_html_entities_in_json: untyped
+      attr_accessor self.escape_html_entities_in_json: untyped
 
       # Sets the precision of encoded time values.
       # Defaults to 3 (equivalent to millisecond precision)
-      attr_accessor time_precision: untyped
+      attr_accessor self.time_precision: untyped
 
       # Sets the encoder used by Rails to encode Ruby objects into JSON strings
       # in +Object#to_json+ and +ActiveSupport::JSON.encode+.
-      attr_accessor json_encoder: untyped
+      attr_accessor self.json_encoder: untyped
     end
   end
 end
@@ -9021,7 +9021,7 @@ module ActiveSupport
 
     def self.logger: () -> untyped
 
-    attr_writer logger: untyped
+    attr_writer self.logger: untyped
 
     def self.log_subscribers: () -> untyped
 
@@ -10083,7 +10083,7 @@ module ActiveSupport
   # to all log subscribers. You can use any queue implementation you want.
   #
   module Notifications
-    attr_accessor notifier: untyped
+    attr_accessor self.notifier: untyped
 
     def self.publish: (untyped name, *untyped args) -> untyped
 
@@ -11123,11 +11123,11 @@ module ActiveSupport
 
     private
 
-    attr_reader subscriber: untyped
+    attr_reader self.subscriber: untyped
 
-    attr_reader notifier: untyped
+    attr_reader self.notifier: untyped
 
-    attr_reader namespace: untyped
+    attr_reader self.namespace: untyped
 
     def self.add_event_subscriber: (untyped event) -> (nil | untyped)
 

--- a/gems/activesupport/6.0.3.2/activesupport-generated.rbs
+++ b/gems/activesupport/6.0.3.2/activesupport-generated.rbs
@@ -506,6 +506,8 @@ module ActiveSupport
 
       def self.build_redis_client: (url: untyped url, **untyped redis_options) -> untyped
 
+      public
+
       attr_reader redis_options: untyped
 
       attr_reader max_key_bytesize: untyped
@@ -601,6 +603,8 @@ module ActiveSupport
       def mget_capable?: () -> untyped
 
       def mset_capable?: () -> untyped
+
+      private
 
       def set_redis_capabilities: () -> untyped
 
@@ -812,6 +816,8 @@ module ActiveSupport
     # Raises an error when the store class cannot be found.
     def self.retrieve_store_class: (untyped store) -> untyped
 
+    public
+
     # An abstract cache store class. There are multiple cache store
     # implementations, each having its own additional features. See the classes
     # under the ActiveSupport::Cache module, e.g.
@@ -866,6 +872,8 @@ module ActiveSupport
       def self.retrieve_pool_options: (untyped options) -> untyped
 
       def self.ensure_connection_pool_added!: () -> untyped
+
+      public
 
       # Creates a new cache. The options will be passed to any write method calls
       # except for <tt>:namespace</tt> which can be used to set the global
@@ -1095,6 +1103,8 @@ module ActiveSupport
       #
       # Some implementations may not support this method.
       def clear: (?untyped? options) -> untyped
+
+      private
 
       def key_matcher: (untyped pattern, untyped options) -> untyped
 
@@ -1463,7 +1473,7 @@ module ActiveSupport
 
       def append: (*untyped callbacks) -> untyped
 
-      def `prepend`: (*untyped callbacks) -> untyped
+      def prepend: (*untyped callbacks) -> untyped
 
       attr_reader chain: untyped
 
@@ -5870,7 +5880,7 @@ module ActiveSupport
 
     def insert: (untyped index, untyped value) -> untyped
 
-    def `prepend`: (untyped value) -> untyped
+    def prepend: (untyped value) -> untyped
 
     def replace: (untyped value) -> untyped
 
@@ -6342,7 +6352,7 @@ module ActiveSupport
     include ActiveSupport::Callbacks
 
     # Returns singleton instance for this class in this thread. If none exists, one is created.
-    def self.`instance`: () -> untyped
+    def self.instance: () -> untyped
 
     # Declares one or more attributes that will be given both class and instance accessor methods.
     def self.attribute: (*untyped names) -> untyped
@@ -6367,6 +6377,8 @@ module ActiveSupport
 
     def self.method_missing: (untyped name, *untyped args) { () -> untyped } -> untyped
 
+    public
+
     attr_accessor attributes: untyped
 
     def initialize: () -> untyped
@@ -6385,6 +6397,8 @@ module ActiveSupport
 
     # Reset all attributes. Should be called before and after actions, when used as a per-request singleton.
     def reset: () -> untyped
+
+    private
 
     def assign_attributes: (untyped new_attributes) -> untyped
 
@@ -6866,7 +6880,7 @@ module ActiveSupport
 
       module ClassMethods
         # :nodoc:
-        def `include`: (untyped included_module) -> untyped
+        def include: (untyped included_module) -> untyped
 
         def method_added: (untyped method_name) -> untyped
       end
@@ -7041,7 +7055,7 @@ module ActiveSupport
       #   PLANETS_POST_2006 = %w(mercury venus earth mars jupiter saturn uranus neptune)
       #   PLANETS = ActiveSupport::Deprecation::DeprecatedConstantProxy.new('PLANETS', 'PLANETS_POST_2006')
       #   PLANETS.class # => Array
-      def `class`: () -> untyped
+      def class: () -> untyped
 
       private
 
@@ -7152,6 +7166,8 @@ module ActiveSupport
     private
 
     def self.accumulate_descendants: (untyped klass, untyped acc) -> untyped
+
+    public
 
     def inherited: (untyped base) -> untyped
 
@@ -7367,6 +7383,8 @@ module ActiveSupport
 
     def self.calculate_total_seconds: (untyped parts) -> untyped
 
+    public
+
     def initialize: (untyped value, untyped parts) -> untyped
 
     def coerce: (untyped other) -> untyped
@@ -7466,6 +7484,8 @@ module ActiveSupport
     # Build ISO 8601 Duration string for this duration.
     # The +precision+ parameter can be used to limit seconds' precision of duration.
     def iso8601: (?precision: untyped? precision) -> untyped
+
+    private
 
     def sum: (untyped sign, ?untyped time) -> untyped
 
@@ -8157,7 +8177,7 @@ module ActiveSupport
         def to_regex: (untyped string) -> ::Regexp
       end
 
-      def self.`instance`: (?::Symbol locale) -> untyped
+      def self.instance: (?::Symbol locale) -> untyped
 
       attr_reader plurals: untyped
 
@@ -9377,7 +9397,11 @@ module ActiveSupport
 
       def self.decode: (untyped message) -> untyped
 
+      public
+
       def verify: (untyped purpose) -> untyped
+
+      private
 
       def match?: (untyped purpose) -> untyped
 
@@ -10830,7 +10854,7 @@ module ActiveSupport
   module PerThreadRegistry
     def self.extended: (untyped object) -> untyped
 
-    def `instance`: () -> untyped
+    def instance: () -> untyped
 
     private
 
@@ -11087,6 +11111,8 @@ module ActiveSupport
 
     def self.pattern_subscribed?: (untyped pattern) -> untyped
 
+    public
+
     attr_reader patterns: untyped
 
     def initialize: () -> untyped
@@ -11094,6 +11120,8 @@ module ActiveSupport
     def start: (untyped name, untyped id, untyped payload) -> untyped
 
     def finish: (untyped name, untyped id, untyped payload) -> untyped
+
+    private
 
     def event_stack: () -> untyped
   end
@@ -12253,6 +12281,8 @@ module ActiveSupport
 
     def self.zones_map: () -> untyped
 
+    public
+
     include Comparable
 
     attr_reader name: untyped
@@ -12416,6 +12446,8 @@ module ActiveSupport
     def init_with: (untyped coder) -> untyped
 
     def encode_with: (untyped coder) -> untyped
+
+    private
 
     def parts_to_time: (untyped parts, untyped now) -> (nil | untyped)
 
@@ -12790,6 +12822,8 @@ class Object
   #   Benchmark.ms { User.all }
   #   # => 0.074
   def self.ms: () { () -> untyped } -> untyped
+
+  public
 
   def unescape: (untyped str, ?untyped escaped) -> untyped
 end

--- a/gems/activesupport/6.0.3.2/activesupport-generated.rbs
+++ b/gems/activesupport/6.0.3.2/activesupport-generated.rbs
@@ -2498,27 +2498,6 @@ class Date
 
   # Overrides the default inspect method with a human readable one, e.g., "Mon, 21 Feb 2005"
   def readable_inspect: () -> untyped
-
-  # Converts a Date instance to a Time, where the time is set to the beginning of the day.
-  # The timezone can be either :local or :utc (default :local).
-  #
-  #   date = Date.new(2007, 11, 10)  # => Sat, 10 Nov 2007
-  #
-  #   date.to_time                   # => 2007-11-10 00:00:00 0800
-  #   date.to_time(:local)           # => 2007-11-10 00:00:00 0800
-  #
-  #   date.to_time(:utc)             # => 2007-11-10 00:00:00 UTC
-  #
-  # NOTE: The :local timezone is Ruby's *process* timezone, i.e. ENV['TZ'].
-  #       If the *application's* timezone is needed, then use +in_time_zone+ instead.
-  def to_time: (?::Symbol form) -> untyped
-
-  # Returns a string which represents the time in used time zone as DateTime
-  # defined by XML Schema:
-  #
-  #   date = Date.new(2015, 05, 23)  # => Sat, 23 May 2015
-  #   date.xmlschema                 # => "2015-05-23T00:00:00+04:00"
-  def xmlschema: () -> untyped
 end
 
 class Date
@@ -2945,12 +2924,6 @@ end
 
 class DateTime
   include DateAndTime::Compatibility
-
-  # Either return an instance of +Time+ with the same UTC offset
-  # as +self+ or an instance of +Time+ representing the same time
-  # in the local system timezone depending on the setting of
-  # on the setting of +ActiveSupport.to_time_preserves_timezone+.
-  def to_time: () -> untyped
 end
 
 class DateTime
@@ -3058,26 +3031,6 @@ module Enumerable[unchecked out Elem]
   # doesn't work well https://bugs.ruby-lang.org/issues/13446
   alias _original_sum_with_required_identity sum
 
-  # Calculates a sum from the elements.
-  #
-  #  payments.sum { |p| p.price * p.tax_rate }
-  #  payments.sum(&:price)
-  #
-  # The latter is a shortcut for:
-  #
-  #  payments.inject(0) { |sum, p| sum + p.price }
-  #
-  # It can also calculate the sum without the use of a block.
-  #
-  #  [5, 15, 10].sum # => 30
-  #  ['foo', 'bar'].sum # => "foobar"
-  #  [[1, 2], [3, 1, 5]].sum # => [1, 2, 3, 1, 5]
-  #
-  # The default sum of an empty list is zero. You can override this default:
-  #
-  #  [].sum(Payment.new(0)) { |i| i.amount } # => Payment.new(0)
-  def sum: (?untyped? identity) { () -> untyped } -> untyped
-
   # Convert an enumerable to a hash keying it by the block return value.
   #
   #   people.index_by(&:login)
@@ -3147,9 +3100,6 @@ class Range[out Elem]
 end
 
 class Array[unchecked out Elem]
-  # nodoc:
-  # Array#sum was added in Ruby 2.4 but it only works with Numeric elements.
-  def sum: (?untyped? init) { () -> untyped } -> untyped
 end
 
 class File
@@ -9909,10 +9859,6 @@ module ActiveSupport
       def now: () -> untyped
 
       def now_cpu: () -> untyped
-
-      def now_cpu: () -> 0
-
-      def now_allocations: () -> 0
 
       def now_allocations: () -> untyped
     end

--- a/gems/activesupport/6.0.3.2/patch.rbs
+++ b/gems/activesupport/6.0.3.2/patch.rbs
@@ -5,13 +5,15 @@ class Object
 end
 
 class Time
-  # alias bug: https://github.com/ruby/rbs/issues/458
+  # It is necessary to satisfy alias target.
+  # TODO: Define this method to correct place.
   def xmlschema: (?::Integer fraction_digits) -> ::String
 end
 
 module ActiveSupport
   class TestCase < ::Minitest::Test
-    # alias bug: https://github.com/ruby/rbs/issues/458
+    # It is necessary to satisfy alias target.
+    # TODO: Define this method to correct place.
     def name: () -> untyped
     def assert_raises: (*untyped) -> untyped
     def refute_empty: (*untyped) -> untyped
@@ -27,22 +29,5 @@ module ActiveSupport
     def refute_predicate: (*untyped) -> untyped
     def refute_respond_to: (*untyped) -> untyped
     def refute_same: (*untyped) -> untyped
-  end
-
-  module Notifications
-    class Fanout
-      module Subscribers
-        class AllMessages
-          # alias bug: https://github.com/ruby/rbs/issues/458
-          def ===: (untyped) -> bool
-        end
-      end
-    end
-  end
-
-  class TimeWithZone
-    # alias bug: https://github.com/ruby/rbs/issues/458
-    def <: (untyped) -> bool
-    def >: (untyped) -> bool
   end
 end

--- a/gems/railties/6.0.3.2/_scripts/generate.rb
+++ b/gems/railties/6.0.3.2/_scripts/generate.rb
@@ -36,6 +36,9 @@ def patch!(name, rbs)
         def new_controller_thread: () { () -> untyped } -> untyped
       end
     RUBY
+
+    # to avoid DuplicatedMethodDefinitionError
+    rbs.gsub!('def commit_cookie_jar!: () -> nil', '# def commit_cookie_jar!: () -> nil') || raise
   when 'railties'
     rbs.gsub!(
       'class NonSymbolAccessDeprecatedHash < HashWithIndifferentAccess',
@@ -93,6 +96,21 @@ def patch!(name, rbs)
       class HashWithIndifferentAccess[T, U] < ActiveSupport::HashWithIndifferentAccess[T, U]
       end
     RBS
+
+    # to avoid DuplicatedMethodDefinitionError
+    rbs.gsub!('def to_time: (?::Symbol form) -> untyped', '# def to_time: (?::Symbol form) -> untyped') or raise
+    rbs.gsub!('def xmlschema: () -> untyped', '# def xmlschema: () -> untyped') or raise
+    rbs.gsub!(<<-RBS.chomp, '') or raise
+  # Either return an instance of +Time+ with the same UTC offset
+  # as +self+ or an instance of +Time+ representing the same time
+  # in the local system timezone depending on the setting of
+  # on the setting of +ActiveSupport.to_time_preserves_timezone+.
+  def to_time: () -> untyped
+    RBS
+    rbs.gsub!('def sum: (?untyped? identity) { () -> untyped } -> untyped', '# def sum: (?untyped? identity) { () -> untyped } -> untyped') or raise
+    rbs.gsub!('def sum: (?untyped? init) { () -> untyped } -> untyped', '# def sum: (?untyped? init) { () -> untyped } -> untyped') or raise
+    rbs.gsub!('def now_cpu: () -> 0', '# def now_cpu: () -> 0') or raise
+    rbs.gsub!('def now_allocations: () -> 0', '# def now_allocations: () -> 0') or raise
   when 'actionview'
     rbs.gsub!(
       'class CheckBoxBuilder < Builder',

--- a/gems/railties/6.0.3.2/_scripts/generate.rb
+++ b/gems/railties/6.0.3.2/_scripts/generate.rb
@@ -111,6 +111,8 @@ def patch!(name, rbs)
     rbs.gsub!('def sum: (?untyped? init) { () -> untyped } -> untyped', '# def sum: (?untyped? init) { () -> untyped } -> untyped') or raise
     rbs.gsub!('def now_cpu: () -> 0', '# def now_cpu: () -> 0') or raise
     rbs.gsub!('def now_allocations: () -> 0', '# def now_allocations: () -> 0') or raise
+
+    rbs.gsub!('module Tryable', 'module Tryable : BasicObject') or raise
   when 'actionview'
     rbs.gsub!(
       'class CheckBoxBuilder < Builder',
@@ -185,6 +187,9 @@ def patch!(name, rbs)
     rbs.gsub!(
       'def []: (untyped name) -> Attribute',
       'def []: (untyped name) -> ::Arel::Attributes::Attribute')
+
+    rbs.gsub!('module TestDatabases', 'module TestDatabases : BasicObject') or raise
+    rbs.gsub!('module TestFixtures', 'module TestFixtures : BasicObject') or raise
   end
 end
 

--- a/gems/railties/6.0.3.2/patch.rbs
+++ b/gems/railties/6.0.3.2/patch.rbs
@@ -5,10 +5,6 @@ module Rails
   end
 
   class Engine < Railtie
-    # bug: rbs prototype rb isn't aware of `class << self` for attr_*
-    def self.isolated: () -> untyped
-    def self.isolated=: (untyped) -> untyped
-
     # alias bug: https://github.com/ruby/rbs/issues/458
     def self.railtie_name: (?untyped? name) -> untyped
   end

--- a/gems/railties/6.0.3.2/patch.rbs
+++ b/gems/railties/6.0.3.2/patch.rbs
@@ -1,25 +1,9 @@
 module Rails
-  class Application < Engine
-    # alias bug: https://github.com/ruby/rbs/issues/458
-    def app: () -> untyped
-  end
-
-  class Engine < Railtie
-    # alias bug: https://github.com/ruby/rbs/issues/458
-    def self.railtie_name: (?untyped? name) -> untyped
-  end
-
   module Generators
     class PluginGenerator < AppBase
-      # alias bug: https://github.com/ruby/rbs/issues/458
+      # It is necessary to satisfy alias target.
+      # TODO: Define this method to correct place.
       def app_path: () -> untyped
-    end
-  end
-
-  module Initializable
-    class Collection[T] < Array[T]
-      def each: () -> ::Enumerator[T, self]
-              | () { (T item) -> void } -> self
     end
   end
 end

--- a/gems/railties/6.0.3.2/railties-generated.rbs
+++ b/gems/railties/6.0.3.2/railties-generated.rbs
@@ -422,7 +422,7 @@ module Rails
   class Application < Engine
     def self.inherited: (untyped base) -> untyped
 
-    def self.`instance`: () -> untyped
+    def self.instance: () -> untyped
 
     def self.create: (?::Hash[untyped, untyped] initial_variable_values) { () -> untyped } -> untyped
 
@@ -847,6 +847,8 @@ module Rails
       def self.relative_command_path: () -> untyped
 
       def self.namespaced_commands: () -> untyped
+
+      public
 
       def help: () -> untyped
     end
@@ -2780,6 +2782,8 @@ module Rails
       # when declaring options curly brackets should be used
       def self.parse_type_and_options: (untyped `type`) -> untyped
 
+      public
+
       def initialize: (untyped name, ?untyped? `type`, ?bool index_type, ?::Hash[untyped, untyped] attr_options) -> untyped
 
       def field_type: () -> untyped
@@ -4303,7 +4307,7 @@ module Rails
       module ClassMethods
         def inherited: (untyped base) -> untyped
 
-        def `instance`: () -> untyped
+        def instance: () -> untyped
 
         def respond_to?: (*untyped args) -> untyped
 
@@ -4510,7 +4514,7 @@ module Rails
 
     # Since Rails::Railtie cannot be instantiated, any methods that call
     # +instance+ are intended to be called only on subclasses of a Railtie.
-    def self.`instance`: () -> untyped
+    def self.instance: () -> untyped
 
     # Allows you to configure the railtie. This is the same method seen in
     # Railtie::Configurable, but this module is no longer required for all
@@ -4532,6 +4536,8 @@ module Rails
     # `#each_registered_block(type, &block)`
     def self.register_block_for: (untyped `type`) { () -> untyped } -> untyped
 
+    public
+
     def initialize: () -> untyped
 
     def configure: () { () -> untyped } -> untyped
@@ -4550,6 +4556,8 @@ module Rails
     def run_runner_blocks: (untyped app) -> untyped
 
     def run_tasks_blocks: (untyped app) -> untyped
+
+    private
 
     # run `&block` in every registered block in `#register_block_for`
     def each_registered_block: (untyped `type`) { () -> untyped } -> untyped

--- a/gems/railties/6.0.3.2/railties-generated.rbs
+++ b/gems/railties/6.0.3.2/railties-generated.rbs
@@ -1943,9 +1943,9 @@ module Rails
   #   # load Blog::Engine with highest priority, followed by application and other railties
   #   config.railties_order = [Blog::Engine, :main_app, :all]
   class Engine < Railtie
-    attr_accessor called_from: untyped
+    attr_accessor self.called_from: untyped
 
-    attr_accessor isolated: untyped
+    attr_accessor self.isolated: untyped
 
     alias self.isolated? self.isolated
 
@@ -4564,7 +4564,7 @@ module Rails
       def initialize: () -> untyped
     end
 
-    attr_writer root: untyped
+    attr_writer self.root: untyped
 
     def self.parse: (untyped paths, env: untyped env) -> untyped
 
@@ -4792,13 +4792,13 @@ end
 module Rails
   extend ActiveSupport::Autoload
 
-  attr_writer application: untyped
+  attr_writer self.application: untyped
 
-  attr_accessor app_class: untyped
+  attr_accessor self.app_class: untyped
 
-  attr_accessor cache: untyped
+  attr_accessor self.cache: untyped
 
-  attr_accessor logger: untyped
+  attr_accessor self.logger: untyped
 
   def self.application: () -> untyped
 


### PR DESCRIPTION
This pull request updates RBS gem to v1.0.0 for Rails gems.


It includes singleton attributes, fixing alias bug, and small fixes.


I've confirmed the `_script/test` successes, and `steep check` runs on a real Rails application with these RBSs.
