### PR TITLE
[rails] Update RBS for Rails to include all dependencies

### DIFF
--- a/gems/actionpack/6.0.3.2/patch.rbs
+++ b/gems/actionpack/6.0.3.2/patch.rbs
@@ -22,3 +22,92 @@ module ActionDispatch
   end
 end
 
+# Remove the fake types for Capybara
+# if the real types are available.
+module Capybara
+  module DSL
+  end
+
+  module Minitest
+    module Assertions
+    end
+  end
+
+  module Poltergeist
+    class Driver
+    end
+  end
+end
+
+# Remove the fake types for Minitest
+# if the real types are available.
+module Minitest
+  module Assertions
+  end
+end
+
+# Remove the fake types for Racc
+# if the real types are available.
+module Racc
+  class Parser
+  end
+end
+
+# Remove the fake types for Rack
+# if the real types are available.
+module Rack
+  class Response
+    module Helpers
+      def location: () -> untyped
+    end
+  end
+
+  class Request
+    module Helpers
+    end
+
+    module Env
+    end
+  end
+
+  module Session
+    module Abstract
+      class SessionHash
+      end
+
+      class PersistedSecure
+        class SecureSessionHash
+        end
+      end
+
+      class Persisted
+      end
+    end
+
+    class SessionId
+    end
+
+    class Dalli
+    end
+  end
+
+  module Cache
+    class MetaStore
+    end
+
+    class EntityStore
+    end
+  end
+
+  module Test
+    class UploadedFile
+    end
+  end
+end
+
+# Remove the fake types for Gem::Version
+# if the real types are available.
+module Gem
+  class Version
+  end
+end

--- a/gems/actionview/6.0.3.2/patch.rbs
+++ b/gems/actionview/6.0.3.2/patch.rbs
@@ -4,3 +4,53 @@ module ActionView
     def self.caching: () -> untyped
   end
 end
+
+# Remove the fake type for Concurrent::Map
+# if the real types are available.
+module Concurrent
+  class Map
+  end
+end
+
+# Remove the fake type for I18n::Config
+# if the real types are available.
+module I18n
+  class Config
+  end
+end
+
+# Remove the fake type for Erubi::Engine
+# if the real types are available.
+module Erubi
+  class Engine
+  end
+end
+
+# Remove the fake rails-dom-testing type
+# if the real types are available.
+module Rails
+  module Dom
+    module Testing
+      module Assertions
+      end
+    end
+  end
+end
+
+# Remove the fake rails-dom-testing type
+# if the real types are available.
+module Rails
+  module Dom
+    module Testing
+      module Assertions
+      end
+    end
+  end
+end
+
+# Remove the fake types for Gem::Version
+# if the real types are available.
+module Gem
+  class Version
+  end
+end

--- a/gems/activejob/6.0.3.2/patch.rbs
+++ b/gems/activejob/6.0.3.2/patch.rbs
@@ -1,0 +1,36 @@
+# Remove the fake type if the real type is available
+module Que
+  class Job
+  end
+end
+
+# Remove the fake type if the real type is available
+class QC
+  class Queue
+  end
+end
+
+# Remove the fake type if the real type is available
+module Sidekiq
+  module Worker
+  end
+end
+
+# Remove the fake type if the real type is available
+module Sneakers
+  module Worker
+  end
+end
+
+# Remove the fake type if the real type is available
+module SuckerPunch
+  module Job
+  end
+end
+
+# Remove the fake types for Gem::Version
+# if the real types are available.
+module Gem
+  class Version
+  end
+end

--- a/gems/activemodel/6.0.3.2/_script/test
+++ b/gems/activemodel/6.0.3.2/_script/test
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -xe
+
+REPO=$(git rev-parse --show-toplevel)/gems
+rbs --repo=$REPO \
+  -rmonitor -rdate -rsingleton -rlogger -rmutex_m -ractivesupport \
+  -ractivemodel validate

--- a/gems/activemodel/6.0.3.2/patch.rbs
+++ b/gems/activemodel/6.0.3.2/patch.rbs
@@ -11,3 +11,10 @@ module ActiveModel
     def `send`: (String name, *untyped args) ?{ (*untyped) -> untyped } -> untyped
   end
 end
+
+# Remove the fake types for Gem::Version
+# if the real types are available.
+module Gem
+  class Version
+  end
+end

--- a/gems/activerecord/6.0.3.2/patch.rbs
+++ b/gems/activerecord/6.0.3.2/patch.rbs
@@ -20,3 +20,22 @@ module ActiveRecord
     end
   end
 end
+
+# Remove the fake PG type if the real type is available
+module PG
+  class Connection
+    def async_exec: (*untyped) -> untyped
+  end
+end
+
+# Remove the fake SimpleDelegator type
+# if the real types are available.
+class SimpleDelegator
+end
+
+# Remove the fake types for Gem::Version
+# if the real types are available.
+module Gem
+  class Version
+  end
+end

--- a/gems/activesupport/6.0.3.2/_script/test
+++ b/gems/activesupport/6.0.3.2/_script/test
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -xe
+
+REPO=$(git rev-parse --show-toplevel)/gems
+rbs --repo=$REPO \
+  -rmonitor -rdate -rsingleton -rlogger -rmutex_m \
+  -ractivesupport validate

