### PR TITLE
[retryable] Fix `sleep` and `sleep_method` signatures

### DIFF
--- a/gems/retryable/3.0/configuration.rbs
+++ b/gems/retryable/3.0/configuration.rbs
@@ -20,8 +20,8 @@ module Retryable
       matching: (String | Regexp) | Array[String | Regexp] | nil,
       not: _Exception | Array[_Exception] | nil,
       on: _Exception | Array[_Exception] | nil,
-      sleep: real | (^(real) -> void) | nil,
-      sleep_method: (^(real) -> void) | nil,
+      sleep: Numeric | (^(Numeric) -> Numeric) | nil,
+      sleep_method: (^(Numeric) -> void) | nil,
       tries: Integer | nil
     }
 


### PR DESCRIPTION
- Fix the incorrect return type (`void` -> `Numeric`) of `sleep` lambda.
- Change `real` to `Numeric` because `Kernel.sleep` receives `Numeric`.
  (See <https://github.com/ruby/rbs/blob/09f21280f6d8041b3d71473b0551199a68818e92/core/kernel.rbs#L374-L375>)

See also <https://github.com/nfedyashev/retryable/blob/aa51cbd7ea570e223161571fe97eb8ca7ce8a535/lib/retryable.rb#L84-L85>.