--- a/gems/activesupport/6.0.3.2/patch.rbs
+++ b/gems/activesupport/6.0.3.2/patch.rbs
@@ -88,3 +88,8 @@ module OpenSSL
   class Cipher
   end
 end
+
+module Rails
+  class Railtie
+  end
+end

--- a/gems/activesupport/6.0.3.2/patch.rbs
+++ b/gems/activesupport/6.0.3.2/patch.rbs
@@ -31,3 +31,60 @@ module ActiveSupport
     def refute_same: (*untyped) -> untyped
   end
 end
+
+# Remove the fake type of Minitest
+# if the real types are available.
+module Minitest
+  class Test
+  end
+end
+
+# Remove the fake type of LibXML
+# if the real types are available.
+module LibXML
+  module XML
+    module SaxParser
+      module Callbacks
+      end
+    end
+  end
+end
+
+# Remove the fake type of Nokogiri
+# if the real types are available.
+module Nokogiri
+  module XML
+    module SAX
+      class Document
+      end
+    end
+  end
+end
+
+# Remove the fake type of TZInfo
+# if the real types are available.
+module TZInfo
+  class Timezone
+  end
+end
+
+# Remove the fake type of DRb
+# if the real types are available.
+module DRb
+  module DRbUndumped
+  end
+end
+
+# Remove the fake types for Gem::Version
+# if the real types are available.
+module Gem
+  class Version
+  end
+end
+
+# Remove the fake types for OpenSSL::Cipher
+# if the real types are available.
+module OpenSSL
+  class Cipher
+  end
+end

--- a/gems/railties/6.0.3.2/_scripts/generate.rb
+++ b/gems/railties/6.0.3.2/_scripts/generate.rb
@@ -15,7 +15,7 @@ end
 def sh!(*cmd, **kwargs)
   puts(cmd.join(' '))
   Open3.capture2(*cmd, **kwargs).then do |out, status|
-    raise unless status.success?
+    raise out unless status.success?
 
     out
   end

--- a/gems/railties/6.0.3.2/_scripts/test
+++ b/gems/railties/6.0.3.2/_scripts/test
@@ -2,12 +2,18 @@
 
 require 'pathname'
 
+VERSION = '6.0.3.2'
+
 def sh!(*args, **kwargs)
   system(*args, **kwargs, exception: true)
 end
 
 base = Pathname(__dir__) / '../'
-repo = base.join('../../').to_s
+repo = base.join('../../')
+
+%w[activemodel activesupport].each do |gem|
+  sh! repo.join(gem, VERSION, '_script/test').to_s
+end
 
 sh!('bundle', 'install', chdir: base.join('_rbs_rails'))
-sh!({ 'RAILS_VERSION' => '6.0.3.2', 'RBS_REPO_DIR' => repo }, 'bundle', 'exec', 'rake', chdir: base.join('_rbs_rails'))
+sh!({ 'RAILS_VERSION' => VERSION, 'RBS_REPO_DIR' => repo.to_s }, 'bundle', 'exec', 'rake', chdir: base.join('_rbs_rails'))

--- a/gems/railties/6.0.3.2/patch.rbs
+++ b/gems/railties/6.0.3.2/patch.rbs
@@ -7,3 +7,65 @@ module Rails
     end
   end
 end
+
+# rbs gem has erb library but it doesn't have ERB::Compiler definition.
+class ERB
+  class Compiler
+  end
+end
+
+# Remove the fake Minitest type
+# if the real type of Minitest is available
+module Minitest
+  class SummaryReporter
+  end
+
+  class StatisticsReporter
+  end
+end
+
+# Remove the fake Rack type
+# if the real type of Minitest is available
+module Rack
+  class Server
+  end
+end
+
+# Remove the fake RDoc type
+# if the real type of Minitest is available
+module RDoc
+  module Generator
+    class SDoc
+    end
+  end
+
+  class Task
+  end
+end
+
+# Remove the fake RDoc type
+# if the real type of Minitest is available
+class Thor
+  class Group
+  end
+
+  module Actions
+    class CreateFile
+    end
+  end
+
+  class Error
+  end
+end
+
+# Remove the fake types for Gem::Version
+# if the real types are available.
+module Gem
+  class Version
+  end
+end
+
+# Remove the fake types for FileUtils
+# if the real types are available.
+module FileUtils
+end

--- a/gems/railties/6.0.3.2/railties-generated.rbs
+++ b/gems/railties/6.0.3.2/railties-generated.rbs
@@ -4099,7 +4099,7 @@ module Rails
     end
 
     class Collection[T] < Array[T]
-      include TSort
+      include TSort[untyped]
 
       alias tsort_each_node each
 


### PR DESCRIPTION
This pull request adds all dependent RBS of Rails to this repository.

Rails gems will include dependent RBS as empty class/module definitions.
I'd like to remove them in the future because they are not parts of Rails gems, but currently the dependencies don't have RBS.
Sowe need to add empty RBSs to them.
For example, it adds `Capybara` RBS to actionpack gem.




see more information https://github.com/pocke/rbs_rails/pull/90